### PR TITLE
Runtime Indexing and Counting

### DIFF
--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -86,7 +86,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		var/datum/error_viewer/error_source/error_source
 		for (var/erroruid in error_sources)
 			error_source = error_sources[erroruid]
-			html += "[error_source.make_link(null, src)]<br>"
+			html += "[error_source.make_link("([length(error_source.errors)] errors) [error_source.name]", src)]<br>"
 
 	else
 		html += "[make_link("organized", null)] | linear<hr>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the total count of each specific runtime type that has occurred to the runtime viewer's "organized" view mode

![image](https://user-images.githubusercontent.com/29362068/131745224-1eba02f9-86ad-4ab7-a488-e4fa9d4fc8dc.png)

## Why It's Good For The Game
Makes it easy to find runtimes that only occur like once versus ones that occur 4,000 times

## Changelog
:cl:
admin: The runtime viewer now shows how many of a specific runtime have occurred
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
