### PR TITLE
Adds Oxygen to the Bubble

### DIFF
--- a/_maps/shuttles/shiptest/ntsv_bubble.dmm
+++ b/_maps/shuttles/shiptest/ntsv_bubble.dmm
@@ -330,6 +330,7 @@
 /obj/structure/sign/poster/official/build{
 	pixel_y = 32
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "rS" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an oxygen tank dispenser to the Bubble. You know, so people can breathe
(Fixes the issue in #219)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes bubble much less painful to play on 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: fighterslam
add: adds oxygen to the bubble-class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
