### PR TITLE
adds 4 new ruins, currently only appearing on sand planets

### DIFF
--- a/_maps/RandomRuins/SandRuins/crash_bar.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_bar.dmm
@@ -45,8 +45,8 @@
 /turf/open/floor/plating,
 /area/whitesands/surface/outdoors)
 "dl" = (
-/obj/structure/table/wood/bar,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -76,12 +76,12 @@
 /turf/open/floor/carpet/nanoweave,
 /area/whitesands/surface/outdoors)
 "eh" = (
-/obj/structure/table/wood/bar,
 /obj/item/toy/figure/bartender{
 	desc = "you feel like you recognize this...";
 	name = "Familiar Bartender action figure";
 	toysay = "What can I get ya?"
 	},
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -236,9 +236,9 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/condiment/peppermill,
-/obj/structure/table/wood/bar,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -323,7 +323,6 @@
 	},
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/structure/table/wood/bar,
-/obj/item/ammo_box/magazine/ak47,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/whitesands/surface/outdoors)
@@ -541,9 +540,6 @@
 /area/whitesands/surface/outdoors)
 "BQ" = (
 /obj/structure/table/wood/bar,
-/obj/item/gun/ballistic/automatic/ak47,
-/obj/item/ammo_box/magazine/ak47,
-/obj/item/ammo_box/magazine/ak47,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/whitesands/surface/outdoors)
@@ -1024,7 +1020,7 @@
 /area/whitesands/surface/outdoors)
 "Wv" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "WV" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -1067,10 +1063,10 @@
 /obj/machinery/firealarm{
 	pixel_y = -28
 	},
-/obj/structure/table/wood/bar,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},

--- a/_maps/RandomRuins/SandRuins/crash_bar.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_bar.dmm
@@ -1,0 +1,1483 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"bK" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"bN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"bU" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"bV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"cP" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"dl" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/whitesands/surface/outdoors)
+"dR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"ed" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"eh" = (
+/obj/structure/table/wood/bar,
+/obj/item/toy/figure/bartender{
+	desc = "you feel like you recognize this...";
+	name = "Familiar Bartender action figure";
+	toysay = "What can I get ya?"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/whitesands/surface/outdoors)
+"el" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"eP" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"fj" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"fn" = (
+/obj/machinery/chem_master/condimaster,
+/obj/item/storage/box/beakers,
+/obj/effect/turf_decal/corner/white/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/mono/dark,
+/area/whitesands/surface/outdoors)
+"fG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"gp" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"gR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"gX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"he" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/whitesands/surface/outdoors)
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/chair/wood,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"hm" = (
+/mob/living/simple_animal/hostile/whitesands/survivor,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"il" = (
+/obj/structure/lattice,
+/mob/living/simple_animal/hostile/whitesands/survivor,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"iu" = (
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/whitesands/surface/outdoors)
+"iD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"iV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"jT" = (
+/obj/item/paper_bin,
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/whitesands/surface/outdoors)
+"kk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"lx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"lH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/whitesands/surface/outdoors)
+"lI" = (
+/obj/structure/table/wood/bar,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/c45,
+/obj/item/ammo_box/magazine/m45,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"mp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"ni" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor7"
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"od" = (
+/turf/closed/wall/mineral/sandstone,
+/area/whitesands/surface/outdoors)
+"oV" = (
+/mob/living/simple_animal/hostile/whitesands/ranged/gunslinger{
+	desc = "One of the few survivors on the planet with working weaponry. Doesn't seem as friendly as the bartenders you're used to."
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/whitesands/surface/outdoors)
+"pa" = (
+/obj/item/toy/cards/deck/kotahi,
+/obj/item/storage/pill_bottle/dice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"qe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"qx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/whitesands/surface/outdoors)
+"qy" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"qW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/structure/table/wood/bar,
+/obj/item/ammo_box/magazine/ak47,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"ry" = (
+/obj/machinery/newscaster{
+	pixel_x = -30;
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono,
+/area/whitesands/surface/outdoors)
+"rR" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/whitesands/surface/outdoors)
+"rY" = (
+/obj/structure/table/wood/bar,
+/obj/item/gun/ballistic/rifle/boltaction/polymer,
+/obj/item/ammo_box/aac_300blk_stripper,
+/obj/item/ammo_box/aac_300blk_stripper,
+/obj/item/ammo_box/aac_300blk_stripper,
+/obj/item/ammo_box/aac_300blk_stripper,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"sn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"sA" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/whitesands/surface/outdoors)
+"sN" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"tI" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor7"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/whitesands/surface/outdoors)
+"tV" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"ud" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"uD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/whitesands/surface/outdoors)
+"vc" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"vR" = (
+/mob/living/simple_animal/hostile/whitesands/survivor,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"wy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"wL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/whitesands/survivor,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"wP" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/whitesands/surface/outdoors)
+"xh" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access = null
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/whitesands/surface/outdoors)
+"xX" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"yv" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/whitesands/surface/outdoors)
+"yU" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"zn" = (
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Ai" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Ar" = (
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Av" = (
+/obj/machinery/smartfridge/drinks,
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"Ax" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"Br" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"BE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"BQ" = (
+/obj/structure/table/wood/bar,
+/obj/item/gun/ballistic/automatic/ak47,
+/obj/item/ammo_box/magazine/ak47,
+/obj/item/ammo_box/magazine/ak47,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Cn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/mineral/sandstone,
+/area/space)
+"CS" = (
+/obj/machinery/status_display/shuttle,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"DU" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck/cas{
+	pixel_y = 8
+	},
+/obj/item/toy/cards/deck/cas/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"Eg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/holopad/emergency/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/whitesands/surface/outdoors)
+"Eq" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/electronics/apc,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"EP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"Fc" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"FA" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/whitesands/surface/outdoors)
+"FI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"FV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/whitesands/ranged/gunslinger,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Gz" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"Ha" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Hc" = (
+/obj/machinery/light,
+/turf/closed/wall/mineral/sandstone,
+/area/whitesands/surface/outdoors)
+"HA" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"HM" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"HU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"HZ" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/whitesands/surface/outdoors)
+"Ig" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"IX" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"Jw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/chair/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"JH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"JJ" = (
+/obj/item/toy/cards/deck/syndicate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"JS" = (
+/obj/machinery/deepfryer,
+/obj/effect/turf_decal/corner/white/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/mono/dark,
+/area/whitesands/surface/outdoors)
+"JT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"Ka" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"Ko" = (
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/corner/white/half,
+/obj/effect/turf_decal/corner/white{
+	dir = 4
+	},
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/plasteel/mono/dark,
+/area/whitesands/surface/outdoors)
+"Kz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"KB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"KJ" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/mob/living/simple_animal/hostile/whitesands/survivor,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"KZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Lg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"LS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"ME" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"MO" = (
+/obj/machinery/vending/boozeomat/all_access{
+	density = 0;
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"Np" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"Nr" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Nt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/whitesands/surface/outdoors)
+"NH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/black,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"OK" = (
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/whitesands/surface/outdoors)
+"OM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/corner/white/half,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/whitesands/surface/outdoors)
+"OY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"OZ" = (
+/turf/closed/wall/mineral/sandstone,
+/area/space)
+"PG" = (
+/obj/structure/table/wood/bar,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"PW" = (
+/obj/machinery/processor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/whitesands/surface/outdoors)
+"Qk" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"QG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"QJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"RK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Sd" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"Tj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"TU" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"Uc" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Ut" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/whitesands/surface/outdoors)
+"Uu" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
+/area/whitesands/surface/outdoors)
+"Uy" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"UH" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30;
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Vw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/whitesands/surface/outdoors)
+"Wu" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"Wv" = (
+/turf/template_noop,
+/area/space)
+"WV" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/closed/wall/mineral/sandstone,
+/area/space)
+"XE" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"XT" = (
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"Yp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Ys" = (
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/firealarm{
+	pixel_y = -28
+	},
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/whitesands/surface/outdoors)
+"Yy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/whitesands/surface/outdoors)
+"ZL" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"ZO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/black,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+
+(1,1,1) = {"
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Wv
+Ar
+Wv
+Wv
+Wv
+Wv
+Wv
+"}
+(2,1,1) = {"
+Wv
+Wv
+Ar
+fj
+fj
+fj
+Ar
+fj
+fj
+Np
+Ar
+Wv
+Wv
+Wv
+Wv
+"}
+(3,1,1) = {"
+Wv
+Wv
+KJ
+Fc
+cP
+cP
+fj
+fj
+cP
+cP
+il
+fj
+fj
+Wv
+Wv
+"}
+(4,1,1) = {"
+Wv
+fj
+IX
+Wu
+Ar
+ZL
+gX
+qy
+Ar
+cP
+cP
+cP
+Sd
+Wv
+Wv
+"}
+(5,1,1) = {"
+fj
+fj
+qe
+xX
+Nt
+aL
+bV
+LS
+NH
+Ai
+yU
+cP
+Ax
+fj
+Wv
+"}
+(6,1,1) = {"
+fj
+Ar
+hf
+ZO
+KZ
+Tj
+sn
+ed
+ni
+Lg
+wy
+Gz
+kk
+el
+fj
+"}
+(7,1,1) = {"
+fj
+fj
+Br
+FA
+QG
+sA
+DU
+gR
+he
+FI
+vc
+eP
+el
+Sd
+fj
+"}
+(8,1,1) = {"
+Wv
+fj
+JH
+BE
+yv
+pa
+JJ
+Uy
+Od
+Kz
+HU
+tV
+Ar
+kk
+fj
+"}
+(9,1,1) = {"
+fj
+Ar
+Jw
+bU
+gp
+rR
+wP
+XE
+tI
+rR
+TU
+XT
+Ar
+Sd
+fj
+"}
+(10,1,1) = {"
+Ar
+fj
+Vw
+HM
+Ut
+jT
+eh
+HZ
+lH
+Ys
+lx
+ME
+fj
+el
+Wv
+"}
+(11,1,1) = {"
+Ar
+Np
+Vw
+sN
+Ka
+dl
+JT
+oV
+Eg
+qx
+OY
+Av
+wL
+Sd
+Wv
+"}
+(12,1,1) = {"
+fj
+fj
+Yp
+XT
+Yy
+CS
+OK
+iu
+uD
+MO
+xh
+XT
+fj
+Wv
+Wv
+"}
+(13,1,1) = {"
+fj
+fj
+dR
+Ha
+Eq
+bK
+HA
+XT
+zn
+Ig
+HA
+HA
+fj
+Wv
+Wv
+"}
+(14,1,1) = {"
+Ar
+fj
+iV
+Uc
+od
+Uu
+JS
+PW
+EP
+UH
+fn
+HA
+Wv
+Wv
+Wv
+"}
+(15,1,1) = {"
+Ar
+Np
+iD
+vR
+od
+OM
+ry
+QJ
+KB
+ud
+fG
+WV
+fj
+Wv
+Wv
+"}
+(16,1,1) = {"
+fj
+fj
+ud
+Hc
+od
+Ko
+el
+FV
+qW
+yU
+fG
+Cn
+fj
+Wv
+Wv
+"}
+(17,1,1) = {"
+Wv
+Np
+Ar
+od
+lI
+mp
+tV
+cP
+BQ
+Ar
+el
+OZ
+fj
+Wv
+Wv
+"}
+(18,1,1) = {"
+Wv
+fj
+Ar
+od
+Qk
+ZL
+wy
+bN
+RK
+Ar
+od
+OZ
+fj
+fj
+Wv
+"}
+(19,1,1) = {"
+Wv
+fj
+Ar
+od
+od
+PG
+rY
+fG
+Nr
+od
+od
+Ar
+fj
+fj
+Wv
+"}
+(20,1,1) = {"
+Wv
+Wv
+Wv
+fj
+OZ
+OZ
+OZ
+OZ
+OZ
+OZ
+Ar
+Ar
+fj
+Wv
+Wv
+"}
+(21,1,1) = {"
+Wv
+Wv
+Wv
+fj
+fj
+Ar
+hm
+fj
+Ar
+Ar
+fj
+Ar
+Wv
+Wv
+Wv
+"}
+(22,1,1) = {"
+Wv
+Wv
+Wv
+Wv
+Np
+fj
+fj
+Ar
+fj
+fj
+Ar
+Wv
+Wv
+Wv
+Wv
+"}

--- a/_maps/RandomRuins/SandRuins/crash_bar.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_bar.dmm
@@ -164,13 +164,10 @@
 /turf/open/floor/plating,
 /area/whitesands/surface/outdoors)
 "hm" = (
-/mob/living/simple_animal/hostile/whitesands/survivor,
+/mob/living/simple_animal/hostile/whitesands/survivor{
+	faction = list("saloon")
+	},
 /turf/open/floor/plating,
-/area/whitesands/surface/outdoors)
-"il" = (
-/obj/structure/lattice,
-/mob/living/simple_animal/hostile/whitesands/survivor,
-/turf/template_noop,
 /area/whitesands/surface/outdoors)
 "iu" = (
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -280,7 +277,8 @@
 /area/whitesands/surface/outdoors)
 "oV" = (
 /mob/living/simple_animal/hostile/whitesands/ranged/gunslinger{
-	desc = "One of the few survivors on the planet with working weaponry. Doesn't seem as friendly as the bartenders you're used to."
+	desc = "One of the few survivors on the planet with working weaponry. Doesn't seem as friendly as the bartenders you're used to.";
+	faction = list("saloon")
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -421,7 +419,9 @@
 	},
 /area/whitesands/surface/outdoors)
 "vR" = (
-/mob/living/simple_animal/hostile/whitesands/survivor,
+/mob/living/simple_animal/hostile/whitesands/survivor{
+	faction = list("saloon")
+	},
 /turf/open/floor/plasteel/dark,
 /area/whitesands/surface/outdoors)
 "wy" = (
@@ -432,7 +432,9 @@
 /area/whitesands/surface/outdoors)
 "wL" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/whitesands/survivor,
+/mob/living/simple_animal/hostile/whitesands/survivor{
+	faction = list("saloon")
+	},
 /turf/open/floor/plating,
 /area/whitesands/surface/outdoors)
 "wP" = (
@@ -619,7 +621,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/mob/living/simple_animal/hostile/whitesands/ranged/gunslinger,
+/mob/living/simple_animal/hostile/whitesands/ranged/gunslinger{
+	faction = list("saloon")
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -760,12 +764,6 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/whitesands/surface/outdoors)
-"KJ" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/mob/living/simple_animal/hostile/whitesands/survivor,
-/turf/template_noop,
 /area/whitesands/surface/outdoors)
 "KZ" = (
 /obj/structure/cable{
@@ -1106,6 +1104,14 @@
 	},
 /turf/open/floor/wood,
 /area/whitesands/surface/outdoors)
+"ZU" = (
+/mob/living/simple_animal/hostile/whitesands/survivor{
+	faction = list("saloon")
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
 
 (1,1,1) = {"
 Wv
@@ -1144,7 +1150,7 @@ Wv
 (3,1,1) = {"
 Wv
 Wv
-KJ
+Np
 Fc
 cP
 cP
@@ -1152,7 +1158,7 @@ fj
 fj
 cP
 cP
-il
+fj
 fj
 fj
 Wv
@@ -1163,7 +1169,7 @@ Wv
 fj
 IX
 Wu
-Ar
+hm
 ZL
 gX
 qy
@@ -1186,7 +1192,7 @@ bV
 LS
 NH
 Ai
-yU
+ZU
 cP
 Ax
 fj

--- a/_maps/RandomRuins/SandRuins/crash_cargo.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_cargo.dmm
@@ -1,0 +1,1115 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/door/poddoor{
+	id = "whiteship_starboard"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"cX" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"du" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"dy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"fC" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"fF" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating/airless,
+/area/whitesands/surface/outdoors)
+"hD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/item/melee/transforming/energy/axe,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"kp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"kw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"kO" = (
+/mob/living/simple_animal/hostile/pirate/melee,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"lf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"lN" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/whitesands/surface/outdoors)
+"mz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"nD" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"nF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/smes,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"nL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"oF" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/storage/bag/trash{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"pJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"pP" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"qb" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"qi" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"qK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/cell/high,
+/obj/item/multitool,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"rl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/fire,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/reagent_containers/syringe,
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"sn" = (
+/obj/structure/lattice,
+/obj/machinery/door/poddoor{
+	id = "whiteship_starboard"
+	},
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"sw" = (
+/obj/machinery/door/poddoor{
+	id = "whiteship_starboard"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"ui" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/rods/twentyfive,
+/obj/item/wrench,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"wo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"xA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stack/cable_coil/red{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"yi" = (
+/turf/open/floor/plating{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
+/area/whitesands/surface/outdoors)
+"yS" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Az" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"AA" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Bb" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/whitesands/surface/outdoors)
+"BN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"BY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Ed" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "whiteship_starboard";
+	name = "Starboard Blast Door Control";
+	pixel_x = -24;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"ED" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"FM" = (
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"FW" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Gs" = (
+/mob/living/simple_animal/hostile/pirate/melee,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"Gz" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"GW" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Hb" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"HY" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/mob/living/simple_animal/hostile/pirate/ranged,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Iv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Kj" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/built{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Ku" = (
+/mob/living/simple_animal/hostile/pirate/melee,
+/turf/open/floor/plating{
+	icon_state = "titanium_dam5"
+	},
+/area/whitesands/surface/outdoors)
+"KX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Lp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Mc" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/door/poddoor{
+	id = "whiteship_starboard"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"MB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/item/wallframe/apc,
+/obj/item/electronics/apc,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"MV" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"No" = (
+/obj/machinery/door/poddoor{
+	id = "whiteship_starboard"
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
+/area/whitesands/surface/outdoors)
+"Np" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"NI" = (
+/turf/open/floor/plating{
+	icon_state = "titanium_dam5"
+	},
+/area/whitesands/surface/outdoors)
+"NP" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/analyzer,
+/obj/item/wrench,
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Oe" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"OM" = (
+/obj/machinery/light/built{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Po" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/machinery/light/small/built{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Pz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/energy/laser/retro,
+/obj/item/melee/transforming/energy/sword/pirate,
+/obj/item/melee/transforming/energy/sword/pirate,
+/obj/item/gun/energy/laser/retro,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"PW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/cable,
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"QX" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"RQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/pirate/ranged,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"RV" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating/airless,
+/area/whitesands/surface/outdoors)
+"Sf" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral,
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Sv" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Tp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate,
+/obj/item/shovel,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"TB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Uc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Um" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"UV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Wv" = (
+/obj/machinery/light/built{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Xl" = (
+/turf/template_noop,
+/area/space)
+"Ya" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"YN" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/dark,
+/area/whitesands/surface/outdoors)
+"Zz" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/whitesands/surface/outdoors)
+
+(1,1,1) = {"
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Um
+Um
+Xl
+"}
+(2,1,1) = {"
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+FM
+Zz
+Bb
+FM
+Xl
+"}
+(3,1,1) = {"
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+FM
+lN
+RV
+fF
+lN
+FM
+"}
+(4,1,1) = {"
+Xl
+Xl
+Xl
+FM
+yS
+FM
+Xl
+lN
+nF
+Hb
+HY
+ED
+lN
+"}
+(5,1,1) = {"
+Xl
+Xl
+Um
+lN
+Kj
+yi
+qi
+lN
+qK
+kw
+MB
+PW
+lN
+"}
+(6,1,1) = {"
+Xl
+Um
+Um
+lN
+nD
+Gs
+wo
+lN
+Po
+Uc
+BN
+lN
+FM
+"}
+(7,1,1) = {"
+Um
+Um
+yi
+BY
+pJ
+Gz
+Oe
+hD
+mz
+Lp
+Tp
+qi
+Xl
+"}
+(8,1,1) = {"
+Um
+yi
+yi
+ui
+Ya
+xA
+yi
+lN
+lN
+lf
+lN
+lN
+Xl
+"}
+(9,1,1) = {"
+Xl
+Um
+lN
+Az
+QX
+Az
+lN
+Oe
+oF
+NI
+yi
+lN
+FM
+"}
+(10,1,1) = {"
+Xl
+Xl
+sn
+FW
+du
+MV
+TB
+Wv
+Sv
+QX
+GW
+Ed
+No
+"}
+(11,1,1) = {"
+Xl
+Um
+No
+qb
+NI
+QX
+kO
+Pz
+NI
+dy
+Iv
+nL
+sw
+"}
+(12,1,1) = {"
+Xl
+Um
+No
+du
+du
+Gz
+QX
+Oe
+KX
+Ku
+kp
+kp
+bT
+"}
+(13,1,1) = {"
+Xl
+Um
+No
+yi
+Oe
+YN
+Oe
+RQ
+Oe
+QX
+kp
+rl
+Mc
+"}
+(14,1,1) = {"
+Um
+yi
+No
+cX
+QX
+AA
+UV
+OM
+QX
+Gz
+pP
+fC
+bT
+"}
+(15,1,1) = {"
+Um
+yi
+lN
+Az
+Az
+Az
+lN
+lN
+NP
+Np
+Sf
+lN
+FM
+"}
+(16,1,1) = {"
+Um
+Um
+yi
+Um
+yi
+yi
+Um
+yi
+yi
+yi
+yi
+Um
+Um
+"}
+(17,1,1) = {"
+Um
+Um
+yi
+yi
+Um
+yi
+Um
+Um
+Um
+yi
+Um
+Um
+Um
+"}
+(18,1,1) = {"
+Xl
+yi
+Xl
+Xl
+yi
+Um
+yi
+yi
+Um
+Um
+Um
+yi
+yi
+"}
+(19,1,1) = {"
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+yi
+Um
+yi
+Um
+yi
+Um
+Xl
+"}
+(20,1,1) = {"
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+yi
+Um
+yi
+Xl
+"}

--- a/_maps/RandomRuins/SandRuins/crash_cargo.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_cargo.dmm
@@ -664,7 +664,6 @@
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/gun/energy/laser/retro,
 /obj/item/melee/transforming/energy/sword/pirate,
-/obj/item/melee/transforming/energy/sword/pirate,
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/plasteel/dark,
 /area/whitesands/surface/outdoors)
@@ -788,7 +787,7 @@
 /area/whitesands/surface/outdoors)
 "Xl" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Ya" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,

--- a/_maps/RandomRuins/SandRuins/crash_cult.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_cult.dmm
@@ -242,7 +242,7 @@
 /area/whitesands/surface/outdoors)
 "jG" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "jI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1

--- a/_maps/RandomRuins/SandRuins/crash_cult.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_cult.dmm
@@ -1,0 +1,1825 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"ax" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"bi" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"bp" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"bU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"cl" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/item/bedsheet/cult,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"cp" = (
+/obj/structure/table,
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/megaphone{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"cE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"cW" = (
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"cY" = (
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"dz" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
+	},
+/obj/structure/rack,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"dF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"dK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"ev" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"eC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"eY" = (
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"fe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/holopad/emergency/command{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"hq" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"hG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"hV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/medical/glass,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"hY" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"ix" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"iz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"iE" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"iJ" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"iV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"jn" = (
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"jt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"jG" = (
+/turf/template_noop,
+/area/space)
+"jI" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"kb" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/corner/green,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"kk" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"ku" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/brown,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"lE" = (
+/obj/item/ectoplasm,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"lQ" = (
+/obj/machinery/door/airlock/mining,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"mR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"nb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"nP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"nU" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"oc" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/obj/machinery/computer/cryopod{
+	pixel_x = 32
+	},
+/obj/machinery/cryopod,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"pN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"pR" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"pV" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"pW" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"qm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/radio/intercom/wideband{
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"qR" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"rO" = (
+/obj/machinery/computer/crew,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"sr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"su" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"ti" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"tl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"tE" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"uO" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"uP" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"vl" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"vE" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"vS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"xg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"xk" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"xz" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"xP" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/whitesands/surface/outdoors)
+"ya" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"ye" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"yf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"yL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"yS" = (
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"yZ" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/item/electronics/apc,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"zn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"zz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"zM" = (
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"zR" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"BT" = (
+/obj/structure/constructshell,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Ck" = (
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Cx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"CP" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Df" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Dy" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"DK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Er" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/closed/wall/mineral/cult,
+/area/whitesands/surface/outdoors)
+"EZ" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Fi" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/whitesands/surface/outdoors)
+"Fk" = (
+/obj/effect/rune/narsie,
+/mob/living/simple_animal/hostile/construct/juggernaut/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/nullrod/armblade/tentacle)
+	},
+/obj/structure/sacrificealtar,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"FX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Gc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Gs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"GF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/construct/wraith/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/rod_of_asclepius)
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"GJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"GM" = (
+/obj/structure/healingfountain,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Hc" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"HH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Ie" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Ir" = (
+/obj/structure/sign/warning/longtermwaste{
+	name = "long term ...  warning sign"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"IF" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/item/kitchen/knife{
+	pixel_x = 16
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"IN" = (
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"IT" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"IY" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/closed/wall/mineral/cult,
+/area/whitesands/surface/outdoors)
+"JY" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/item/storage/firstaid/o2,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"KJ" = (
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "whiteship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -22;
+	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "whiteship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -22;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/item/areaeditor/shuttle,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"LB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"LN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"LP" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"LV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Mf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Mq" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Mz" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"MQ" = (
+/obj/docking_port/mobile{
+	callTime = 250;
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 11;
+	height = 17;
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Salvage Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 33
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"MT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/machinery/cryopod,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"NM" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"NO" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Og" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Os" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"OJ" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/obj/item/bedsheet/cult,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Pi" = (
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Qb" = (
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Qg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Ql" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/closed/wall/mineral/cult,
+/area/whitesands/surface/outdoors)
+"Qt" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"QB" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/trash/plate{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/trash/plate{
+	pixel_y = 12
+	},
+/obj/item/trash/plate{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"QT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"QU" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Rk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"SI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"TL" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/brown,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"TP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Ud" = (
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Uz" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"UT" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/gun/energy/laser/retro,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"VG" = (
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"VP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"We" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/whitesands/surface/outdoors)
+"Wf" = (
+/mob/living/simple_animal/hostile/construct/artificer/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/necromantic_stone)
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Wl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"WM" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"WR" = (
+/obj/item/chainsaw,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Xr" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Xt" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Xu" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"XJ" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Ya" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/mineral/cult,
+/area/whitesands/surface/outdoors)
+"Yw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Zp" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"ZQ" = (
+/turf/closed/wall/mineral/cult,
+/area/whitesands/surface/outdoors)
+
+(1,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jn
+cE
+eC
+Ir
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+"}
+(2,1,1) = {"
+jn
+jn
+ZQ
+ZQ
+ZQ
+jn
+jG
+zR
+mR
+WR
+zR
+jG
+jn
+jn
+jn
+jn
+jn
+jn
+"}
+(3,1,1) = {"
+ZQ
+Wf
+HH
+yS
+QT
+jn
+jG
+zR
+lE
+Wl
+zR
+jG
+yL
+Xt
+bi
+uO
+kb
+ZQ
+"}
+(4,1,1) = {"
+ZQ
+Pi
+HH
+BT
+HH
+ZQ
+jG
+zR
+Gs
+Wl
+zR
+jG
+ZQ
+Mq
+LB
+TP
+IN
+ZQ
+"}
+(5,1,1) = {"
+Er
+ax
+Pi
+xk
+xg
+IY
+jG
+jn
+Cx
+pN
+jn
+jG
+ZQ
+Dy
+Os
+nU
+Qt
+zR
+"}
+(6,1,1) = {"
+Ya
+Mz
+Pi
+cY
+Wl
+Ql
+ZQ
+xP
+We
+QT
+xP
+zR
+ZQ
+Zp
+QB
+hG
+IF
+zR
+"}
+(7,1,1) = {"
+EZ
+GM
+Fk
+QU
+pW
+zn
+uP
+Og
+hY
+Pi
+nP
+Pi
+bU
+dF
+Uz
+yf
+ix
+zR
+"}
+(8,1,1) = {"
+Hc
+Pi
+Pi
+iJ
+Pi
+Fi
+zR
+ZQ
+su
+TP
+xP
+zR
+ZQ
+Xu
+SI
+eY
+Xr
+zR
+"}
+(9,1,1) = {"
+jn
+HH
+Pi
+HH
+DK
+jn
+jG
+ZQ
+We
+Pi
+jn
+jG
+jn
+yS
+iz
+Wl
+VG
+zR
+"}
+(10,1,1) = {"
+ZQ
+yS
+yf
+eY
+CP
+ZQ
+jG
+zR
+iE
+QT
+zR
+jG
+jn
+OJ
+oc
+MT
+cl
+jn
+"}
+(11,1,1) = {"
+ZQ
+jn
+ZQ
+jn
+jn
+ZQ
+jG
+zR
+mR
+Qg
+zR
+jG
+jn
+ZQ
+ZQ
+jn
+jn
+jn
+"}
+(12,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+ZQ
+We
+yf
+zR
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+"}
+(13,1,1) = {"
+ZQ
+ZQ
+jn
+jn
+ZQ
+ZQ
+jG
+ZQ
+We
+pN
+zR
+jG
+jn
+jn
+jn
+ZQ
+ZQ
+ZQ
+"}
+(14,1,1) = {"
+ZQ
+ku
+LV
+Yw
+yZ
+jn
+jG
+jn
+iE
+HH
+jn
+jG
+ZQ
+NO
+cW
+ti
+hq
+zR
+"}
+(15,1,1) = {"
+xP
+zR
+Wl
+ad
+dz
+jn
+zR
+xP
+We
+Wl
+xP
+ZQ
+ZQ
+vl
+Qb
+ZQ
+zR
+xP
+"}
+(16,1,1) = {"
+MQ
+jt
+jI
+FX
+ya
+lQ
+Pi
+Rk
+Cx
+HH
+hV
+Pi
+zz
+GJ
+Ie
+bp
+nb
+LP
+"}
+(17,1,1) = {"
+xP
+zR
+LN
+Df
+ev
+ZQ
+zR
+xP
+zM
+HH
+ZQ
+zR
+xP
+kk
+iV
+jn
+zR
+xP
+"}
+(18,1,1) = {"
+jn
+TL
+sr
+IT
+vE
+jn
+jG
+jn
+We
+yS
+ZQ
+jG
+jn
+xz
+VP
+pR
+JY
+zR
+"}
+(19,1,1) = {"
+jn
+jn
+zR
+zR
+jn
+jn
+jG
+ZQ
+We
+QT
+jn
+jG
+jn
+jn
+zR
+zR
+jn
+jn
+"}
+(20,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+ZQ
+Cx
+Pi
+jn
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+"}
+(21,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jG
+ZQ
+ZQ
+ye
+dK
+xP
+ZQ
+jG
+jG
+jG
+jG
+jG
+jG
+"}
+(22,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jn
+ZQ
+KJ
+vS
+NM
+WM
+ZQ
+ZQ
+jG
+jG
+jG
+jG
+jG
+"}
+(23,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+XJ
+pV
+qm
+GF
+fe
+Gc
+tE
+XJ
+jG
+jG
+jG
+jG
+jG
+"}
+(24,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+XJ
+rO
+qR
+yf
+QT
+tl
+Mf
+ZQ
+jG
+jG
+jG
+jG
+jG
+"}
+(25,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+XJ
+XJ
+Ck
+cp
+UT
+Ud
+ZQ
+ZQ
+jG
+jG
+jG
+jG
+jG
+"}
+(26,1,1) = {"
+jG
+jG
+jG
+jG
+jG
+jG
+XJ
+XJ
+XJ
+XJ
+ZQ
+ZQ
+jG
+jG
+jG
+jG
+jG
+jG
+"}

--- a/_maps/RandomRuins/SandRuins/crash_kitchen.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_kitchen.dmm
@@ -1,0 +1,749 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aq" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"br" = (
+/obj/structure/sign/donk{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"cl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"dr" = (
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"dA" = (
+/obj/structure/extinguisher_cabinet,
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"fE" = (
+/obj/structure/curtain/bounty,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/eighties,
+/area/whitesands/surface/outdoors)
+"ga" = (
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"gg" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"gO" = (
+/obj/structure/table,
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"gS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"im" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/eighties,
+/area/whitesands/surface/outdoors)
+"it" = (
+/obj/structure/girder,
+/turf/open/space/basic,
+/area/whitesands/surface/outdoors)
+"iH" = (
+/turf/template_noop,
+/area/space)
+"ju" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"jX" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"lN" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_y = 2
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"me" = (
+/obj/structure/table,
+/obj/structure/frame/machine,
+/obj/structure/table,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"pa" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/whitesands/surface/outdoors)
+"pc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"sI" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"sQ" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"sV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"tm" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"tI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/sign/solgov_seal{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"uM" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/whitesands/surface/outdoors)
+"vc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"wq" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/whitesands/surface/outdoors)
+"wG" = (
+/obj/structure/girder,
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"xh" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"xi" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"xD" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/kitchen/knife,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"xU" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"yB" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/whitesands/surface/outdoors)
+"yE" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/mineral/titanium,
+/area/whitesands/surface/outdoors)
+"Al" = (
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"DF" = (
+/obj/machinery/door/window/westleft,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/whitesands/surface/outdoors)
+"Fq" = (
+/obj/item/electronics/apc,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/whitesands/surface/outdoors)
+"Hv" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"HU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"HV" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/item/soap,
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/whitesands/surface/outdoors)
+"Ka" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"KR" = (
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Lz" = (
+/obj/effect/mob_spawn/human/corpse{
+	head = 0;
+	mob_species = /datum/species/golem
+	},
+/obj/item/ammo_casing/spent{
+	dir = 1;
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/gun/ballistic/automatic/zip_pistol{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Mi" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"Nb" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"QS" = (
+/obj/structure/chair/comfy/teal,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/whitesands/surface/outdoors)
+"Rt" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sgwindowshut";
+	name = "external shutters"
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+"RL" = (
+/obj/structure/lattice,
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Sh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/door/window/westright,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/atmospherics/components/binary/pump/layer2,
+/turf/open/floor/plating/foam,
+/area/whitesands/surface/outdoors)
+"Te" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"TX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
+	dir = 8
+	},
+/obj/item/oar,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = -24
+	},
+/obj/structure/closet/emcloset/wall{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/whitesands/surface/outdoors)
+"TZ" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/whitesands/surface/outdoors)
+"UA" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/machinery/gibber,
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/whitesands/surface/outdoors)
+"Vn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/nanoweave/purple,
+/area/whitesands/surface/outdoors)
+"Vy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/button/door{
+	id = "sgkitchen";
+	name = "Kitchen Shutters";
+	pixel_y = -22
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("cricket")
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/white{
+	dir = 2
+	},
+/obj/effect/turf_decal/corner/bar/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/whitesands/surface/outdoors)
+"VG" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	piping_layer = 2
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("cricket")
+	},
+/turf/open/floor/plasteel/tech,
+/area/whitesands/surface/outdoors)
+"WP" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/whitesands/surface/outdoors)
+
+(1,1,1) = {"
+iH
+iH
+iH
+uM
+uM
+uM
+wq
+jX
+sQ
+uM
+uM
+iH
+iH
+iH
+iH
+iH
+"}
+(2,1,1) = {"
+yE
+VG
+Sh
+TX
+pa
+yB
+TZ
+pa
+pa
+it
+dr
+dr
+uM
+iH
+iH
+iH
+"}
+(3,1,1) = {"
+Nb
+Nb
+dr
+pa
+pa
+KR
+Vn
+ju
+xU
+tI
+Ka
+fE
+KR
+uM
+iH
+iH
+"}
+(4,1,1) = {"
+Nb
+UA
+tm
+Te
+xh
+sQ
+jX
+gS
+dr
+QS
+cl
+im
+gg
+sQ
+uM
+iH
+"}
+(5,1,1) = {"
+Rt
+xD
+pc
+WP
+lN
+sV
+sQ
+gO
+dr
+Fq
+ga
+Al
+jX
+KR
+uM
+uM
+"}
+(6,1,1) = {"
+Rt
+me
+jX
+Lz
+aq
+sQ
+jX
+HU
+pa
+HV
+DF
+pa
+sQ
+uM
+iH
+iH
+"}
+(7,1,1) = {"
+Mi
+Hv
+KR
+Vy
+dr
+br
+vc
+dA
+pa
+Nb
+pa
+pa
+uM
+iH
+iH
+iH
+"}
+(8,1,1) = {"
+RL
+pa
+pa
+xi
+wG
+gg
+jX
+jX
+sQ
+Nb
+uM
+iH
+iH
+iH
+iH
+iH
+"}
+(9,1,1) = {"
+iH
+iH
+uM
+uM
+sQ
+KR
+sI
+sQ
+uM
+uM
+iH
+iH
+iH
+iH
+iH
+iH
+"}
+(10,1,1) = {"
+iH
+iH
+iH
+iH
+iH
+uM
+uM
+uM
+iH
+iH
+iH
+iH
+iH
+iH
+iH
+iH
+"}
+(11,1,1) = {"
+iH
+iH
+iH
+iH
+iH
+iH
+uM
+iH
+iH
+iH
+iH
+iH
+iH
+iH
+iH
+iH
+"}

--- a/_maps/RandomRuins/SandRuins/crash_kitchen.dmm
+++ b/_maps/RandomRuins/SandRuins/crash_kitchen.dmm
@@ -78,7 +78,7 @@
 /area/whitesands/surface/outdoors)
 "iH" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "ju" = (
 /obj/structure/cable{
 	icon_state = "1-2"

--- a/config/sandruinblacklist.txt
+++ b/config/sandruinblacklist.txt
@@ -6,3 +6,7 @@
 ##MISC
 #_maps/RandomRuins/SandRuins/whitesands_surface_hermit.dmm
 #_maps/RandomRuins/SandRuins/whitesands_surface_solgovcrash.dmm
+#_maps/RandomRuins/SandRuins/crash_kitchen.dmm
+#_maps/RandomRuins/SandRuins/crash_bar.dmm
+#_maps/RandomRuins/SandRuins/crash_cargo.dmm
+#_maps/RandomRuins/SandRuins/crash_cult.dmm

--- a/config/sandruinblacklist.txt
+++ b/config/sandruinblacklist.txt
@@ -1,4 +1,4 @@
-#Listing maps here will blacklist them from generating in the ice moon.
+#Listing maps here will blacklist them from generating on the sand planet.
 #Maps must be the full path to them
 #A list of maps valid to blacklist can be found in _maps\RandomRuins\IceRuins
 #SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START

--- a/whitesands/code/datums/ruins/whitesands.dm
+++ b/whitesands/code/datums/ruins/whitesands.dm
@@ -177,3 +177,28 @@
 	placement_weight = 0.5
 	suffix = "whitesands_surface_camp_saloon.dmm"
 	allow_duplicates = FALSE
+
+//Crashed Shiptests//
+/datum/map_template/ruin/whitesands/crash_kitchen
+	name = "Crashed Kitchen"
+	description = "A crashed part of some unlucky ship."
+	id = "crash-kitchen"
+	suffix = "crash_kitchen.dmm"
+
+/datum/map_template/ruin/whitesands/crash_bar
+	name = "Crashed Bar"
+	description = "A crashed part of some unlucky ship. Was once a bar."
+	id = "crash-bar"
+	suffix = "crash_bar.dmm"
+
+/datum/map_template/ruin/whitesands/crash_cargo
+	name = "Crashed Cargo Bay"
+	description = "A crashed part of some unlucky ship. Has been taken over by pirates"
+	id = "crash-cargo"
+	suffix = "crash_cargo.dmm"
+
+/datum/map_template/ruin/whitesands/crash_cult
+	name = "Crashed Cult Ship"
+	description = "A crashed part of some unlucky ship. Has been occupied by a cult."
+	id = "crash-cult"
+	suffix = "crash_cult.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the crashed segments of shiptests as ruins
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more ruins good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The ruins of crashed ships can now be found on planets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
