### PR TITLE
Click ship to teleport

### DIFF
--- a/code/modules/overmap/dynamic_events.dm
+++ b/code/modules/overmap/dynamic_events.dm
@@ -23,6 +23,13 @@
 	. = ..()
 	choose_level_type()
 
+/obj/structure/overmap/dynamic/attack_ghost(mob/user)
+	if(reserve_dock)
+		user.forceMove(get_turf(reserve_dock))
+		return TRUE
+	else
+		return
+
 /obj/structure/overmap/dynamic/Destroy()
 	. = ..()
 	QDEL_NULL(reserve)

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -50,6 +50,13 @@
 	. = ..()
 	SSovermap.simulated_ships -= src
 
+/obj/structure/overmap/ship/simulated/attack_ghost(mob/user)
+	if(shuttle)
+		user.forceMove(get_turf(shuttle))
+		return TRUE
+	else
+		return
+
 /obj/structure/overmap/ship/simulated/proc/initial_name()
 	if(mass < SHIP_SIZE_THRESHOLD)
 		return //You don't DESERVE a name >:(


### PR DESCRIPTION
## About The Pull Request

click an overmap object to teleport to its docking port. only works on loaded Z levels (no ghosts loading everything at once)

## Why It's Good For The Game

this simple change makes it much easier to find an associated overmap ship or object.

## Changelog

:cl:
add: You can now click an overmap object to teleport to the interior map.
/:cl: