### PR TITLE
Fix podspawned machines being depowered

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -165,7 +165,7 @@ Class Procs:
 	. = ..()
 	power_change()
 	RegisterSignal(src, COMSIG_ENTER_AREA, .proc/power_change)
-	
+
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
 	end_processing()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -138,7 +138,7 @@ Class Procs:
 		armor = list("melee" = 25, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 70)
 	. = ..()
 	GLOB.machines += src
-
+	RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, .proc/power_change)
 	if(ispath(circuit, /obj/item/circuitboard) && (mapload || apply_default_parts))
 		circuit = new circuit
 		circuit.apply_default_parts(src)
@@ -165,7 +165,7 @@ Class Procs:
 	. = ..()
 	power_change()
 	RegisterSignal(src, COMSIG_ENTER_AREA, .proc/power_change)
-
+	
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
 	end_processing()


### PR DESCRIPTION
pods spawn their items in the pod hyperlane on the centcom Z level which has no power, so when they arrive in a powered area they don't work. This PR causes power to update when a machine changes Z levels.

I paid 35000 spondulicks for a jukebox and it didn't work, WTF

:cl:
fix: Fixed cargo ordered jukebox not working without admin assistance
/:cl: