### PR TITLE
`check_regex.py` backport updates from Haven

### DIFF
--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -21,6 +21,7 @@
 #
 
 standards:
+  - exactly: [0, 'mangled characters', '[\u0000\uFFFF\uFFFD]']
   - exactly: [8, 'escapes', '\\\\(red|blue|green|black|b|i[^mc])']
   - exactly: [9, 'Del()s', '\WDel\(']
 


### PR DESCRIPTION
## About The Pull Request

This PRs improves the `check_regex.py` utility tool with following:
* Bugfix for wrong initialization of 2D list causing data corruption
* Bugfix for Windows path normalization mangling analysis and result output
* Added safety for encoding of DM files, it will instead print errors for every file that are not encoded with preferred encoding (utf-8 by default), and fail when such file was found
* Added a rule to detect mangled characters, characters caused by haphazardous change of encoding to UTF-8 from an other encoding.

From:
* https://github.com/Haven-13/Haven-Urist/pull/77
* https://github.com/Haven-13/Haven-Urist/pull/81

## Why It's Good For The Game

foo

## Changelog
:cl:
/:cl: