### PR TITLE
[DNM] Missing Vendor Item Sprites Workaround

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4620,6 +4620,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"lQ" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "lR" = (
 /obj/effect/turf_decal/corner/red{
 	dir = 1
@@ -6267,6 +6275,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
+"pe" = (
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "pg" = (
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -6789,6 +6801,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"qc" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "qd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -7903,6 +7925,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
+"sz" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "sG" = (
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
@@ -8591,6 +8618,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"uo" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "up" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -8747,6 +8779,11 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
+"uK" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "uL" = (
 /obj/machinery/button/door/indestructible{
 	id = "nukeop_ready";
@@ -10364,6 +10401,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"yR" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "yU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -10705,6 +10746,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
+"zK" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/machinery/vending/cola/shamblers,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "zL" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -11159,6 +11208,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Bp" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Bs" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -11606,6 +11660,7 @@
 /obj/effect/turf_decal/corner/brown{
 	dir = 4
 	},
+/obj/machinery/vending/classicbeats,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Cp" = (
@@ -12143,6 +12198,11 @@
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
+"Dj" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/syndichem,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Dq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/industrial/warning{
@@ -12392,6 +12452,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"DK" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "DL" = (
 /obj/item/clothing/suit/wizrobe/black,
 /obj/item/clothing/head/wizard/black,
@@ -12989,6 +13057,10 @@
 /obj/item/reagent_containers/food/snacks/sashimi,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Ff" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Fh" = (
 /turf/open/floor/plasteel,
 /area/centcom/holding)
@@ -13551,6 +13623,10 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
+"GA" = (
+/obj/machinery/vending/custom,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "GC" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -14062,6 +14138,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"Hy" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "HA" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14121,6 +14202,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"HE" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "HF" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14539,6 +14624,16 @@
 "Il" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeobserve)
+"Im" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -15399,6 +15494,10 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
+"Kl" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Kn" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/corner/neutral{
@@ -16154,6 +16253,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"Mr" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Ms" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -16300,6 +16404,10 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Ni" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -16311,6 +16419,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Nl" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "Nm" = (
 /obj/structure/closet/crate,
 /obj/item/vending_refill/autodrobe,
@@ -16359,6 +16472,10 @@
 "NE" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/podStorage)
+"NF" = (
+/obj/machinery/vending/sustenance,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "NG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -16387,6 +16504,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"NK" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "NO" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
@@ -16619,6 +16744,7 @@
 /area/centcom/holding)
 "Pm" = (
 /obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Po" = (
@@ -16627,6 +16753,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Pq" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "Pr" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -16650,6 +16784,7 @@
 /obj/effect/turf_decal/corner/brown{
 	dir = 1
 	},
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Pz" = (
@@ -16746,6 +16881,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"PZ" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/plasmaresearch,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Qb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16969,6 +17109,16 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Rn" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Ro" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -17012,6 +17162,11 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Ry" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "RA" = (
 /obj/effect/turf_decal/corner/bar,
 /obj/effect/turf_decal/corner/bar{
@@ -17052,6 +17207,26 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"RT" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
+"RY" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
+"Sa" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "Sd" = (
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
@@ -17084,6 +17259,14 @@
 /obj/item/camera,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/photobooth)
+"Ss" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Su" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
@@ -17123,6 +17306,10 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"Sz" = (
+/obj/machinery/vending/cart,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "SB" = (
 /obj/structure/curtain,
 /obj/structure/window/reinforced/tinted{
@@ -17168,6 +17355,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
+"SL" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "SN" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -17354,6 +17546,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"TN" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "TS" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -17378,6 +17575,16 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"TW" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/engineering,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Uc" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -17452,6 +17659,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"UC" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -17531,6 +17746,14 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UX" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "UY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -17648,6 +17871,11 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel,
 /area/centcom/holding)
+"Vx" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Vz" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -17710,6 +17938,7 @@
 /obj/effect/turf_decal/corner/brown{
 	dir = 4
 	},
+/obj/machinery/vending/cola/sodie,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "VR" = (
@@ -17784,6 +18013,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"Wr" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "Ws" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -17809,6 +18046,7 @@
 /obj/effect/turf_decal/corner/brown{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Wx" = (
@@ -17837,6 +18075,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
+"WL" = (
+/obj/machinery/vending/modularpc,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "WM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -17866,6 +18108,10 @@
 "WO" = (
 /turf/closed/indestructible/wood,
 /area/centcom/holding)
+"WP" = (
+/obj/machinery/vending/mining_equipment,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -17984,6 +18230,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Xh" = (
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Xl" = (
@@ -18025,6 +18272,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"Xv" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Xy" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Airlock"
@@ -18076,6 +18331,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
+"XG" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "XK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
@@ -18115,6 +18374,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
+"XZ" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/magivend,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Ya" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -18124,6 +18393,26 @@
 /obj/item/reagent_containers/food/snacks/chawanmushi,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yg" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
+"Yl" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "Ym" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/wood,
@@ -18140,6 +18429,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yr" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/four)
 "Yt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -18164,6 +18458,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"YB" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "YE" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -18397,6 +18695,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Zz" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "ZA" = (
 /obj/machinery/power/smes/magical,
 /obj/effect/turf_decal/industrial/warning,
@@ -18439,6 +18742,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"ZL" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel,
+/area/centcom/supplypod/loading/three)
 "ZN" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan{
@@ -18475,6 +18783,7 @@
 /obj/effect/turf_decal/corner/brown{
 	dir = 1
 	},
+/obj/machinery/vending/toyliberationstation,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "ZS" = (
@@ -67823,10 +68132,10 @@ Yn
 NO
 NO
 Yn
-EZ
-EZ
-EZ
-EZ
+Yg
+Yl
+Sa
+qc
 EZ
 QM
 Yn
@@ -68080,10 +68389,10 @@ Yn
 Yv
 yf
 Yn
-Vn
-PW
-Vn
-PW
+sz
+HE
+Nl
+YB
 Vn
 zZ
 Yn
@@ -68337,9 +68646,9 @@ sZ
 UM
 UM
 sZ
-Vn
-PW
-Vn
+Ry
+XG
+SL
 PW
 Vn
 zZ
@@ -68594,9 +68903,9 @@ sZ
 QO
 QO
 sZ
-Vn
-PW
-Vn
+ZL
+pe
+RT
 PW
 Vn
 zZ
@@ -68851,9 +69160,9 @@ Yn
 Sv
 Ru
 Yn
-Vn
-Vn
-Vn
+Hy
+uo
+Zz
 Vn
 Vn
 zZ
@@ -69108,9 +69417,9 @@ Yn
 NO
 NO
 Yn
-Tz
-Tz
-Tz
+UX
+Pq
+Wr
 Tz
 Tz
 zE
@@ -69623,10 +69932,10 @@ aa
 aa
 Yn
 Pv
-Pv
-Pv
-Pv
-Pv
+Im
+TW
+XZ
+Rn
 ZQ
 Yn
 NE
@@ -69880,10 +70189,10 @@ aa
 aa
 Yn
 Pm
-Pm
-Pm
-Xh
-Xh
+RY
+Vx
+Ff
+Ni
 Wt
 Yn
 NE
@@ -70137,11 +70446,11 @@ aa
 aa
 Yn
 Xh
-Xh
-Pm
-Xh
-Xh
-Wt
+yR
+Bp
+WP
+Kl
+UC
 Yn
 NE
 NE
@@ -70393,12 +70702,12 @@ Yn
 aa
 aa
 Yn
-Xh
-Xh
-Pm
-Xh
-Xh
-Wt
+Sz
+GA
+TN
+WL
+NF
+DK
 Yn
 NE
 NE
@@ -70650,12 +70959,12 @@ Yn
 aa
 aa
 Yn
-Pm
-Pm
-Pm
-Pm
-Pm
-Wt
+Mr
+uK
+Yr
+PZ
+Dj
+zK
 Yn
 NE
 NE
@@ -70908,10 +71217,10 @@ aa
 aa
 Yn
 Co
-Co
-Co
-Co
-Co
+lQ
+Ss
+NK
+Xv
 VP
 Yn
 NE


### PR DESCRIPTION
## About The Pull Request

This PR is a temporary workaround for the missing vendor item sprites.  It can be test merged while I work on the full fix.

When a vendor is created, they call Initialize() then build_inventory(), which puts references to all the vendor's items into GLOB.vending_products.

Then when the game is starting, /datum/asset/spritesheet/vending/register() is eventually called, which loads the vendor item sprites named in GLOB.vending_products into the vendor spritesheet.  This appears to be the only time this function runs.

Any vendor that is created after /datum/asset/spritesheet/vending/register() runs, will load its items into GLOB.vending_products, but those item sprites will not be loaded into the vendor spritesheet.  Therefore there is no sprite for the vendor to display.

This workaround functions by forceloading all the vendor items into GLOB.vending_products by putting all the vendors onto CentCom at round start.  This is not a good long term solution, and I will be investigating other options in the near future.

## Why It's Good For The Game

Makes it easier to tell items apart in vendors.

## Changelog
:cl:
fix: Item stickers have been taped back onto the vending machines
/:cl:
