### PR TITLE
`check_regex.py` - bitwise shifting update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ tools/LinuxOneShot/TGS_Logs
 # Common build tooling
 !/tools/build
 code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
+
+# tool-generated files
+check_regex_output.txt

--- a/tools/ci/check_regex.py
+++ b/tools/ci/check_regex.py
@@ -71,7 +71,7 @@ cases = [
     exactly(22, "world << uses", r'world[ \t]*<<'),
     exactly(0, "world.log << uses", r'world.log[ \t]*<<'),
 
-    exactly(946, "<< uses", r'(?<!<)<<(?!<)'),
+    exactly(305, "<< uses", r'(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)'),
     exactly(0, "incorrect indentations", r'^(?:  +)(?!\*)'),
     exactly(0, "superflous whitespace", r'[ \t]+$'),
     exactly(36, "mixed indentation", r'^( +\t+|\t+ +)'),


### PR DESCRIPTION
## About The Pull Request

Basically a mirroring an update I made at an other codebase using the same script: https://github.com/Haven-13/Haven-Urist/pull/72

>I noticed an issue with << uses would detect and add bitwise shifts to the matchings, when it was intended to find user << file and similar non-numerical/bitwise uses.


## Why It's Good For The Game

Less misleading CI. Developers and contributors may have better time.

## Changelog
:cl:
/:cl:
