### PR TITLE
Goliaf can no longer smash walls (+Bear expansion pack)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -81,6 +81,7 @@
 	icon_living = "snowbear"
 	icon_dead = "snowbear_dead"
 	desc = "It's a polar bear, in space, but not actually in space."
+	environment_smash = ENVIRONMENT_SMASH_MINERALS
 	weather_immunities = list("snow")
 
 /mob/living/simple_animal/hostile/bear/russian

--- a/whitesands/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/whitesands/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -23,6 +23,7 @@
 	armor = list("melee" = 10, "bullet" = 15, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	harm_intent_damage = 0
 	obj_damage = 100
+	environment_smash = ENVIRONMENT_SMASH_MINERALS
 	melee_damage_lower = 12
 	melee_damage_upper = 20
 	attack_verb_continuous = "pulverizes"


### PR DESCRIPTION
## About The Pull Request

adds ENVIRONMENT_SMASH_MINERALS to goliaths and polar bears, this means they can't break solid walls. They're still capable of causing a lot of trouble by pushing objects around but having your ship reduced to swiss cheese by a group of these sucks donkey dick

If anyone has other plans for changing or reworking goliaths please let me know

## Why It's Good For The Game

I hope to alleviate some pain.

## Changelog
:cl:
balance: Goliaths cannot smash walls 
/:cl: