### PR TITLE
[Fix] Missing Vendor Item Sprites Fix

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -354,7 +354,28 @@
 	name = "vending"
 
 /datum/asset/spritesheet/vending/register()
-	for (var/k in GLOB.vending_products)
+	var/list/vendor_type_list = typesof(/obj/machinery/vending)
+	var/list/vending_products = list()
+
+	for(var/vendor_type in vendor_type_list)
+		var/obj/machinery/vending/V = new vendor_type()
+		if (V.products)
+			for(var/typepath in V.products)
+				vending_products[typepath] = 1
+		if (V.contraband)
+			for(var/typepath in V.contraband)
+				vending_products[typepath] = 1
+		if (V.premium)
+			for(var/typepath in V.premium)
+				vending_products[typepath] = 1
+		qdel(V)
+
+	var/obj/machinery/mineral/equipment_vendor/V = new /obj/machinery/mineral/equipment_vendor()
+	for(var/typepath in V.prize_list)
+		vending_products[typepath] = 1
+	qdel(V)
+
+	for (var/k in vending_products)
 		var/atom/item = k
 		if (!ispath(item, /atom))
 			continue

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -75,15 +75,6 @@
 	src.equipment_path = path
 	src.cost = cost
 
-/obj/machinery/mineral/equipment_vendor/Initialize()
-	. = ..()
-	build_inventory()
-
-/obj/machinery/mineral/equipment_vendor/proc/build_inventory()
-	for(var/p in prize_list)
-		var/datum/data/mining_equipment/M = p
-		GLOB.vending_products[M.equipment_path] = 1
-
 /obj/machinery/mineral/equipment_vendor/update_icon_state()
 	if(powered())
 		icon_state = initial(icon_state)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -293,7 +293,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			if (dump_amount >= 16)
 				return
 
-GLOBAL_LIST_EMPTY(vending_products)
 /**
 	* Build the inventory of the vending machine from it's product and record lists
 	*
@@ -311,7 +310,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 		var/atom/temp = typepath
 		var/datum/data/vending_product/R = new /datum/data/vending_product()
-		GLOB.vending_products[typepath] = 1
 		R.name = initial(temp.name)
 		if(istype(temp, /obj/item/stack)) //Include stack amount
 			var/obj/item/stack/S = temp


### PR DESCRIPTION
## About The Pull Request

Currently vending machines are missing some item preview sprites inside their TGUI windows.

When the atoms subsystem initializes, it call Initialize() on every atom in world.  When this happens on a vendor, it calls build_inventory(), which puts references to all the vendor's items into GLOB.vending_products.

When the Assets susbsystem initalizes, /datum/asset/spritesheet/vending/register() is eventually called, which loads the vendor item sprites named in GLOB.vending_products into the vendor spritesheet. This appears to be the only time this function runs.

Any vendor that is created after /datum/asset/spritesheet/vending/register() runs, will load its items into GLOB.vending_products, but those item sprites will not be loaded into the vendor spritesheet. Therefore there is no sprite for the vendor to display.

There were two somewhat obvious solutions to this problem:

1) Call /datum/asset/spritesheet/vending/register() to rebuild the spritesheet whenever a new ship is loaded.

This function eventually calls the asset transporter, which I believe is the function that causes Byond to download resources when a client connects.  It did not seem like a good idea to invoke this while players are connected.

2) Make GLOB.vending_products contain all items from all vendor types when it loads as part of the atoms subsystem.

Since the atoms subsystem initializes every atom in world, and not all vendor types are present in world at round start, this is not possible without having all vendors exist at round start.  See #284.

My Solution:

/datum/asset/spritesheet/vending/register() is the function that builds the vendor spritesheet, so you can instead populate vending_products inside this function by iterating over all vendor subtypes.

Included Refactorings:

vending_products is no longer a global, since only one function needs to access it.

/obj/machinery/mineral/equipment_vendor/Initialize() and /obj/machinery/mineral/equipment_vendor/build_inventory() were removed because they're only purpose was to populate GLOB.vending_products.

## Why It's Good For The Game

Makes it easier to tell items apart in vendors.

## Changelog
:cl:
fix: Vending machines display item preview sprites again
/:cl:
