### PR TITLE
Euclidean Movement Port & Minor Fixes

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -4,6 +4,8 @@
 
 #define NUM_E 2.71828183
 
+#define SQRT_2 1.414214
+
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
 

--- a/code/datums/mapgen/biomes/_biome.dm
+++ b/code/datums/mapgen/biomes/_biome.dm
@@ -14,11 +14,12 @@
 ///This proc handles the creation of a turf of a specific biome type
 /datum/biome/proc/generate_turf(var/turf/gen_turf)
 	gen_turf.ChangeTurf(turf_type, initial(turf_type.baseturfs), CHANGETURF_DEFER_CHANGE)
-	if(length(fauna_types) && prob(fauna_density))
+	var/area/A = gen_turf.loc
+	if(length(fauna_types) && prob(fauna_density) && (A.area_flags & MOB_SPAWN_ALLOWED))
 		var/mob/fauna = pick(fauna_types)
 		new fauna(gen_turf)
 
-	if(length(flora_types) && prob(flora_density))
+	if(length(flora_types) && prob(flora_density) && (A.area_flags & FLORA_ALLOWED))
 		var/obj/structure/flora = pick(flora_types)
 		new flora(gen_turf)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -139,7 +139,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		add_delay *= 2
+		add_delay *= SQRT_2
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -259,7 +259,7 @@ SUBSYSTEM_DEF(overmap)
 			ruin_type = new ruin_type
 
 	var/datum/turf_reservation/fixed/encounter_reservation = SSmapping.request_fixed_reservation()
-	encounter_reservation.fill_in(border_turf_type = /turf/closed/indestructible/blank, area_override = target_area)
+	encounter_reservation.fill_in(/turf/open/space, /turf/closed/indestructible/blank, target_area)
 
 	if(ruin_type) // loaded in after the reservation so we can place inside the reservation
 		var/turf/ruin_turf = locate(rand(encounter_reservation.bottom_left_coords[1]+6,encounter_reservation.top_right_coords[1]-ruin_type.width-6),

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -231,24 +231,29 @@ SUBSYSTEM_DEF(overmap)
 	var/list/ruin_list = SSmapping.space_ruins_templates
 	var/datum/map_generator/mapgen
 	var/area/target_area
+	var/turf/surface = /turf/open/space
 	if(planet_type)
 		switch(planet_type)
 			if(DYNAMIC_WORLD_LAVA)
 				ruin_list = SSmapping.lava_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/lavaland
 				target_area = /area/overmap_encounter/planetoid/lava
+				surface = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 			if(DYNAMIC_WORLD_ICE)
 				ruin_list = SSmapping.ice_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/icemoon/surface
 				target_area = /area/overmap_encounter/planetoid/ice
+				surface = /turf/open/floor/plating/asteroid/snow/icemoon
 			if(DYNAMIC_WORLD_SAND)
 				ruin_list = SSmapping.sand_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/whitesands
 				target_area = /area/overmap_encounter/planetoid/sand
+				surface = /turf/open/floor/plating/asteroid/whitesands
 			if(DYNAMIC_WORLD_JUNGLE)
 				ruin_list = SSmapping.jungle_ruins_templates
 				mapgen = new /datum/map_generator/jungle_generator
 				target_area = /area/overmap_encounter/planetoid/jungle
+				surface = /turf/open/floor/plating/dirt/jungle
 			if(DYNAMIC_WORLD_ASTEROID)
 				ruin_list = null
 				mapgen = new /datum/map_generator/cave_generator/asteroid
@@ -259,7 +264,7 @@ SUBSYSTEM_DEF(overmap)
 			ruin_type = new ruin_type
 
 	var/datum/turf_reservation/fixed/encounter_reservation = SSmapping.request_fixed_reservation()
-	encounter_reservation.fill_in(/turf/open/space, /turf/closed/indestructible/blank, target_area)
+	encounter_reservation.fill_in(surface, /turf/closed/indestructible/blank, target_area)
 
 	if(ruin_type) // loaded in after the reservation so we can place inside the reservation
 		var/turf/ruin_turf = locate(rand(encounter_reservation.bottom_left_coords[1]+6,encounter_reservation.top_right_coords[1]-ruin_type.width-6),

--- a/whitesands/code/modules/overmap/ships/_ships.dm
+++ b/whitesands/code/modules/overmap/ships/_ships.dm
@@ -137,7 +137,7 @@
 /obj/structure/overmap/ship/proc/accelerate(direction, acceleration)
 	var/heading = get_heading()
 	if(!(direction in GLOB.cardinals))
-		acceleration /= SQRT_2 //Makes it so going diagonally isn't sqrt(2)x as efficient
+		acceleration *= 2 //Makes it so going diagonally isn't 2x as efficient
 	if(heading && (direction & DIRFLIP(heading))) //This is so if you burn in the opposite direction you're moving, you can actually reach zero
 		if(EWCOMPONENT(direction))
 			acceleration = min(acceleration, abs(speed[1]))
@@ -158,7 +158,7 @@
   */
 /obj/structure/overmap/ship/proc/decelerate(acceleration)
 	if(speed[1] && speed[2]) //another check to make sure that deceleration isn't sqrt(2)x as fast when moving diagonally
-		adjust_speed(-SIGN(speed[1]) * min(acceleration / SQRT_2, abs(speed[1])), -SIGN(speed[2]) * min(acceleration / SQRT_2, abs(speed[2])))
+		adjust_speed(-SIGN(speed[1]) * min(acceleration * 0.5, abs(speed[1])), -SIGN(speed[2]) * min(acceleration * 0.5, abs(speed[2])))
 	else if(speed[1])
 		adjust_speed(-SIGN(speed[1]) * min(acceleration, abs(speed[1])), 0)
 	else if(speed[2])

--- a/whitesands/code/modules/overmap/ships/_ships.dm
+++ b/whitesands/code/modules/overmap/ships/_ships.dm
@@ -137,7 +137,7 @@
 /obj/structure/overmap/ship/proc/accelerate(direction, acceleration)
 	var/heading = get_heading()
 	if(!(direction in GLOB.cardinals))
-		acceleration *= 2 //Makes it so going diagonally isn't 2x as efficient
+		acceleration *= 0.5 //Makes it so going diagonally isn't 2x as efficient
 	if(heading && (direction & DIRFLIP(heading))) //This is so if you burn in the opposite direction you're moving, you can actually reach zero
 		if(EWCOMPONENT(direction))
 			acceleration = min(acceleration, abs(speed[1]))
@@ -157,7 +157,7 @@
   * * acceleration - How much to decelerate by
   */
 /obj/structure/overmap/ship/proc/decelerate(acceleration)
-	if(speed[1] && speed[2]) //another check to make sure that deceleration isn't sqrt(2)x as fast when moving diagonally
+	if(speed[1] && speed[2]) //another check to make sure that deceleration isn't 2x as fast when moving diagonally
 		adjust_speed(-SIGN(speed[1]) * min(acceleration * 0.5, abs(speed[1])), -SIGN(speed[2]) * min(acceleration * 0.5, abs(speed[2])))
 	else if(speed[1])
 		adjust_speed(-SIGN(speed[1]) * min(acceleration, abs(speed[1])), 0)

--- a/whitesands/code/modules/overmap/ships/_ships.dm
+++ b/whitesands/code/modules/overmap/ships/_ships.dm
@@ -1,5 +1,3 @@
-#define MOVING(speed) speed
-
 /**
   * ## Overmap ships
   * Basically, any overmap object that is capable of moving by itself.
@@ -84,7 +82,7 @@
   * Returns whether or not the ship is moving in any direction.
   */
 /obj/structure/overmap/ship/proc/is_still()
-	return !MOVING(speed[1]) && !MOVING(speed[2])
+	return !speed[1] && !speed[2]
 
 /**
   * Returns the total speed in all directions.
@@ -102,12 +100,12 @@
   */
 /obj/structure/overmap/ship/proc/get_heading()
 	var/direction = 0
-	if(MOVING(speed[1]))
+	if(speed[1])
 		if(speed[1] > 0)
 			direction |= EAST
 		else
 			direction |= WEST
-	if(MOVING(speed[2]))
+	if(speed[2])
 		if(speed[2] > 0)
 			direction |= NORTH
 		else
@@ -260,5 +258,3 @@
 		icon_state = base_icon_state
 	if(integrity < initial(integrity) / 4)
 		icon_state = "[icon_state]_damaged"
-
-#undef MOVING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports Citadel-Station-13/Citadel-Station-13#14911, fixes the inability to throw items on strange energy signal (space ruin) encounters, and makes the overmap icon actually display the correct heading.

Fixes: #22

## Changelog
:cl:
tweak: Diagonal movement now takes √2 as long instead of twice as long as orthogonal movement
fix: You can throw items on all space ruins now
fix: Overmap icons for ships now show the correct heading.
fix: encounter ruin spawns no longer can be busted through to space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
