### PR TITLE
fix local playsounds falloff

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -173,7 +173,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 			S.y = dy
 		else
 			S.y = 1	//To make sure the mono sound doesn't make you feel like you're dying.
-		S.falloff = max_distance || 0 //use max_distance, else just use 0 as we are a direct sound so falloff isnt relevant.
+		S.falloff = max_distance || 1
 
 		if(S.environment == SOUND_ENVIRONMENT_NONE)
 			if(sound_environment_override != SOUND_ENVIRONMENT_NONE)


### PR DESCRIPTION
## About The Pull Request

Fixes local_playsound falloff. Instruments didn't specify a max_distance for the sound to play so it defaults to zero and doesn't play unless you're on the exact turf as the instrument

## Why It's Good For The Game

featuring bugs from the WhiteSands codebase
i must listen to among us trap remix

## Changelog
:cl:
fix: Fixed musical instruments only playing sound on the turf they're in
/:cl: