### PR TITLE
Make ruin docks load threir roundstart templates

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -99,6 +99,8 @@
 					port.dwidth = port_y_offset - 1
 					port.dheight = width - port_x_offset
 
+			port.load()
+
 //Whatever special stuff you want
 /datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)
 	if(movement_force)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -318,6 +318,11 @@
 	if(name == "shuttle")
 		name = "shuttle[SSshuttle.mobile.len]"
 
+	if(!mapload) // If maploaded, will be called in code\datums\shuttles.dm
+		load()
+
+
+/obj/docking_port/mobile/proc/load()
 	shuttle_areas = list()
 	var/list/all_turfs = return_ordered_turfs(x, y, z, dir)
 	for(var/i in 1 to all_turfs.len)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -185,6 +185,8 @@
 	if(mapload)
 		for(var/turf/T in return_turfs())
 			T.flags_1 |= NO_RUINS_1
+		if(SSshuttle.initialized) // If the docking port is loaded via map but SSshuttle has already init (therefore this would never be called)
+			load_roundstart()
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#f00")


### PR DESCRIPTION

## About The Pull Request
![image](https://user-images.githubusercontent.com/29362068/121987076-5bc19d00-cd5d-11eb-887a-5ff9a9abe8ee.png)

## Why It's Good For The Game
Ruins with shuttles kind of need the shuttles to work, so them not spawning in at all was a bit annoying.

## Changelog
:cl:
fix: Stationary docking ports with roundstart templates defined will now spawn those templates when loaded in via map template.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
