### PR TITLE
Fixes a bug with loading some ships in via shuttle manipulator

### DIFF
--- a/_maps/shuttles/amogus_sus.dmm
+++ b/_maps/shuttles/amogus_sus.dmm
@@ -38,6 +38,7 @@
 	dwidth = 30;
 	height = 26;
 	id = "skeld";
+	launch_status = 0;
 	port_direction = 8;
 	undock_roundstart = 1;
 	width = 48

--- a/_maps/shuttles/bar_ship.dmm
+++ b/_maps/shuttles/bar_ship.dmm
@@ -409,6 +409,7 @@
 	dwidth = 5;
 	height = 29;
 	id = "bar";
+	launch_status = 0;
 	name = "diner ship";
 	port_direction = 2;
 	undock_roundstart = 1;

--- a/_maps/shuttles/engi_moth.dmm
+++ b/_maps/shuttles/engi_moth.dmm
@@ -1839,6 +1839,7 @@
 	dwidth = 16;
 	height = 27;
 	id = "moth";
+	launch_status = 0;
 	port_direction = 8;
 	undock_roundstart = 1;
 	width = 24

--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -100,6 +100,19 @@
 "bV" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 12;
+	height = 17;
+	id = "mining_ship";
+	launch_status = 0;
+	name = "mining ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	undock_roundstart = 1;
+	width = 28
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "ci" = (
@@ -697,6 +710,7 @@
 /area/ship/engineering)
 "qW" = (
 /obj/machinery/light,
+/obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "qX" = (
@@ -769,6 +783,10 @@
 "tU" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
+/area/ship/cargo)
+"tX" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "uk" = (
 /obj/structure/cable/yellow,
@@ -1340,6 +1358,7 @@
 	desc = "A moth.";
 	name = "moth"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "HR" = (
@@ -1809,17 +1828,6 @@
 /area/ship/cargo)
 "SQ" = (
 /obj/machinery/door/airlock/external,
-/obj/docking_port/mobile{
-	can_move_docking_ports = 1;
-	dir = 4;
-	dwidth = 8;
-	height = 28;
-	id = "mining_ship";
-	name = "mining ship";
-	port_direction = 2;
-	undock_roundstart = 1;
-	width = 17
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -2419,7 +2427,7 @@ zx
 pi
 FP
 FP
-FP
+tX
 nR
 uV
 xn

--- a/_maps/shuttles/ntsv_skipper.dmm
+++ b/_maps/shuttles/ntsv_skipper.dmm
@@ -422,6 +422,7 @@
 /obj/docking_port/mobile{
 	dir = 4;
 	id = "skipper";
+	launch_status = 0;
 	port_direction = 2
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/radio_funny.dmm
+++ b/_maps/shuttles/radio_funny.dmm
@@ -111,6 +111,7 @@
 	dwidth = 5;
 	height = 13;
 	id = "radio";
+	launch_status = 0;
 	port_direction = 2;
 	undock_roundstart = 1;
 	width = 11

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -1353,6 +1353,7 @@
 	dwidth = 5;
 	height = 11;
 	id = "caravantrade1";
+	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Small Freighter";
 	port_direction = 8;

--- a/_maps/shuttles/ruin_solgov_exploration_pod.dmm
+++ b/_maps/shuttles/ruin_solgov_exploration_pod.dmm
@@ -88,6 +88,8 @@
 	height = 6;
 	id = "solgovruin1";
 	name = "SolGov Exploration Pod";
+	port_direction = 8;
+	preferred_direction = 4;
 	width = 4
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
## About The Pull Request

This changes the `launch_status` variable's value from `-1` to `0` for all ships changed. This was what caused parts of our ships to fuck off to who knows where when they were spawned in via the shuttle manipulator.

## Why It's Good For The Game

what if i Want to spawn in the shetland okay??

## Changelog
:cl:
fix: All mainline ships should be able to be loaded in with the shuttle manipulator now
/:cl:

