### PR TITLE
Ship cargo direct deposits

### DIFF
--- a/whitesands/code/modules/economy/selling_pad.dm
+++ b/whitesands/code/modules/economy/selling_pad.dm
@@ -44,7 +44,7 @@
 		sell_account.adjust_money(value)
 		to_chat(user, "<span class='notice'>You deposit [I]. The Vessel Budget is now [sell_account.account_balance] cr.</span>")
 		qdel(I)
-		return
+		return TRUE
 	return ..()
 
 /obj/machinery/computer/selling_pad_control/multitool_act(mob/living/user, obj/item/multitool/I)

--- a/whitesands/code/modules/economy/selling_pad.dm
+++ b/whitesands/code/modules/economy/selling_pad.dm
@@ -32,6 +32,21 @@
 	. = ..()
 	sell_account = port.current_ship?.ship_account
 
+/obj/machinery/computer/selling_pad_control/attackby(obj/item/I, mob/user)
+	var/value = 0
+	if(istype(I, /obj/item/stack/spacecash))
+		var/obj/item/stack/spacecash/C = I
+		value = C.value * C.amount
+	else if(istype(I, /obj/item/holochip))
+		var/obj/item/holochip/H = I
+		value = H.credits
+	if(value)
+		sell_account.adjust_money(value)
+		to_chat(user, "<span class='notice'>You deposit [I]. The Vessel Budget is now [sell_account.account_balance] cr.</span>")
+		qdel(I)
+		return
+	return ..()
+
 /obj/machinery/computer/selling_pad_control/multitool_act(mob/living/user, obj/item/multitool/I)
 	. = ..()
 	if (istype(I.buffer, /obj/machinery/selling_pad))


### PR DESCRIPTION
## About The Pull Request

You can now add money to a ship budget by attacking the cargo pad terminal with holochips or space cash

## Why It's Good For The Game

Gives cold hard cash a use when trading I dunno

## Changelog
:cl:
add: Press holochips against a cargo hold terminal to add credits to the linked ship budget.
/:cl: