### PR TITLE
Fix hole into space on riggs

### DIFF
--- a/_maps/shuttles/shiptest/rigger.dmm
+++ b/_maps/shuttles/shiptest/rigger.dmm
@@ -3531,7 +3531,7 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/communications)
 "Rz" = (
 /obj/structure/grille,


### PR DESCRIPTION
:cl:
Fixed riggs class sloop having a hole where the vending machine should be
/:cl: