### PR TITLE
decal painter buff

### DIFF
--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -36,7 +36,7 @@ standards:
   - exactly: [22, 'world<< uses', 'world[ \t]*<<']
   - exactly: [0, 'world.log<< uses', 'world.log[ \t]*<<']
 
-  - exactly: [306, 'non-bitwise << uses', '(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)']
+  - exactly: [307, 'non-bitwise << uses', '(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)']
   - exactly: [0, 'incorrect indentations', '^(?:  +)(?!\*)']
   - exactly: [0, 'superflous whitespace', '[ \t]+$']
   - exactly: [36, 'mixed indentation', '^( +\t+|\t+ +)']

--- a/whitesands/code/game/objects/items/airlock_painter.dm
+++ b/whitesands/code/game/objects/items/airlock_painter.dm
@@ -129,91 +129,158 @@
 
 /obj/item/decal_painter
 	name = "decal painter"
-	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click to change design." //WS Edit - Floor Painters
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
 	item_state = "decalsprayer"
+	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles. Decals break when the floor tiles are removed. Use it inhand to change the design."
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500)
-	var/stored_dir = 2
-	var/stored_color = ""
-	var/stored_decal = "warningline"
-	var/stored_decal_total = "warningline"
-	var/color_list = list("","red","white")
-	var/dir_list = list(1,2,4,8)
-	var/decal_list = list(list("Warning Line","warningline"),
-			list("Warning Line Corner","warninglinecorner"),
-			list("Caution Label","caution"),
-			list("Directional Arrows","arrows"),
-			list("Stand Clear Label","stand_clear"),
-			list("Box","box"),
-			list("Box Corner","box_corners"),
-			list("Delivery Marker","delivery"),
-			list("Warning Box","warn_full"))
 
-/obj/item/decal_painter/afterattack(atom/target, mob/user, proximity)
-	. = ..()
-	var/turf/open/floor/F = target
+	var/decal_icon
+	var/decal_state = "loadingarea"
+	var/decal_dir = SOUTH
+	var/decal_color = "#FFFFFF"
+
+	var/list/allowed_directions = list("north", "east", "south", "west")
+
+	var/list/allowed_states = list(
+	"loadingarea","delivery","warning","warningcorner","warningcee","warningfulltile","warningfull","box_corners","box","caution","stand_clear",
+	"arrows","overstripe","overstripecorner","overstripefull","overstripecee","stripe","stripecorner","stripefull","stripecee","stripefulltile",
+	"danger","dangercorner","dangerfull","dangercee",
+	"chapel", "outline", "spline_fancy",
+	"spline_fancy_corner","spline_fancy_cee","spline_fancy_full","spline_plain","pline_plain_cee",
+	"spline_plain_full","solarpanel","shutoff","traction","manydot",
+	"techfloor_edges","techfloor_corners","techfloororange_edges","techfloororange_corners",
+	"manydot_tiled","pryhole","corner_white","corner_oldtile","corner_kafel",
+	"corner_techfloor_gray","corner_techfloor_grid","steel_grid","steel_decals1","steel_decals2",
+	"steel_decals3","steel_decals4","steel_decals5","steel_decals6","steel_decals7",
+	"steel_decals8","steel_decals9","steel_decals10","steel_decals_central1","steel_decals_central2",
+	"steel_decals_central3","steel_decals_central4","steel_decals_central5","steel_decals_central_6","steel_decals_central7",
+	"bordercolor","bordercolorcorner","bordercolorcorner2","bordercolorfull","bordercolorcee",
+	"bordercolorhalf","bordercolormonofull","borderfloor_white","borderfloorcorner_white","borderfloorcorner2_white",
+	"siding_line","siding_corner","siding_end","siding_thinplating_line","siding_thinplating_end",
+	"siding_thinplating_corner","siding_wideplating_line","siding_wideplating_end","siding_wideplating_corner","siding_wood_line",
+	"siding_wood_corner","siding_wood_end"
+	)
+
+	var/list/color_disallowed = list(
+	"loadingarea","chapel","solarpanel","techfloor_edges",
+	"techfloororange_edges","techfloor_corners","techfloororange_corners",
+	"techfloor_hole_left","techfloor_hole_right","corner_techfloor_gray",
+	"corner_techfloor_grid","steel_grid","warning","warningcorner","warningfull","warningcee",
+	"warningfulltile","danger","dangercorner","dangerfull","dangercee"
+	)
+
+	var/list/decal_no_dirs = list("delivery", "warningfull", "box", "warningfulltile", "overstripefull", "stripefull", "stripefulltile", "outline","spline_fancy_full","spline_plain_full","solarpanel","traction","manydot","manydot_tiled","dangerfull","bordercolorfull","bordercolormonofull","",)
+	var/list/decal_eight_dirs = list()
+
+/obj/item/decal_painter/afterattack(var/atom/A, var/mob/user, proximity, params)
 	if(!proximity)
-		to_chat(user, "<span class='notice'>You need to get closer!</span>")
 		return
-	if(isturf(F))
-		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, CLEAN_TYPE_PAINT, color, null, null, alpha)
-		playsound(src.loc, 'sound/effects/spray2.ogg', 50, TRUE)
 
-/obj/item/decal_painter/AltClick(mob/user)
-	. = ..()
-	ui_interact(user)
+	var/turf/open/floor/F = A
+	if(!istype(F))
+		to_chat(user, "<span class='warning'>\The [src] can only be used on flooring.</span>")
+		return
+	if(color_disallowed.Find(decal_state))
+		F.AddComponent(/datum/component/decal, 'whitesands/icons/turf/decals.dmi', decal_state, decal_dir, CLEAN_TYPE_PAINT, color, null, null, alpha)
+	else
+		F.AddComponent(/datum/component/decal, 'whitesands/icons/turf/decals.dmi', decal_state, decal_dir, CLEAN_TYPE_PAINT, decal_color, null, null, alpha)
+	playsound(src.loc, 'sound/effects/spray2.ogg', 50, TRUE)
 
-/obj/item/decal_painter/proc/update_decal_path()
-	var/yellow_fix = "" //This will have to do until someone refactors markings.dm
-	if (stored_color)
-		yellow_fix = "_"
-	stored_decal_total = "[stored_decal][yellow_fix][stored_color]"
-	return
+/obj/item/decal_painter/attack_self(var/mob/user)
+	if(!user)
+		return FALSE
+	user.set_machine(src)
+	interact(user)
+	return TRUE
 
-/obj/item/decal_painter/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "DecalPainter", name)
-		ui.open()
+/obj/item/decal_painter/interact(mob/user as mob) //TODO: Make TGUI for this because ouch
+	if(!decal_icon)
+		decal_icon = icon('whitesands/icons/turf/decals.dmi', decal_state, decal_dir)
+	user << browse_rsc(decal_icon, "floor.png")
+	var/dat = {"
+		<center>
+			<img style="-ms-interpolation-mode: nearest-neighbor;" src="floor.png" width=128 height=128 border=4>
+		</center>
+		<center>
+			<a href="?src=[UID()];cycleleft=1">&lt;-</a>
+			<a href="?src=[UID()];choose_state=1">Choose Style</a>
+			<a href="?src=[UID()];cycleright=1">-&gt;</a>
+		</center>
+		<div class='statusDisplay'>Style: [decal_state]</div>
+		<center>
+			<a href="?src=[UID()];cycledirleft=1">&lt;-</a>
+			<a href="?src=[UID()];choose_dir=1">Choose Direction</a>
+			<a href="?src=[UID()];cycledirright=1">-&gt;</a>
+		</center>
+		<div class='statusDisplay'>Direction: [dir2text(decal_dir)]</div>
+		<center>
+			<a href="?src=[UID()];choose_color=1">Choose Color</a>
+		</center>
+	"}
 
-/obj/item/decal_painter/ui_data(mob/user)
-	var/list/data = list()
-	data["decal_direction"] = stored_dir
-	data["decal_color"] = stored_color
-	data["decal_style"] = stored_decal
-	data["decal_list"] = list()
-	data["color_list"] = list()
-	data["dir_list"] = list()
+	var/datum/browser/popup = new(user, "decal_painter", name, 225, 310)
+	popup.set_content(dat)
+	popup.open()
 
-	for(var/i in decal_list)
-		data["decal_list"] += list(list(
-			"name" = i[1],
-			"decal" = i[2]
-		))
-	for(var/j in color_list)
-		data["color_list"] += list(list(
-			"colors" = j
-		))
-	for(var/k in dir_list)
-		data["dir_list"] += list(list(
-			"dirs" = k
-		))
-	return data
-
-/obj/item/decal_painter/ui_act(action,list/params)
+/obj/item/decal_painter/Topic(href, href_list)
 	if(..())
 		return
-	switch(action)
-		//Lists of decals and designs
-		if("select decal")
-			var/selected_decal = params["decals"]
-			stored_decal = selected_decal
-		if("select color")
-			var/selected_color = params["colors"]
-			stored_color = selected_color
-		if("selected direction")
-			var/selected_direction = text2num(params["dirs"])
-			stored_dir = selected_direction
-	update_decal_path()
-	. = TRUE
+
+	if(href_list["choose_state"])
+		var/state = input("Please select a style", "[src]") as null|anything in allowed_states
+		if(state)
+			decal_state = state
+			check_directional_tile()
+	if(href_list["choose_dir"])
+		var/seldir = input("Please select a direction", "[src]") as null|anything in allowed_directions
+		if(seldir)
+			decal_dir = text2dir(seldir)
+	if(href_list["cycledirleft"])
+		var/index = allowed_directions.Find(dir2text(decal_dir))
+		index--
+		if(index < 1)
+			index = allowed_directions.len
+		decal_dir = text2dir(allowed_directions[index])
+	if(href_list["cycledirright"])
+		var/index = allowed_directions.Find(dir2text(decal_dir))
+		index++
+		if(index > allowed_directions.len)
+			index = 1
+		decal_dir = text2dir(allowed_directions[index])
+	if(href_list["cycleleft"])
+		var/index = allowed_states.Find(decal_state)
+		index--
+		if(index < 1)
+			index = allowed_states.len
+		decal_state = allowed_states[index]
+		check_directional_tile()
+	if(href_list["cycleright"])
+		var/index = allowed_states.Find(decal_state)
+		index++
+		if(index > allowed_states.len)
+			index = 1
+		decal_state = allowed_states[index]
+		check_directional_tile()
+	if(href_list["choose_color"])
+		if(!(color_disallowed.Find(decal_state)))
+			var/chosen_colour = input(usr, "", "Choose Color", decal_color) as color|null
+			if (!isnull(chosen_colour) && usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
+				decal_color = chosen_colour
+
+
+	decal_icon = icon('whitesands/icons/turf/decals.dmi', decal_state, decal_dir)
+	if(usr)
+		attack_self(usr)
+
+/obj/item/decal_painter/proc/check_directional_tile()
+	if(decal_eight_dirs.Find(decal_state))
+		allowed_directions = list("north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest")
+	else
+		if(decal_no_dirs.Find(decal_state))
+			allowed_directions = list("south")
+		else
+			allowed_directions = list("north", "east", "south", "west")
+
+	if(!(dir2text(decal_dir) in allowed_directions))
+		decal_dir = SOUTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With the new baytiles, ship decoration contains a massive amount of decal use, and players should have the option to use these decals on their own, whether to repair damage to their ship, or to completely redecorate it. This adds many (not all) of the decals available to mappers to the decal painter, as well as allowing the decal painter to select a hex color for most decals. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More customization is a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Decal painter has been reworked to have many, many more decals available.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
