### PR TITLE
Minor Technophile Sect Fixes

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -180,8 +180,8 @@
 	if(!..())
 		return FALSE
 	var/obj/item/stock_parts/cell/the_cell = I
-	if(the_cell.charge < 3000)
-		to_chat("<span class='notice'>[GLOB.deity] does not accept pity amounts of power.</span>")
+	if(the_cell.charge < 3000)   // stops people from grabbing cells out of APCs
+		to_chat(L, "<span class='notice'>[GLOB.deity] does not accept pity amounts of power.</span>")
 		return FALSE
 	return TRUE
 
@@ -190,6 +190,6 @@
 	if(!is_type_in_typecache(I, desired_items_typecache))
 		return
 	var/obj/item/stock_parts/cell/the_cell = I
-	adjust_favor(round(the_cell.charge/3000), L)
+	adjust_favor(round(the_cell.charge/500), L)
 	to_chat(L, "<span class='notice'>You offer [the_cell]'s power to [GLOB.deity], pleasing them.</span>")
 	qdel(I)


### PR DESCRIPTION
## About The Pull Request

Three minor changes:

1) The message saying a power cell doesn't have enough charge to sacrifice didn't display.  This was caused by a missing argument.
2) The synth conversion rite used to cost 39 fully charged t4 power cells.  I reduced this to 7 t4, 9 t3, 13 t2, or 25 t1 cells, by changing the favor rate from 1 per 3000 charge to 1 per 500 charge.
3) I added a comment pointing out the lower limit on accepted cell charge is there to prevent players from sacrificing the power cells in every APC.  Because the natural reaction to a changed favor per charge rate would be to change the minimum-required charge to match it.

## Why It's Good For The Game

Makes the Technophile sect slightly more friendly to use.

## Changelog
:cl:
tweak: Technophile synth conversion is now semi-affordable
fix: Fixed missing Technophile cell-rejection message
/:cl:
