### PR TITLE
Cricket mapping patch

### DIFF
--- a/_maps/configs/cricket.json
+++ b/_maps/configs/cricket.json
@@ -1,19 +1,18 @@
 {
-	"map_name": "Solgov-issue Cricket Scout",
+	"map_name": "Cricket-Class Solgov Intel Scout",
 	"map_short_name": "Solgov Cricket",
 	"map_path": "_maps/shuttles/shiptest/solgov_cricket.dmm",
 	"map_id" : "solgov_cricket",
 	"job_slots": {
 		"Captain": 1,
 		"SolGov Representative": 1,
-		"Medical Doctor": 1,
 		"Chemist": 1,
 		"Station Engineer": 2,
 		"Shaft Miner": 2,
-		"Cargo Technician": 2,
+		"Cargo Technician": 1,
 		"Security Officer": 1,
 		"Cook": 1,
 		"Assistant": 3
 	},
-	"cost": 860
+	"cost": 780
 }

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -1209,11 +1209,7 @@
 /area/ship/crew/dorm)
 "oN" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/suit_storage_unit/open,
-/obj/item/clothing/suit/space/solgov,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/solgov,
+/obj/machinery/suit_storage_unit/solgov,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
 "oY" = (
@@ -3492,6 +3488,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Qy" = (
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "QF" = (

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -576,7 +576,7 @@
 /area/ship/hallway/port)
 "gz" = (
 /obj/machinery/door/airlock/solgov{
-	name = "Solgov Office"
+	name = "SolGov Office"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1500,7 +1500,7 @@
 /area/ship/engineering/engine)
 "rK" = (
 /obj/structure/closet/wall{
-	name = "Solgov fatigues closet";
+	name = "SolGov fatigues closet";
 	pixel_y = 32
 	},
 /obj/item/clothing/under/solgov/formal,

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -28,6 +28,7 @@
 	dir = 4
 	},
 /obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/eastright,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "az" = (
@@ -62,6 +63,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
+/obj/item/storage/bag/chemistry,
 /obj/item/healthanalyzer{
 	pixel_x = 4
 	},
@@ -109,10 +111,10 @@
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
-/obj/item/storage/box/beakers/variety,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/syringe/charcoal,
 /obj/effect/turf_decal/lumos/tile/blue/fulltile,
+/obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "bg" = (
@@ -210,6 +212,11 @@
 "cx" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "cC" = (
@@ -219,6 +226,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
+/obj/structure/chair/plastic,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "cE" = (
@@ -226,6 +234,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/storage/overmap_ship{
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "cI" = (
@@ -233,6 +244,7 @@
 /obj/structure/fluff/paper/corner,
 /obj/item/clothing/neck/cloak/qm,
 /obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/item/storage/bag/trash,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "cO" = (
@@ -245,10 +257,20 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "cR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -268,6 +290,9 @@
 /obj/effect/turf_decal/lumos/tile/blue/half{
 	dir = 1
 	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "dn" = (
@@ -279,6 +304,27 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/engine)
+"dv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/supplypod_beacon,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"dz" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 4;
+	name = "External to Filter"
+	},
+/turf/open/floor/plasteel,
+/area/ship/engineering/atmospherics)
 "dI" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -287,6 +333,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "dW" = (
@@ -296,6 +344,15 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"ea" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/window/plasma/reinforced/spawner/north,
+/obj/machinery/door/window/eastleft,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "eh" = (
@@ -340,11 +397,18 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "eB" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
+	dir = 8
+	},
+/obj/item/oar,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = -24
+	},
+/obj/structure/closet/emcloset/wall{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
@@ -369,6 +433,18 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"eH" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/north,
+/obj/machinery/door/window/eastleft,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "eT" = (
@@ -399,6 +475,15 @@
 	},
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
+"fl" = (
+/obj/machinery/mineral/ore_redemption{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "fn" = (
 /obj/machinery/computer/monitor{
 	dir = 1
@@ -444,14 +529,9 @@
 /area/ship/engineering/engine)
 "fC" = (
 /obj/machinery/smartfridge/chemistry,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ship/medical)
-"fF" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "fI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -468,6 +548,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/start/lieutenant,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/solgov)
 "fS" = (
@@ -494,7 +575,9 @@
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
 "gz" = (
-/obj/machinery/door/airlock/solgov,
+/obj/machinery/door/airlock/solgov{
+	name = "Solgov Office"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -514,8 +597,18 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/solgov)
+"gK" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/aft)
 "gP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -552,6 +645,11 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "hv" = (
@@ -637,6 +735,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
+"hV" = (
+/obj/effect/turf_decal/lumos/tile/brown/half,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "hW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -668,6 +770,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "io" = (
@@ -677,14 +785,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
@@ -720,14 +825,14 @@
 "jc" = (
 /obj/structure/table,
 /obj/machinery/microwave,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "jf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -886,35 +991,21 @@
 /turf/open/floor/carpet/nanoweave/orange,
 /area/ship/hallway/aft)
 "lH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/carpet/nanoweave/orange,
-/area/ship/hallway/aft)
-"lY" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/hallway/aft)
 "ma" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
@@ -982,9 +1073,8 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
@@ -1061,6 +1151,11 @@
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/cloth/fancy,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
 /turf/open/floor/plating,
 /area/ship/crew/solgov)
 "oo" = (
@@ -1074,6 +1169,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
@@ -1090,7 +1188,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm)
 "oz" = (
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1109,7 +1209,11 @@
 /area/ship/crew/dorm)
 "oN" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/suit_storage_unit/open,
+/obj/item/clothing/suit/space/solgov,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/solgov,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
 "oY" = (
@@ -1189,7 +1293,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "pn" = (
-/obj/machinery/door/airlock/grunge,
+/obj/machinery/door/airlock/grunge{
+	name = "Telecommunications"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1218,6 +1324,7 @@
 /area/ship/cargo)
 "pC" = (
 /obj/structure/ore_box,
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "pI" = (
@@ -1258,6 +1365,7 @@
 /obj/structure/closet/cardboard,
 /obj/item/cigbutt/cigarbutt,
 /obj/item/toy/plush/snakeplushie,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "qr" = (
@@ -1282,8 +1390,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "qL" = (
@@ -1300,7 +1413,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "qT" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
@@ -1331,10 +1444,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -1348,12 +1457,25 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet/nanoweave/orange,
 /area/ship/hallway/aft)
+"rm" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/window/eastleft,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "rp" = (
 /obj/structure/lattice,
 /obj/structure/lattice/catwalk,
@@ -1361,33 +1483,55 @@
 /turf/template_noop,
 /area/ship/external)
 "rG" = (
-/obj/machinery/vending/autodrobe/all_access,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/chair/comfy/teal,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "rI" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "rK" = (
-/obj/machinery/vending/clothing,
+/obj/structure/closet/wall{
+	name = "Solgov fatigues closet";
+	pixel_y = 32
+	},
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov/elite,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/suit/toggle/solgov,
+/obj/item/clothing/suit/solgov_trenchcoat,
+/obj/item/clothing/head/beret/solgov,
+/obj/item/clothing/head/beret/solgov,
+/obj/item/clothing/head/beret/solgov/plain,
+/obj/item/clothing/head/beret/solgov/plain,
+/obj/item/clothing/head/beret/solgov/plain,
+/obj/item/clothing/accessory/waistcoat/solgov,
+/obj/item/clothing/accessory/waistcoat/solgov,
+/obj/item/radio/headset/solgov,
+/obj/item/radio/headset/solgov,
+/obj/item/radio/headset/solgov,
+/obj/item/radio/headset/solgov,
+/obj/item/radio/headset/solgov,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "rM" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/structure/mopbucket,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "rN" = (
@@ -1442,19 +1586,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
 "sA" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/hallway/aft)
 "sF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1483,10 +1622,11 @@
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/hallway/fore)
 "ta" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
+/mob/living/simple_animal/pet/fox/Renault,
+/obj/structure/bed/dogbed/renault,
 /turf/open/floor/wood,
 /area/ship/crew/solgov)
 "tg" = (
@@ -1529,17 +1669,12 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/ship/engineering)
-"tT" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
-	dir = 8
-	},
-/obj/item/oar,
-/turf/open/floor/plasteel/dark,
-/area/ship/hallway/aft)
 "tV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "ua" = (
 /obj/structure/table,
@@ -1565,7 +1700,7 @@
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "up" = (
 /obj/machinery/vending/coffee,
@@ -1580,6 +1715,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "uy" = (
@@ -1615,9 +1753,6 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "uF" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/power/terminal{
 	dir = 4
@@ -1625,7 +1760,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/box,
+/obj/machinery/selling_pad,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "uM" = (
 /turf/open/floor/wood,
@@ -1659,11 +1796,15 @@
 /area/ship/engineering/communications)
 "vb" = (
 /obj/machinery/iv_drip,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "vc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
@@ -1718,7 +1859,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "vV" = (
 /obj/structure/railing,
@@ -1761,10 +1902,19 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/button/door{
+	id = "sgwindowshut";
+	name = "External Window Shutters";
+	pixel_x = 6;
+	pixel_y = 30
+	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "ws" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -1778,6 +1928,11 @@
 "wM" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
 /turf/open/floor/plating,
 /area/ship/bridge)
 "wS" = (
@@ -1795,13 +1950,16 @@
 /area/ship/engineering/atmospherics)
 "xd" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "xi" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "xy" = (
 /obj/machinery/vending/cola/random,
@@ -1836,7 +1994,9 @@
 /turf/open/floor/eighties,
 /area/ship/crew/dorm)
 "yq" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	name = "server room airlock"
+	},
 /obj/effect/turf_decal/lumos/tile/blue/checker,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/fans/tiny,
@@ -1863,6 +2023,9 @@
 "yU" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "yX" = (
@@ -1881,7 +2044,6 @@
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/hallway/fore)
 "yZ" = (
-/obj/machinery/door/airlock/command,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1896,6 +2058,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge"
 	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
@@ -1921,6 +2086,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad/emergency/command,
+/obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "zk" = (
@@ -1940,6 +2106,7 @@
 /obj/item/radio/intercom/wideband,
 /obj/item/newspaper,
 /obj/item/megaphone/command,
+/obj/item/radio/headset/solgov/alt,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "zo" = (
@@ -1972,6 +2139,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "zH" = (
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "zI" = (
@@ -2180,7 +2350,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "Cb" = (
-/obj/machinery/door/airlock/medical,
+/obj/machinery/door/airlock/medical{
+	name = "Infirmary"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2192,6 +2364,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/blue/fulltile,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Cc" = (
@@ -2207,7 +2380,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "Co" = (
 /obj/structure/extinguisher_cabinet,
@@ -2272,6 +2445,9 @@
 /area/ship/engineering/communications)
 "CV" = (
 /obj/machinery/vending/boozeomat/all_access,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "Da" = (
@@ -2349,7 +2525,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/lumos/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Eo" = (
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner,
@@ -2366,16 +2545,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/item/toy/plush/spider,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Er" = (
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow{
+	pixel_x = -4;
 	pixel_y = 8
 	},
 /obj/item/clothing/gloves/color/fyellow{
-	pixel_y = 4
+	pixel_x = 4
 	},
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -2431,8 +2615,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = -32
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -2440,7 +2624,9 @@
 /turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "FI" = (
-/obj/machinery/atmospherics/components/binary/valve/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "FJ" = (
@@ -2491,6 +2677,9 @@
 /area/ship/hallway/aft)
 "GD" = (
 /obj/machinery/vending/mining_equipment,
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "GK" = (
@@ -2561,26 +2750,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer2,
 /obj/machinery/door/window/westright,
 /obj/structure/window/reinforced/spawner,
+/obj/machinery/atmospherics/components/binary/pump/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
-"Hl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/nanoweave/beige,
-/area/ship/hallway/starboard)
 "Hy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2658,6 +2832,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/starboard)
 "HX" = (
@@ -2731,6 +2908,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/starboard)
 "IH" = (
@@ -2747,7 +2925,10 @@
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/starboard)
 "IQ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
 "IR" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -2755,11 +2936,20 @@
 "Ji" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Jk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
+	name = "Air to Distro";
 	target_pressure = 480
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -2770,26 +2960,25 @@
 /area/ship/engineering/atmospherics)
 "Jo" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Jz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/valve/on/layer4{
-	dir = 4
-	},
 /obj/machinery/camera/autoname{
 	dir = 1;
 	network = list("cricket")
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 8;
+	name = "Waste to Filter"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -2866,7 +3055,7 @@
 /area/ship/crew/solgov)
 "Ky" = (
 /obj/effect/decal/cleanable/generic,
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "KG" = (
@@ -2886,15 +3075,20 @@
 	},
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/starboard)
-"KP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"KT" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
 	},
-/turf/open/floor/carpet/nanoweave/beige,
-/area/ship/hallway/starboard)
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/eastleft,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "KU" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/hallway/aft)
 "Lb" = (
 /obj/structure/fluff/paper,
@@ -2914,6 +3108,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/starboard)
@@ -2966,6 +3163,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "MN" = (
@@ -2981,11 +3181,16 @@
 	},
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
-"MX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"MO" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/window/eastright,
+/turf/open/floor/plating,
 /area/ship/engineering/engine)
 "MY" = (
 /obj/structure/table,
@@ -2999,6 +3204,9 @@
 	dir = 1;
 	network = list("cricket")
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "Nb" = (
@@ -3008,8 +3216,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/item/storage/overmap_ship{
-	pixel_x = -22
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
@@ -3021,7 +3229,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
 "Ny" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Bay"
+	},
 /obj/effect/turf_decal/lumos/tile/yellow/half,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3039,12 +3249,20 @@
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "NG" = (
-/obj/machinery/vending/snack/random,
 /obj/machinery/camera/autoname{
 	network = list("cricket")
 	},
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/hallway/port)
+"NQ" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "NZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3068,17 +3286,14 @@
 /obj/effect/decal/cleanable/squid_ink,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"Ol" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/storage)
 "Ou" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/gibber,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "Ov" = (
@@ -3109,6 +3324,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "OO" = (
@@ -3120,6 +3338,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/stamp/qm,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "OR" = (
@@ -3127,23 +3346,21 @@
 /obj/machinery/door/window/northright,
 /obj/item/clipboard,
 /obj/item/multitool,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "sgcargodesk"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "OU" = (
-/obj/machinery/mineral/ore_redemption{
-	dir = 1;
-	input_dir = 2;
-	output_dir = 1
-	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/machinery/autolathe,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgcargodesk"
+	},
+/obj/effect/turf_decal/lumos/tile/brown/fulltile,
+/turf/open/floor/plasteel,
 /area/ship/cargo)
 "OY" = (
 /obj/structure/cable{
@@ -3163,7 +3380,9 @@
 /turf/template_noop,
 /area/ship/external)
 "Ph" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3175,6 +3394,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "Px" = (
@@ -3185,7 +3407,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo)
 "PJ" = (
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	name = "Brig"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3201,12 +3425,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
-"PM" = (
-/obj/machinery/door_timer{
-	id = "sgbrig"
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security)
 "PN" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -3216,7 +3434,7 @@
 /area/ship/security)
 "PO" = (
 /obj/machinery/door/window/brigdoor/security/cell/westleft{
-	id = "sgbrig"
+	id = "Holding Cell"
 	},
 /obj/effect/turf_decal/lumos/tile/red/half{
 	dir = 4
@@ -3232,6 +3450,10 @@
 "PU" = (
 /obj/effect/turf_decal/lumos/tile/red/checker,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/flasher{
+	id = "Holding Cell";
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Qf" = (
@@ -3241,6 +3463,9 @@
 "Qm" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3261,21 +3486,12 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Qw" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Qy" = (
-/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "QF" = (
@@ -3293,6 +3509,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
@@ -3313,19 +3532,25 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
-/obj/machinery/light,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light,
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner,
+/obj/item/radio/intercom{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "QT" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "Re" = (
@@ -3346,7 +3571,9 @@
 	pixel_y = 26
 	},
 /obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "Rj" = (
@@ -3361,6 +3588,7 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/storage/bag/construction,
 /obj/item/storage/box/stockparts/basic{
 	pixel_x = 2;
 	pixel_y = 6
@@ -3371,6 +3599,9 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 27
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "Rn" = (
@@ -3378,6 +3609,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/tool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "Rr" = (
@@ -3389,6 +3623,9 @@
 /obj/effect/turf_decal/lumos/tile/yellow/fullcorner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "Rz" = (
@@ -3396,6 +3633,9 @@
 	id = "sgengistore"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "RA" = (
@@ -3422,6 +3662,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "sgkitchen"
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "RH" = (
@@ -3437,11 +3680,11 @@
 /area/ship/engineering/engine)
 "RK" = (
 /obj/effect/decal/cleanable/oil/streak,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
@@ -3456,6 +3699,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "RQ" = (
@@ -3467,6 +3713,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/glowstick,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "Sa" = (
@@ -3479,6 +3728,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "Sm" = (
@@ -3487,6 +3739,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "sgkitchen"
+	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
@@ -3500,6 +3755,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
@@ -3519,6 +3777,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "Sx" = (
@@ -3527,6 +3791,15 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -3543,7 +3816,26 @@
 /obj/machinery/button/door{
 	id = "sgcargodesk";
 	name = "Cargo Desk Shutter";
+	pixel_x = 10;
 	pixel_y = 22
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"Te" = (
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -3556,6 +3848,10 @@
 	pixel_y = -32
 	},
 /obj/item/ammo_box/magazine/co9mm,
+/obj/item/desk_flag/solgov{
+	pixel_x = 12;
+	pixel_y = -6
+	},
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/security)
 "To" = (
@@ -3566,6 +3862,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "TG" = (
@@ -3574,28 +3873,43 @@
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = 8
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "TJ" = (
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "TM" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/lumos/tile/brown/half{
 	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "TV" = (
-/obj/machinery/autolathe,
+/obj/machinery/computer/cargo/express{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "TW" = (
@@ -3628,10 +3942,18 @@
 /obj/machinery/camera/autoname{
 	network = list("cricket")
 	},
+/obj/machinery/door_timer{
+	id = "Holding Cell";
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/security)
 "TZ" = (
 /obj/structure/closet/secure_closet/lieutenant,
+/obj/item/taperecorder,
+/obj/item/clothing/neck/petcollar,
+/obj/item/pet_carrier,
+/obj/item/radio/headset/solgov/alt,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/solgov)
 "Um" = (
@@ -3672,6 +3994,9 @@
 /obj/item/reagent_containers/glass/rag,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/kitchen/knife,
+/obj/effect/turf_decal/lumos/tile/bar/checker{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ship/crew/canteen)
 "UP" = (
@@ -3824,14 +4149,21 @@
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "Xl" = (
+/obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "Xo" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/cans/sixsoda,
 /turf/open/floor/plasteel/checker,
 /area/ship/storage)
 "Xv" = (
 /obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/lumos/tile/brown/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "XD" = (
@@ -3883,20 +4215,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "YJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/lumos/tile/brown/half,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "YL" = (
-/obj/machinery/ore_silo,
 /obj/machinery/camera/autoname{
 	dir = 8;
 	network = list("cricket")
 	},
+/obj/machinery/computer/selling_pad_control{
+	dir = 8
+	},
+/obj/effect/turf_decal/lumos/tile/brown/fullcorner,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "YP" = (
@@ -3910,13 +4247,25 @@
 /area/ship/security)
 "YS" = (
 /obj/structure/chair/office,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/security)
 "YU" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/medical)
+"Zf" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/ship/hallway/port)
 "Zh" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/suit/armor/vest/solgov/rep{
+	name = "\proper slim SolGov armor vest"
+	},
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/head/beret/solgov,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/security)
 "Zj" = (
@@ -3932,6 +4281,11 @@
 "Zp" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "Zq" = (
@@ -3959,6 +4313,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
+"ZU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/external)
 "ZV" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
@@ -3991,10 +4351,10 @@ zR
 "}
 (2,1,1) = {"
 ZV
-ay
-ay
-dI
-dI
+KT
+NQ
+eH
+MO
 yC
 gP
 ky
@@ -4006,11 +4366,11 @@ ky
 ky
 ky
 ky
-WU
+ZU
 yC
+rm
 dI
-dI
-ay
+ea
 ay
 ZV
 zR
@@ -4058,7 +4418,7 @@ zx
 BL
 DR
 kz
-BR
+dz
 MC
 Qv
 UY
@@ -4085,8 +4445,8 @@ BO
 Jk
 Fp
 Jo
-MX
-Qw
+yC
+aI
 Vp
 AE
 rN
@@ -4176,7 +4536,7 @@ Dd
 yC
 OY
 GK
-fF
+yC
 yC
 kz
 lw
@@ -4254,10 +4614,10 @@ Mz
 BX
 Hk
 eB
-tT
 QG
+gK
 in
-lY
+QG
 oy
 oD
 oD
@@ -4318,8 +4678,8 @@ zU
 CK
 oD
 jf
-KP
-Ol
+LC
+Od
 RK
 WR
 vb
@@ -4479,7 +4839,7 @@ OK
 Sx
 XE
 az
-To
+hV
 cx
 zR
 "}
@@ -4504,7 +4864,7 @@ LV
 OI
 ST
 XV
-pC
+To
 pC
 cx
 zR
@@ -4528,9 +4888,9 @@ mU
 Ig
 LC
 OO
-To
-XV
-To
+Te
+dv
+fl
 QJ
 OI
 WU
@@ -4551,8 +4911,8 @@ yR
 AR
 Dg
 np
-Hl
-KP
+HE
+LC
 OR
 TJ
 YE
@@ -4621,7 +4981,7 @@ YU
 wd
 Mg
 jR
-pf
+Zf
 qd
 tg
 vV
@@ -4683,7 +5043,7 @@ qd
 qd
 IR
 Mv
-PM
+Mw
 TY
 YS
 Tj

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -131,6 +131,13 @@
 	helmet_type = /obj/item/clothing/head/radiation
 	storage_type = /obj/item/geiger_counter
 
+/obj/machinery/suit_storage_unit/solgov
+	name = "solgov suit storage unit"
+	suit_type = /obj/item/clothing/suit/space/solgov
+	helmet_type = /obj/item/clothing/head/helmet/space/solgov
+	mask_type = /obj/item/clothing/mask/breath
+	storage_type = /obj/item/tank/internals/emergency_oxygen/engi
+
 /obj/machinery/suit_storage_unit/open
 	state_open = TRUE
 	density = FALSE
@@ -517,3 +524,27 @@
 		I.play_tool_sound(src, 50)
 		visible_message("<span class='notice'>[usr] pries open \the [src].</span>", "<span class='notice'>You pry open \the [src].</span>")
 		open_machine()
+
+// Mapping helper unit takes whatever lies on top of it
+/obj/machinery/suit_storage_unit/inherit/Initialize(mapload)
+	. = ..()
+	wires = new /datum/wires/suit_storage_unit(src)
+	if(mapload)
+		addtimer(CALLBACK(src, .proc/inherit_contents), 0)
+
+/obj/machinery/suit_storage_unit/inherit/proc/inherit_contents()
+	var/turf/T = src.loc
+	for(var/atom/movable/AM in T)
+		if(istype(AM, /obj/item/clothing/suit/space))
+			AM.forceMove(src)
+			suit = AM
+		else if(istype(AM, /obj/item/clothing/head/helmet/space))
+			AM.forceMove(src)
+			helmet = AM
+		else if(istype(AM, /obj/item/clothing/mask))
+			AM.forceMove(src)
+			mask = AM
+		else if(istype(AM, /obj/item))
+			AM.forceMove(src)
+			storage = AM
+	update_icon()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -528,23 +528,23 @@
 // Mapping helper unit takes whatever lies on top of it
 /obj/machinery/suit_storage_unit/inherit/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/suit_storage_unit(src)
 	if(mapload)
-		addtimer(CALLBACK(src, .proc/inherit_contents), 0)
+		return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/suit_storage_unit/inherit/proc/inherit_contents()
+/obj/machinery/suit_storage_unit/inherit/LateInitialize()
+	. = ..()
 	var/turf/T = src.loc
 	for(var/atom/movable/AM in T)
-		if(istype(AM, /obj/item/clothing/suit/space))
+		if(istype(AM, /obj/item/clothing/suit/space) && !suit)
 			AM.forceMove(src)
 			suit = AM
-		else if(istype(AM, /obj/item/clothing/head/helmet/space))
+		else if(istype(AM, /obj/item/clothing/head/helmet/space) && !helmet)
 			AM.forceMove(src)
 			helmet = AM
-		else if(istype(AM, /obj/item/clothing/mask))
+		else if(istype(AM, /obj/item/clothing/mask) && !mask)
 			AM.forceMove(src)
 			mask = AM
-		else if(istype(AM, /obj/item))
+		else if(istype(AM, /obj/item) && !storage)
 			AM.forceMove(src)
 			storage = AM
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some tweaks to the Solgov-Cricket to make it more up-to-date with modern shiptesting standards.
Full name has been changed from Solgov-Issued Cricket Scout to Cricket-Class Solgov Intel Scout so the class name comes first on the ship list, making it easier to read for.
- Airlocks relabelled to their respective departments
- Dormitory clothing vendors replaced with solgov fatigues locker
- Bridge includes external window shutter controls
- Cargo bay reorganised to fit express supply units
- Starter mining equipment includes GPS
- Added fridge of ingredients in the storeroom
- Renault the fox added to the Solgov office
- Additional chairs added throughout the ship to reduce workplace hazards as a result of shuttle turbulence
-  Aft-Hall airlock made smaller to improve cycle speeds
- Telecomms engineering hardsuit replaced with Solgov vacuum suit
- Chemistry bag added to the infirmary pantry
![newcricket](https://user-images.githubusercontent.com/39249137/132103080-a0e901aa-5562-4f74-b6da-af7d501829f1.png)
Additionally, added a mapping helper object `/obj/machinery/suit_storage_unit/inherit`. A suit storage unit which will pick up any spacesuit equipment left in it's turf on mapload similar to closets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes map gooder
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added suit storage mapping helper
tweak: tweaked design of the cricket-class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
