### PR TITLE
Basic spawn point selection system

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -631,8 +631,11 @@ SUBSYSTEM_DEF(job)
 		return
 	..()
 
-/datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
-	var/atom/destination
+/datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE, atom/destination)
+	if(destination)
+		destination.JoinPlayerHere(M, buckle)
+		return TRUE
+
 	if(M.mind && M.mind.assigned_role && length(GLOB.jobspawn_overrides[M.mind.assigned_role])) //We're doing something special today.
 		destination = pick(GLOB.jobspawn_overrides[M.mind.assigned_role])
 		destination.JoinPlayerHere(M, FALSE)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -631,3 +631,6 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
+
+/obj/machinery/proc/on_area_rename(title, oldtitle)
+	return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -76,6 +76,9 @@
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
 
+	if(name == initial(name))
+		name = get_area_name(src)
+
 /obj/machinery/door/proc/set_init_door_layer()
 	if(density)
 		layer = closingLayer
@@ -464,3 +467,6 @@
 	. = ..()
 	if(. && !(machine_stat & NOPOWER))
 		autoclose_in(rand(0.5 SECONDS, 3 SECONDS))
+
+/obj/machinery/door/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -211,23 +211,9 @@
 	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
 
 /area/proc/rename_area(new_name)
-	var/prevname = "[name]"
-	set_area_machinery_title(src, new_name, prevname)
+	var/prev_name = name
+	for(var/obj/machinery/M in src)
+		M.on_area_rename(new_name, prev_name)
 	name = new_name
 	sortTim(GLOB.sortedAreas, /proc/cmp_name_asc)
 	return TRUE
-
-/proc/set_area_machinery_title(area/A, title, oldtitle)
-	if(!oldtitle) // or replacetext goes to infinite loop
-		return
-	for(var/obj/machinery/airalarm/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/power/apc/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/components/unary/vent_pump/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/door/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	//TODO: much much more. Unnamed airlocks, cameras, etc.

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -851,6 +851,9 @@
 		new /obj/item/stack/cable_coil(loc, 3)
 	qdel(src)
 
+/obj/machinery/airalarm/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)
+
 #undef AALARM_MODE_SCRUBBING
 #undef AALARM_MODE_VENTING
 #undef AALARM_MODE_PANIC

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -310,6 +310,9 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.set_volume(1000)
 
+/obj/machinery/atmospherics/components/unary/vent_pump/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)
+
 // mapping
 
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -293,6 +293,9 @@
 	pipe_vision_img.plane = ABOVE_HUD_PLANE
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 100, TRUE)
 
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1
 	piping_layer = 1
 	icon_state = "scrub_map-1"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -189,7 +189,11 @@
 				to_chat(usr, "<span class='warning'>Server is full.</span>")
 				return
 
-		AttemptLateSpawn(href_list["SelectedJob"])
+		var/atom/destination = tgui_input_list(usr, "Please select a location to spawn at.", "Spawn Location", SSjob.latejoin_trackers)
+		if(!destination)
+			return
+
+		AttemptLateSpawn(href_list["SelectedJob"], destination)
 		return
 
 	if(!ready && href_list["preference"])
@@ -291,7 +295,7 @@
 		return JOB_UNAVAILABLE_GENERIC
 	return JOB_AVAILABLE
 
-/mob/dead/new_player/proc/AttemptLateSpawn(rank)
+/mob/dead/new_player/proc/AttemptLateSpawn(rank, destination)
 	var/error = IsJobUnavailable(rank)
 	if(error != JOB_AVAILABLE)
 		alert(src, get_job_unavailable_error_message(error, rank))
@@ -326,7 +330,7 @@
 	var/datum/job/job = SSjob.GetJob(rank)
 
 	if(job && !job.override_latejoin_spawn(character))
-		SSjob.SendToLateJoin(character)
+		SSjob.SendToLateJoin(character, destination)
 		if(!arrivals_docked)
 			var/atom/movable/screen/splash/Spl = new(character.client, TRUE)
 			Spl.Fade(TRUE)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1517,6 +1517,9 @@
 			L.update(FALSE)
 		CHECK_TICK
 
+/obj/machinery/power/apc/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)
+
 #undef UPSTATE_CELL_IN
 #undef UPSTATE_OPENED1
 #undef UPSTATE_OPENED2

--- a/whitesands/code/game/machinery/cryopod.dm
+++ b/whitesands/code/game/machinery/cryopod.dm
@@ -188,6 +188,8 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 /obj/machinery/cryopod/LateInitialize()
 	update_icon()
 	find_control_computer()
+	if(name == initial(name))
+		name = "[get_area_name(src)] cryogenic freezer"
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent = 0)
 	for(var/M in GLOB.cryopod_computers)
@@ -240,7 +242,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	..()
 	icon_state = "cryopod-open"
 	density = TRUE
-	name = initial(name)
 
 /obj/machinery/cryopod/container_resist_act(mob/living/user)
 	visible_message("<span class='notice'>[occupant] emerges from [src]!</span>",
@@ -385,7 +386,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	handle_objectives()
 	QDEL_NULL(occupant)
 	open_machine()
-	name = initial(name)
 
 /obj/machinery/cryopod/MouseDrop_T(mob/living/target, mob/user)
 	if(!istype(target) || user.incapacitated() || !target.Adjacent(user) || !Adjacent(user) || !ismob(target) || (!ishuman(user) && !iscyborg(user)) || !istype(user.loc, /turf) || target.buckled)
@@ -456,7 +456,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	close_machine(target)
 
 	to_chat(target, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
-	name = "[name] ([occupant.name])"
 	log_admin("<span class='notice'>[key_name(target)] entered a stasis pod.</span>")
 	message_admins("[key_name_admin(target)] entered a stasis pod. (<A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 	add_fingerprint(target)
@@ -464,3 +463,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 //Attacks/effects.
 /obj/machinery/cryopod/blob_act()
 	return //Sorta gamey, but we don't really want these to be destroyed.
+
+/obj/machinery/cryopod/on_area_rename(title, oldtitle)
+	name = replacetext(name, oldtitle, title)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Provides a simple prompt as to which ship you want to spawn at. 
![image](https://user-images.githubusercontent.com/29362068/125174036-26577600-e188-11eb-857d-cda8b51e024d.png)
(weird double scrollbar and heading covering unrelated issue, will look into that at some point)

## Why It's Good For The Game
Allows people to join on different ships. You can't really tell what each ship is as of yet, but it's something.

## Changelog
:cl:
add: Basic spawn point selection system for selecting where you want to spawn on latejoin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
