### PR TITLE
Fixes powernets going to war after a shuttle moves

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -329,9 +329,9 @@ All ShuttleMove procs go here
 	if(. & MOVE_AREA)
 		. |= MOVE_CONTENTS
 
-/obj/structure/cable/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
+/obj/structure/cable/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	cut_cable_from_powernet(FALSE)
+	powernet?.Destroy()
 
 /obj/structure/cable/lateShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -331,7 +331,7 @@ All ShuttleMove procs go here
 
 /obj/structure/cable/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	powernet?.Destroy()
+	qdel(powernet)
 
 /obj/structure/cable/lateShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Should fix powernets being stupid when a shuttle moves, so now machines and cables are all connected within about 15 seconds. (Machines reacting to their new powernet and APC overlay loading might take longer sometimes.)
This is not what I wanted to spend my evening doing.

## Why It's Good For The Game

I heard the issue was bad (#15)

## Changelog
:cl:
fix: fixes powernet jank at least somewhat
/:cl:
