### PR TITLE
Removes character references

### DIFF
--- a/_maps/shuttles/engi_moth.dmm
+++ b/_maps/shuttles/engi_moth.dmm
@@ -661,14 +661,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
-"ui" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/item/toy/plush/moth{
-	name = "Radi Shipscorch";
-	suicide_count = 3
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ship/bridge)
 "up" = (
 /obj/machinery/status_display/shuttle{
 	shuttle_id = "moth"
@@ -2208,7 +2200,7 @@ Zc
 vw
 jC
 nL
-ui
+mR
 gk
 vI
 "}

--- a/_maps/shuttles/engi_moth.dmm
+++ b/_maps/shuttles/engi_moth.dmm
@@ -390,12 +390,18 @@
 "mC" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/item/areaeditor/shuttle,
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	desc = "A plushie depicting a warrior-like mothperson. You find the prospect of dodging all of its projectile attacks daunting.";
+	name = "meditative moth plushie"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "mR" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	desc = "A plushie depicting a mothperson. Smells like incense.";
+	name = "dreamy moth plushie"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "mV" = (
@@ -666,7 +672,8 @@
 "ui" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/item/toy/plush/moth{
-	desc = "A plushie depicting a creepy mothperson. It's killed three people.";
+	desc = "An unsettling mothperson plushie. You can't seem to forget its gaze.";
+	name = "radiant moth plushie";
 	suicide_count = 3
 	},
 /turf/open/floor/mineral/plastitanium/red,

--- a/_maps/shuttles/engi_moth.dmm
+++ b/_maps/shuttles/engi_moth.dmm
@@ -390,10 +390,12 @@
 "mC" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/item/areaeditor/shuttle,
+/obj/item/toy/plush/moth,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "mR" = (
 /obj/structure/chair/comfy/shuttle,
+/obj/item/toy/plush/moth,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "mV" = (
@@ -660,6 +662,14 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"ui" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/toy/plush/moth{
+	desc = "A plushie depicting a creepy mothperson. It's killed three people.";
+	suicide_count = 3
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "up" = (
 /obj/machinery/status_display/shuttle{
@@ -2200,7 +2210,7 @@ Zc
 vw
 jC
 nL
-mR
+ui
 gk
 vI
 "}

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -666,7 +666,7 @@
 
 /obj/item/toy/plush/moth
 	name = "moth plushie"
-	desc = "A plushie depicting an adorable mothperson. It's a huggable bug!"
+	desc = "A plushie depicting an adorable mothperson, featuring realistic mothperson agony sounds every time you hug it."
 	icon_state = "moffplush"
 	item_state = "moffplush"
 	attack_verb = list("fluttered", "flapped")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the moth referencing my character from Kugel, replaces it with three hollow knight references instead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Radi Shipscorch is the worst feature of the Kugelblitz
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Radi Shipscorch 
tweak: mothperson plush description globally altered so as to no longer reference tgstation static "Hugbug"
add: more moths to Kugel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
