### PR TITLE
Update `check_regex.py`

### DIFF
--- a/tools/ci/check_regex.py
+++ b/tools/ci/check_regex.py
@@ -67,12 +67,12 @@ cases = [
     exactly(22, "world << uses", r'world[ \t]*<<'),
     exactly(0, "world.log << uses", r'world.log[ \t]*<<'),
 
-    exactly(945, "<< uses", r'(?<!<)<<(?!<)'),
+    exactly(946, "<< uses", r'(?<!<)<<(?!<)'),
     exactly(0, "incorrect indentations", r'^(?:  +)(?!\*)'),
     exactly(0, "superflous whitespace", r'[ \t]+$'),
     exactly(36, "mixed indentation", r'^( +\t+|\t+ +)'),
 
-    exactly(2242, "indentions inside #defines", r'^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))')
+    exactly(2243, "indentions inside #defines", r'^(\s*)#define (\w*)( {2,}| ?\t+)(?!(\/\/|\/\*))')
 ]
 # With the potential exception of << if you increase any
 # of these numbers you're probably doing it wrong


### PR DESCRIPTION
## About The Pull Request

A PR had added one more use of `<<` and one define with indentations between name and value. So the CI is failing because of it.

## Why It's Good For The Game

Make CI work again.

## Changelog
:cl:
/:cl: