### PR TITLE
Fix Survey Handheld Feedback

### DIFF
--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -29,7 +29,9 @@
 
 	var/my_z = "[get_virtual_z_level()]"
 	if(z_active[my_z])
-		visible_message("Warning: interference detected in current sector")
+		src.visible_message("<span class='warning'>Warning: interference detected in current sector</span>")
+		flick(icon_state + "-corrupted", src)
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
 		return
 
 	if(!z_history[my_z])
@@ -37,23 +39,26 @@
 
 	active = TRUE
 	z_active[my_z] = TRUE
+	var/turf/src_turf = get_turf(src)
 	while(user.get_active_held_item() == src)
 		to_chat(user, "<span class='notice'>You begin to scan your surroundings with [src].</span>")
 
 		var/penalty = 1 - (z_history[my_z] - 1) * 0.01 // You lose one percent of value are are one percent slower
 		if(!penalty || penalty < 0.20) // If you are below 20% value, do nothing and abort
-			visible_message("Warning: unable to locate valuable information in current sector.")
+			flick(icon_state + "-corrupted", src)
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
+			src_turf.visible_message("<span class='warning'>Warning: unable to locate valuable information in current sector.</span>")
 			break
 
 		if(!do_after_mob(user, list(src), survey_delay / penalty))
 			flick(icon_state + "-corrupted", src)
-			playsound(src, 'sound/machines/buzz-sigh.ogg')
-			visible_message("Warning: results corrupted. Please try again.")
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
+			src_turf.visible_message("<span class='warning'>Warning: results corrupted. Please try again.</span>")
 			break
 
 		flick(icon_state + "print", src)
-		playsound(src, 'sound/machines/chime.ogg')
-		visible_message("Data recorded and enscribed to research packet.")
+		playsound(src, 'sound/machines/chime.ogg', 20)
+		src_turf.visible_message("<span class='notice'>Data recorded and enscribed to research packet.</span>")
 		z_history[my_z]++
 
 		var/obj/item/result = new /obj/item/research_notes(user.loc, survey_value * penalty, pick(list("astronomy", "physics", "planets", "space")))

--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -3,8 +3,8 @@
 	desc = "A small tool designed for quick and inefficient data collection about your local star sector."
 	icon = 'icons/obj/item/survey_handheld.dmi'
 	icon_state = "survey"
-	var/static/list/z_active = list() // TODO: ONLY ONE ACTIVE PER VIRTUAL Z
-	var/static/list/z_history = list() // TODO: DEPRECIATION BY VIRTUAL Z
+	var/static/list/z_active = list()
+	var/static/list/z_history = list()
 	var/active = FALSE
 	var/survey_value = 50
 	var/survey_delay = 4 SECONDS

--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -27,11 +27,13 @@
 	if(active)
 		return
 
+	var/turf/src_turf = get_turf(src)
+
 	var/my_z = "[get_virtual_z_level()]"
 	if(z_active[my_z])
-		src.visible_message("<span class='warning'>Warning: interference detected in current sector</span>")
 		flick(icon_state + "-corrupted", src)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
+		src_turf.visible_message("<span class='warning'>Warning: interference detected in current sector</span>")
 		return
 
 	if(!z_history[my_z])
@@ -39,7 +41,6 @@
 
 	active = TRUE
 	z_active[my_z] = TRUE
-	var/turf/src_turf = get_turf(src)
 	while(user.get_active_held_item() == src)
 		to_chat(user, "<span class='notice'>You begin to scan your surroundings with [src].</span>")
 


### PR DESCRIPTION
## About The Pull Request

I noticed that the survey handhelds didn't seem to indicate when they had finished all possible research in a given virtual-z.  I took a look at the code and it appears that they are intended to send feedback messages as well as play sounds.

visible_message() wouldn't show messages to players because the item was in-hand.  If I dropped a survey handheld, I would be able to see the message for corrupted data.  This is fixed by calling visible_message() on the turf instead.

![image](https://user-images.githubusercontent.com/7697956/133939722-4c65c8c3-148b-4d26-853a-2e1090a1b991.png)
![image](https://user-images.githubusercontent.com/7697956/133939768-fce23c8b-6015-40e5-aab2-2c2dc0292468.png)
![image](https://user-images.githubusercontent.com/7697956/133939729-323a6ea5-1d7f-4789-b912-172d7759d318.png)

The calls to playsound() were failing because they didn't include the volume parameter.  My guess is that it defaults to zero.

I also added the buzz sound and flick to the warnings for interference and completed survey.

I have to admit that it can be a bit spammy:
![image](https://user-images.githubusercontent.com/7697956/133939701-9d5e66e6-f1e4-4950-8f75-6e30b03d228d.png)

You can also run around with it while spam clicking to make a bunch of noise.

Also removed some completed todo comments while I'm here.

## Why It's Good For The Game

Makes it more clear if your survey is running and why it might not be.

## Changelog
:cl:
fix: Survey handhelds let you know if/why they failed and make noise 
/:cl:
