### PR TITLE
Basic round-ending system

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -14,6 +14,12 @@
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
 
+// Jump status defines
+#define BS_JUMP_IDLE			"Idle"
+#define BS_JUMP_CALLED			"Called"
+#define BS_JUMP_INITIATED		"Initiated"
+#define BS_JUMP_COMPLETED		"Completed"
+
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"
 #define SHUTTLE_NOT_A_DOCKING_PORT "not a docking port"

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -23,10 +23,8 @@ SUBSYSTEM_DEF(statpanels)
 			"Playing/Connected: [get_active_player_count()]/[GLOB.clients.len]"
 		)
 
-		if(SSshuttle.emergency)
-			var/ETA = SSshuttle.emergency.getModeStr()
-			if(ETA)
-				global_data += "[ETA] [SSshuttle.emergency.getTimerStr()]"
+		if(SSshuttle.jump_mode != BS_JUMP_IDLE)
+			global_data += "Jump: [SSshuttle.jump_mode] [round(timeleft(SSshuttle.jump_timer)/10)]"
 		encoded_global_data = url_encode(json_encode(global_data))
 		src.currentrun = GLOB.clients.Copy()
 		mc_data_encoded = null

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -158,11 +158,7 @@ SUBSYSTEM_DEF(vote)
 			//WS Begin - Autotransfer
 			if("transfer")
 				if(. == "Initiate Crew Transfer")
-					//TODO find a cleaner way to do this
-					SSshuttle.requestEvac(null,"Crew transfer requested.")
-					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
-					if(C)
-						C.post_status("shuttle")
+					SSshuttle.request_jump()
 			//WS End
 
 			if("map")
@@ -223,15 +219,7 @@ SUBSYSTEM_DEF(vote)
 
 			//WS Begin - Autotransfer
 			if("transfer")
-				var/list/ignore_vote = list(
-					SHUTTLE_IGNITING,
-					SHUTTLE_CALL,
-					SHUTTLE_ENDGAME,
-					SHUTTLE_ESCAPE,
-					SHUTTLE_DOCKED,
-					SHUTTLE_PREARRIVAL
-				)
-				if(SSshuttle.emergency.mode in ignore_vote)
+				if(SSshuttle.jump_mode != BS_JUMP_IDLE)
 					return FALSE
 				choices.Add("Initiate Crew Transfer","Continue Playing")
 			//WS End

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -225,7 +225,7 @@
 		return FALSE
 	if(replacementmode && round_converted == 2)
 		return replacementmode.check_finished()
-	if(SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_ENDGAME))
+	if(SSshuttle.jump_mode == BS_JUMP_COMPLETED)
 		return TRUE
 	if(station_was_nuked)
 		return TRUE

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -746,6 +746,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(confirm != "Yes")
 		return
 
+	SSshuttle.request_jump()
 	SSshuttle.emergency.request()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Call Shuttle") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-called the emergency shuttle.")
@@ -763,6 +764,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		return
 
+	SSshuttle.cancel_jump()
 	SSshuttle.emergency.cancel()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Cancel Shuttle") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-recalled the emergency shuttle.")

--- a/whitesands/code/modules/overmap/helm.dm
+++ b/whitesands/code/modules/overmap/helm.dm
@@ -144,6 +144,9 @@
 	var/obj/structure/overmap/ship/simulated/S = current_ship
 	switch(action)
 		if("act_overmap")
+			if(SSshuttle.jump_mode == BS_JUMP_INITIATED)
+				to_chat(usr, "<span class='warning'>You've already escaped. Never going back to that place again!</span>")
+				return
 			var/obj/structure/overmap/to_act = locate(params["ship_to_act"])
 			say(S.overmap_object_act(usr, to_act))
 		if("undock")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
An *extremely* basic and barebones way to end rounds as a player, specifically with crew transfer votes. 

## Why It's Good For The Game
It's not great that admins are required to end rounds, so this should remedy that

## Changelog
:cl:
add: Basic way to end rounds IC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
