### PR TITLE
Fixes simplemob surgery not working

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -61,6 +61,9 @@
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())
 		return TRUE
+	if((I.item_flags & SURGICAL_TOOL) && user.a_intent == INTENT_HELP)
+		attempt_initiate_surgery(I, src, user)
+		return TRUE
 	user.changeNext_move(CLICK_CD_MELEE)
 	return I.attack(src, user)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -56,18 +56,11 @@
 		mode() // Activate held item
 
 /mob/living/carbon/attackby(obj/item/I, mob/user, params)
-	var/be_nice = FALSE
-	// if(body_position == LYING_DOWN) //WS - Fix IPC surgery
-	if((I.item_flags & SURGICAL_TOOL) && user.a_intent == INTENT_HELP)
-		attempt_initiate_surgery(I, src, user)
-		be_nice = TRUE
 	for(var/datum/surgery/S in surgeries)
 		if(body_position == LYING_DOWN || !S.lying_required)
 			if((S.self_operable || user != src) && (user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM))
 				if(S.next_step(user ,user.a_intent))
 					return 1
-	if(be_nice)//so that if we don't stab them after starting a surgery that can't be started with a sharp tool
-		return 1
 	return ..()
 
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title

## Why It's Good For The Game
xenobiology*

*note, xenobiology being good does not necessarily represent the views and/or beliefs of the author of this PR

## Changelog
:cl:
fix; You can now do surgery on slimes and other non-carbon mobs you can do... surgery on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
