### PR TITLE
Cleaning Up Warnings from Default Config

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -551,9 +551,6 @@ AUTO_PROFILE
 ## Uncomment to enable discord auto-roling when users link their BYOND and Discord accounts
 #ENABLE_DISCORD_AUTOROLE
 
-## Set to a value greater than zero to require a user to have at least this many hours of living role time to be assigned the role
-REQUIRED_LIVING_HOURS 0
-
 ## Add your discord bot token here. Make sure it has the ability to manage roles
 #DISCORD_TOKEN someDiscordToken
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -241,9 +241,6 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## If non-human species are barred from joining as a head of staff
 #ENFORCE_HUMAN_AUTHORITY
 
-## If late-joining players have a chance to become a traitor/changeling
-ALLOW_LATEJOIN_ANTAGONISTS
-
 ## Comment this out to disable the antagonist reputation system. This system rewards players who participate in the game instead of greytiding by giving them slightly higher odds to
 ## roll antagonist in subsequent rounds until they get it.
 ##
@@ -588,21 +585,6 @@ ECONOMY
 
 ## Put the name of your custom currency here
 METACURRENCY_NAME Metacoin
-
-## Crew objectives
-ALLOW_CREW_OBJECTIVES
-
-## Choose which Engine to start the round with. Weight is after the comma. Setting the weight to 0 removes the engine from rotation.
-BOX_RANDOM_ENGINE Box SM,3
-BOX_RANDOM_ENGINE Box Tesla,3
-BOX_RANDOM_ENGINE Box Singulo,3
-BOX_RANDOM_ENGINE Box SM 1x3,1
-BOX_RANDOM_ENGINE Box SM 5x5,1
-BOX_RANDOM_ENGINE Box SM 3x,0
-BOX_RANDOM_ENGINE Box TEG,3
-BOX_RANDOM_ENGINE Box Empty,0
-BOX_RANDOM_ENGINE Box Antimatter,1
-BOX_RANDOM_ENGINE Box P.A.C.M.A.N,1
 
 ## Overmap Settings ##
 

--- a/whitesands/code/controllers/configuration/entries/game_options.dm
+++ b/whitesands/code/controllers/configuration/entries/game_options.dm
@@ -11,12 +11,6 @@
 	min_val = 10
 	max_val = 20
 
-/datum/config_entry/keyed_list/box_random_engine
-	key_mode = KEY_MODE_TEXT
-	value_mode = VALUE_MODE_NUM
-	lowercase = FALSE
-	splitter = ","
-
 /datum/config_entry/number/max_overmap_event_clusters
 	config_entry_value = 10
 

--- a/whitesands/code/modules/client/loadout/loadout_general.dm
+++ b/whitesands/code/modules/client/loadout/loadout_general.dm
@@ -178,7 +178,7 @@
 	path = /obj/item/toy/balloon/corgi
 	cost = 2500
 
-/datum/gear/mask/surgical
+/datum/gear/surgical_mask
 	display_name = "surgical mask"
 	path = /obj/item/clothing/mask/surgical
 	cost = 1200


### PR DESCRIPTION
## About The Pull Request

The default config includes multiple values that cause the game to throw warnings when it starts:

Unknown setting in configuration: 'allow_latejoin_antagonists'
Unknown setting in configuration: 'allow_crew_objectives'
Unknown setting in configuration: 'required_living_hours'
WARNING: Loadout - Missing display name: /datum/gear/mask in whitesands/code/modules/client/loadout/loadout.dm at line 24 src:  usr: .

Explanation:

allow_latejoin_antagonists and allow_crew_objectives were removed in #227.

required_living_hours was never used, it was removed from TG in PR 54080.

/datum/gear/mask is being referenced because all subtypes of /datum/gear are being iterated over.  /datum/gear/mask/surgical exists, but /datum/gear/mask does not, so this warning is thrown.  This is fixed by removing the unneeded subtyping, by changing datum/gear/mask/surgical to /datum/gear/surgical_mask.

I also removed the references to box_random_engine because Box Station is no longer in rotation.

## Why It's Good For The Game

Warnings are errors

## Changelog
:cl:
config: Cleaned up some warnings in the default config
/:cl:
