### PR TITLE
Changes encounter type selection to actually mean something

### DIFF
--- a/code/__DEFINES/~whitesands_defines/overmap.dm
+++ b/code/__DEFINES/~whitesands_defines/overmap.dm
@@ -7,6 +7,7 @@
 #define DYNAMIC_WORLD_SAND				"sand"
 #define DYNAMIC_WORLD_JUNGLE			"jungle"
 #define DYNAMIC_WORLD_ASTEROID			"asteroid"
+#define DYNAMIC_WORLD_SPACERUIN			"space"
 
 //Possible ship states
 #define OVERMAP_SHIP_IDLE				"idle"

--- a/whitesands/code/modules/overmap/dynamic_events.dm
+++ b/whitesands/code/modules/overmap/dynamic_events.dm
@@ -52,7 +52,7 @@
   */
 /obj/structure/overmap/dynamic/proc/choose_level_type()
 	if(!probabilities)
-		probabilities = list(DYNAMIC_WORLD_LAVA = length(SSmapping.lava_ruins_templates), DYNAMIC_WORLD_ICE = length(SSmapping.ice_ruins_templates), DYNAMIC_WORLD_JUNGLE = length(SSmapping.jungle_ruins_templates), DYNAMIC_WORLD_SAND = length(SSmapping.sand_ruins_templates), FALSE = length(SSmapping.space_ruins_templates), DYNAMIC_WORLD_ASTEROID = 30)
+		probabilities = list(DYNAMIC_WORLD_LAVA = length(SSmapping.lava_ruins_templates), DYNAMIC_WORLD_ICE = length(SSmapping.ice_ruins_templates), DYNAMIC_WORLD_JUNGLE = length(SSmapping.jungle_ruins_templates), DYNAMIC_WORLD_SAND = length(SSmapping.sand_ruins_templates), DYNAMIC_WORLD_SPACERUIN = length(SSmapping.space_ruins_templates), DYNAMIC_WORLD_ASTEROID = 30)
 	var/chosen = pickweight(probabilities)
 	mass = rand(50, 100) * 1000000 //50 to 100 million tonnes //this was a stupid feature
 	switch(chosen)
@@ -87,7 +87,7 @@
 			icon_state = "asteroid"
 			mass = rand(1, 1000) * 100
 			color = COLOR_GRAY
-		else // Space ruin
+		if(DYNAMIC_WORLD_SPACERUIN)
 			name = "weak energy signal"
 			desc = "A very weak energy signal emenating from space."
 			planet = FALSE

--- a/whitesands/code/modules/overmap/dynamic_events.dm
+++ b/whitesands/code/modules/overmap/dynamic_events.dm
@@ -16,6 +16,8 @@
 	var/planet
 	///The virtual z-level the level occupies
 	var/virtual_z_level
+	///List of probabilities for each type of planet.
+	var/static/list/probabilities
 
 /obj/structure/overmap/dynamic/Initialize(mapload)
 	. = ..()
@@ -49,47 +51,49 @@
   * Chooses a type of level for the dynamic level to use.
   */
 /obj/structure/overmap/dynamic/proc/choose_level_type()
-	var/chosen = rand(0, 6)
-	mass = rand(50, 100) * 1000000 //50 to 100 million tonnes
+	if(!probabilities)
+		probabilities = list(DYNAMIC_WORLD_LAVA = length(SSmapping.lava_ruins_templates), DYNAMIC_WORLD_ICE = length(SSmapping.ice_ruins_templates), DYNAMIC_WORLD_JUNGLE = length(SSmapping.jungle_ruins_templates), DYNAMIC_WORLD_SAND = length(SSmapping.sand_ruins_templates), FALSE = length(SSmapping.space_ruins_templates), DYNAMIC_WORLD_ASTEROID = 30)
+	var/chosen = pickweight(probabilities)
+	mass = rand(50, 100) * 1000000 //50 to 100 million tonnes //this was a stupid feature
 	switch(chosen)
-		if(0)
-			name = "weak energy signal"
-			desc = "A very weak energy signal emenating from space."
-			planet = FALSE
-			icon_state = "strange_event"
-			color = null
-			mass = 0 //Space doesn't weigh anything
-		if(1)
+		if(DYNAMIC_WORLD_LAVA)
 			name = "strange lava planet"
 			desc = "A very weak energy signal originating from a planet with lots of seismic and volcanic activity."
 			planet = DYNAMIC_WORLD_LAVA
 			icon_state = "globe"
 			color = COLOR_ORANGE
-		if(2)
+		if(DYNAMIC_WORLD_ICE)
 			name = "strange ice planet"
 			desc = "A very weak energy signal originating from a planet with traces of water and extremely low temperatures."
 			planet = DYNAMIC_WORLD_ICE
 			icon_state = "globe"
 			color = COLOR_BLUE_LIGHT
-		if(3)
+		if(DYNAMIC_WORLD_JUNGLE)
 			name = "strange jungle planet"
 			desc = "A very weak energy signal originating from a planet teeming with life."
 			planet = DYNAMIC_WORLD_JUNGLE
 			icon_state = "globe"
 			color = COLOR_LIME
-		if(4)
+		if(DYNAMIC_WORLD_SAND)
 			name = "strange sand planet"
 			desc = "A very weak energy signal originating from a planet with many traces of silica."
 			planet = DYNAMIC_WORLD_SAND
 			icon_state = "globe"
 			color = COLOR_GRAY
-		if(5 to 6)
+		if(DYNAMIC_WORLD_ASTEROID)
 			name = "large asteroid"
 			desc = "A large asteroid with significant traces of minerals."
 			planet = DYNAMIC_WORLD_ASTEROID
 			icon_state = "asteroid"
 			mass = rand(1, 1000) * 100
 			color = COLOR_GRAY
+		else // Space ruin
+			name = "weak energy signal"
+			desc = "A very weak energy signal emenating from space."
+			planet = FALSE
+			icon_state = "strange_event"
+			color = null
+			mass = 0 //Space doesn't weigh anything
 	desc += !preserve_level && "It may not still be here if you leave it."
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that encounter ruin type selection is based off of the amount of ruins in the codebase. This makes it so that every ruin *technically* has an equal chance of spawning.

## Why It's Good For The Game
No more spam of repetitive jungle planets that have no ruins, and no more extreme comparitive rareness of space encounters.

## Changelog
:cl:
tweak: Makes it so that encounter ruin type selection is based off of the amount of ruins in the codebase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
