### PR TITLE
Dwayne upgrade

### DIFF
--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -1217,8 +1217,10 @@
 /obj/item/gun/energy/kinetic_accelerator,
 /obj/item/pickaxe/silver,
 /obj/item/pickaxe/silver,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/dark,
-/area/ship/hallway/central)
+/area/ship/crew)
 "Fz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -1328,7 +1330,7 @@
 "GU" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
-/area)
+/area/ship/crew)
 "Hs" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew)
@@ -1790,6 +1792,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ship/crew)
+"RU" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/clothing/suit/hooded/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/turf/open/floor/plating,
+/area/ship/cargo)
 "Sw" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/delivery,
@@ -2154,13 +2163,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
-"ZF" = (
-/obj/structure/closet/crate/wooden,
-/obj/item/clothing/suit/hooded/explorer,
-/obj/item/clothing/suit/hooded/explorer,
-/obj/item/clothing/suit/hooded/explorer,
-/turf/open/floor/plating,
-/area/ship/cargo)
 "ZN" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
@@ -2475,7 +2477,7 @@ DB
 FP
 FP
 kT
-ZF
+RU
 DB
 GU
 ST

--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -351,6 +351,7 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
 /obj/item/circuitboard/computer/arcade/orion_trail,
+/obj/item/kinetic_crusher,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "jD" = (
@@ -1206,15 +1207,16 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pickaxe/emergency,
-/obj/item/pickaxe/emergency,
-/obj/item/pickaxe/emergency,
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /obj/item/clothing/glasses/meson/prescription,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/pickaxe/silver,
+/obj/item/pickaxe/silver,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Fz" = (
@@ -1326,7 +1328,7 @@
 "GU" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
-/area/ship/hallway/central)
+/area)
 "Hs" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew)
@@ -2152,6 +2154,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
+"ZF" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/clothing/suit/hooded/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/turf/open/floor/plating,
+/area/ship/cargo)
 "ZN" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /turf/open/floor/plasteel/dark,
@@ -2466,7 +2475,7 @@ DB
 FP
 FP
 kT
-FP
+ZF
 DB
 GU
 ST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Editing of items available on Dwayne:
Removed 3x emergency pickaxe 
Added 2x silver-tipped pickaxe
Added 3x explorer suit
Added 2x mining satchel
Added 1x automatic mining scanner
Added 1x kinetic accelerator

Weird amounts of things is to force people to either fight over objects or delegate roles who gets what tldr we do a little trolling

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dwayne is supposed to be a mining ship but has the worst mining gear out of any ship. Why.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Dwayne now comes with more gear to make it have slightly better mining capacity than other ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
