### PR TITLE
Fix energy gun charge overlays, again

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -213,26 +213,28 @@
 	. = ..()
 	if(!automatic_charge_overlays)
 		return
+	// Every time I see code this "flexible", a kitten fucking dies
 	var/overlay_icon_state = "[icon_state]_charge"
+	var/obj/item/ammo_casing/energy/shot = ammo_type[modifystate ? select : 1]
 	var/ratio = get_charge_ratio()
 	if(ratio == 0)
 		if(modifystate)
-			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-			overlay_icon_state += "_[shot.select_name]"
 			. += "[icon_state]_[shot.select_name]"
 		. += "[icon_state]_empty"
 	else
 		if(!shaded_charge)
+			if (modifystate)
+				overlay_icon_state += "_[shot.select_name]"
 			var/mutable_appearance/charge_overlay = mutable_appearance(icon, overlay_icon_state)
 			for(var/i = ratio, i >= 1, i--)
 				charge_overlay.pixel_x = ammo_x_offset * (i - 1)
 				charge_overlay.pixel_y = ammo_y_offset * (i - 1)
 				. += new /mutable_appearance(charge_overlay)
-		if(modifystate)
-			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-			. += "[icon_state]_charge[ratio]_[shot.select_name]" //:drooling_face:
 		else
-			. += "[icon_state]_charge[ratio]"
+			if(modifystate)
+				. += "[icon_state]_charge[ratio]_[shot.select_name]" //:drooling_face:
+			else
+				. += "[icon_state]_charge[ratio]"
 
 ///Used by update_icon_state() and update_overlays()
 /obj/item/gun/energy/proc/get_charge_ratio()


### PR DESCRIPTION
## About The Pull Request

Admittedly. I did not understand the energy gun code here well enough. But the issue that was caused by my lack of understanding of the code when I did PR #312. But this time this should be the charm.

The old buggy code:
https://streamable.com/8s5ew6

The new fixed code:
https://streamable.com/1uo7e9

## Why It's Good For The Game

Unfucks my mistakes. The immersion of shiptesting will be perfect.

## Changelog
:cl:
fix: Fixed the bug affecting a specific group of energy guns not displaying their charge states.
/:cl: