### PR TITLE
Mutant colors can be set slightly darker

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -177,7 +177,7 @@
 				if(new_mutantcolor)
 					var/temp_hsv = RGBtoHSV(new_mutantcolor)
 
-					if(ReadHSV(temp_hsv)[3] >= ReadHSV("#7F7F7F")[3]) // mutantcolors must be bright
+					if(ReadHSV(temp_hsv)[3] >= ReadHSV("#191919")[3]) // mutantcolors must be bright
 						H.dna.features["mcolor"] = sanitize_hexcolor(new_mutantcolor)
 
 					else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1524,7 +1524,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				pref_species = new newtype()
 				//Now that we changed our species, we must verify that the mutant colour is still allowed.
 				var/temp_hsv = RGBtoHSV(features["mcolor"])
-				if(features["mcolor"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#7F7F7F")[3]))
+				if(features["mcolor"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#191919")[3]))
 					features["mcolor"] = pref_species.default_color
 				user << browse(null, "window=speciespick")
 				ShowChoices(user)
@@ -1703,7 +1703,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
 						if(new_mutantcolor == "#000000")
 							features["mcolor"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#7F7F7F")[3]) // mutantcolors must be bright, but only if they affect the skin
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#191919")[3]) // mutantcolors must be bright, but only if they affect the skin
 							features["mcolor"] = sanitize_hexcolor(new_mutantcolor)
 						else
 							to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -422,7 +422,7 @@
 							newcolor += ascii2text(ascii+31)	//letters B to F - translates to lowercase
 						else
 							break
-				if(ReadHSV(newcolor)[3] >= ReadHSV("#7F7F7F")[3])
+				if(ReadHSV(newcolor)[3] >= ReadHSV("#191919")[3])
 					N.dna.features["mcolor"] = newcolor
 			N.regenerate_icons()
 

--- a/whitesands/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/whitesands/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -66,7 +66,7 @@
 	var/color_choice = input(usr, "What color will you change to?", "Color Change") as null | color
 	if (color_choice)
 		var/temp_hsv = RGBtoHSV(color_choice)
-		if (ReadHSV(temp_hsv)[3] >= ReadHSV("#7f7f7f")[3])
+		if (ReadHSV(temp_hsv)[3] >= ReadHSV("#191919")[3])
 			H.dna.species.fixed_mut_color = sanitize_hexcolor(color_choice)
 			H.update_body()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Old minimum luminosity for mutant colors was really fucking bright, meaning you could at best have mid-grey characters- this is the darkest possible Teshari before this PR: 
![image](https://user-images.githubusercontent.com/32314478/133258649-7a347d44-6c3f-4974-8f79-90528d25cb0e.png)
This tweaks it so you can actually have darkly-colored characters that use mutant color:
![image](https://user-images.githubusercontent.com/32314478/133259020-648fbb73-083d-45a6-836e-74769f6266c0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
customization increased while still preventing the issue that minimum mutant color brightness was probably added to prevent (multiplicatively layering black over anything makes it a hardblack blob)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: minimum mutantcolor luminosity moved from 47 to 7: you can now have lizards, IPCs, teshari etc that are darkly colored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
