### PR TITLE
Utility jumpskirt no longer covers legs.

### DIFF
--- a/whitesands/code/modules/clothing/under/misc.dm
+++ b/whitesands/code/modules/clothing/under/misc.dm
@@ -11,6 +11,7 @@
 /obj/item/clothing/under/utility/skirt //trolled.
 	name = "utility jumpskirt"
 	desc = "A somewhat uncomfortable suit designed to be as cheap as possible to manufacture. This one has a skirt."
+	body_parts_covered = CHEST|GROIN|ARMS
 	icon_state = "utility_skirt"
 	item_state = "utility_skirt"
 	can_adjust = FALSE


### PR DESCRIPTION
## About The Pull Request
Title. The utility jumpskirt no longer covers the legs. This allows digitigrade legs to properly show with it now.

## Why It's Good For The Game

Consistency with other skirts in regards to armor coverage and showing digitigrade legs.

## Changelog
:cl:
tweak: Utility jumpskirt no longer covers legs, allowing digitigrade legs to show while wearing them
/:cl:
