### PR TITLE
Fixes prescription glasses not being given to the jobs that should have them with nearsighted.

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -260,6 +260,8 @@
 	name = "Nearsighted"
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
 	value = -1
+	var/obj/item/glasses
+	var/where
 	gain_text = "<span class='danger'>Things far away from you start looking blurry.</span>"
 	lose_text = "<span class='notice'>You start seeing faraway things normally again.</span>"
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
@@ -303,10 +305,22 @@
 
 	if(!glasses_type)
 		glasses_type = /obj/item/clothing/glasses/regular
-	glasses_type = new(get_turf(H))
-		if(!H.equip_to_slot_if_possible(glasses_type, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE))
-		H.put_in_hands(glasses_type)
-	H.regenerate_icons()
+	glasses = new glasses_type(get_turf(quirk_holder))
+	var/list/slots = list(
+		"on your face, silly!" = ITEM_SLOT_EYES,
+		"in your left pocket." = ITEM_SLOT_LPOCKET,
+		"in your right pocket." = ITEM_SLOT_RPOCKET,
+		"in your backpack." = ITEM_SLOT_BACKPACK,
+		"in your hands." = ITEM_SLOT_HANDS
+	)
+	where = H.equip_in_one_of_slots(glasses, slots, FALSE) || "at your feet, don't drop them next time!"
+
+/datum/quirk/nearsighted/post_add()
+	if(where == "in your backpack.")
+		var/mob/living/carbon/human/H = quirk_holder
+		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+
+	to_chat(quirk_holder, "<span class='notice'>There is a set of profession-assigned prescription glasses [where] These are valuable equipment for someone nearsighted like you. Keep them safe and clean! It's unlikely there are any spares.</span>")
 
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -269,42 +269,43 @@
 
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/glasses_type
-     switch(quirk_holder.mind.assigned_role)
-			//Security
-			if("Head of Security")
-				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
-			if("Warden")
-				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
-			if("Security Officer")
-				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
-			//Science
-			if("Research Director")
-				glasses_type = /obj/item/clothing/glasses/science/prescription
-			if("Scientist")
-				glasses_type = /obj/item/clothing/glasses/science/prescription
-			if("Chemist")
-				glasses_type = /obj/item/clothing/glasses/science/prescription
-			//Health
-			if("Chief Medical Officer")
-				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
-			if("Medical Doctor")
-				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
-			//Meson
-			if("Chief Engineer")
-				glasses_type = /obj/item/clothing/glasses/meson/prescription
-			if("Station Engineer")
-				glasses_type = /obj/item/clothing/glasses/meson/prescription
-			if("Atmospheric Technician")
-				glasses_type = /obj/item/clothing/glasses/meson/prescription
-			if("Shaft Miner")
-				glasses_type = /obj/item/clothing/glasses/meson/prescription
-				
-		if(!glasses_type)
+	var/obj/item/glasses_type
+
+	switch(quirk_holder.mind.assigned_role)
+		//Security
+		if("Head of Security")
+			glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+		if("Warden")
+			glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+		if("Security Officer")
+			glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+		//Science
+		if("Research Director")
+			glasses_type = /obj/item/clothing/glasses/science/prescription
+		if("Scientist")
+			glasses_type = /obj/item/clothing/glasses/science/prescription
+		if("Chemist")
+			glasses_type = /obj/item/clothing/glasses/science/prescription
+		//Health
+		if("Chief Medical Officer")
+			glasses_type = /obj/item/clothing/glasses/hud/health/prescription
+		if("Medical Doctor")
+			glasses_type = /obj/item/clothing/glasses/hud/health/prescription
+		//Meson
+		if("Chief Engineer")
+			glasses_type = /obj/item/clothing/glasses/meson/prescription
+		if("Station Engineer")
+			glasses_type = /obj/item/clothing/glasses/meson/prescription
+		if("Atmospheric Technician")
+			glasses_type = /obj/item/clothing/glasses/meson/prescription
+		if("Shaft Miner")
+			glasses_type = /obj/item/clothing/glasses/meson/prescription
+
+	if(!glasses_type)
 		glasses_type = /obj/item/clothing/glasses/regular
-	glasses = new glasses_type(get_turf(quirk_holder))
-		if(!H.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE))
-		H.put_in_hands(glasses)
+	glasses_type = new(get_turf(H))
+		if(!H.equip_to_slot_if_possible(glasses_type, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE))
+		H.put_in_hands(glasses_type)
 	H.regenerate_icons()
 
 /datum/quirk/nyctophobia

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -260,11 +260,11 @@
 	name = "Nearsighted"
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
 	value = -1
-	var/obj/item/glasses
-	var/where
 	gain_text = "<span class='danger'>Things far away from you start looking blurry.</span>"
 	lose_text = "<span class='notice'>You start seeing faraway things normally again.</span>"
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
+	var/obj/item/glasses
+	var/where
 
 /datum/quirk/nearsighted/add()
 	quirk_holder.become_nearsighted(ROUNDSTART_TRAIT)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -269,10 +269,45 @@
 
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
-	H.put_in_hands(glasses)
-	H.equip_to_slot(glasses, ITEM_SLOT_EYES)
-	H.regenerate_icons() //this is to remove the inhand icon, which persists even if it's not in their hands
+	var/obj/glasses_type
+     switch(quirk_holder.mind.assigned_role)
+			//Security
+			if("Head of Security")
+				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+			if("Warden")
+				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+			if("Security Officer")
+				glasses_type = /obj/item/clothing/glasses/hud/security/prescription
+			//Science
+			if("Research Director")
+				glasses_type = /obj/item/clothing/glasses/science/prescription
+			if("Scientist")
+				glasses_type = /obj/item/clothing/glasses/science/prescription
+			if("Chemist")
+				glasses_type = /obj/item/clothing/glasses/science/prescription
+			//Health
+			if("Chief Medical Officer")
+				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
+			if("Medical Doctor")
+				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
+			if("Chemist")
+				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
+			//Meson
+			if("Chief Engineer")
+				glasses_type = /obj/item/clothing/glasses/meson/prescription
+			if("Station Engineer")
+				glasses_type = /obj/item/clothing/glasses/meson/prescription
+			if("Atmospheric Technician")
+				glasses_type = /obj/item/clothing/glasses/meson/prescription
+			if("Shaft Miner")
+				glasses_type = /obj/item/clothing/glasses/meson/prescription
+				
+		if(!glasses_type)
+		glasses_type = /obj/item/clothing/glasses/regular
+	glasses = new glasses_type(get_turf(quirk_holder))
+		if(!H.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE))
+		H.put_in_hands(glasses)
+	H.regenerate_icons()
 
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -290,8 +290,6 @@
 				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
 			if("Medical Doctor")
 				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
-			if("Chemist")
-				glasses_type = /obj/item/clothing/glasses/hud/health/prescription
 			//Meson
 			if("Chief Engineer")
 				glasses_type = /obj/item/clothing/glasses/meson/prescription

--- a/whitesands/code/modules/client/loadout/loadout_eyewear.dm
+++ b/whitesands/code/modules/client/loadout/loadout_eyewear.dm
@@ -17,31 +17,6 @@
 	display_name = "glasses, jamjar prescription"
 	path = /obj/item/clothing/glasses/regular/jamjar
 
-//Probably overpowerd but honestly idc
-/datum/gear/eyewear/glasses/hud
-	subtype_path = /datum/gear/eyewear/glasses/hud
-	cost = 2000
-
-/datum/gear/eyewear/glasses/hud/pmed
-	display_name = "HUDglasses, prescription health"
-	path = /obj/item/clothing/glasses/hud/health/prescription
-	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
-
-/datum/gear/eyewear/glasses/hud/psec
-	display_name = "HUDglasses, prescription security"
-	path = /obj/item/clothing/glasses/hud/security/prescription
-	allowed_roles = list("Security Officer", "Warden", "Head of Security")
-
-/datum/gear/eyewear/glasses/hud/pmeson
-	display_name = "HUDglasses, prescription meson"
-	path = /obj/item/clothing/glasses/meson/prescription
-	allowed_roles = list("Shaft Miner", "Station Engineer", "Atmospheric Technician", "Chief Engineer")
-
-/datum/gear/eyewear/glasses/hud/psci
-	display_name = "HUDglasses, prescription science"
-	path = /obj/item/clothing/glasses/science/prescription
-	allowed_roles = list("Chemist", "Scientist", "Research Director")
-
 //Misc
 /datum/gear/eyewear/eyepatch
 	display_name = "eyepatch"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that it gives a job it's relevant type of prescriptionhud when they have nearsighted, which was supposed to be handled by gear but these get overriden and stay as a permanent hud instead, which is no good, as such it closes #266. It also makes it look for a suitable spot for your glasses instead of just overriding them. May warrant a rewrite of the example nearsighted quirk at some point. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes nearsighted characters not rely on the ship actually having the proper type of prescriptionhud AND makes it so nearsighted characters can have another type of eyewear on them at roundstart from gear, job or otherwise, why not let them have an eyepatch anyways?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed prescriptionHUDs from gear and made them be given by the nearsighted quirk instead, which doesn't override your starting glasses anymore.
fix: No more roundstart permanent HUD from deleted gear item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
