### PR TITLE
Two Space Ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
@@ -13,6 +13,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered)
+"aW" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
 "bm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
@@ -206,8 +213,8 @@
 	name = "armory locker";
 	pixel_x = 32
 	},
-/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawn,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/gun/ballistic/shotgun/automatic,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered)
 "hL" = (
@@ -257,6 +264,12 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"jy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "jE" = (
 /obj/item/stack/rods,
@@ -368,6 +381,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/ruin/unpowered)
+"nz" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
+"nI" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
 "oc" = (
 /turf/open/floor/engine/hull,
 /area/ruin/unpowered)
@@ -472,12 +500,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/ruin/unpowered)
-"rz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/unpowered)
 "rM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/port_gen/pacman/super,
@@ -514,14 +536,6 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/unpowered)
-"sH" = (
-/obj/structure/girder/displaced,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg1"
-	},
 /area/ruin/unpowered)
 "sU" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -659,6 +673,13 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"wd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
 "wi" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -976,13 +997,6 @@
 /obj/item/rack_parts,
 /turf/template_noop,
 /area/template_noop)
-"Gd" = (
-/obj/structure/girder/displaced,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/ruin/unpowered)
 "Hl" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1072,13 +1086,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
-"KF" = (
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/unpowered)
 "KJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1096,6 +1103,12 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"Lc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "Lo" = (
 /obj/structure/door_assembly/door_assembly_hatch,
@@ -1123,13 +1136,6 @@
 "Mf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
-"Mu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
 /area/ruin/unpowered)
 "My" = (
 /obj/structure/lattice,
@@ -1200,13 +1206,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"OU" = (
-/obj/structure/girder/displaced,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/unpowered)
 "OW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1260,13 +1259,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"QJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	broken = 1;
-	icon_state = "platingdmg1"
-	},
-/area/ruin/unpowered)
 "QV" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -1320,6 +1312,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/ruin/unpowered)
+"RX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
 "Sm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1355,12 +1354,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"Tr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/unpowered)
 "Ty" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/structure/cable{
@@ -1369,6 +1362,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/stairs,
+/area/ruin/unpowered)
+"TC" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "TM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1725,7 +1725,7 @@ ZO
 ZO
 ZO
 ZO
-QJ
+RX
 hO
 ZO
 ZO
@@ -1886,8 +1886,8 @@ jE
 Uy
 Uy
 zH
-QJ
-rz
+RX
+jy
 uk
 hO
 ZO
@@ -1991,8 +1991,8 @@ ZO
 PU
 ZO
 Vm
-QJ
-QJ
+RX
+RX
 hO
 ZO
 ZO
@@ -2044,7 +2044,7 @@ ZO
 Uy
 Uy
 Uy
-rz
+jy
 DS
 ZO
 ZO
@@ -2803,7 +2803,7 @@ Uy
 ZO
 ZO
 Ra
-QJ
+RX
 mK
 ZO
 ZO
@@ -2856,7 +2856,7 @@ ZO
 ZO
 Uy
 iB
-Tr
+Lc
 Ra
 ZO
 Ry
@@ -2868,7 +2868,7 @@ mK
 ZO
 ZO
 My
-Gd
+TC
 Ra
 Ra
 Ry
@@ -2915,7 +2915,7 @@ Ry
 OW
 Ry
 pM
-QJ
+RX
 JX
 ZO
 MZ
@@ -2955,7 +2955,7 @@ ZO
 ZO
 mK
 AD
-OU
+aW
 zY
 Ra
 Ry
@@ -3005,7 +3005,7 @@ ZO
 ZO
 ZO
 ZO
-QJ
+RX
 uJ
 AI
 sU
@@ -3109,7 +3109,7 @@ ZO
 ZO
 ZO
 Uy
-KF
+nz
 XE
 gq
 ls
@@ -3171,7 +3171,7 @@ wi
 Qh
 Qh
 Qh
-sH
+nI
 VP
 rO
 ED
@@ -3180,7 +3180,7 @@ ZO
 ZO
 ZO
 Vv
-Tr
+Lc
 bN
 yw
 zt
@@ -3218,12 +3218,12 @@ Uy
 ZO
 ZO
 ZO
-rz
+jy
 aO
 Ry
 mK
 ZO
-QJ
+RX
 Ew
 El
 pJ
@@ -3234,7 +3234,7 @@ Uy
 mK
 Mf
 Ra
-Tr
+Lc
 Ry
 ef
 Ry
@@ -3270,7 +3270,7 @@ Uy
 ZO
 ZO
 ZO
-Tr
+Lc
 AD
 Ra
 ZO
@@ -3367,9 +3367,9 @@ ZO
 ZO
 DS
 DS
-rz
+jy
 tZ
-rz
+jy
 DS
 DS
 ZO
@@ -3420,10 +3420,10 @@ hO
 DS
 AX
 xy
-rz
+jy
 Uy
 mK
-rz
+jy
 wN
 jE
 ZO
@@ -3445,7 +3445,7 @@ Ra
 Ry
 io
 oP
-rz
+jy
 mK
 wb
 ZO
@@ -3470,13 +3470,13 @@ ZO
 ZO
 hO
 AX
-QJ
+RX
 pJ
 ZO
 Uy
 ZO
 WV
-QJ
+RX
 ZO
 cr
 ZO
@@ -3498,7 +3498,7 @@ Ra
 mK
 Ra
 xM
-QJ
+RX
 ZO
 ZO
 ZO
@@ -3574,7 +3574,7 @@ ZO
 ZO
 DS
 rr
-rz
+jy
 Vm
 ZO
 ZO
@@ -3627,7 +3627,7 @@ ZO
 DS
 hO
 Uy
-QJ
+RX
 ZO
 ZO
 Uy
@@ -3678,9 +3678,9 @@ ZO
 ZO
 ZO
 WV
-QJ
+RX
 mK
-rz
+jy
 od
 ZO
 ZO
@@ -3892,7 +3892,7 @@ ZO
 ZO
 ZO
 ZO
-Mu
+wd
 ZO
 ZO
 ZO

--- a/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
@@ -1,0 +1,4068 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aH" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"aL" = (
+/obj/effect/gibspawner/human,
+/turf/template_noop,
+/area/template_noop)
+"aO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"bm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bG" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"bJ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/rods,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"bN" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull,
+/area/ruin/unpowered)
+"cr" = (
+/obj/structure/girder/displaced,
+/turf/template_noop,
+/area/template_noop)
+"dx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"dC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/door_assembly/door_assembly_mhatch,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"dN" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ef" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/door_assembly/door_assembly_mhatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/ruin/unpowered)
+"eg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull,
+/area/ruin/unpowered)
+"eD" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"eJ" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"fs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/closet/wall{
+	name = "armory locker";
+	pixel_x = 32
+	},
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"fP" = (
+/obj/item/shard,
+/turf/template_noop,
+/area/template_noop)
+"gj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"gp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse/charredskeleton,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"gq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/unpowered)
+"gH" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/template_noop,
+/area/template_noop)
+"gM" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"gN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"hv" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"hJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 12
+	},
+/obj/structure/closet/wall{
+	name = "armory locker";
+	pixel_x = 32
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawn,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"hL" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"hO" = (
+/turf/closed/wall/material,
+/area/ruin/unpowered)
+"io" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"iB" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"iT" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ji" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs/right,
+/area/ruin/unpowered)
+"jl" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"jE" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"jH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"kl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "8-10"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"kp" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/ruin/unpowered)
+"kN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 8
+	},
+/turf/template_noop,
+/area/ruin/unpowered)
+"kT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"lm" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"lq" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"ls" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"lS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"md" = (
+/obj/structure/door_assembly/door_assembly_mhatch,
+/turf/template_noop,
+/area/template_noop)
+"mK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
+"mX" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"oc" = (
+/turf/open/floor/engine/hull,
+/area/ruin/unpowered)
+"od" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 2;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"oh" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"oP" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/yellow,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"oQ" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"pv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"pF" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"pJ" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"pM" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"qy" = (
+/obj/effect/turf_decal/bot,
+/obj/item/rack_parts,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"qZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/door_assembly/door_assembly_grunge,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/ruin/unpowered)
+"ri" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"rr" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"rt" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"rM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"rO" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"sg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"st" = (
+/obj/structure/door_assembly/door_assembly_grunge,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"sE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/unpowered)
+"sU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs,
+/area/ruin/unpowered)
+"tp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"tG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"tJ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"tW" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"tZ" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"uk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/rust,
+/area/ruin/unpowered)
+"ut" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"uJ" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"uV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"ve" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 12
+	},
+/obj/structure/closet/wall{
+	name = "suit locker";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"vs" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"vz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "8-10"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"vJ" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/components/binary/pump/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"vR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"vV" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wb" = (
+/obj/item/shard,
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"wi" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"wx" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"wF" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"wN" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"xy" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"xM" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"yg" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold4w/orange,
+/turf/template_noop,
+/area/ruin/unpowered)
+"yv" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/template_noop,
+/area/template_noop)
+"yw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs/left,
+/area/ruin/unpowered)
+"yx" = (
+/obj/structure/lattice,
+/obj/structure/girder/displaced,
+/turf/template_noop,
+/area/template_noop)
+"yE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"zt" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"zE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"zH" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "pile";
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"zI" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"zY" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	id = "pirateshutters";
+	name = "blast shutters"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"AC" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"AD" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"AI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/glasses/thermal/eyepatch,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"AV" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"AX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"BG" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"BX" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Cc" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"CA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"CZ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "external access hatch"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"Dl" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Dt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"DS" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered)
+"El" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"En" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull,
+/area/ruin/unpowered)
+"Ew" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ED" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Fc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"FA" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"FT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/door_assembly/door_assembly_mhatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"FW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"FY" = (
+/obj/structure/lattice,
+/obj/item/rack_parts,
+/turf/template_noop,
+/area/template_noop)
+"Hl" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"HE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"HL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"HQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "8-10"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Iv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"IH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1;
+	pixel_x = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"IW" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"Jg" = (
+/obj/item/chair/plastic,
+/turf/template_noop,
+/area/template_noop)
+"Jj" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"JX" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Kw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"KJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"KO" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"Lo" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/turf/template_noop,
+/area/template_noop)
+"Lu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"LT" = (
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Mf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"My" = (
+/obj/structure/lattice,
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"MM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"MZ" = (
+/obj/item/roller,
+/turf/template_noop,
+/area/template_noop)
+"Nt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Nx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Oa" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Oe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"OC" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/template_noop,
+/area/template_noop)
+"OW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"Pa" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"Pq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Ps" = (
+/obj/item/wrench,
+/turf/template_noop,
+/area/template_noop)
+"PU" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/template_noop,
+/area/template_noop)
+"Qf" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/stack/cable_coil/cut/red,
+/turf/template_noop,
+/area/template_noop)
+"Qh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered)
+"Qk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Qy" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "pile";
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"QV" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"Ra" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/unpowered)
+"Rj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Rl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/wall{
+	name = "armory locker";
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/drinks/bottle/rum,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Rt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Ry" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered)
+"RP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/door_assembly/door_assembly_grunge,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/ruin/unpowered)
+"Sm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"Sw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/pod/dark,
+/area/ruin/unpowered)
+"SL" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
+"SQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/unpowered)
+"Tj" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"Ty" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs,
+/area/ruin/unpowered)
+"TM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Ug" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"Ui" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Ut" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/ruin/unpowered)
+"Uu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Uy" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Uz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/structure/closet/wall{
+	name = "suit locker";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"UJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Vm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/template_noop,
+/area/template_noop)
+"Vo" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"Vv" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 1;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"VP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/plastic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"VX" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Wn" = (
+/obj/effect/turf_decal/lumos/tile/neutral/fulltile,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"WA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"WB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/unpowered)
+"WV" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"XE" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"XJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "5-9"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"XL" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange,
+/turf/template_noop,
+/area/ruin/unpowered)
+"XR" = (
+/obj/structure/cable{
+	icon_state = "8-10"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"YK" = (
+/obj/structure/cable,
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"YM" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/shard,
+/obj/item/clothing/head/pirate/captain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+"YO" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/template_noop,
+/area/template_noop)
+"YX" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ZA" = (
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
+"ZO" = (
+/turf/template_noop,
+/area/template_noop)
+"ZQ" = (
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/shard,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered)
+
+(1,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(2,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(3,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+DS
+hO
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Mf
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(4,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+hO
+AX
+AX
+Kw
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+WV
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(5,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+DS
+lm
+vs
+Kw
+IW
+vs
+hO
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+PU
+ZO
+ZO
+ZO
+ZO
+QV
+hO
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(6,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+AX
+IW
+SL
+AX
+SL
+IW
+AX
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+Uy
+Uy
+zH
+Mf
+Mf
+uk
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(7,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+AX
+Kw
+AX
+CA
+AX
+Kw
+FA
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+HL
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+Uy
+Mf
+YX
+tJ
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(8,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+Kw
+SL
+Jj
+Hl
+vs
+lm
+Kw
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+gH
+pJ
+ZO
+ZO
+ZO
+ZO
+ZO
+PU
+ZO
+Vm
+Mf
+Mf
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(9,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+hO
+hv
+hv
+tG
+vs
+lm
+DS
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+Uy
+Uy
+Uy
+Mf
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(10,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+hO
+AX
+bG
+AX
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(11,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+hO
+Sm
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+PU
+DS
+pJ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(12,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+kN
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Mf
+ZO
+ZO
+yx
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(13,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+Ut
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+XL
+Ut
+Uy
+ZO
+ZO
+WV
+HL
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(14,1,1) = {"
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+Ut
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+Ut
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(15,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+Ut
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(16,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+Uy
+Uy
+Uy
+Uy
+Uy
+Uy
+Uy
+Ut
+Uy
+Uy
+Uy
+Uy
+Uy
+Uy
+ZO
+ZO
+ZO
+Uy
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(17,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+kN
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(18,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+Uy
+Uy
+Ut
+Ut
+XL
+XL
+XL
+XL
+XL
+yg
+XL
+XL
+XL
+Ut
+sE
+Uy
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+fP
+ZO
+ZO
+"}
+(19,1,1) = {"
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+Ut
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Ra
+Ra
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(20,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+Uy
+ZO
+ZO
+Uy
+Uy
+ZO
+ZO
+ZO
+ZO
+Ra
+Ra
+Ra
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Ry
+rM
+ZA
+vR
+Ra
+Ra
+BX
+ZO
+jE
+ZO
+ZO
+"}
+(21,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+eg
+eg
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Ry
+iT
+vJ
+Nt
+FW
+Dt
+eD
+Mf
+ZO
+ZO
+Tj
+"}
+(22,1,1) = {"
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+Uy
+ZO
+Uy
+ZO
+ZO
+Qy
+ZO
+ZO
+Uy
+bV
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ug
+ZO
+ZO
+ZO
+Ra
+Ra
+Ry
+FT
+kl
+gN
+Dl
+YK
+ZO
+ZO
+ZO
+"}
+(23,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+yv
+ZO
+ZO
+ZO
+ZO
+ZO
+md
+ZO
+ZO
+ZO
+ZO
+Ra
+WA
+Ry
+Ra
+Ra
+ZO
+ZO
+ZO
+ZO
+"}
+(24,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+fP
+Uy
+ZO
+ZO
+Ra
+Mf
+Mf
+ZO
+ZO
+Ra
+Pa
+Mf
+ZO
+ZO
+ZO
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+WV
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(25,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+Uy
+iB
+Mf
+Ra
+ZO
+Ry
+Oe
+Ry
+Ra
+vV
+Mf
+ZO
+ZO
+My
+Ew
+Ra
+Ra
+Ry
+Sw
+Ry
+Ra
+Ra
+ZO
+yv
+cr
+YO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(26,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Ry
+Iv
+Qh
+Ry
+Ry
+Ry
+OW
+Ry
+pM
+Mf
+JX
+ZO
+MZ
+ZO
+Ra
+mX
+ji
+kT
+uV
+Cc
+hL
+Ry
+Ra
+ZO
+ZO
+ZO
+ED
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(27,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+Mf
+AD
+Ew
+zY
+Ra
+Ry
+Wn
+ve
+Uz
+ut
+Ry
+CZ
+Ry
+Mf
+ZO
+ZO
+ZO
+ZO
+aL
+Ra
+AC
+aH
+vz
+WB
+Rj
+Fc
+IH
+SQ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(28,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Mf
+uJ
+AI
+sU
+KJ
+RP
+AV
+Ty
+KO
+XJ
+qZ
+zE
+Uu
+tp
+FY
+ZO
+ZO
+ZO
+ZO
+Qf
+BG
+Cc
+yE
+Nx
+Vo
+Ui
+Qk
+SQ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(29,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+tW
+pF
+wx
+YM
+gj
+Ra
+wF
+TM
+gp
+bK
+Qh
+VX
+XR
+aL
+dx
+Uy
+od
+ZO
+Lo
+ZO
+dN
+HE
+UJ
+Rt
+oh
+oh
+Pq
+SQ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(30,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+XE
+XE
+gq
+ls
+Ra
+Ry
+zI
+hJ
+Rl
+fs
+Ry
+ZQ
+HL
+ZO
+ZO
+ZO
+Mf
+ZO
+ZO
+OC
+jl
+rt
+HQ
+pv
+Lu
+Lu
+ri
+SQ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(31,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+kp
+ZO
+ZO
+Uy
+ZO
+Ra
+Ry
+wi
+Qh
+Qh
+Qh
+Ew
+VP
+rO
+ED
+YO
+ZO
+ZO
+ZO
+Vv
+Mf
+bN
+yw
+zt
+sg
+qy
+Cc
+Ry
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(32,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ut
+ZO
+Uy
+ZO
+ZO
+ZO
+Mf
+aO
+Ry
+Mf
+ZO
+Mf
+Ew
+El
+pJ
+aL
+Jg
+ZO
+Uy
+Mf
+Mf
+Ra
+Mf
+Ry
+ef
+Ry
+Ra
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(33,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+kN
+ZO
+Uy
+ZO
+ZO
+ZO
+Mf
+AD
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+MM
+jH
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(34,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+DS
+st
+hO
+DS
+ZO
+ZO
+fP
+ZO
+oc
+oQ
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Mf
+Ra
+Ry
+dC
+Ry
+Ra
+Ra
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(35,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+DS
+AX
+tZ
+AX
+DS
+DS
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+yv
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+eJ
+Mf
+Oa
+bm
+gM
+lS
+LT
+bJ
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(36,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+DS
+AX
+xy
+AX
+Uy
+AX
+AX
+wN
+jE
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Ry
+io
+oP
+Mf
+mK
+wb
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(37,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+AX
+AX
+pJ
+ZO
+Uy
+ZO
+WV
+AX
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Ra
+Mf
+Ra
+xM
+Mf
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(38,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+hO
+rr
+lq
+QV
+Uy
+Uy
+ZO
+PU
+hO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(39,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+rr
+AX
+Vm
+ZO
+ZO
+Uy
+ZO
+Uy
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+Ps
+ZO
+ZO
+ZO
+fP
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(40,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+hO
+Uy
+AX
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+ZO
+ZO
+En
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+jE
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(41,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+WV
+AX
+AX
+AX
+od
+ZO
+ZO
+ZO
+ED
+Uy
+ZO
+ZO
+ZO
+ZO
+ZO
+eg
+Uy
+bV
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(42,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+DS
+ZO
+DS
+DS
+jE
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+eg
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(43,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Uy
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+PU
+ZO
+ZO
+ZO
+ZO
+Ra
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(44,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(45,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Kw
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cr
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(46,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(47,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(48,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(49,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+PU
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}
+(50,1,1) = {"
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+"}

--- a/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/fueldepot.dmm
@@ -16,7 +16,10 @@
 "bm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "bG" = (
 /obj/effect/decal/cleanable/oil/streak,
@@ -33,7 +36,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/rods,
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "bK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -108,7 +113,9 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "eJ" = (
 /obj/structure/girder/displaced,
@@ -218,7 +225,9 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "iB" = (
 /obj/structure/lattice,
@@ -233,7 +242,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "ji" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -255,7 +266,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "kl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -318,7 +331,9 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "lS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -330,7 +345,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "md" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
@@ -339,7 +356,7 @@
 "mK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
 "mX" = (
@@ -455,6 +472,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/ruin/unpowered)
+"rz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
 "rM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/port_gen/pacman/super,
@@ -492,6 +515,14 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/ruin/unpowered)
+"sH" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
 "sU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -512,13 +543,17 @@
 "tJ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "tW" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "tZ" = (
 /obj/effect/decal/cleanable/oil,
@@ -604,12 +639,16 @@
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "vV" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "wb" = (
 /obj/item/shard,
@@ -659,13 +698,18 @@
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/rods,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "xy" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "xM" = (
 /obj/structure/frame/machine,
@@ -765,7 +809,10 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "AI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -839,7 +886,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "Dt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -858,7 +907,9 @@
 "El" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/mineral/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "En" = (
 /obj/effect/decal/cleanable/oil/streak,
@@ -902,7 +953,10 @@
 	},
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "FW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -912,13 +966,23 @@
 	icon_state = "1-5"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "FY" = (
 /obj/structure/lattice,
 /obj/item/rack_parts,
 /turf/template_noop,
 /area/template_noop)
+"Gd" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/unpowered)
 "Hl" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -936,7 +1000,10 @@
 "HL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "HQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -953,7 +1020,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "IH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1003,6 +1072,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
+"KF" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
 "KJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1039,11 +1115,21 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "Mf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"Mu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "My" = (
 /obj/structure/lattice,
@@ -1057,7 +1143,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "MZ" = (
 /obj/item/roller,
@@ -1112,6 +1200,13 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"OU" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
 "OW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1123,7 +1218,10 @@
 "Pa" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "Pq" = (
 /obj/effect/turf_decal/stripes/line,
@@ -1162,8 +1260,17 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"QJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
 "QV" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "Ra" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -1219,6 +1326,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange{
 	dir = 8
 	},
+/obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "Sw" = (
@@ -1228,7 +1336,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/pod/dark,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered)
 "SL" = (
 /obj/effect/turf_decal/bot,
@@ -1245,6 +1355,12 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"Tr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/unpowered)
 "Ty" = (
 /obj/effect/turf_decal/lumos/tile/neutral/fulltile,
 /obj/structure/cable{
@@ -1281,7 +1397,9 @@
 "Uu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "Uy" = (
 /obj/structure/lattice,
@@ -1371,7 +1489,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/unpowered)
 "WB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1444,14 +1564,17 @@
 "YX" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered)
 "ZA" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
 "ZO" = (
@@ -1602,7 +1725,7 @@ ZO
 ZO
 ZO
 ZO
-Mf
+QJ
 hO
 ZO
 ZO
@@ -1710,7 +1833,7 @@ ZO
 ZO
 ZO
 ZO
-QV
+mK
 hO
 DS
 DS
@@ -1763,8 +1886,8 @@ jE
 Uy
 Uy
 zH
-Mf
-Mf
+QJ
+rz
 uk
 hO
 ZO
@@ -1815,7 +1938,7 @@ Uy
 ZO
 ZO
 Uy
-Mf
+mK
 YX
 tJ
 DS
@@ -1868,8 +1991,8 @@ ZO
 PU
 ZO
 Vm
-Mf
-Mf
+QJ
+QJ
 hO
 ZO
 ZO
@@ -1921,7 +2044,7 @@ ZO
 Uy
 Uy
 Uy
-Mf
+rz
 DS
 ZO
 ZO
@@ -2074,7 +2197,7 @@ ZO
 ZO
 ZO
 ZO
-Mf
+mK
 ZO
 ZO
 yx
@@ -2553,7 +2676,7 @@ Nt
 FW
 Dt
 eD
-Mf
+mK
 ZO
 ZO
 Tj
@@ -2680,13 +2803,13 @@ Uy
 ZO
 ZO
 Ra
-Mf
-Mf
+QJ
+mK
 ZO
 ZO
 Ra
 Pa
-Mf
+mK
 ZO
 ZO
 ZO
@@ -2733,7 +2856,7 @@ ZO
 ZO
 Uy
 iB
-Mf
+Tr
 Ra
 ZO
 Ry
@@ -2741,11 +2864,11 @@ Oe
 Ry
 Ra
 vV
-Mf
+mK
 ZO
 ZO
 My
-Ew
+Gd
 Ra
 Ra
 Ry
@@ -2792,7 +2915,7 @@ Ry
 OW
 Ry
 pM
-Mf
+QJ
 JX
 ZO
 MZ
@@ -2830,9 +2953,9 @@ ZO
 jE
 ZO
 ZO
-Mf
+mK
 AD
-Ew
+OU
 zY
 Ra
 Ry
@@ -2843,7 +2966,7 @@ ut
 Ry
 CZ
 Ry
-Mf
+mK
 ZO
 ZO
 ZO
@@ -2882,7 +3005,7 @@ ZO
 ZO
 ZO
 ZO
-Mf
+QJ
 uJ
 AI
 sU
@@ -2986,7 +3109,7 @@ ZO
 ZO
 ZO
 Uy
-XE
+KF
 XE
 gq
 ls
@@ -3002,7 +3125,7 @@ HL
 ZO
 ZO
 ZO
-Mf
+mK
 ZO
 ZO
 OC
@@ -3048,7 +3171,7 @@ wi
 Qh
 Qh
 Qh
-Ew
+sH
 VP
 rO
 ED
@@ -3057,7 +3180,7 @@ ZO
 ZO
 ZO
 Vv
-Mf
+Tr
 bN
 yw
 zt
@@ -3095,12 +3218,12 @@ Uy
 ZO
 ZO
 ZO
-Mf
+rz
 aO
 Ry
-Mf
+mK
 ZO
-Mf
+QJ
 Ew
 El
 pJ
@@ -3108,10 +3231,10 @@ aL
 Jg
 ZO
 Uy
-Mf
+mK
 Mf
 Ra
-Mf
+Tr
 Ry
 ef
 Ry
@@ -3147,7 +3270,7 @@ Uy
 ZO
 ZO
 ZO
-Mf
+Tr
 AD
 Ra
 ZO
@@ -3244,9 +3367,9 @@ ZO
 ZO
 DS
 DS
-AX
+rz
 tZ
-AX
+rz
 DS
 DS
 ZO
@@ -3297,10 +3420,10 @@ hO
 DS
 AX
 xy
-AX
+rz
 Uy
-AX
-AX
+mK
+rz
 wN
 jE
 ZO
@@ -3322,7 +3445,7 @@ Ra
 Ry
 io
 oP
-Mf
+rz
 mK
 wb
 ZO
@@ -3347,13 +3470,13 @@ ZO
 ZO
 hO
 AX
-AX
+QJ
 pJ
 ZO
 Uy
 ZO
 WV
-AX
+QJ
 ZO
 cr
 ZO
@@ -3372,10 +3495,10 @@ ZO
 ZO
 ZO
 Ra
-Mf
+mK
 Ra
 xM
-Mf
+QJ
 ZO
 ZO
 ZO
@@ -3398,7 +3521,7 @@ ZO
 ZO
 ZO
 hO
-rr
+tJ
 lq
 QV
 Uy
@@ -3451,7 +3574,7 @@ ZO
 ZO
 DS
 rr
-AX
+rz
 Vm
 ZO
 ZO
@@ -3504,7 +3627,7 @@ ZO
 DS
 hO
 Uy
-AX
+QJ
 ZO
 ZO
 Uy
@@ -3555,9 +3678,9 @@ ZO
 ZO
 ZO
 WV
-AX
-AX
-AX
+QJ
+mK
+rz
 od
 ZO
 ZO
@@ -3769,7 +3892,7 @@ ZO
 ZO
 ZO
 ZO
-Kw
+Mu
 ZO
 ZO
 ZO

--- a/_maps/RandomRuins/SpaceRuins/transport18.dmm
+++ b/_maps/RandomRuins/SpaceRuins/transport18.dmm
@@ -1,0 +1,3398 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ai" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ax" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"aE" = (
+/obj/effect/turf_decal/bot,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/trash/can{
+	pixel_y = -8
+	},
+/obj/item/trash/can{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"aT" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/transport18aft)
+"aV" = (
+/obj/effect/turf_decal/number/zero{
+	color = "#000000";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"aZ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ba" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/template_noop,
+/area/template_noop)
+"bh" = (
+/obj/structure/cable/cyan{
+	icon_state = "6-10"
+	},
+/obj/item/stack/cable_coil/cut/red,
+/obj/machinery/light/small/built{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"bT" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"cN" = (
+/obj/structure/lattice,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/template_noop,
+/area/template_noop)
+"dp" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"dq" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/space/has_grav/transport18mid)
+"dy" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"dE" = (
+/obj/machinery/plumbing/input,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"dH" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"dU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"eg" = (
+/turf/template_noop,
+/area/template_noop)
+"et" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/trash/plate{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"eJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"eK" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"eS" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"eY" = (
+/obj/item/wallframe/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"fw" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"fx" = (
+/obj/item/wallframe/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"fy" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"fE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"gf" = (
+/obj/effect/turf_decal/number/one,
+/turf/closed/wall,
+/area/ruin/space/has_grav/transport18mid)
+"gm" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"go" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"gp" = (
+/obj/item/clothing/shoes/magboots,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/transport18aft)
+"gs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/transport18aft)
+"gx" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"gD" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"gY" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"gZ" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"hn" = (
+/obj/structure/sign/warning/enginesafety,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/transport18aft)
+"iy" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"iD" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"iE" = (
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"iW" = (
+/obj/machinery/light/small/broken,
+/obj/effect/turf_decal/bot,
+/obj/machinery/plumbing/tank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"iZ" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"jl" = (
+/obj/item/trash/can,
+/turf/template_noop,
+/area/template_noop)
+"jq" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"jr" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"jz" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"jP" = (
+/obj/item/trash/can{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"jV" = (
+/obj/machinery/power/shuttle/engine/liquid/oil{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"km" = (
+/obj/item/stack/sheet/metal,
+/turf/template_noop,
+/area/template_noop)
+"kC" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"kK" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"kR" = (
+/obj/item/wirecutters,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"la" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"lf" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/plumbing/tank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"lK" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"lN" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"lT" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"lV" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wallframe/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "transp19";
+	name = "Container Blast Door Control";
+	pixel_x = 5
+	},
+/obj/machinery/button/door{
+	id = "transp19_windows";
+	name = "Window Shutter Control";
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"lY" = (
+/obj/effect/turf_decal/number/two,
+/turf/closed/wall,
+/area/ruin/space/has_grav/transport18mid)
+"mb" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater/tank{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"md" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod,
+/area/ruin/space/transport18aft)
+"me" = (
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"mj" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"mt" = (
+/obj/machinery/door/poddoor/multi_tile/three_tile_hor{
+	id = "transp19"
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"mA" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod,
+/area/ruin/space/has_grav/transport18mid)
+"mI" = (
+/obj/structure/sign/warning/nosmoking,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/transport18aft)
+"mU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"mX" = (
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"ne" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"np" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ns" = (
+/obj/item/stack/ducts/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"nw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"nx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/plumbing/tank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"nJ" = (
+/obj/effect/decal/cleanable/food/flour,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"nL" = (
+/obj/structure/bed,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"oa" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"of" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ot" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ou" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/trash/can{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"oL" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"oP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"oQ" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"oT" = (
+/obj/structure/girder,
+/turf/template_noop,
+/area/template_noop)
+"po" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"pr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"pE" = (
+/obj/machinery/power/shuttle/engine/liquid/oil{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"pF" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"pN" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"pR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"qf" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 2;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"qJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"qM" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"qY" = (
+/obj/machinery/light/broken,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"re" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/space/has_grav/transport18mid)
+"rC" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/transport18mid)
+"rF" = (
+/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"rV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/obj/item/trash/plate{
+	pixel_x = -5
+	},
+/obj/item/trash/plate{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"sr" = (
+/obj/effect/turf_decal/number/five{
+	dir = 1
+	},
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/transport18mid)
+"tb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"tu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"tJ" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"tK" = (
+/obj/structure/table_frame,
+/obj/item/shard{
+	icon_state = "tiny"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"tY" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "transp19_windows"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"uj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"uo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ur" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"uC" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"uQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"vg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/shard,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"vo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/transport18aft)
+"vr" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/template_noop,
+/area/template_noop)
+"vN" = (
+/obj/item/clothing/gloves/color/fyellow/old,
+/obj/item/stack/cable_coil/cyan,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"wb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"wi" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"wu" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"wC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"wD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "transp19_windows"
+	},
+/obj/structure/grille/broken,
+/obj/item/shard,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"wN" = (
+/obj/item/trash/can{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"wU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"xm" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"xq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/transport18mid)
+"xz" = (
+/obj/effect/turf_decal/number/one{
+	color = "#000000"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"xA" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 2;
+	icon_state = "plating"
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"xD" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"yk" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/template_noop,
+/area/template_noop)
+"yv" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"yy" = (
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"yG" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "transp19_windows"
+	},
+/obj/structure/grille,
+/obj/item/shard,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"yI" = (
+/obj/item/trash/can{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"zp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/door_assembly/door_assembly_public,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/transport18mid)
+"zr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"zB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"zE" = (
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"zG" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"zL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"zN" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"zY" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Ah" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"AU" = (
+/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"Bh" = (
+/obj/item/trash/can{
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Bv" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"BD" = (
+/obj/item/stack/ducts/fifty,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"BM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"BO" = (
+/obj/effect/turf_decal/number/five{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/ruin/space/has_grav/transport18mid)
+"CH" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"CK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/door_assembly/door_assembly_hatch,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"CX" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Dh" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"Dk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/number/eight{
+	color = "#000000"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"Do" = (
+/obj/effect/turf_decal/number/three{
+	dir = 1
+	},
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/transport18mid)
+"Dr" = (
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Dy" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"DF" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"DM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"EB" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"ES" = (
+/obj/item/stack/cable_coil/cut/cyan,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"EW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/shard{
+	icon_state = "tiny"
+	},
+/obj/structure/table_frame,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Fc" = (
+/obj/effect/turf_decal/number/eight{
+	color = "#000000"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"Fq" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"FF" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"Go" = (
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/organ/stomach,
+/obj/item/trash/can{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Gp" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Gq" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "transp19_windows"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Hd" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/shard,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Hr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/transport18aft)
+"HN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/paper/crumpled/fluff{
+	info = "Well, journal, it's just you, me, and twelve tons of beer. Haven't heard back from the engineer in about a day since he cooked up that crazy plan to fuel the thrusters with beer, so I reckon I'll go out with a bang. At least I'll die happy."
+	},
+/obj/item/trash/can{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Io" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Ir" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Iy" = (
+/obj/machinery/door/poddoor/multi_tile/three_tile_hor{
+	id = "transp19";
+	state_open = 1
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"IG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"IT" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/transport18mid)
+"Jk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Jl" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/trash/candy,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Jx" = (
+/obj/item/stack/cable_coil/cut/yellow,
+/turf/template_noop,
+/area/template_noop)
+"JM" = (
+/obj/item/construction/plumbing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"JR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/public,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"JV" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "pile";
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/item/broken_bottle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Kv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"KZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can{
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Lg" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Lq" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"LD" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"LE" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"LI" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/item/stack/cable_coil/cut/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"Mi" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater/tank{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/transport18aft)
+"MA" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/built{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"MV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"NA" = (
+/obj/structure/chair,
+/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"ND" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/template_noop,
+/area/template_noop)
+"NH" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Oi" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "transp19_windows"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"OS" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Pm" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"Pq" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-5"
+	},
+/obj/item/stack/cable_coil/cut/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"PC" = (
+/obj/structure/lattice,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "plating"
+	},
+/turf/template_noop,
+/area/template_noop)
+"PJ" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"PV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"PW" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"PZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Qh" = (
+/obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Qi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"Qu" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/transport18aft)
+"QP" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"QS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/can{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/item/trash/can{
+	pixel_y = -8
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Ro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Sd" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/transport18mid)
+"Si" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Sr" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"SI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"SQ" = (
+/obj/structure/mirror{
+	broken = 1;
+	desc = "Oh no, seven years of bad luck!";
+	icon_state = "mirror_broke";
+	pixel_y = 24
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/item/shard{
+	icon_state = "tiny"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Tp" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Tu" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"TD" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/paper/stack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"TU" = (
+/obj/item/wallframe/apc,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"TZ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"Uu" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/transport18aft)
+"Ux" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/item/stack/cable_coil/cut/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"UB" = (
+/obj/item/stack/ducts/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Va" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Vm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/airless,
+/area/ruin/space/has_grav/transport18mid)
+"VG" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 1;
+	icon_state = "plating"
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Wb" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"Wf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Wr" = (
+/obj/effect/turf_decal/number/zero{
+	color = "#000000"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"Wx" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/fluff/paper/stack{
+	dir = 5
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/transport18mid)
+"WA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Xb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/transport18aft)
+"Xc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/transport18mid)
+"XQ" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large{
+	name = "damp crate"
+	},
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"XU" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/transport18mid)
+"YC" = (
+/obj/effect/turf_decal/number/one{
+	color = "#000000";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/transport18mid)
+"YJ" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Zl" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+"Zn" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/plumbing/tank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/transport18mid)
+"Zz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/transport18aft)
+"ZH" = (
+/obj/item/stack/sheet/mineral/titanium,
+/turf/template_noop,
+/area/template_noop)
+"ZX" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/plating,
+/area/ruin/space/transport18aft)
+
+(1,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+mj
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+Hr
+eg
+Gp
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(2,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+Hr
+aT
+eg
+eg
+eg
+eg
+mj
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(3,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(4,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+vo
+PJ
+eg
+eg
+eg
+eg
+eg
+jl
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(5,1,1) = {"
+eg
+eg
+mj
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(6,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(7,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+oT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(8,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(9,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+Gp
+eg
+eg
+eg
+zL
+eg
+eg
+eg
+eg
+eg
+eg
+jV
+jV
+eg
+eg
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+"}
+(10,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+LD
+eg
+PJ
+eg
+eg
+eg
+wU
+eg
+eg
+mb
+mb
+Hr
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(11,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+Hr
+Hr
+eg
+eg
+Jx
+PJ
+eg
+PJ
+eg
+eg
+Xb
+wu
+ZX
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(12,1,1) = {"
+eg
+eg
+eg
+eg
+pE
+pE
+eg
+eg
+eg
+eg
+Jx
+eg
+eg
+km
+PJ
+eg
+PJ
+CX
+PJ
+zL
+Zl
+PC
+eg
+yk
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(13,1,1) = {"
+eg
+eg
+eg
+Hr
+Mi
+Mi
+Hr
+eg
+PJ
+PJ
+eg
+eg
+PJ
+PJ
+iD
+eg
+Hr
+pr
+eg
+wU
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(14,1,1) = {"
+eg
+eg
+eg
+Hr
+nw
+nw
+Hr
+eg
+yv
+xA
+PJ
+gp
+eg
+eg
+Hr
+eg
+Hr
+PJ
+PJ
+PJ
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(15,1,1) = {"
+eg
+eg
+eg
+Hr
+gx
+nw
+Hr
+eg
+Hr
+jq
+Pq
+PJ
+eg
+vr
+Hr
+eg
+hn
+PJ
+eg
+eg
+PJ
+eg
+mj
+eg
+eg
+eg
+eg
+ND
+eg
+eg
+"}
+(16,1,1) = {"
+eg
+eg
+eg
+Hr
+EB
+gx
+Hr
+Hr
+Hr
+bh
+fw
+PJ
+VG
+mX
+Wb
+Hr
+Hr
+wb
+qf
+eg
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(17,1,1) = {"
+eg
+eg
+eg
+Hr
+eY
+gm
+Uu
+po
+Ux
+FF
+Qu
+jq
+Xb
+Zz
+LI
+PJ
+zL
+zN
+zG
+PJ
+Hr
+aT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(18,1,1) = {"
+eg
+eg
+eg
+Hr
+AU
+Qi
+Hr
+Hr
+Pm
+Dh
+ES
+xm
+kR
+rF
+Hr
+eg
+LE
+kC
+Xb
+eg
+PJ
+Hr
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(19,1,1) = {"
+eg
+eg
+eg
+Hr
+ns
+Qi
+Hr
+eg
+Hr
+lT
+vN
+wi
+TU
+qM
+eK
+PJ
+cN
+Hr
+Hr
+eg
+eg
+Hr
+eg
+eg
+eg
+eg
+eg
+jl
+eg
+eg
+"}
+(20,1,1) = {"
+eg
+eg
+eg
+aT
+Hr
+Hr
+aT
+eg
+aT
+yv
+mI
+md
+Hr
+Hr
+gs
+eg
+PJ
+eg
+PJ
+eg
+eg
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(21,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+TZ
+Ir
+TZ
+eg
+PJ
+eg
+tJ
+gZ
+IT
+IT
+Fq
+rC
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(22,1,1) = {"
+eg
+eg
+eg
+IT
+IT
+xq
+IT
+Fq
+lN
+IT
+TZ
+Ir
+TZ
+eg
+eg
+eg
+tJ
+xD
+Tu
+dp
+Tu
+fy
+IT
+eg
+eg
+ND
+eg
+eg
+eg
+eg
+"}
+(23,1,1) = {"
+eg
+eg
+eg
+rC
+Zn
+BM
+Zn
+uo
+dp
+IT
+TZ
+fx
+TZ
+eg
+eg
+eg
+IT
+MA
+uo
+dp
+BM
+Bv
+lY
+eg
+ND
+eg
+eg
+eg
+eg
+eg
+"}
+(24,1,1) = {"
+eg
+eg
+eg
+Do
+lf
+BM
+Zn
+UB
+iW
+rC
+TZ
+Kv
+TZ
+PJ
+PJ
+PJ
+IT
+dp
+BM
+dp
+BM
+dp
+Iy
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(25,1,1) = {"
+eg
+eg
+eg
+mt
+xD
+BM
+dp
+BM
+dp
+rC
+TZ
+Kv
+TZ
+eg
+PJ
+eg
+QP
+uo
+BM
+BM
+zY
+uo
+pF
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(26,1,1) = {"
+eg
+eg
+eg
+Si
+BM
+dE
+BM
+BM
+BM
+Sd
+oL
+Kv
+CK
+PJ
+PJ
+ba
+IT
+dp
+zY
+dp
+BM
+wC
+eS
+ND
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(27,1,1) = {"
+eg
+eg
+eg
+Si
+xD
+JM
+dp
+BM
+PW
+IT
+TZ
+Kv
+TZ
+ZH
+eg
+eg
+IT
+DM
+BM
+dp
+uo
+Bv
+lY
+eg
+eg
+eg
+eg
+eg
+eg
+ND
+"}
+(28,1,1) = {"
+eg
+eg
+eg
+Do
+ur
+BM
+Sr
+BM
+CH
+IT
+TZ
+tb
+tJ
+mj
+eg
+eg
+rC
+dp
+uo
+fy
+uo
+YJ
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(29,1,1) = {"
+eg
+eg
+eg
+IT
+nx
+uo
+BD
+uo
+YJ
+rC
+TZ
+Kv
+pN
+eg
+mj
+PJ
+rC
+IT
+rC
+rC
+IT
+IT
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(30,1,1) = {"
+eg
+jl
+eg
+IT
+IT
+rC
+rC
+rC
+IT
+IT
+TZ
+tu
+TZ
+PJ
+eg
+eg
+eg
+PJ
+eg
+PJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(31,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+TZ
+Kv
+TZ
+eg
+eg
+eg
+eg
+PJ
+eg
+PJ
+eg
+km
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(32,1,1) = {"
+eg
+eg
+eg
+IT
+rC
+rC
+IT
+IT
+rC
+rC
+TZ
+Ir
+TZ
+IT
+IT
+rC
+rC
+IT
+tJ
+tJ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(33,1,1) = {"
+eg
+eg
+eg
+IT
+lK
+WA
+ne
+me
+ne
+IT
+TZ
+Ir
+TZ
+IT
+fy
+oP
+fy
+BM
+la
+Io
+eg
+eg
+eg
+eg
+jl
+eg
+eg
+eg
+eg
+eg
+"}
+(34,1,1) = {"
+eg
+eg
+jl
+sr
+oa
+yI
+uC
+QS
+jr
+IT
+TZ
+ot
+TZ
+rC
+YJ
+BM
+fy
+uo
+Va
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(35,1,1) = {"
+jl
+eg
+eg
+mt
+oa
+KZ
+oa
+Wf
+oa
+IT
+TZ
+Kv
+TZ
+IT
+xD
+qJ
+aZ
+pR
+wC
+mt
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(36,1,1) = {"
+eg
+eg
+eg
+pF
+KZ
+SI
+wN
+uQ
+ou
+dq
+oL
+Kv
+Sd
+re
+BM
+BM
+Ro
+fE
+uo
+pF
+eg
+jl
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(37,1,1) = {"
+eg
+eg
+eg
+pF
+oa
+Bh
+aE
+Go
+oa
+rC
+TZ
+Kv
+TZ
+rC
+la
+BM
+dp
+uo
+wC
+pF
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(38,1,1) = {"
+eg
+eg
+eg
+BO
+of
+BM
+ne
+HN
+XQ
+rC
+TZ
+Ir
+TZ
+rC
+DF
+BM
+YJ
+BM
+Va
+gf
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(39,1,1) = {"
+eg
+eg
+eg
+rC
+ne
+iE
+oa
+jP
+oa
+IT
+TZ
+mU
+TZ
+rC
+fy
+uo
+fy
+uo
+YJ
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+jl
+eg
+"}
+(40,1,1) = {"
+eg
+eg
+eg
+rC
+rC
+rC
+IT
+IT
+rC
+IT
+TZ
+Ir
+TZ
+IT
+rC
+Io
+tJ
+IT
+IT
+IT
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(41,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+ZH
+eg
+TZ
+Ir
+TZ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+jl
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(42,1,1) = {"
+eg
+eg
+eg
+eg
+TZ
+TZ
+yG
+tJ
+TZ
+TZ
+TZ
+mA
+TZ
+TZ
+TZ
+TZ
+tY
+TZ
+TZ
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(43,1,1) = {"
+eg
+eg
+eg
+eg
+Dk
+MV
+JV
+NA
+EW
+TZ
+kK
+ai
+oQ
+TZ
+SQ
+uj
+uj
+tK
+Wr
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(44,1,1) = {"
+eg
+eg
+eg
+eg
+YC
+rV
+nJ
+dy
+et
+TZ
+gD
+Jk
+qY
+TZ
+Dr
+np
+np
+nL
+xz
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(45,1,1) = {"
+eg
+eg
+eg
+eg
+aV
+Dy
+Qh
+Jl
+zr
+ax
+zr
+IG
+zr
+zp
+Vm
+dH
+uj
+iy
+Fc
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(46,1,1) = {"
+eg
+eg
+eg
+eg
+XU
+TZ
+TZ
+TZ
+TZ
+TZ
+TZ
+JR
+TZ
+TZ
+TZ
+TZ
+TZ
+go
+tJ
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(47,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+TZ
+TZ
+TZ
+lV
+TD
+iZ
+bT
+PV
+Hd
+Lq
+TZ
+TZ
+tJ
+eg
+mj
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(48,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+XU
+TZ
+TZ
+zE
+NH
+zB
+Tp
+Xc
+Lg
+OS
+TZ
+tJ
+yy
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(49,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+XU
+TZ
+Wx
+Ah
+dU
+vg
+eJ
+gY
+PZ
+TZ
+XU
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(50,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+XU
+tY
+tY
+jz
+jz
+jz
+yG
+tY
+XU
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}
+(51,1,1) = {"
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+tY
+tY
+Gq
+wD
+Oi
+mj
+eg
+eg
+ZH
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+eg
+"}

--- a/_maps/RandomRuins/SpaceRuins/transport18.dmm
+++ b/_maps/RandomRuins/SpaceRuins/transport18.dmm
@@ -347,8 +347,10 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/has_grav/transport18mid)
 "jV" = (
-/obj/machinery/power/shuttle/engine/liquid/oil{
-	dir = 4
+/obj/machinery/power/shuttle/engine/liquid{
+	dir = 4;
+	fuel_reagents = list(/datum/reagent/consumable/ethanol/beer = 50);
+	name = "modified thruster"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/transport18aft)
@@ -655,8 +657,10 @@
 	},
 /area/ruin/space/transport18aft)
 "pE" = (
-/obj/machinery/power/shuttle/engine/liquid/oil{
-	dir = 4
+/obj/machinery/power/shuttle/engine/liquid{
+	dir = 4;
+	fuel_reagents = list(/datum/reagent/consumable/ethanol/beer = 50);
+	name = "modified thruster"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/transport18aft)

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -350,3 +350,16 @@
 	name = "Hell Factory Office"
 	icon_state = "red"
 	area_flags = VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA | NOTELEPORT
+
+//Ruin of Transport 18
+/area/ruin/space/has_grav/transport18fore
+	name = "Booze Cruise Fore"
+	icon_state = "crew_quarters"
+
+/area/ruin/space/has_grav/transport18mid
+	name = "Booze Cruise Hold"
+	icon_state = "cargo_bay"
+
+/area/ruin/space/transport18aft
+	name = "Booze Cruise Aft"
+	icon_state = "engine"

--- a/whitesands/code/datums/ruins/space.dm
+++ b/whitesands/code/datums/ruins/space.dm
@@ -22,9 +22,20 @@
 	suffix = "spacegym.dmm"
 	name = "Space Gym"
 	description = "A gym, lost in space, where many grunts and moaning could be heard."
-	
+
 /datum/map_template/ruin/space/oldshuttle
 	id = "oldcode-nukeops"
 	suffix = "oldcodeops.dmm"
 	name = "Strange Infiltrator"
 	description = "A nuclear operative's ship, drifing along the stars. This thing looks like it belongs in ancient times."
+
+/datum/map_template/ruin/space/transport18
+	id = "transport18"
+	suffix = "transport_18.dmm"
+	name = "Booze Cruise"
+	description = "A freighter, damaged beyond repair and surrounded by a cloud of aluminum and... beer foam?"
+
+/datum/map_template/ruin/space/fueldepot
+	id = "fueldepot"
+	suffix = "fuel_depot.dmm"
+	description = "An orbital refueling station with the remains of a ship lodged among the debris."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new space ruins: a derelict fuel depot and a ruined freighter with an unusual cargo.

## Why It's Good For The Game

things to see, stuff to loot

## Changelog
:cl:
add: Added two new space ruins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
