### PR TITLE
Adds five character slots

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1				//Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 5
+	var/max_save_slots = 10
 
 	//non-preference stuff
 	var/muted = 0
@@ -153,7 +153,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			load_path(C.ckey)
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 10
+				max_save_slots = 15
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
 		if("extra character slot" in purchased_gear)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds five character slots, I have no fucking idea how this interacts with the buyable character slot because I have no way of testing without a DB. similarly I have no fucking way of testing if it works with byond members but whatever
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We have so many fucking species and theoretically when we expand upon loadouts having more characters to fulfill different roles will be more useful. the only person who loses here is me, when you losers make ten to sixteen characters and this shit gets put directly on my regular consumer laptop hard drive. Actually I just checked and all the player saves so far are only 691 KB (nice)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: regular character slots bumped from 5 to 10. byond member character slots bumped from 10 to 15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
