### PR TITLE
Remove bat stunlock and make its knockback in space more reasonable.

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -579,7 +579,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "baseball_bat"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 10
+	force = 12
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 3.5)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -618,7 +618,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		homerun_ready = 0
 		return
 	else if(!target.anchored)
-		target.throw_at(throw_target, rand(1,2), 7, user)
+		target.throw_at(throw_target, rand(1,2), 2, user, gentle = TRUE)
 
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"


### PR DESCRIPTION
## About The Pull Request
Removes the ability for baseball bats to stun people when knocking them into walls or other people. Also reduces the speed of people knocked back by baseball bats to make it more manageable in space. To compensate baseball bat damage has been increased to 12 when it was previously 10. 

## Why It's Good For The Game
The stunlock from the baseball bat let players trap other players in a cycle of damage that they could not escape from, ensuring their demise. Additionally the high speed at which the baseball bat threw players in space both immediately removed them from fights and made it very hard for them to return to their spaceship.

## Changelog
:cl:
balance: The baseball bat is no longer capable of stunlocking and has had its knockback in space reduced to a more manageable level. To compensate, its damage has been slightly buffed from 10 to 12.
/:cl:
