### PR TITLE
Adds extremely basic placeholder trading methods

### DIFF
--- a/_maps/shuttles/shiptest/amogus_sus.dmm
+++ b/_maps/shuttles/shiptest/amogus_sus.dmm
@@ -446,6 +446,10 @@
 "gq" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/office)
+"gC" = (
+/obj/machinery/computer/cargo/express,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "gI" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -965,7 +969,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "nT" = (
-/obj/machinery/piratepad,
+/obj/machinery/selling_pad,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "ok" = (
@@ -4092,7 +4096,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/starboard)
 "XF" = (
-/obj/machinery/computer/piratepad_control,
+/obj/machinery/computer/selling_pad_control,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "XM" = (
@@ -5138,7 +5142,7 @@ GO
 xR
 Do
 iY
-Yh
+gC
 hs
 Yh
 FY

--- a/_maps/shuttles/shiptest/libertatia.dmm
+++ b/_maps/shuttles/shiptest/libertatia.dmm
@@ -1250,13 +1250,13 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Ks" = (
-/obj/machinery/computer/piratepad_control,
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/selling_pad_control,
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "KD" = (
-/obj/machinery/piratepad,
 /obj/effect/turf_decal/box,
+/obj/machinery/selling_pad,
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "KS" = (

--- a/_maps/shuttles/shiptest/ntsv_skipper.dmm
+++ b/_maps/shuttles/shiptest/ntsv_skipper.dmm
@@ -448,6 +448,13 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/ship/engineering/engine)
+"fd" = (
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/obj/machinery/selling_pad,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "fg" = (
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /obj/structure/cable{
@@ -2962,6 +2969,7 @@
 /obj/effect/turf_decal/lumos/tile/brown/fullcorner{
 	dir = 8
 	},
+/obj/machinery/computer/selling_pad_control,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "LC" = (
@@ -3576,6 +3584,21 @@
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/ship/engineering/atmospherics)
+"TT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 4
+	},
+/obj/machinery/computer/cargo/express{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "Uj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4452,7 +4475,7 @@ ov
 GF
 HN
 Rd
-FA
+fd
 Kf
 Kf
 Kf
@@ -4485,7 +4508,7 @@ KN
 Rd
 Lz
 CQ
-CQ
+TT
 vQ
 oC
 uQ

--- a/_maps/shuttles/shiptest/solgov_carina.dmm
+++ b/_maps/shuttles/shiptest/solgov_carina.dmm
@@ -727,6 +727,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/machinery/computer/selling_pad_control{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "nA" = (
@@ -1391,6 +1394,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/cargo/express{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "vI" = (
@@ -1563,6 +1569,10 @@
 /obj/item/weldingtool/mini,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
+"xZ" = (
+/obj/machinery/selling_pad,
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "yg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3839,7 +3849,7 @@ Wo
 bI
 bU
 nx
-TN
+xZ
 vG
 fv
 cW

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -228,7 +228,7 @@
 		SET_BITFLAG_LIST(canSmoothWith)
 
 	var/area/ship/current_ship_area = get_area(src)
-	if(!mapload && istype(current_ship_area))
+	if(!mapload && istype(current_ship_area) && current_ship_area.mobile_port)
 		connect_to_shuttle(current_ship_area.mobile_port, current_ship_area.mobile_port.get_docked())
 
 	var/temp_list = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -227,6 +227,10 @@
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 
+	var/area/ship/current_ship_area = get_area(src)
+	if(!mapload && istype(current_ship_area))
+		connect_to_shuttle(current_ship_area.mobile_port, current_ship_area.mobile_port.get_docked())
+
 	var/temp_list = list()
 	for(var/i in custom_materials)
 		temp_list[SSmaterials.GetMaterialRef(i)] = custom_materials[i] //Get the proper instanced version

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -405,3 +405,8 @@
 	name = "Outpost Status Display (Computer Board)"
 	icon_state = "supply"
 	build_path = /obj/machinery/computer/security/mining
+
+/obj/item/circuitboard/computer/selling_pad_control
+	name = "Cargo hold control terminal (Computer Board)"
+	icon_state = "supply"
+	build_path = /obj/machinery/computer/selling_pad_control

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1236,6 +1236,17 @@ WS End */
 	icon_state = "supply"
 	build_path = /obj/machinery/rnd/production/techfab/department/cargo
 
+/obj/item/circuitboard/machine/selling_pad
+	name = "Cargo hold pad (Machine Board)"
+	icon_state = "supply"
+	build_path = /obj/machinery/selling_pad
+	req_components = list(
+		/obj/item/stock_parts/subspace/amplifier = 2,
+		/obj/item/stock_parts/subspace/transmitter = 2,
+		/obj/item/stock_parts/subspace/crystal = 1,
+		/obj/item/stock_parts/scanning_module = 2,
+		/obj/item/stock_parts/micro_laser = 2)
+
 //Misc
 /obj/item/circuitboard/machine/sheetifier
 	name = "Sheet-meister 2000 (Machine Board)"

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -151,6 +151,8 @@
 				SSshuttle.moveShuttle(SSshuttle.supply, SSshuttle.supply_home_port, TRUE)
 			. = TRUE
 		if("add")
+			if(istype(src, /obj/machinery/computer/cargo/express))
+				return
 			var/id = text2path(params["id"])
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -14,7 +14,6 @@
 	icon_screen = "supply_express"
 	circuit = /obj/item/circuitboard/computer/cargo/express
 	blockade_warning = "Bluespace instability detected. Delivery impossible."
-	req_access = list(ACCESS_QM)
 
 	var/message
 	var/printed_beacons = 0 //number of beacons printed. Used to determine beacon names.
@@ -25,10 +24,19 @@
 	var/cooldown = 0 //cooldown to prevent printing supplypod beacon spam
 	var/locked = TRUE //is the console locked? unlock with ID
 	var/usingBeacon = FALSE //is the console in beacon mode? exists to let beacon know when a pod may come in
+	/// The account to charge purchases to, defaults to the cargo budget
+	var/datum/bank_account/charge_account
 
 /obj/machinery/computer/cargo/express/Initialize()
 	. = ..()
 	packin_up()
+	if(!charge_account)
+		charge_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+
+/obj/machinery/computer/cargo/express/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	. = ..()
+	if(port.current_ship)
+		charge_account = port.current_ship.ship_account
 
 /obj/machinery/computer/cargo/express/Destroy()
 	if(beacon)
@@ -95,15 +103,14 @@
 /obj/machinery/computer/cargo/express/ui_data(mob/user)
 	var/canBeacon = beacon && (isturf(beacon.loc) || ismob(beacon.loc))//is the beacon in a valid location?
 	var/list/data = list()
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	if(D)
-		data["points"] = D.account_balance
+	if(charge_account)
+		data["points"] = charge_account.account_balance
 	data["locked"] = locked//swipe an ID to unlock
 	data["siliconUser"] = user.has_unlimited_silicon_privilege
 	data["beaconzone"] = beacon ? get_area(beacon) : ""//where is the beacon located? outputs in the tgui
 	data["usingBeacon"] = usingBeacon //is the mode set to deliver to the beacon or the cargobay?
 	data["canBeacon"] = !usingBeacon || canBeacon //is the mode set to beacon delivery, and is the beacon in a valid location?
-	data["canBuyBeacon"] = cooldown <= 0 && D.account_balance >= BEACON_COST
+	data["canBuyBeacon"] = cooldown <= 0 && charge_account.account_balance >= BEACON_COST
 	data["beaconError"] = usingBeacon && !canBeacon ? "(BEACON ERROR)" : ""//changes button text to include an error alert if necessary
 	data["hasBeacon"] = beacon != null//is there a linked beacon?
 	data["beaconName"] = beacon ? beacon.name : "No Beacon Found"
@@ -142,14 +149,12 @@
 			if (beacon)
 				beacon.update_status(SP_READY) //turns on the beacon's ready light
 		if("printBeacon")
-			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-			if(D)
-				if(D.adjust_money(-BEACON_COST))
-					cooldown = 10//a ~ten second cooldown for printing beacons to prevent spam
-					var/obj/item/supplypod_beacon/C = new /obj/item/supplypod_beacon(drop_location())
-					C.link_console(src, usr)//rather than in beacon's Initialize(), we can assign the computer to the beacon by reusing this proc)
-					printed_beacons++//printed_beacons starts at 0, so the first one out will be called beacon # 1
-					beacon.name = "Supply Pod Beacon #[printed_beacons]"
+			if(charge_account?.adjust_money(-BEACON_COST))
+				cooldown = 10//a ~ten second cooldown for printing beacons to prevent spam
+				var/obj/item/supplypod_beacon/C = new /obj/item/supplypod_beacon(drop_location())
+				C.link_console(src, usr)//rather than in beacon's Initialize(), we can assign the computer to the beacon by reusing this proc)
+				printed_beacons++//printed_beacons starts at 0, so the first one out will be called beacon # 1
+				beacon.name = "Supply Pod Beacon #[printed_beacons]"
 
 
 		if("add")//Generate Supply Order first
@@ -171,9 +176,8 @@
 			var/list/empty_turfs
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason)
 			var/points_to_check
-			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-			if(D)
-				points_to_check = D.account_balance
+			if(charge_account)
+				points_to_check = charge_account.account_balance
 			if(!(obj_flags & EMAGGED))
 				if(SO.pack.cost <= points_to_check)
 					var/LZ
@@ -193,7 +197,7 @@
 						if(empty_turfs && empty_turfs.len)
 							LZ = pick(empty_turfs)
 					if (SO.pack.cost <= points_to_check && LZ)//we need to call the cost check again because of the CHECK_TICK call
-						D.adjust_money(-SO.pack.cost)
+						charge_account.adjust_money(-SO.pack.cost)
 						new /obj/effect/DPtarget(LZ, podType, SO)
 						. = TRUE
 						update_icon()
@@ -205,7 +209,7 @@
 						LAZYADD(empty_turfs, T)
 						CHECK_TICK
 					if(empty_turfs && empty_turfs.len)
-						D.adjust_money(-(SO.pack.cost * (0.72*MAX_EMAG_ROCKETS)))
+						charge_account.adjust_money(-(SO.pack.cost * (0.72*MAX_EMAG_ROCKETS)))
 
 						SO.generateRequisition(get_turf(src))
 						for(var/i in 1 to MAX_EMAG_ROCKETS)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -113,6 +113,13 @@
 					M.playsound_local(get_turf(sound_atom), 'sound/machines/twobeep_high.ogg', 50, TRUE)
 					to_chat(M, "[icon2html(icon_source, M)] <span class='notice'>[message]</span>")
 
+/datum/bank_account/ship
+	add_to_accounts = FALSE
+
+/datum/bank_account/ship/New(newname, budget)
+	account_holder = newname
+	account_balance = budget
+
 /datum/bank_account/department
 	account_holder = "Guild Credit Agency"
 	var/department_id = "REPLACE_ME"

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -41,7 +41,6 @@
 	if(!shuttle)
 		CRASH("Simulated overmap ship created without associated shuttle!")
 	name = shuttle.name
-	job_slots = shuttle.source_template.job_slots
 	calculate_mass()
 	initial_name()
 	refresh_engines()

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -6,6 +6,13 @@
 	var/list/job_slots = list("Assistant" = 5, "Captain" = 1)
 	///Manifest list of people on the ship
 	var/list/manifest = list()
+	///Shipwide bank account
+	var/datum/bank_account/ship/ship_account
+
+/obj/structure/overmap/ship/simulated/Initialize(mapload, obj/docking_port/mobile/_shuttle)
+	. = ..()
+	job_slots = shuttle.source_template.job_slots
+	ship_account = new(name, 7500)
 
 /**
   * Bastardized version of GLOB.manifest.manifest_inject, but used per ship

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/overmap/ship/simulated/Initialize(mapload, obj/docking_port/mobile/_shuttle)
 	. = ..()
-	job_slots = shuttle.source_template.job_slots
+	job_slots = shuttle.source_template.job_slots.Copy()
 	ship_account = new(name, 7500)
 
 /**

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -248,6 +248,14 @@
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/board/selling
+	name = "Computer Design (Cargo Hold Control Terminal)"
+	desc = "Allows for the construction of circuit boards used to build a Cargo Hold Control Terminal."
+	id = "selling_console"
+	build_path = /obj/item/circuitboard/computer/selling_pad_control
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+
 /datum/design/board/comm_monitor
 	name = "Computer Design (Telecommunications Monitoring Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunications monitor."

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -587,6 +587,14 @@
 	category = list ("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
+/datum/design/board/selling_pad
+	name = "Machine Design (Cargo Hold Pad)"
+	desc = "The circuit board for a Cargo Hold Pad."
+	id = "selling_pad"
+	build_path = /obj/item/circuitboard/machine/selling_pad
+	category = list ("Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+
 /datum/design/board/paystand
 	name = "Machine Design (Pay Stand)"
 	desc = "The circuit board for a paystand."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -432,7 +432,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 	design_ids = list("s-receiver", "s-bus", "s-broadcaster", "s-processor", "s-hub", "s-server", "s-relay", "comm_monitor", "comm_server",
-	"s-ansible", "s-filter", "s-amplifier", "ntnet_relay", "s-treatment", "s-analyzer", "s-crystal", "s-transmitter", "s-messaging")
+	"s-ansible", "s-filter", "s-amplifier", "ntnet_relay", "s-treatment", "s-analyzer", "s-crystal", "s-transmitter", "s-messaging", "selling_console", "selling_pad")
 
 /datum/techweb_node/integrated_HUDs
 	id = "integrated_HUDs"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3399,6 +3399,7 @@
 #include "whitesands\code\modules\clothing\under\jobs\rnd.dm"
 #include "whitesands\code\modules\clothing\under\jobs\security.dm"
 #include "whitesands\code\modules\clothing\under\jobs\service.dm"
+#include "whitesands\code\modules\economy\selling_pad.dm"
 #include "whitesands\code\modules\events\borers.dm"
 #include "whitesands\code\modules\food_and_drinks\drinks\bottles.dm"
 #include "whitesands\code\modules\food_and_drinks\drinks\cans.dm"

--- a/whitesands/code/modules/economy/selling_pad.dm
+++ b/whitesands/code/modules/economy/selling_pad.dm
@@ -2,15 +2,16 @@
 /obj/machinery/selling_pad
 	name = "cargo hold pad"
 	icon = 'icons/obj/telescience.dmi'
-	icon_state = "lpad"
+	icon_state = "lpad-idle-o"
 	circuit = /obj/item/circuitboard/machine/selling_pad
 
 /obj/machinery/selling_pad/multitool_act(mob/living/user, obj/item/multitool/I)
 	. = ..()
-	if (istype(I))
-		to_chat(user, "<span class='notice'>You register [src] in [I]s buffer.</span>")
-		I.buffer = src
-		return TRUE
+	if(!multitool_check_buffer(user, I))
+		return
+	to_chat(user, "<span class='notice'>You register [src] in [I]s buffer.</span>")
+	I.buffer = src
+	return TRUE
 
 /obj/machinery/computer/selling_pad_control
 	name = "cargo hold control terminal"
@@ -29,11 +30,11 @@
 
 /obj/machinery/computer/selling_pad_control/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	. = ..()
-	sell_account = port.current_ship.ship_account
+	sell_account = port.current_ship?.ship_account
 
 /obj/machinery/computer/selling_pad_control/multitool_act(mob/living/user, obj/item/multitool/I)
 	. = ..()
-	if (istype(I) && istype(I.buffer, /obj/machinery/selling_pad))
+	if (istype(I.buffer, /obj/machinery/selling_pad))
 		to_chat(user, "<span class='notice'>You link [src] with [I.buffer] in [I] buffer.</span>")
 		pad = WEAKREF(I.buffer)
 		return TRUE
@@ -145,8 +146,8 @@
 		status_report += "Nothing"
 
 	sell_pad.visible_message("<span class='notice'>[sell_pad] activates!</span>")
-	flick("[initial(sell_pad.icon_state)]-beam", pad)
-	sell_pad.icon_state = "[initial(sell_pad.icon_state)]-idle-o"
+	flick("lpad-beam", pad)
+	sell_pad.icon_state = "lpad-idle-o"
 	sending = FALSE
 
 /obj/machinery/computer/selling_pad_control/proc/start_sending()
@@ -157,8 +158,8 @@
 		return
 	sending = TRUE
 	status_report = "Sending..."
-	sell_pad.visible_message("<span class='notice'>[pad] starts charging up.</span>")
-	sell_pad.icon_state = "[initial(sell_pad.icon_state)]-idle"
+	sell_pad.visible_message("<span class='notice'>[sell_pad] starts charging up.</span>")
+	sell_pad.icon_state = "lpad-idle"
 	sending_timer = addtimer(CALLBACK(src,.proc/send),warmup_time, TIMER_STOPPABLE)
 
 /obj/machinery/computer/selling_pad_control/proc/stop_sending()
@@ -169,5 +170,5 @@
 		return
 	sending = FALSE
 	status_report = "Ready for delivery."
-	sell_pad.icon_state = "[initial(sell_pad.icon_state)]-idle-o"
+	sell_pad.icon_state = "lpad-idle-o"
 	deltimer(sending_timer)

--- a/whitesands/code/modules/economy/selling_pad.dm
+++ b/whitesands/code/modules/economy/selling_pad.dm
@@ -1,0 +1,175 @@
+//Pad & Pad Terminal
+/obj/machinery/selling_pad
+	name = "cargo hold pad"
+	icon = 'icons/obj/telescience.dmi'
+	icon_state = "lpad-idle-o"
+	var/idle_state = "lpad-idle-o"
+	var/warmup_state = "lpad-idle"
+	var/sending_state = "lpad-beam"
+	var/cargo_hold_id
+
+/obj/machinery/selling_pad/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
+	if (istype(I))
+		to_chat(user, "<span class='notice'>You register [src] in [I]s buffer.</span>")
+		I.buffer = src
+		return TRUE
+
+/obj/machinery/computer/selling_pad_control
+	name = "cargo hold control terminal"
+	var/status_report = "Ready for delivery."
+	var/datum/weakref/pad
+	var/warmup_time = 100
+	var/sending = FALSE
+	var/datum/bank_account/sell_account
+	var/datum/export_report/total_report
+	var/sending_timer
+	var/cargo_hold_id
+
+/obj/machinery/computer/selling_pad_control/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/selling_pad_control/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	. = ..()
+	sell_account = port.current_ship?.ship_account
+
+/obj/machinery/computer/selling_pad_control/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
+	if (istype(I) && istype(I.buffer,/obj/machinery/selling_pad))
+		to_chat(user, "<span class='notice'>You link [src] with [I.buffer] in [I] buffer.</span>")
+		pad = WEAKREF(I.buffer)
+		return TRUE
+
+/obj/machinery/computer/selling_pad_control/LateInitialize()
+	. = ..()
+	if(cargo_hold_id)
+		for(var/obj/machinery/selling_pad/P in GLOB.machines)
+			if(P.cargo_hold_id == cargo_hold_id)
+				pad = P
+				return
+	else
+		var/obj/machinery/selling_pad/sell_pad = locate() in range(4,src)
+		pad = WEAKREF(sell_pad)
+
+/obj/machinery/computer/selling_pad_control/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CargoHoldTerminal", name)
+		ui.open()
+
+/obj/machinery/computer/selling_pad_control/ui_data(mob/user)
+	var/list/data = list()
+	data["points"] = sell_account.account_balance
+	data["pad"] = pad.resolve() ? TRUE : FALSE
+	data["sending"] = sending
+	data["status_report"] = status_report
+	return data
+
+/obj/machinery/computer/selling_pad_control/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	if(!pad.resolve())
+		return
+
+	switch(action)
+		if("recalc")
+			recalc()
+			. = TRUE
+		if("send")
+			start_sending()
+			. = TRUE
+		if("stop")
+			stop_sending()
+			. = TRUE
+
+/obj/machinery/computer/selling_pad_control/proc/recalc()
+	if(sending)
+		return
+	var/obj/machinery/selling_pad/sell_pad = pad.resolve()
+	if(!sell_pad)
+		return
+
+	status_report = "Predicted value: "
+	var/value = 0
+	var/datum/export_report/ex = new
+	for(var/atom/movable/AM in get_turf(sell_pad))
+		if(AM == sell_pad)
+			continue
+		export_item_and_contents(AM, apply_elastic = FALSE, dry_run = TRUE, external_report = ex)
+
+	for(var/datum/export/E in ex.total_amount)
+		status_report += E.total_printout(ex,notes = FALSE)
+		status_report += " "
+		value += ex.total_value[E]
+
+	if(!value)
+		status_report += "0"
+
+/obj/machinery/computer/selling_pad_control/proc/send()
+	if(!sending)
+		return
+
+	var/obj/machinery/selling_pad/sell_pad = pad.resolve()
+	if(!sell_pad)
+		return
+
+	var/datum/export_report/ex = new
+
+	for(var/atom/movable/AM in get_turf(sell_pad))
+		if(AM == sell_pad)
+			continue
+		export_item_and_contents(AM, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
+
+	status_report = "Sold: "
+	var/value = 0
+	for(var/datum/export/E in ex.total_amount)
+		var/export_text = E.total_printout(ex,notes = FALSE) //Don't want nanotrasen messages, makes no sense here.
+		if(!export_text)
+			continue
+
+		status_report += export_text
+		status_report += " "
+		value += ex.total_value[E]
+
+	if(!total_report)
+		total_report = ex
+	else
+		total_report.exported_atoms += ex.exported_atoms
+		for(var/datum/export/E in ex.total_amount)
+			total_report.total_amount[E] += ex.total_amount[E]
+			total_report.total_value[E] += ex.total_value[E]
+
+	sell_account.adjust_money(value)
+
+	if(!value)
+		status_report += "Nothing"
+
+	sell_pad.visible_message("<span class='notice'>[sell_pad] activates!</span>")
+	flick(sell_pad.sending_state,pad)
+	sell_pad.icon_state = sell_pad.idle_state
+	sending = FALSE
+
+/obj/machinery/computer/selling_pad_control/proc/start_sending()
+	if(sending)
+		return
+	var/obj/machinery/selling_pad/sell_pad = pad.resolve()
+	if(!sell_pad)
+		return
+	sending = TRUE
+	status_report = "Sending..."
+	sell_pad.visible_message("<span class='notice'>[pad] starts charging up.</span>")
+	sell_pad.icon_state = sell_pad.warmup_state
+	sending_timer = addtimer(CALLBACK(src,.proc/send),warmup_time, TIMER_STOPPABLE)
+
+/obj/machinery/computer/selling_pad_control/proc/stop_sending()
+	if(!sending)
+		return
+	var/obj/machinery/selling_pad/sell_pad = pad.resolve()
+	if(!sell_pad)
+		return
+	sending = FALSE
+	status_report = "Ready for delivery."
+	sell_pad.icon_state = sell_pad.idle_state
+	deltimer(sending_timer)

--- a/whitesands/code/modules/economy/selling_pad.dm
+++ b/whitesands/code/modules/economy/selling_pad.dm
@@ -2,7 +2,7 @@
 /obj/machinery/selling_pad
 	name = "cargo hold pad"
 	icon = 'icons/obj/telescience.dmi'
-	icon_state = "lpad-idle-o"
+	icon_state = "lpad"
 	circuit = /obj/item/circuitboard/machine/selling_pad
 
 /obj/machinery/selling_pad/multitool_act(mob/living/user, obj/item/multitool/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the selling pad and console, as well as fixes the express cargo console (which I never realized was broken until just now) for the purpose of basic trading. Not added on maps yet, will likely do before PR is merged

**CODE NOTE:** I made it so that all objects that are initialized in /area/ship areas run connect_to_shuttle() after init if they're not being loaded at map placement time. I think this will be good for consistency so that all ship-based things get it called so they do shuttle-specific initialization, but I don't know if it's good for performance/how connect_to_shuttle() was meant to be used. I have it done in a decently performant (I think) way by just checking the area for its mobile_port var, but I realize adding even one small thing to *every single atom's* init proc can really add up.

## Why It's Good For The Game
Honestly I don't think it is that good, since it'll reduce player dependency on each other for supplies, but at the moment it feels like this is somewhat needed just to make it so supplies *can* be replenished.

## Changelog
:cl:
add: Selling pads and their respective consoles to enable ship crews to sell unneeded or rare items and then purchase them with an express console.
fix: Express cargo consoles work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
