### PR TITLE
re-areas several ruins shuttles and does minor fixes to some mainline shuttles

### DIFF
--- a/_maps/shuttles/amogus_sus.dmm
+++ b/_maps/shuttles/amogus_sus.dmm
@@ -638,15 +638,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
-"kq" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/ship/engineering)
 "kv" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -891,10 +882,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/fore)
-"nN" = (
-/obj/machinery/door/window/eastleft,
-/turf/open/floor/plasteel,
-/area/ship/engineering)
 "nP" = (
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/machinery/light{
@@ -2432,12 +2419,6 @@
 "Ho" = (
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
-"Hs" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/ship/engineering)
 "Hx" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4362,7 +4343,7 @@ EX
 Lj
 Za
 oy
-nN
+Qy
 mG
 hC
 fj
@@ -4447,8 +4428,8 @@ dX
 HD
 HD
 IZ
-Hs
-kq
+gL
+yh
 NP
 YM
 WQ

--- a/_maps/shuttles/engi_moth.dmm
+++ b/_maps/shuttles/engi_moth.dmm
@@ -286,6 +286,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/holopad/emergency/engineering,
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "jz" = (
@@ -304,6 +305,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/holopad,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "jF" = (
@@ -1800,9 +1802,7 @@
 "Yy" = (
 /obj/structure/window/plasma/reinforced/spawner/east,
 /obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
 /turf/open/floor/engine/o2,
 /area/ship/engineering/atmospherics)
 "YB" = (

--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -1966,6 +1966,7 @@
 /area/ship/engineering)
 "VV" = (
 /obj/structure/table,
+/obj/item/defibrillator/loaded,
 /obj/item/stack/medical/suture,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/glass/bottle/epinephrine{

--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -1593,6 +1593,7 @@
 	pixel_x = -30;
 	pixel_y = 30
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "OE" = (
@@ -1632,6 +1633,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "OU" = (

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -6,7 +6,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "ax" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/silver{
@@ -15,8 +15,14 @@
 /obj/item/stack/sheet/mineral/silver{
 	amount = 25
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "aP" = (
 /obj/machinery/door/airlock{
 	name = "Crew Quarters"
@@ -31,8 +37,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "bg" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -40,8 +49,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "bu" = (
 /obj/machinery/door/airlock{
 	name = "Crew Cabins"
@@ -57,8 +69,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "bI" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/box/white/corners,
@@ -71,8 +86,11 @@
 /obj/item/stack/sheet/mineral/diamond{
 	amount = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "bR" = (
 /obj/structure/toilet{
 	dir = 4
@@ -86,15 +104,21 @@
 /turf/open/floor/plasteel/showroomfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "ct" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -102,10 +126,18 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "cX" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/yellow,
@@ -115,15 +147,18 @@
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "ec" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "eP" = (
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_cargo";
@@ -135,16 +170,19 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "fk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "fD" = (
 /turf/template_noop,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "gs" = (
 /obj/structure/closet/secure_closet/freezer{
 	locked = 0;
@@ -184,7 +222,7 @@
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "gw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -196,18 +234,21 @@
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "hk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "if" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/space,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "ig" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -215,7 +256,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "jg" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -230,18 +271,30 @@
 /turf/open/floor/plasteel/showroomfloor{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
-"lt" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/area/ship/crew)
+"jr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/item/wrench,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ship/cargo)
+"lt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/space_heater,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "lx" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -249,19 +302,22 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged4"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "lC" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "lM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -270,16 +326,20 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "mo" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/wrench,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
+"mu" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
 "mw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -301,15 +361,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "mZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/trade1{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -319,26 +379,47 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/computer/autopilot{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
+"nM" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
 "oj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "ot" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "oS" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "pR" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -351,10 +432,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
+"pU" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
 "qp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -362,10 +449,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "qM" = (
 /obj/machinery/airalarm/all_access{
 	dir = 4;
@@ -375,14 +465,35 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
+"rf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched1"
+	},
+/area/ship/cargo)
 "rF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "sf" = (
 /obj/machinery/light{
 	dir = 1
@@ -399,7 +510,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "si" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -413,7 +524,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "ss" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
@@ -423,14 +534,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "tg" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "tj" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -443,13 +561,13 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "ur" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "uA" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -481,7 +599,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "uS" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/space,
 /obj/effect/turf_decal/tile/neutral{
@@ -495,13 +613,19 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "vt" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "vO" = (
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_cargo";
@@ -515,15 +639,21 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "xz" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-9"
+	},
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "yn" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/titanium{
@@ -543,7 +673,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "yC" = (
 /obj/machinery/button/door{
 	id = "caravantrade1_bolt";
@@ -558,7 +688,7 @@
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "zd" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -566,19 +696,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "zy" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Ax" = (
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/airless{
 	icon_state = "floorscorched2"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "AM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -592,8 +722,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "AX" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -601,16 +734,19 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Bu" = (
 /obj/item/stack/sheet/mineral/titanium,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged1"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Bx" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -633,7 +769,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -647,8 +783,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "CR" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -666,15 +805,18 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "CU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "floorscorched1"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Dt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -687,10 +829,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "DQ" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -700,16 +845,22 @@
 /obj/item/stack/sheet/mineral/gold{
 	amount = 25
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "El" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "Eo" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/template_noop,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "EI" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/syndicate/melee/sword/space/stormtrooper,
@@ -719,7 +870,7 @@
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "EQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -739,7 +890,7 @@
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "EW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -756,7 +907,7 @@
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "EZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -769,17 +920,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Fv" = (
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "Fx" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
 	},
 /turf/template_noop,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "GJ" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -787,14 +938,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "Hv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "Ib" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -805,8 +962,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "Ja" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -824,7 +984,7 @@
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "Jv" = (
 /turf/template_noop,
 /area/template_noop)
@@ -837,7 +997,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "Ko" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -849,19 +1009,19 @@
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "KC" = (
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 8
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "KX" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "Lr" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -871,19 +1031,22 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
+"Lt" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew)
 "LK" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "LM" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_bridge"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "LX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/door_assembly/door_assembly_min{
@@ -895,17 +1058,22 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Mb" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "NL" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -922,7 +1090,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "NY" = (
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_cargo";
@@ -936,7 +1104,7 @@
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Od" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -964,18 +1132,15 @@
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "Ov" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Ow" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/shuttle/caravan/trade1{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -983,10 +1148,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/computer/helm{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "OK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -999,8 +1167,14 @@
 	amount = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "PM" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
@@ -1032,30 +1206,36 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "Qk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Qs" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Small Freighter APC";
-	pixel_x = 24;
-	req_access = null;
-	start_charge = 0
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "QU" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1066,7 +1246,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "QY" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1078,7 +1258,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Rw" = (
 /obj/machinery/door/airlock{
 	id_tag = "caravantrade1_cabin2";
@@ -1100,55 +1280,67 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "RI" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "RN" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "Su" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged3"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Td" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "TP" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Ut" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "UW" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "VD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -1172,22 +1364,28 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "VT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "Wm" = (
 /obj/machinery/door/airlock{
 	id_tag = "caravantrade1_cabin1";
@@ -1210,7 +1408,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "Wr" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1221,7 +1419,10 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
+"WI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo)
 "WU" = (
 /obj/machinery/airalarm/all_access{
 	dir = 4;
@@ -1232,8 +1433,11 @@
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/crew)
 "WX" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -1244,14 +1448,8 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
 	},
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "WZ" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/twenty,
 /obj/item/stack/sheet/glass{
@@ -1263,8 +1461,14 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/engineering/engine)
 "Xh" = (
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_cargo";
@@ -1275,13 +1479,17 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "XI" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/emcloset,
@@ -1296,7 +1504,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
+"Yk" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "YR" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1309,7 +1520,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/freighter1)
+/area/ship/bridge)
 "Zk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -1324,8 +1535,23 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark/airless,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
+"ZY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
 "ZZ" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -1338,16 +1564,16 @@
 	amount = 20
 	},
 /turf/open/floor/plasteel/airless/dark,
-/area/shuttle/caravan/freighter1)
+/area/ship/cargo)
 
 (1,1,1) = {"
-Jv
+El
+El
+El
+vt
+vt
+El
 KX
-vt
-vt
-vt
-KC
-Fv
 Jv
 Jv
 Jv
@@ -1356,15 +1582,15 @@ Jv
 (2,1,1) = {"
 Fv
 mo
-mo
-mo
-mo
-mo
 El
-KX
-vt
 KC
-Jv
+KC
+El
+El
+ZY
+ZY
+ZY
+mu
 "}
 (3,1,1) = {"
 El
@@ -1374,10 +1600,10 @@ WZ
 lt
 zd
 El
-mo
-mo
-mo
-Fv
+nM
+nM
+nM
+mu
 "}
 (4,1,1) = {"
 El
@@ -1390,7 +1616,7 @@ El
 OK
 ax
 tg
-El
+WI
 "}
 (5,1,1) = {"
 El
@@ -1403,14 +1629,14 @@ El
 DQ
 oS
 bI
-El
+WI
 "}
 (6,1,1) = {"
-El
+Lt
 GJ
 Rw
 PM
-El
+WI
 Qk
 ct
 Zk
@@ -1421,9 +1647,9 @@ eP
 (7,1,1) = {"
 Wr
 Mb
-El
-El
-El
+Lt
+Lt
+WI
 ss
 CU
 ZZ
@@ -1432,24 +1658,24 @@ RI
 NY
 "}
 (8,1,1) = {"
-El
+Lt
 bg
 Wm
 uA
-Fv
+mu
 sf
-VT
+jr
 ot
 hk
 AX
 Xh
 "}
 (9,1,1) = {"
-El
+Lt
 bu
-El
-El
-El
+Lt
+Lt
+WI
 QY
 if
 Ax
@@ -1458,11 +1684,11 @@ Su
 eP
 "}
 (10,1,1) = {"
-El
+Lt
 cx
-El
+Lt
 bR
-El
+WI
 ap
 VN
 lx
@@ -1473,11 +1699,11 @@ vO
 (11,1,1) = {"
 Wr
 pR
-El
+Lt
 jg
-El
-El
-CU
+WI
+WI
+rf
 xz
 Ov
 Td
@@ -1502,7 +1728,7 @@ gs
 cX
 EQ
 VT
-El
+WI
 XI
 Ut
 Td
@@ -1510,26 +1736,26 @@ fD
 fD
 "}
 (14,1,1) = {"
-El
+Lt
 NL
 Bx
-El
+Lt
 aP
-El
-El
+WI
+WI
 zy
 fD
 fD
 Jv
 "}
 (15,1,1) = {"
-El
-El
-El
-El
+Yk
+Yk
+Yk
+Yk
 Ib
 LK
-El
+Yk
 Jv
 Jv
 Jv
@@ -1549,13 +1775,13 @@ Jv
 Jv
 "}
 (17,1,1) = {"
-Fv
-El
-El
-El
+pU
+Yk
+Yk
+Yk
 AM
-El
-El
+Yk
+Yk
 Jv
 Jv
 Jv
@@ -1563,12 +1789,12 @@ Jv
 "}
 (18,1,1) = {"
 Jv
-El
+Yk
 Ja
 qM
 Xt
 mw
-El
+Yk
 Jv
 Jv
 Jv

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "af" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "aE" = (
 /obj/structure/closet{
 	name = "pirate outfits"
@@ -14,7 +14,7 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 5
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "bd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -27,14 +27,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "de" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -49,8 +52,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "dE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63,13 +72,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "fh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "fL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -81,7 +93,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "fS" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -93,7 +105,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "fU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/red,
@@ -101,20 +113,35 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "hh" = (
 /mob/living/simple_animal/hostile/pirate{
 	environment_smash = 0
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
+"hN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/ship/security)
 "hT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -122,7 +149,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -135,8 +162,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "iF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -151,8 +181,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "iX" = (
 /obj/structure/table,
 /obj/machinery/door/window/southleft{
@@ -172,21 +205,21 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "jh" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
 /obj/item/wrench,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "jo" = (
 /obj/structure/table,
 /obj/machinery/airalarm/all_access{
@@ -204,7 +237,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "kl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -212,7 +245,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "ku" = (
 /obj/structure/rack,
 /obj/item/storage/bag/money/vault,
@@ -224,21 +257,27 @@
 	name = "Pegwing"
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "kY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "le" = (
 /obj/machinery/porta_turret/syndicate/pod{
 	dir = 5;
 	faction = list("pirate")
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
+"lu" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
 "lG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -252,7 +291,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
+"lY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ship/medical)
 "mr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -271,8 +317,19 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
+"mF" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "caravanpirate_bridge"
+	},
+/turf/open/floor/plating,
+/area/ship/security)
 "mI" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute{
@@ -285,15 +342,22 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "na" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "nD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -304,7 +368,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "oe" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -317,10 +381,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "oF" = (
 /obj/structure/closet{
 	name = "pirate outfits"
@@ -334,10 +401,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "oL" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "oO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -345,9 +412,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/computer/camera_advanced/shuttle_docker/nav,
+/obj/machinery/computer/autopilot,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "oT" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -373,7 +440,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "pK" = (
 /obj/item/stack/sheet/mineral/gold{
 	amount = 25
@@ -397,13 +464,23 @@
 /obj/item/coin/gold,
 /obj/item/coin/gold,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "pS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "pZ" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/firealarm{
@@ -420,14 +497,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "qo" = (
 /obj/machinery/porta_turret/syndicate/pod{
 	dir = 6;
 	faction = list("pirate")
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "qC" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box{
@@ -448,7 +525,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "qX" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
@@ -460,7 +537,10 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
+"rI" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew)
 "sr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -469,12 +549,21 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "su" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "th" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -483,8 +572,11 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "to" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/rum{
@@ -493,20 +585,26 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "tM" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/pirate/ranged{
 	environment_smash = 0
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "ul" = (
 /obj/structure/table,
 /obj/item/retractor,
 /obj/item/hemostat,
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -518,15 +616,21 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "vd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "vq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -537,14 +641,17 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 6
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "vW" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "wL" = (
 /obj/machinery/button/door{
 	id = "caravanpirate_bolt_port";
@@ -560,7 +667,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "wX" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -571,8 +678,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "wZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -587,15 +697,32 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "xg" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
+"xR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "yt" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -605,7 +732,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "yu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -620,8 +747,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "yW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -634,7 +764,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "zB" = (
 /obj/machinery/button/door{
 	id = "caravanpirate_bolt_starboard";
@@ -652,12 +782,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "Ag" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Ah" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -667,7 +797,7 @@
 	id_tag = "caravanpirate_bolt_starboard"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "Av" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -677,12 +807,15 @@
 	name = "Medbay"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "AP" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Bi" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -690,7 +823,7 @@
 	id = "caravanpirate_bridge"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "BI" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -699,7 +832,7 @@
 	},
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "BL" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -707,37 +840,39 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "Cb" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Pirate Cutter APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "DY" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "Ek" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "EB" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -763,13 +898,16 @@
 	environment_smash = 0
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "EK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "FM" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -790,26 +928,40 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "Gh" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
+"Gw" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
 "GO" = (
 /obj/machinery/porta_turret/syndicate/pod{
 	dir = 9;
 	faction = list("pirate")
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/template_noop)
+/area/ship/engineering)
 "GQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -822,14 +974,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "GR" = (
 /obj/structure/table,
 /obj/item/coin/gold,
 /obj/item/coin/silver,
 /obj/item/coin/silver,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
+"Hp" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/security)
 "HD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -838,7 +993,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "HO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -848,13 +1003,16 @@
 	name = "Armory"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "II" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Jb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -874,7 +1032,7 @@
 	width = 22
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Jv" = (
 /turf/template_noop,
 /area/template_noop)
@@ -888,7 +1046,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Ku" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -896,7 +1054,7 @@
 	id_tag = "caravanpirate_bolt_starboard"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "Ld" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/tile/neutral{
@@ -910,7 +1068,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
+"LG" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/medical)
 "NM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -923,32 +1084,38 @@
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "ON" = (
 /obj/machinery/porta_turret/syndicate/pod{
 	dir = 10;
 	faction = list("pirate")
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/template_noop)
+/area/ship/engineering)
 "Pc" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "Pn" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
+"QQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security)
 "Rq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Rz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -958,7 +1125,7 @@
 	id_tag = "caravanpirate_bolt_port"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "RC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -969,8 +1136,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "RK" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -978,14 +1148,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "Sd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -994,7 +1164,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/medical)
 "Sk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1003,16 +1173,22 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "SF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "SR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -1021,13 +1197,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "Ty" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
 "UP" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -1036,16 +1213,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "Wb" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/crew)
 "Wd" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/template_noop)
+/area/ship/engineering)
 "Xq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -1055,7 +1232,10 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
+"Yb" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew)
 "Yo" = (
 /obj/structure/table,
 /obj/item/storage/box/lethalshot,
@@ -1070,19 +1250,33 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/security)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 "Zo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/pirate)
+/area/ship/engineering)
+"Zp" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "caravanpirate_bridge"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
 "ZY" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1098,7 +1292,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/pirate)
+/area/ship/bridge)
 
 (1,1,1) = {"
 Jv
@@ -1177,33 +1371,33 @@ Jv
 "}
 (6,1,1) = {"
 Jv
-af
+LG
 Ld
 Rq
 oe
 ul
-af
+Hp
 Yo
 wX
 un
-Ld
-af
+Gw
+Hp
 Jv
 "}
 (7,1,1) = {"
 oL
-af
-af
+LG
+LG
 na
 su
 Ag
-af
+Hp
 jo
 tM
 sr
-af
-af
-oL
+Hp
+Hp
+QQ
 "}
 (8,1,1) = {"
 Jb
@@ -1212,28 +1406,28 @@ Rz
 kl
 EK
 mI
-af
+Hp
 pZ
 pS
 fU
 Ku
-Sd
+hN
 Ah
 "}
 (9,1,1) = {"
 oL
-af
-af
+LG
+LG
 wL
-su
+lY
 Kd
-af
+Hp
 oT
 hh
 zB
-af
-af
-oL
+Hp
+Hp
+QQ
 "}
 (10,1,1) = {"
 Jv
@@ -1242,33 +1436,33 @@ Ld
 nD
 bH
 II
-af
+Hp
 iX
 vd
 GQ
-Ld
-Bi
+Gw
+mF
 Jv
 "}
 (11,1,1) = {"
 Jv
 oL
-af
+LG
 AP
 Av
-af
-af
-af
+LG
+Hp
+Hp
 HO
-af
-af
-oL
+Hp
+Hp
+QQ
 Jv
 "}
 (12,1,1) = {"
 Jv
 Jv
-af
+rI
 aE
 SF
 vq
@@ -1276,14 +1470,14 @@ NM
 fS
 RC
 oF
-af
+rI
 Jv
 Jv
 "}
 (13,1,1) = {"
 Jv
 Jv
-af
+rI
 hT
 yu
 hZ
@@ -1291,7 +1485,7 @@ wZ
 de
 iF
 Wb
-af
+rI
 Jv
 Jv
 "}
@@ -1299,13 +1493,13 @@ Jv
 Jv
 Jv
 le
-af
+rI
 xg
 qC
 pK
 Sk
 ku
-af
+rI
 qo
 Jv
 Jv
@@ -1314,13 +1508,13 @@ Jv
 Jv
 Jv
 Jv
-oL
-af
-af
-af
+Yb
+lu
+lu
+lu
 mr
-af
-oL
+lu
+Yb
 Jv
 Jv
 Jv
@@ -1330,11 +1524,11 @@ Jv
 Jv
 Jv
 Jv
-af
+lu
 to
 BI
 Yw
-af
+lu
 Jv
 Jv
 Jv
@@ -1345,11 +1539,11 @@ Jv
 Jv
 Jv
 Jv
-af
+lu
 GR
 ZY
-Yw
-af
+xR
+lu
 Jv
 Jv
 Jv
@@ -1360,11 +1554,11 @@ Jv
 Jv
 Jv
 Jv
-af
+lu
 DY
 lG
 SR
-af
+lu
 Jv
 Jv
 Jv
@@ -1375,11 +1569,11 @@ Jv
 Jv
 Jv
 Jv
-af
+lu
 UP
 dE
 Xq
-af
+lu
 Jv
 Jv
 Jv
@@ -1390,11 +1584,11 @@ Jv
 Jv
 Jv
 Jv
-Bi
+Zp
 oO
 EB
 bd
-Bi
+Zp
 Jv
 Jv
 Jv
@@ -1405,11 +1599,11 @@ Jv
 Jv
 Jv
 Jv
-Bi
-Bi
+Zp
+Zp
 fL
-Bi
-Bi
+Zp
+Zp
 Jv
 Jv
 Jv
@@ -1421,9 +1615,9 @@ Jv
 Jv
 Jv
 Jv
-Bi
-Bi
-Bi
+Zp
+Zp
+Zp
 Jv
 Jv
 Jv

--- a/_maps/shuttles/ruin_solgov_exploration_pod.dmm
+++ b/_maps/shuttles/ruin_solgov_exploration_pod.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship)
+/area/ship/bridge)
 "d" = (
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship)
+/area/ship/bridge)
 "g" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 8
@@ -13,14 +13,17 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/ship)
+/area/ship/bridge)
 "j" = (
 /obj/machinery/computer/helm{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/ship)
+/area/ship/bridge)
 "s" = (
 /obj/machinery/power/smes/shuttle{
 	dir = 8
@@ -28,17 +31,35 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/window/westright,
 /turf/open/floor/plating,
-/area/ship)
+/area/ship/bridge)
+"w" = (
+/obj/machinery/power/smes/shuttle{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/window/westleft,
+/turf/open/floor/plating,
+/area/ship/bridge)
 "y" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/ship)
+/area/ship/bridge)
 "z" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship)
+/area/ship/bridge)
 "B" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -49,14 +70,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/mineral/titanium/yellow,
-/area/ship)
+/area/ship/bridge)
 "E" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/nav{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/ship)
+/area/ship/bridge)
 "G" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/cable{
@@ -69,7 +91,13 @@
 	width = 4
 	},
 /turf/open/floor/plating,
-/area/ship)
+/area/ship/bridge)
+"J" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/ship/bridge)
 "U" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -77,12 +105,15 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/ship)
+/area/ship/bridge)
 "Y" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/plating,
-/area/ship)
+/area/ship/bridge)
 
 (1,1,1) = {"
 a
@@ -99,7 +130,7 @@ d
 (3,1,1) = {"
 a
 y
-y
+J
 a
 "}
 (4,1,1) = {"
@@ -111,7 +142,7 @@ G
 (5,1,1) = {"
 a
 s
-s
+w
 a
 "}
 (6,1,1) = {"

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -6,7 +6,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "az" = (
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
@@ -23,14 +23,14 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "bo" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "bB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45,7 +45,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "bN" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -60,7 +60,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "cB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -73,13 +73,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "dZ" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "gl" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = "caravansyndicate3_bolt_port";
@@ -99,7 +99,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ha" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -114,7 +114,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ka" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -124,7 +124,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ns" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -152,7 +152,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "qE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -164,7 +164,7 @@
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "rz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -176,7 +176,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "rU" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -184,14 +184,14 @@
 	id = "caravansyndicate3_bridge"
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "rV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -205,12 +205,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "sn" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ss" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -219,7 +219,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "uy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -234,7 +234,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "vw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -248,7 +248,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "wH" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -257,7 +257,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "xC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -272,7 +272,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Bp" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -280,14 +280,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "BQ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Cm" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -301,7 +301,7 @@
 	dir = 9
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Dt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -315,7 +315,7 @@
 /obj/item/crowbar/red,
 /obj/machinery/light/small,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Dx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -329,7 +329,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "EO" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/airalarm/syndicate{
@@ -337,7 +337,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Fa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -351,14 +351,14 @@
 /obj/item/storage/belt/military,
 /obj/item/crowbar/red,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Gx" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "HJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -373,7 +373,7 @@
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/storage/belt/military,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "HM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -382,7 +382,7 @@
 	environment_smash = 0
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Ij" = (
 /obj/machinery/turretid{
 	ailock = 1;
@@ -401,7 +401,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "IR" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/hatch{
@@ -423,7 +423,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "IU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -439,7 +439,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Jv" = (
 /turf/template_noop,
 /area/template_noop)
@@ -454,7 +454,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Lq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -468,7 +468,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "NH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -482,7 +482,7 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Pt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -508,11 +508,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/orange/hidden,
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "PL" = (
 /obj/machinery/porta_turret/syndicate/energy,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "PY" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 1
@@ -522,13 +522,13 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Rj" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Sl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
@@ -548,10 +548,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Tn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "UD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -559,7 +559,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "US" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -569,7 +569,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Vf" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Ready Room";
@@ -589,14 +589,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "Wr" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "YU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -606,10 +606,10 @@
 	},
 /obj/item/clothing/under/syndicate/combat,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ZB" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ZI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -621,14 +621,14 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/crowbar/red,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ZJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "fuel pump"
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ZK" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -644,15 +644,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 "ZZ" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/caravan/syndicate3)
+/area/ship/crew)
 
 (1,1,1) = {"
 ZB

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -7,13 +7,13 @@
 	environment_smash = 0
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "cU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "dw" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4
@@ -22,7 +22,7 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30,7 +30,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "fh" = (
 /obj/machinery/camera/xray{
 	c_tag = "External View";
@@ -42,13 +42,13 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "na" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "qx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67,13 +67,13 @@
 	name = "engine fuel pump"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "tH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "tU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security,
@@ -81,13 +81,13 @@
 	dir = 6
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "us" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "uW" = (
 /obj/machinery/button/door{
 	id = "caravansyndicate1_bolt";
@@ -100,13 +100,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/camera_advanced/shuttle_docker/nav,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "vD" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "vK" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
@@ -121,7 +121,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "wV" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/hatch{
@@ -144,7 +144,7 @@
 	width = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "zu" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4
@@ -153,13 +153,13 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "Fs" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "Jv" = (
 /turf/template_noop,
 /area/template_noop)
@@ -168,10 +168,10 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 "YX" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/syndicate1)
+/area/ship/security)
 
 (1,1,1) = {"
 Jv

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "ac" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ak" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/external{
@@ -23,7 +23,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "am" = (
 /obj/machinery/light{
 	dir = 4
@@ -33,7 +33,7 @@
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ar" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44,10 +44,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
-"at" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/engine)
+/area/ship/cargo)
 "av" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -66,21 +63,21 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "aw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ay" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "aC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -90,11 +87,11 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "aJ" = (
 /obj/structure/sign/warning/enginesafety,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "aK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -108,7 +105,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "aL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -122,12 +119,10 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "aS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -137,12 +132,11 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "bg" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/box/corners{
-	dir = 1;
-	icon_state = "box_corners"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -152,7 +146,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/smes/engineering{
@@ -165,15 +159,11 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "bm" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset/anchored,
@@ -198,7 +188,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bn" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/external{
@@ -216,7 +206,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot_white,
@@ -225,12 +215,11 @@
 	name = "NTMS-037 Bay Blast door"
 	},
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "by" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -241,10 +230,10 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "bG" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/shuttle{
@@ -266,7 +255,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -282,10 +271,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
-"bK" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/crew)
+/area/ship/cargo)
 "bL" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -296,7 +282,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
@@ -312,17 +298,23 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bO" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 4;
-	icon_state = "propulsion_l"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/crew)
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "bP" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -333,7 +325,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "bQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -351,7 +343,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -363,7 +355,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -377,7 +369,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -388,7 +380,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -401,7 +393,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "bY" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/shuttle{
@@ -420,7 +412,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "bZ" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
@@ -434,42 +426,45 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "ca" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /mob/living/simple_animal/hostile/netherworld/blankbody{
 	environment_smash = 0
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "cb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "cf" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ci" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/delivery,
@@ -483,7 +478,7 @@
 	suit_type = /obj/item/clothing/suit/space
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cj" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/delivery,
@@ -493,7 +488,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ck" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
@@ -509,18 +504,15 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line,
@@ -528,20 +520,24 @@
 	pixel_y = -23
 	},
 /obj/machinery/light/small/built,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "cr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/weldingtool/largetank,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/machinery/light,
-/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/wrench,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "cv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -551,7 +547,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cw" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/command{
@@ -565,13 +561,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "cB" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/meter,
@@ -583,8 +579,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "cJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset/anchored,
@@ -598,7 +597,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -606,7 +605,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "cM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -619,7 +618,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "cV" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/stripes/line,
@@ -633,11 +632,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "cW" = (
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "cX" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/stripes/line,
@@ -652,7 +651,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "cY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -670,7 +669,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "cZ" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
@@ -681,19 +680,18 @@
 	},
 /obj/item/stack/rods,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "da" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table_frame,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "db" = (
 /obj/structure/chair/sofa/corner{
 	color = "#c45c57";
-	dir = 1;
-	icon_state = "sofacorner"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -706,19 +704,22 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "dc" = (
 /obj/structure/chair/sofa/left{
 	color = "#c45c57"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "de" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/watertank,
@@ -738,11 +739,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "dh" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/crew)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "eo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -755,10 +761,19 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "fs" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/abandoned/crew)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "fu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -776,7 +791,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "fv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -792,35 +807,27 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
-"fO" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/plaque/static_plaque/golden/captain{
-	pixel_x = 32
-	},
-/obj/item/gun/energy/laser/retro,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned/crew)
+/area/ship/cargo)
 "gp" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/crew)
-"gC" = (
-/obj/machinery/computer/shuttle/white_ship{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"gC" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -829,8 +836,11 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/computer/autopilot{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "hh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -843,7 +853,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "hR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -853,7 +863,7 @@
 	},
 /obj/item/stack/rods/fifty,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "hS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/shuttle{
@@ -865,7 +875,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "ig" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/shuttle{
@@ -877,7 +887,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "ih" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -889,7 +899,7 @@
 	pixel_x = 27
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "io" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -904,7 +914,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "iA" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -912,7 +922,7 @@
 	},
 /obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "iM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -922,7 +932,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "jx" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/table,
@@ -941,15 +951,18 @@
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "jK" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-17";
-	pixel_x = 8;
-	pixel_y = 3
+/obj/structure/closet/secure_closet/personal,
+/obj/item/gun/energy/laser/retro,
+/obj/structure/plaque/static_plaque/golden/captain{
+	pixel_x = 32
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/carpet,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "jU" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -964,14 +977,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "ko" = (
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4;
 	name = "Old Mining Turret"
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
+"kA" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering/engine)
 "mv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot_white,
@@ -985,18 +1001,10 @@
 	name = "off ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "mz" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows";
-	name = "Exterior Window Blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/crew)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew)
 "ng" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -1020,21 +1028,19 @@
 	pixel_y = 26
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "oj" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 4;
-	icon_state = "computer";
-	view_range = 14
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/helm{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "ox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "oP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1043,16 +1049,15 @@
 	dir = 10
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "pu" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "qk" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -1076,7 +1081,32 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
+"qp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 8
+	},
+/obj/machinery/door/window/westright,
+/turf/open/floor/plating/airless,
+/area/ship/engineering/engine)
+"qw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering/engine)
 "rc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1087,14 +1117,25 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "rs" = (
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4;
 	name = "Old Mining Turret"
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
+"rX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "sl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1116,20 +1157,38 @@
 	pixel_y = 18
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "sD" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "sG" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/tray,
 /obj/item/reagent_containers/food/snacks/burger/bearger,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
+"sW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "vb" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1144,7 +1203,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "vv" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1155,7 +1214,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "vC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -1180,10 +1239,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
-"vT" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/abandoned/engine)
+/area/ship/cargo)
 "wc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1202,7 +1258,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "wh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -1213,7 +1269,24 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
+"xe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "xi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1230,7 +1303,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "xk" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1254,29 +1327,21 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "xF" = (
 /obj/structure/chair/sofa/right{
 	color = "#c45c57";
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/shuttle/abandoned/bar)
-"ya" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows";
-	name = "Exterior Window Blast door"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/crew/canteen)
 "yn" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
@@ -1292,7 +1357,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "zH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1300,17 +1365,21 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
+"zM" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew)
 "AB" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 4;
-	icon_state = "propulsion_l"
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/engine)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "AE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/shuttle{
@@ -1327,30 +1396,32 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "AP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
+"AQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering/engine)
 "AS" = (
 /obj/machinery/door/poddoor{
 	id = "whiteship_port";
 	name = "NTMS-037 Bay Blast door"
 	},
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Bm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /turf/open/floor/wood,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "Bu" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1358,7 +1429,7 @@
 	name = "Cockpit Emergency Blast door"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "BS" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1372,7 +1443,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "BZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -1392,7 +1463,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "Ca" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/stripes/line{
@@ -1405,7 +1476,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "Ch" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -1414,7 +1485,7 @@
 	name = "off ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Ci" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -1425,11 +1496,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Cv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1441,18 +1511,33 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
-"CP" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows";
-	name = "Exterior Window Blast door"
+/area/ship/cargo)
+"Cx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
+"CP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Da" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/stripes/line,
@@ -1460,7 +1545,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "EG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -1475,7 +1560,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "EU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -1489,7 +1574,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "Fz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/command{
@@ -1508,7 +1593,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "FB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -1521,20 +1606,43 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
-"HP" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/area/ship/bridge)
+"GM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 8
+	},
+/obj/machinery/door/window/westleft,
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
+"Hm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/smes/shuttle{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/window/westleft,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating/airless,
+/area/ship/engineering/engine)
+"HP" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/weldingtool/largetank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Ih" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1545,17 +1653,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "Jf" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/abandoned/engine)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/engine)
 "Jz" = (
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	dir = 4;
 	name = "Old Mining Turret"
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Ke" = (
 /obj/machinery/door/poddoor{
 	id = "whiteship_port";
@@ -1567,7 +1675,7 @@
 	name = "off ramp"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -1591,7 +1699,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/area/ship/engineering/engine)
 "KM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1599,7 +1707,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "KR" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -1614,7 +1722,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/carpet,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "La" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1623,7 +1731,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "LC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1640,7 +1748,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Mj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/delivery,
@@ -1651,11 +1759,11 @@
 	suit_type = /obj/item/clothing/suit/space
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "MI" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "MY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/evac{
@@ -1676,12 +1784,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "NB" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -1694,12 +1801,11 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "NI" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -1710,7 +1816,7 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "Oi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1721,12 +1827,55 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
+"OH" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"PS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "engine fuel pump"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Qw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering/engine)
 "Rq" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1735,7 +1884,21 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
+"Sf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Sk" = (
 /obj/structure/closet/secure_closet/freezer{
 	locked = 0;
@@ -1749,11 +1912,10 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/item/reagent_containers/food/snacks/sandwich,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "Ti" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -1764,7 +1926,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/crew)
+/area/ship/crew)
 "Tn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1773,10 +1935,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Ua" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/abandoned/crew)
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows";
+	name = "Exterior Window Blast door"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Ud" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
@@ -1800,18 +1968,17 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Uv" = (
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "UY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1834,12 +2001,21 @@
 	pixel_x = 23
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
+"Va" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Vh" = (
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/machinery/computer/security/telescreen{
@@ -1851,10 +2027,10 @@
 /obj/effect/turf_decal/bot,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "Vx" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "We" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -1866,7 +2042,35 @@
 /obj/item/radio/off,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
+"Wg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"WM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/smes/shuttle{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/window/westright,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating/airless,
+/area/ship/engineering/engine)
 "XQ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -1875,7 +2079,7 @@
 	},
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
 "XR" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1889,7 +2093,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "Yu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -1901,12 +2105,11 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "YB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/donkpockets{
@@ -1927,7 +2130,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "YJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -1946,7 +2149,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "YL" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1964,7 +2167,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "Zg" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -1981,24 +2184,22 @@
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 2;
-	dwidth = 11;
+	dwidth = 13;
 	height = 13;
-	icon_state = "pinonclose";
 	id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;
-	width = 22
+	width = 24
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/cargo)
+/area/ship/cargo)
 "Zt" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2013,7 +2214,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned/bar)
+/area/ship/crew/canteen)
 "ZA" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2028,7 +2229,20 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned/bridge)
+/area/ship/bridge)
+"ZF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/areaeditor/shuttle,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 
 (1,1,1) = {"
 aa
@@ -2217,12 +2431,12 @@ ac
 aC
 cv
 cK
-bK
-bK
-bK
+mz
+mz
+mz
 wc
-bK
-bK
+mz
+mz
 aa
 "}
 (14,1,1) = {"
@@ -2243,22 +2457,22 @@ aa
 (15,1,1) = {"
 aa
 aa
-at
+Jf
 aJ
 bY
-at
-bK
+Jf
+mz
 cW
-bK
+mz
 xk
 NI
-bK
+mz
 aa
 "}
 (16,1,1) = {"
 aa
 aa
-at
+Jf
 aK
 bZ
 Kz
@@ -2273,26 +2487,26 @@ aa
 (17,1,1) = {"
 aa
 aa
-ya
+Ua
 aL
 cC
 de
-bK
-bK
-bK
+mz
+mz
+mz
 AE
-bK
+mz
 rs
 aa
 "}
 (18,1,1) = {"
 aa
 aa
-ya
+Ua
 aS
 ca
 cq
-bK
+mz
 KR
 io
 AP
@@ -2303,12 +2517,12 @@ aa
 (19,1,1) = {"
 aa
 aa
-at
+Jf
 bi
 cb
 cr
-bK
-fO
+zM
+mz
 jK
 Bm
 Ti
@@ -2318,15 +2532,15 @@ aa
 (20,1,1) = {"
 aa
 aa
-at
-at
+Jf
+Jf
 CP
-CP
+Va
 dh
-bK
 mz
 mz
-bK
+mz
+mz
 aa
 aa
 "}
@@ -2335,28 +2549,58 @@ aa
 aa
 Jf
 HP
-HP
-HP
+OH
+Wg
 fs
 gp
-gp
-gp
-fs
+PS
+rX
+Ua
 aa
 aa
 "}
 (22,1,1) = {"
 aa
 aa
-vT
+Jf
 AB
-AB
-AB
-fs
+xe
+Sf
+ZF
 bO
-bO
-bO
+sW
+Cx
 Ua
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+kA
+qp
+WM
+Hm
+kA
+WM
+Hm
+GM
+kA
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+AQ
+Qw
+qw
+qw
+kA
+qw
+qw
+Qw
+AQ
 aa
 aa
 "}


### PR DESCRIPTION
## About The Pull Request

this re-areas the caravan raid shuttles and the solgov exploration pod so that they should work properly

this also adds a holopad roundstart to the bridges of the Dwayne and the Kugelblitz and converts the Kilo into a functional shuttle

## Why It's Good For The Game

yes

## Changelog
:cl:
fix: caravan raid and the solgov exploration pod ruin should work for real now
/:cl:
