### PR TITLE
Stops Issues from Getting Tags From Referenced Testmerges

### DIFF
--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -2,7 +2,7 @@
 matchTitle: true
 
 # Determines if we search the body (optional). Defaults to true.
-matchBody: true
+matchBody: false
 
 # Determines if label matching is case sensitive (optional). Defaults to true.
 caseSensitive: false


### PR DESCRIPTION
## About The Pull Request

The keywordlabeler bot has been adding the "do not merge" tag to several issues.  This was caused by it searching the body of the issues and seeing the [DNM] string included in the titles of some of the testmerges.  An example is #232.

This can be fixed by telling the bot to stop searching the body of the issue when deciding what tags to add.  However there doesn't appear to be a way to tell it to treat issues and PRs differently, so that means it will also not search a PR's body.

This will make it so the search strings for tags must be in the title of PRs and issues.  However it appears this is already the standard.  I don't know if this is the way you want this fixed, so I'm leaving this here as an option.
