### PR TITLE
Phazon Core-Preference Message Removal

### DIFF
--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1054,7 +1054,7 @@
 			"key" = /obj/item/assembly/signaler/anomaly, //WS Edit - Any anomaly core for Phazons
 			"action" = ITEM_DELETE,
 			"back_key" = TOOL_WELDER,
-			"desc" = "Bluespace anomaly core socket is open.",
+			"desc" = "Anomaly core socket is open.",
 			"icon_state" = "phazon24"
 		)
 	)

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -234,12 +234,10 @@
 
 /obj/item/mecha_parts/chassis/phazon/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(istype(I, /obj/item/assembly/signaler/anomaly) && !istype(I, /obj/item/assembly/signaler/anomaly/bluespace))
-		to_chat(user, "The anomaly core socket only accepts bluespace anomaly cores!")
 
 /obj/item/mecha_parts/part/phazon_torso
 	name="\improper Phazon torso"
-	desc="A Phazon torso part. The socket for the bluespace core that powers the exosuit's unique phase drives is located in the middle."
+	desc="A Phazon torso part. The socket for the anomaly core that powers the exosuit's unique phase drives is located in the middle."
 	icon_state = "phazon_harness"
 
 /obj/item/mecha_parts/part/phazon_head

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -232,9 +232,6 @@
 	name = "\improper Phazon chassis"
 	construct_type = /datum/component/construction/unordered/mecha_chassis/phazon
 
-/obj/item/mecha_parts/chassis/phazon/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
 /obj/item/mecha_parts/part/phazon_torso
 	name="\improper Phazon torso"
 	desc="A Phazon torso part. The socket for the anomaly core that powers the exosuit's unique phase drives is located in the middle."


### PR DESCRIPTION
## About The Pull Request

Bugfix for https://github.com/Whitesands13/Whitesands/issues/825.

The Phazon says it requires a bluespace anom core to complete, but the type of anom core doesn't matter.  I removed the message saying a non-bluespace core is incorrect, and two descriptions of Phazon parts implying the anom core must be bluespace.

![image](https://user-images.githubusercontent.com/7697956/133545349-1d066ee1-bb7c-4c37-8118-6a53b29acf06.png)
![image](https://user-images.githubusercontent.com/7697956/133545449-320b7108-7f1d-4bc4-94a3-a52a1af304f3.png)
![image](https://user-images.githubusercontent.com/7697956/133545496-8fce09b0-af29-4aa4-b283-c6cf64ea938c.png)

## Why It's Good For The Game

Makes misleading descriptions match actual functionality.

Lets me get my first PR on this repo out of the way, so I can start opening an inordinate number of issues.

## Changelog
:cl:
fix: Phazons no longer say they need bluespace cores
/:cl:
