### PR TITLE
Fixes crew manifest duplication with one simple trick

### DIFF
--- a/code/modules/mob/dead/crew_manifest.dm
+++ b/code/modules/mob/dead/crew_manifest.dm
@@ -1,4 +1,4 @@
-//datum/crew_manifest
+/datum/crew_manifest
 
 /datum/crew_manifest/ui_state(mob/user)
 	return GLOB.always_state

--- a/code/modules/mob/dead/crew_manifest.dm
+++ b/code/modules/mob/dead/crew_manifest.dm
@@ -1,4 +1,4 @@
-/datum/crew_manifest
+//datum/crew_manifest
 
 /datum/crew_manifest/ui_state(mob/user)
 	return GLOB.always_state
@@ -11,6 +11,11 @@
 	if (!ui)
 		ui = new(user, src, "CrewManifest")
 		ui.open()
+
+/datum/crew_manifest/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
 
 /datum/crew_manifest/ui_static_data(mob/user)
 	return list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Copy pastes crew_manifest.dm from tgstation13
(https://github.com/tgstation/tgstation/blob/master/code/modules/mob/dead/crew_manifest.dm)
(mostly)fixing the bug where crew manifest still showed the player that cryoed and respawned
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad?
Bug kill?
## Changelog
:cl: celotajstg
fix: (Mostly) Fixes duplicated crew manifest entries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
