### PR TITLE
Fix charge overlays for energy guns

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -215,12 +215,6 @@
 		return
 	var/overlay_icon_state = "[icon_state]_charge"
 	var/ratio = get_charge_ratio()
-	if(!shaded_charge)
-		var/mutable_appearance/charge_overlay = mutable_appearance(icon, overlay_icon_state)
-		for(var/i = ratio, i >= 1, i--)
-			charge_overlay.pixel_x = ammo_x_offset * (i - 1)
-			charge_overlay.pixel_y = ammo_y_offset * (i - 1)
-			. += new /mutable_appearance(charge_overlay)
 	if(ratio == 0)
 		if(modifystate)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
@@ -228,6 +222,12 @@
 			. += "[icon_state]_[shot.select_name]"
 		. += "[icon_state]_empty"
 	else
+		if(!shaded_charge)
+			var/mutable_appearance/charge_overlay = mutable_appearance(icon, overlay_icon_state)
+			for(var/i = ratio, i >= 1, i--)
+				charge_overlay.pixel_x = ammo_x_offset * (i - 1)
+				charge_overlay.pixel_y = ammo_y_offset * (i - 1)
+				. += new /mutable_appearance(charge_overlay)
 		if(modifystate)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 			. += "[icon_state]_charge[ratio]_[shot.select_name]" //:drooling_face:

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -215,24 +215,24 @@
 		return
 	var/overlay_icon_state = "[icon_state]_charge"
 	var/ratio = get_charge_ratio()
-	if(modifystate)
-		var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-		overlay_icon_state += "_[shot.select_name]"
-		. += "[icon_state]_[shot.select_name]"
+	if(!shaded_charge)
+		var/mutable_appearance/charge_overlay = mutable_appearance(icon, overlay_icon_state)
+		for(var/i = ratio, i >= 1, i--)
+			charge_overlay.pixel_x = ammo_x_offset * (i - 1)
+			charge_overlay.pixel_y = ammo_y_offset * (i - 1)
+			. += new /mutable_appearance(charge_overlay)
 	if(ratio == 0)
+		if(modifystate)
+			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+			overlay_icon_state += "_[shot.select_name]"
+			. += "[icon_state]_[shot.select_name]"
 		. += "[icon_state]_empty"
 	else
-		if(!shaded_charge)
-			var/mutable_appearance/charge_overlay = mutable_appearance(icon, overlay_icon_state)
-			for(var/i = ratio, i >= 1, i--)
-				charge_overlay.pixel_x = ammo_x_offset * (i - 1)
-				charge_overlay.pixel_y = ammo_y_offset * (i - 1)
-				. += new /mutable_appearance(charge_overlay)
+		if(modifystate)
+			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+			. += "[icon_state]_charge[ratio]_[shot.select_name]" //:drooling_face:
 		else
 			. += "[icon_state]_charge[ratio]"
-			if(modifystate)
-				var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-				. += "[icon_state]_charge[ratio]_[shot.select_name]" //:drooling_face:
 
 ///Used by update_icon_state() and update_overlays()
 /obj/item/gun/energy/proc/get_charge_ratio()


### PR DESCRIPTION
## About The Pull Request

Fixes #310. In short, the overlays were being indiscriminately overlaid without attention to the attributes of the gun. So less overlays are being added, which should hopefully improve the performance as well.

https://user-images.githubusercontent.com/13331724/135781871-dc094af8-84b3-4cb8-9fa9-45a80db5dbfc.mp4

## Why It's Good For The Game

Flawless game.

## Changelog
:cl:
fix: Fixed charge overlays for the energy guns.
/:cl:
