### PR TITLE
People orbited by wisps now *spin two times faster

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -333,6 +333,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define LACKING_LOCOMOTION_APPENDAGES_TRAIT "lacking-locomotion-appengades" //trait associated to not having locomotion appendages nor the ability to fly or float
 #define LACKING_MANIPULATION_APPENDAGES_TRAIT "lacking-manipulation-appengades" //trait associated to not having fine manipulation appendages such as hands
 #define HANDCUFFED_TRAIT "handcuffed"
+#define ORBITED_TRAIT "orbited"
 /// Trait granted by [/obj/item/warpwhistle]
 #define WARPWHISTLE_TRAIT "warpwhistle"
 ///Turf trait for when a turf is transparent

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -271,12 +271,14 @@
 		to_chat(user, "<span class='notice'>You release the wisp. It begins to bob around your head.</span>")
 		icon_state = "lantern"
 		wisp.orbit(user, 20)
+		ADD_TRAIT(user, ORBITED_TRAIT, "orbited")
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed")
 
 	else
 		to_chat(user, "<span class='notice'>You return the wisp to the lantern.</span>")
 		icon_state = "lantern-blue"
 		wisp.forceMove(src)
+		REMOVE_TRAIT(user, ORBITED_TRAIT, "orbited")
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned")
 
 /obj/item/wisp_lantern/Initialize()

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -68,7 +68,9 @@
 
 /datum/emote/spin/run_emote(mob/user, params ,  type_override, intentional)
 	. = ..()
-	if(.)
+	if(HAS_TRAIT(user, ORBITED_TRAIT))
+		user.spin(40, 2)
+	else
 		user.spin(20, 1)
 
 		if((iscyborg(user) || isanimal(user)) && user.has_buckled_mobs())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes mobs orbited by wisps to spin faster when using *spin.
## Why It's Good For The Game
That is a very good question, but first we need to get two definitions from *legitemate* scientific sites:
Celestial body is an aggregation of matter in space that can be considered a single unit
A Satellite(moon) is a celestial body orbiting a different, larger celestial body

Therefor a spaceman in space and a wisp orbiting him can be defined as a celestial body and it's satellite
Now keeping that in mind look at this graph about planets in our solar system
https://imgur.com/J9PNOm3


You can clearly make out that the more moons a body has the faster it's rotation speed is
why wouldn't our celestial body(the player) be different?

Concluding, its only logical to assume due to laws of physics and astronomy that a person orbited by a wisp would spin faster than a normal human
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: People orbited by wisps now spin two times faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
