### PR TITLE
Major IPC Fixes

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -247,6 +247,8 @@
 	return ..()
 
 /obj/item/organ/brain/mmi_holder/Insert(mob/living/carbon/C, special = 0, no_id_transfer = FALSE)
+	if(special)
+		return
 	if(!stored_mmi)
 		qdel(src)
 		return

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -235,9 +235,8 @@
 	icon_state = "brain-x"
 
 /obj/item/organ/brain/mmi_holder
-	name = "brain"
-	slot = "brain"
-	zone = "chest"
+	name = "positronic brain"
+	zone = BODY_ZONE_CHEST
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
 	remove_on_qdel = FALSE
@@ -248,72 +247,45 @@
 	return ..()
 
 /obj/item/organ/brain/mmi_holder/Insert(mob/living/carbon/C, special = 0, no_id_transfer = FALSE)
-	owner = C
-	C.internal_organs |= src
-	C.internal_organs_slot[slot] = src
-	loc = null
-	//the above bits are copypaste from organ/proc/Insert, because I couldn't go through the parent here.
-
 	if(!stored_mmi)
 		qdel(src)
-
-	if(istype(stored_mmi, /obj/item/mmi/posibrain) && stored_mmi.brainmob)
-		if(C.key)
-			C.ghostize()
-		var/mob/living/brain/B = stored_mmi.brainmob
-		if(stored_mmi.brainmob.mind)
-			B.mind.transfer_to(C)
-		else
-			C.key = B.key
-
-	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		if(H.dna && H.dna.species && (REVIVESBYHEALING in H.dna.species.species_traits))
-			if(H.health > 0 && !H.hellbound)
-				H.revive(0)
-
-	update_from_mmi()
-
-/obj/item/organ/brain/mmi_holder/Remove(var/mob/living/user, special = 0)
-	if(!special)
-		if(stored_mmi)
-			. = stored_mmi
-			if(owner.mind)
-				owner.mind.transfer_to(stored_mmi.brainmob)
-			stored_mmi.loc = owner.loc
-			if(stored_mmi.brainmob)
-				var/mob/living/brain/B = stored_mmi.brainmob
-				spawn(0)
-					if(B)
-						B.stat = 0
-			stored_mmi = null
-
-	..()
-	spawn(0)//so it can properly keep surgery going
-		qdel(src)
-
-/obj/item/organ/brain/mmi_holder/proc/update_from_mmi()
-	if(!stored_mmi)
 		return
-	name = stored_mmi.name
-	desc = stored_mmi.desc
-	icon = stored_mmi.icon
-	icon_state = stored_mmi.icon_state
+	brainmob = stored_mmi.brainmob
+	return ..()
 
-/obj/item/organ/brain/mmi_holder/posibrain/Initialize(var/obj/item/mmi/MMI)
+/obj/item/organ/brain/mmi_holder/Remove(mob/living/user, special = 0)
+	if(special)
+		return
+	if(!stored_mmi)
+		. = ..()
+		qdel(src)
+		return
+	stored_mmi.forceMove(get_turf(owner)) // so we can get the turf of the owner
+	..()
+	stored_mmi = null
+	qdel(src)
+
+/obj/item/organ/brain/mmi_holder/transfer_identity(mob/living/L)
 	. = ..()
-	if(MMI && istype(MMI, /obj/item/mmi/posibrain))
-		stored_mmi = MMI
-		MMI.forceMove(src)
+	brainmob.loc = null
+	brainmob.forceMove(stored_mmi) //moves the brainmob to the stored mmi
+	stored_mmi.set_brainmob(brainmob) //sets the mmi's brainmob to the current one
+	stored_mmi.name = "positronic brain ([L.real_name])"
+	stored_mmi.icon_state = "posibrain-occupied" //renames mmi and switches it to the "activated" icon
+	brainmob.container = stored_mmi
+	brainmob.set_stat(CONSCIOUS) //mmis are conscious
+	brainmob.remove_from_dead_mob_list()
+	brainmob.add_to_alive_mob_list() //mmis are technically alive I guess?
+	brainmob.reset_perspective() //resets perspective to the mmi
+	brainmob = null //clears the brainmob var so it doesn't get deleted when the holder is destroyed
+
+/obj/item/organ/brain/mmi_holder/posibrain/Initialize(mapload, obj/item/mmi/mmi)
+	. = ..()
+	if(mmi && istype(mmi))
+		stored_mmi = mmi
+		mmi.forceMove(src)
 	else
 		stored_mmi = new /obj/item/mmi/posibrain/ipc(src)
-	spawn(5)
-		if(owner && stored_mmi)
-			stored_mmi.name = "positronic brain ([owner.real_name])"
-			stored_mmi.brainmob.real_name = owner.real_name
-			stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
-			stored_mmi.icon_state = "posibrain-occupied"
-			update_from_mmi()
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -114,6 +114,14 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/carbon/attack_hand(mob/living/carbon/human/user)
 
+	for(var/datum/surgery/S in surgeries)
+		if(body_position != LYING_DOWN && S.lying_required)
+			continue
+		if(!S.self_operable && user == src)
+			continue
+		if(S.next_step(user, user.a_intent))
+			return TRUE
+
 	for(var/thing in diseases)
 		var/datum/disease/D = thing
 		if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -293,6 +293,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		var/obj/item/organ/oldorgan = C.getorganslot(slot) //used in removing
 		var/obj/item/organ/neworgan = slot_mutantorgans[slot] //used in adding
+
+		if(isnull(neworgan)) //If null is specified, just delete the old organ and call it a day
+			QDEL_NULL(oldorgan)
+			continue
+
 		var/used_neworgan = FALSE
 		neworgan = new neworgan()
 		var/should_have = neworgan.get_availability(src) //organ proc that points back to a species trait (so if the species is supposed to have this organ)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -153,6 +153,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	//Do NOT remove by setting to null. use OR make a RESPECTIVE TRAIT (removing stomach? add the NOSTOMACH trait to your species)
 	//why does it work this way? because traits also disable the downsides of not having an organ, removing organs but not having the trait will make your species die
+	//shut up you're not my mother
 
 	///Replaces default brain with a different organ
 	var/obj/item/organ/brain/mutantbrain = /obj/item/organ/brain

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -13,6 +13,7 @@
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
 	mutantlungs = null //no more collecting change for you
+	mutantappendix = null
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
@@ -47,9 +48,6 @@
 
 /datum/species/ipc/on_species_gain(mob/living/carbon/C) // Let's make that IPC actually robotic.
 	. = ..()
-	var/obj/item/organ/appendix/appendix = C.getorganslot("appendix") // Easiest way to remove it.
-	appendix.Remove(C)
-	QDEL_NULL(appendix)
 	if(ishuman(C) && !change_screen)
 		change_screen = new
 		change_screen.Grant(C)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -1,9 +1,9 @@
 /datum/species/ipc // im fucking lazy mk2 and cant get sprites to normally work
 	name = "IPC" //inherited from the real species, for health scanners and things
 	id = "ipc"
+	sexes = FALSE
 	say_mod = "states" //inherited from a user's real species
-	sexes = 0
-	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH,NO_BONES) //all of these + whatever we inherit from the real species
+	species_traits = list(AGENDER,NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH,NO_BONES) //all of these + whatever we inherit from the real species
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_LIMBATTACHMENT)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutantbrain = /obj/item/organ/brain/mmi_holder/posibrain
@@ -12,12 +12,13 @@
 	mutantliver = /obj/item/organ/liver/cybernetic/upgraded/ipc
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
+	mutantlungs = null //no more collecting change for you
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
 	meat = /obj/item/stack/sheet/plasteel{amount = 5}
 	skinned_type = /obj/item/stack/sheet/metal{amount = 10}
-	exotic_blood = "oil"
+	exotic_blood = /datum/reagent/fuel/oil
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
@@ -31,16 +32,13 @@
 	attack_sound = 'sound/items/trayhit1.ogg'
 	allow_numbers_in_name = TRUE
 	deathsound = "sound/voice/borg_deathsound.ogg"
-	var/saved_screen //for saving the screen when they die
-	var/list/initial_species_traits //for getting these values back for assume_disguise()
-	var/list/initial_inherent_traits
-	changesource_flags = MIRROR_BADMIN | WABBAJACK
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	loreblurb = "Integrated Positronic Chassis or \"IPC\" for short, are synthetic lifeforms composed of an Artificial \
 	Intelligence program encased in a bipedal robotic shell. They are fragile, allergic to EMPs, and the butt of endless toaster jokes. \
 	Just as easy to repair as they are to destroy, they might just get their last laugh in as you're choking on neurotoxins. Beep Boop."
 	ass_image = 'icons/ass/assmachine.png'
-
-
+	/// The last screen used when the IPC died.
+	var/saved_screen
 	var/datum/action/innate/change_screen/change_screen
 
 /datum/species/ipc/random_name(unique)
@@ -80,7 +78,11 @@
 	saved_screen = C.dna.features["ipc_screen"]
 	C.dna.features["ipc_screen"] = "BSOD"
 	C.update_body()
-	sleep(3 SECONDS)
+	addtimer(CALLBACK(src, .proc/post_death, C), 5 SECONDS)
+
+/datum/species/ipc/proc/post_death(mob/living/carbon/C)
+	if(C.stat < DEAD)
+		return
 	C.dna.features["ipc_screen"] = null // Turns off their monitor on death.
 	C.update_body()
 
@@ -163,16 +165,16 @@
 			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
 			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
 
+
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
 	H.dna.features["ipc_screen"] = "BSOD"
 	H.update_body()
 	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
-	sleep(3 SECONDS)
-	H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")
-	sleep(3 SECONDS)
-	H.say("Finalizing setup...")
-	sleep(3 SECONDS)
+	addtimer(CALLBACK(src, .proc/post_revival, H), 6 SECONDS)
+
+/datum/species/ipc/proc/post_revival(mob/living/carbon/human/H)
+	if(H.stat < DEAD)
+		return
 	H.say("Unit [H.real_name] is fully functional. Have a nice day.")
 	H.dna.features["ipc_screen"] = saved_screen
 	H.update_body()
-	return

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -236,6 +236,10 @@
 			update_disabled()
 		if(updating_health)
 			owner.updatehealth()
+		if(owner.dna?.species && (REVIVESBYHEALING in owner.dna.species.species_traits))
+			if(owner.health > 0 && !owner.hellbound)
+				owner.revive(FALSE)
+				owner.cure_husk() // If it has REVIVESBYHEALING, it probably can't be cloned. No husk cure.
 	cremation_progress = min(0, cremation_progress - ((brute_dam + burn_dam)*(100/max_damage)))
 	return update_bodypart_damage_state()
 

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -68,7 +68,7 @@
 	time = 64
 	name = "manipulate organs"
 	repeatable = TRUE
-	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100)
+	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100, /obj/item/mmi = 100)
 	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 35)
 	var/current_type
 	var/obj/item/organ/I = null
@@ -107,6 +107,7 @@
 	if(istype(tool, /obj/item/mmi))//this whole thing is only used for robotic surgery in organ_mani_robotic.dm :*
 		current_type = "posibrain"
 		var/obj/item/bodypart/affected = target.get_bodypart(check_zone(target_zone))
+		var/obj/item/mmi/P = tool
 		if(!affected)
 			return -1
 		if(affected.status != ORGAN_ROBOTIC)
@@ -121,15 +122,8 @@
 		if(target.internal_organs_slot[ORGAN_SLOT_BRAIN])
 			to_chat(user, "<span class='notice'>[target] already has a brain! You'd rather not find out what would happen with two in there.</span>")
 			return -1
-		var/obj/item/mmi/P = tool
-		if(!istype(P))
-			return -1
 		if(!P.brainmob || !P.brainmob.client)
 			to_chat(user, "<span class='notice'>[tool] has no life in it, this would be pointless!</span>")
-			return -1
-		var/obj/item/organ/meatslab = tool
-		if(!meatslab.useable)
-			to_chat(user, "<span class='warning'>[I] seems to have been chewed on, you can't use this!</span>")
 			return -1
 
 	//WS End
@@ -166,18 +160,12 @@
 
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	if(current_type == "posibrain")
-		if(istype(tool, /obj/item/organ_storage))
-			tool.icon_state = "evidenceobj"
-			tool.desc = "A container for holding body parts."
-			tool.cut_overlays()
-			tool = tool.contents[1]
-
-		user.temporarilyRemoveItemFromInventory(tool)
-		spawn(1)
-			I = new /obj/item/organ/brain/mmi_holder/posibrain(tool)
-			I.Insert(target)
-			user.visible_message("<span class='notice'>[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!</span>",
-				"<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>")
+		user.temporarilyRemoveItemFromInventory(tool, TRUE)
+		I = new /obj/item/organ/brain/mmi_holder/posibrain(null, tool)
+		I.Insert(target)
+		display_results(user, target, "<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'>[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!</span>",
+			"<span class='notice'>[user] inserts something into [target]'s [parse_zone(target_zone)]!</span>")
 
 	else if(current_type == "insert")
 		if(istype(tool, /obj/item/organ_storage))

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -71,32 +71,32 @@
 	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100, /obj/item/mmi = 100)
 	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 35)
 	var/current_type
-	var/obj/item/organ/I = null
+	var/obj/item/organ/manipulated_organ = null
 
 /datum/surgery_step/manipulate_organs/New()
 	..()
 	implements = implements + implements_extract
 
 /datum/surgery_step/manipulate_organs/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	I = null
+	manipulated_organ = null
 	if(istype(tool, /obj/item/organ_storage))
 		if(!tool.contents.len)
 			to_chat(user, "<span class='warning'>There is nothing inside [tool]!</span>")
 			return -1
-		I = tool.contents[1]
-		if(!isorgan(I))
-			to_chat(user, "<span class='warning'>You cannot put [I] into [target]'s [parse_zone(target_zone)]!</span>")
+		manipulated_organ = tool.contents[1]
+		if(!isorgan(manipulated_organ))
+			to_chat(user, "<span class='warning'>You cannot put [manipulated_organ] into [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
-		tool = I
+		tool = manipulated_organ
 	if(isorgan(tool))
 		current_type = "insert"
-		I = tool
-		if(target_zone != I.zone || target.getorganslot(I.slot))
-			to_chat(user, "<span class='warning'>There is no room for [I] in [target]'s [parse_zone(target_zone)]!</span>")
+		manipulated_organ = tool
+		if(target_zone != manipulated_organ.zone || target.getorganslot(manipulated_organ.slot))
+			to_chat(user, "<span class='warning'>There is no room for [manipulated_organ] in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
 		var/obj/item/organ/meatslab = tool
 		if(!meatslab.useable)
-			to_chat(user, "<span class='warning'>[I] seems to have been chewed on, you can't use this!</span>")
+			to_chat(user, "<span class='warning'>[manipulated_organ] seems to have been chewed on, you can't use this!</span>")
 			return -1
 		display_results(user, target, "<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>",
 			"<span class='notice'>[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
@@ -107,7 +107,7 @@
 	if(istype(tool, /obj/item/mmi))//this whole thing is only used for robotic surgery in organ_mani_robotic.dm :*
 		current_type = "posibrain"
 		var/obj/item/bodypart/affected = target.get_bodypart(check_zone(target_zone))
-		var/obj/item/mmi/P = tool
+		var/obj/item/mmi/target_mmi = tool
 		if(!affected)
 			return -1
 		if(affected.status != ORGAN_ROBOTIC)
@@ -122,7 +122,7 @@
 		if(target.internal_organs_slot[ORGAN_SLOT_BRAIN])
 			to_chat(user, "<span class='notice'>[target] already has a brain! You'd rather not find out what would happen with two in there.</span>")
 			return -1
-		if(!P.brainmob || !P.brainmob.client)
+		if(!target_mmi.brainmob || !target_mmi.brainmob.client)
 			to_chat(user, "<span class='notice'>[tool] has no life in it, this would be pointless!</span>")
 			return -1
 
@@ -147,13 +147,13 @@
 				organs -= O
 				organs[O.name] = O
 
-			I = input("Remove which organ?", "Surgery", null, null) as null|anything in sortList(organs)
-			if(I && user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
-				I = organs[I]
-				if(!I)
+			manipulated_organ = input("Remove which organ?", "Surgery", null, null) as null|anything in sortList(organs)
+			if(manipulated_organ && user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
+				manipulated_organ = organs[manipulated_organ]
+				if(!manipulated_organ)
 					return -1
-				display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [parse_zone(target_zone)]...</span>",
-					"<span class='notice'>[user] begins to extract [I] from [target]'s [parse_zone(target_zone)].</span>",
+				display_results(user, target, "<span class='notice'>You begin to extract [manipulated_organ] from [target]'s [parse_zone(target_zone)]...</span>",
+					"<span class='notice'>[user] begins to extract [manipulated_organ] from [target]'s [parse_zone(target_zone)].</span>",
 					"<span class='notice'>[user] begins to extract something from [target]'s [parse_zone(target_zone)].</span>")
 			else
 				return -1
@@ -161,23 +161,23 @@
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	if(current_type == "posibrain")
 		user.temporarilyRemoveItemFromInventory(tool, TRUE)
-		I = new /obj/item/organ/brain/mmi_holder/posibrain(null, tool)
-		I.Insert(target)
+		manipulated_organ = new /obj/item/organ/brain/mmi_holder/posibrain(null, tool)
+		manipulated_organ.Insert(target)
 		display_results(user, target, "<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'>[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!</span>",
 			"<span class='notice'>[user] inserts something into [target]'s [parse_zone(target_zone)]!</span>")
 
 	else if(current_type == "insert")
 		if(istype(tool, /obj/item/organ_storage))
-			I = tool.contents[1]
+			manipulated_organ = tool.contents[1]
 			tool.icon_state = initial(tool.icon_state)
 			tool.desc = initial(tool.desc)
 			tool.cut_overlays()
-			tool = I
+			tool = manipulated_organ
 		else
-			I = tool
-		user.temporarilyRemoveItemFromInventory(I, TRUE)
-		I.Insert(target)
+			manipulated_organ = tool
+		user.temporarilyRemoveItemFromInventory(manipulated_organ, TRUE)
+		manipulated_organ.Insert(target)
 		display_results(user, target, "<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'>[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!</span>",
 			"<span class='notice'>[user] inserts something into [target]'s [parse_zone(target_zone)]!</span>")
@@ -192,13 +192,13 @@
 			B.leave_victim()
 			return FALSE
 		//WS end
-		if(I && I.owner == target)
-			display_results(user, target, "<span class='notice'>You successfully extract [I] from [target]'s [parse_zone(target_zone)].</span>",
-				"<span class='notice'>[user] successfully extracts [I] from [target]'s [parse_zone(target_zone)]!</span>",
+		if(manipulated_organ && manipulated_organ.owner == target)
+			display_results(user, target, "<span class='notice'>You successfully extract [manipulated_organ] from [target]'s [parse_zone(target_zone)].</span>",
+				"<span class='notice'>[user] successfully extracts [manipulated_organ] from [target]'s [parse_zone(target_zone)]!</span>",
 				"<span class='notice'>[user] successfully extracts something from [target]'s [parse_zone(target_zone)]!</span>")
-			log_combat(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
-			I.Remove(target)
-			I.forceMove(get_turf(target))
+			log_combat(user, target, "surgically removed [manipulated_organ.name] from", addition="INTENT: [uppertext(user.a_intent)]")
+			manipulated_organ.Remove(target)
+			manipulated_organ.forceMove(get_turf(target))
 		else
 			display_results(user, target, "<span class='warning'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>",
 				"<span class='notice'>[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Half of me was brought to a more peaceful state knowing I for the most part corrected the error I did long ago in porting these... things. The other half of me just feels like [this](https://pastebin.com/xncDbUbU).

![image](https://user-images.githubusercontent.com/29362068/131444306-25d080f8-0b2d-4277-9d27-d192e1464ca0.png)
I despise you.

Fixes a bunch of fundamental IPC bugs as well as a related general surgery bug.

Fixes: #112

## Why It's Good For The Game
Hopefully makes IPCs actually playable

## Changelog
:cl:
fix: IPCs no longer have useless lungs.
fix: IPC brains can now be removed as posibrains and then any posibrain can be stuck into an IPC body. Like it was supposed to a year ago.
fix: You can actually revive IPCs by healing them above 0 health.
fix: You can actually do surgery steps that require an empty hand on carbons again.
fix: aheals no longer ghost you
tweak: IPCs actually have oil blood now. Probably.
code: You can now set mutantorgans to `null` to just not give the species an organ there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
