### PR TITLE
Riggs Table Fix

### DIFF
--- a/_maps/shuttles/shiptest/rigger.dmm
+++ b/_maps/shuttles/shiptest/rigger.dmm
@@ -14,7 +14,6 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "az" = (
-/obj/structure/table/wood/bar,
 /obj/item/folder/red,
 /obj/item/stamp/hos{
 	pixel_x = 8;
@@ -30,6 +29,7 @@
 /obj/item/storage/fancy/cigarettes{
 	pixel_x = -10
 	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "aC" = (
@@ -58,7 +58,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "aJ" = (
-/obj/structure/table/wood/bar,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -6;
 	pixel_y = 10
@@ -68,6 +67,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "aN" = (
@@ -2713,12 +2713,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
 "GQ" = (
-/obj/structure/table/wood/bar,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -6;
 	pixel_y = 10
 	},
 /obj/item/folder,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/office)
 "GT" = (
@@ -4021,12 +4021,12 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/crew/office)
 "Xw" = (
-/obj/structure/table/wood/bar,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
 	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/ship/crew/office)
 "XD" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
resolves #272 
Replaces the Riggs-class' wood tables from the indestructible emergency bar shuttle ones to just normal wood.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs fixed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed the tables on the riggs-class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
