### PR TITLE
Removes access requirements for all APCs/air alarms

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -66,7 +66,7 @@
 	idle_power_usage = 4
 	active_power_usage = 8
 	power_channel = AREA_USAGE_ENVIRON
-	req_access = list(ACCESS_ATMOSPHERICS)
+	//req_access = list(ACCESS_ATMOSPHERICS)
 	max_integrity = 250
 	integrity_failure = 0.33
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -165,8 +165,8 @@
 		terminal.connect_to_network()
 
 /obj/machinery/power/apc/New(turf/loc, ndir, building=0)
-	if (!req_access)
-		req_access = list(ACCESS_ENGINE_EQUIP)
+	/*if (!req_access)
+		req_access = list(ACCESS_ENGINE_EQUIP)*/
 	if (!armor)
 		armor = list("melee" = 20, "bullet" = 20, "laser" = 10, "energy" = 100, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Temporarily removes access requirements for all APCs and air alarms to compensate for the lower populations and smaller maps.

warning: webedit

## Why It's Good For The Game
Allows everyone on the crew to control APCs and air alarms instead of just engineers

## Changelog
:cl:
tweak: APCs/air alarms no longer require any access to unlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
