### PR TITLE
Species Blurbs updates, makes Jellypeople better to play as

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -31,8 +31,7 @@
 	var/EMPeffect = FALSE
 	var/emag_effect = FALSE                          //WS Edit -- Multitool Color Change
 	var/static/unhealthy_color = rgb(237, 164, 149)  //WS Edit -- Multitool Color Change
-	loreblurb = "Ethereals are organic humanoid beings with a blood that has strange luminiscent and electrical properties. \
-				Ethereals are barred from most authority roles on Nanotrasen stations and are not protected by the AI's default Asimov laws."
+	loreblurb = "Ethereals are organic humanoid beings with a blood that has strange luminiscent and electrical properties. They require electricity to survive, rather than food, and cast bright, colorful light from their bodies."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
 	var/obj/effect/dummy/lighting_obj/ethereal_light
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -13,10 +13,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	ass_image = 'icons/ass/asscat.png'
-	loreblurb = "Felinids have a long history with Space Station 13. One of the earliest events still recorded, in much simpler times, shows cat ears and tails were perhaps just a consumer product \
-				available in the galaxy. Innocent enough as well, at least concerning what Felinids were, pet collars became the height of niche fashion a year after cat ears returned to shelves. \
-				Though consumers complained cat ears and collars could not be put on together, the manufacturers questioned who would be unable to wear ears on their head, a tail somewhere unpleasant \
-				and a collar on their neck all together. Market researchers claimed these complaints were from children not suited to the product given the letters were written in colourful crayon. "
+	loreblurb = "Humans with genetic modifications spliced from the domestic cat. These are by far the most common human genemod. There's a lot of rumors about potential issues in the culture or psychology of felinids, but the only proven differences between felinids and unmodified humans are physically apparent, such as the more iconic ears and tails, or minor alterations such as fangs or slit-eyes."
 
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -9,9 +9,7 @@
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	loreblurb = "Originating from Earth and making up the bulk of Nanotrasen's workforce, Humans are known for their adaptability and intelligence. \
-	 As only a limited amount of trust is afforded to non-Human employees, members of this species can enjoy numerous comforts. \
-	 What they lack in scales, claws and tails, they make up for in solidarity and institutionalized racism."
+	loreblurb = "Stamina-oriented hairless primates who call their system 'Sol'. Extremely common, and so adaptable it's almost funny. For whatever reason, almost every major conflict in recent memory was spearheaded by humans. They value food with high sugar and fat content."
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
 	return TRUE	//Pure humans are always allowed in all roles.

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -4,8 +4,10 @@
 	id = "jelly"
 	default_color = "00FF90"
 	say_mod = "chirps"
-	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,NO_BONES)
+	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,NO_BONES,HAIR,FACEHAIR)
 	inherent_traits = list(TRAIT_TOXINLOVER)
+	hair_color = "mutcolor"
+	hair_alpha = 150
 	mutantlungs = /obj/item/organ/lungs/slime
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
@@ -19,6 +21,7 @@
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/jelly
 	ass_image = 'icons/ass/assslime.png'
+	loreblurb = "Alien beings made of a gelatinous substance. It's relatively common to be transformed into a jellyperson from another species due to the mutagenic properties of less intelligent slime beings, but many truly alien jelly people also exist. Their blood is toxic, and the properties of poisonous and poison-healing substances are inverted for them."
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
 	if(regenerate_limbs)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -19,10 +19,7 @@
 	mutanttongue = /obj/item/organ/tongue/moth //WS Edit - Insectoid language
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/moth
-	loreblurb = "Originating from the ruins of an unknown company's abandoned bluespace research facility, mothpeople are the mutated forms \
-				of the pests that were quick to set into the facility after it was abandoned, not a human teleporter malfunction as many believe. \
-				Their initial limited intelligence led to moffic, their \"native\" language. Generations later, most mothpeople still speak this language. \
-				After finally being discovered by an unknown craft, mothpeople were quick to spread out across the galaxy and are now as commonplace as their natural counterparts."
+	loreblurb = "Horrifying giant bug monsters, or possibly cute and fluffy cuddlebugs, depending on who you ask. Astoundingly common in every corner of space, their origin is typically assumed to be misdirected gene modification or mutation of regular Sol moths. Their wings, while pretty, are non-functional in standard gravity levels."
 	wings_icons = list("Megamoth", "Mothra")
 	has_innate_wings = TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -22,8 +22,8 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	outfit_important_for_life = /datum/outfit/plasmaman
 	species_language_holder = /datum/language_holder/skeleton
-	loreblurb = "The product of plasma experimentation on a human colony, these strange abominations lead a difficult life of breathing plasma and bursting into flames when exposed to oxygen. \
-	Logically speaking, they make for bad crewmembers. However, they don't have a choice but to work for the only corporation that can supply them with plasma."
+	loreblurb = "These strange abominations lead a difficult life of breathing plasma and bursting into flames when exposed to oxygen. Although where they come from is unknown, as not even plasmamen themselves typically seem to know for sure, their similarity to the human skeleton leads to the rumor that they're humans who were injured horribly in a plasma fire, losing their memories. Or  maybe they're just weird aliens, those things tend to look like humans all the time anyways. \
+	Spacers frequently groan at the prospect of having a plasmaman as a member of their crew, as they have difficult needs that tend to contrast with oxygen-breathing organic lifeforms. But hey, purple skeletons."
 
 	// Body temperature for Plasmen is much lower human as they can handle colder environments
 	bodytemp_normal = (BODYTEMP_NORMAL - 40)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -459,7 +459,7 @@ ROUNDSTART_RACES squid
 
 ## Races that are better than humans in some ways, but worse in others
 ROUNDSTART_RACES ethereal
-#ROUNDSTART_RACES jelly
+ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES golem
 #ROUNDSTART_RACES adamantine
 #ROUNDSTART_RACES plasma

--- a/whitesands/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/whitesands/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	species_language_holder = /datum/language_holder/dwarf
 	loreblurb = "A species of squat, sturdy creatures drenched in facial hair with a fondness for drink and industry.\
 	 They superficially look like short humans, but they have engorged livers, thick skin, and a specialized gall bladder\
-	 that processes alcohol into vital nutrients that the dwarf cannot live without, making them compulsory drunkards."
+	 that processes alcohol into vital nutrients that the dwarf cannot live without, making them compulsory drunkards. They are from Canada."
 
 /mob/living/carbon/human/species/dwarf //species admin spawn path
 	race = /datum/species/dwarf //and the race the path is set to.

--- a/whitesands/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/whitesands/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -59,9 +59,7 @@ GLOBAL_LIST_INIT(spider_last, world.file2list("strings/names/spider_last.txt"))
 	mutanttongue = /obj/item/organ/tongue/spider
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/spider
-	loreblurb = "A competitive species, evolved to enjoy working, Arachnids make up a small yet rapidly growing space in Nanotrasen’s workforce. \
-	Seen as valued assets due to their hard working tendencies, they are commonly found on stations near independent Arachnid civilizations. \
-	While their males are well integrated into NT's station crews, the females are voracious and dominant, and have willfully resisted integration (with deadly consequences)."
+	loreblurb = "A species biologically predisposed to a highly competitive attitude and with a strong work ethic, Arachnids make up a growing minority within the workforces of most factions. Males are commonly found on outposts near independent Arachnid civilizations, but the dominant arachnid \"Matriarchs\" have willfully resisted integration into most factions (with deadly consequences.)"
 	var/web_cooldown = 30
 	var/web_ready = TRUE
 	var/spinner_rate = 75

--- a/whitesands/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/whitesands/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -30,7 +30,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	loreblurb = "A race of squid-like amphibians with an odd appearance. \
 	They posses the ability to change their pigmentation at will, often leading to confusion. \
-	Nanotrasen ensures that the squid people do not eat human grey matter, and such reports will be discarded."
+	It's frequently rumored that they eat human grey matter. This is definitely, absolutely, most certainly not in any way at all true."
 
 /datum/species/squid/random_name(gender,unique,lastname)
 	if(unique)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The lore blurbs of most of the roundstart species have been altered to account for the lack of Nanotrasen as a primary focus of gameplay, of any changes to lore that may happen, and to just generally be more well-written or not directly copied from tg's wiki. 
Also, Jellypeople have a lore blurb now, as well as being able to select hair and facial hair styles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As we move towards a different tone in lore it's better for in game text to reflect this. Nanotrasen isn't our focus so our lore blurbs shouldn't read like Nanotrasen employee pamphlets. Jellypeople in particular have always been available in the config historically but nobody really ever played them because they looked like shit and their description told you to yell at a coder and cook enchiladas. Also, some of the lore blurbs just kind of sucked.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Jellypeople have a lore blurb finally
tweak: Jellypeople can have hair now
tweak: edited or fully rewrote most of the roundstart species lore blurbs
config: jellypeople default to roundstart in config in the repo now, they already were on serverside config though
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
