### PR TITLE
Fix being able to autoconnect to other holopads

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -32,7 +32,6 @@
 	var/datum/action/innate/end_holocall/hangup	//hangup action
 
 	var/call_start_time
-	var/head_call = FALSE //calls from a head of staff autoconnect, if the recieving pad is not secure.
 
 //creates a holocall made by `caller` from `calling_pad` to `callees`
 /datum/holocall/New(mob/living/caller, obj/machinery/holopad/calling_pad, list/callees, elevated_access = FALSE)
@@ -40,21 +39,13 @@
 	user = caller
 	calling_pad.outgoing_call = src
 	calling_holopad = calling_pad
-	head_call = elevated_access
 	dialed_holopads = list()
 
 	for(var/I in callees)
 		var/obj/machinery/holopad/H = I
 		if(!QDELETED(H) && H.is_operational())
 			dialed_holopads += H
-			if(head_call)
-				if(H.secure)
-					calling_pad.say("Auto-connection refused, falling back to call mode.")
-					H.say("Incoming call.")
-				else
-					H.say("Incoming connection.")
-			else
-				H.say("Incoming call.")
+			H.say("Incoming call.")
 			LAZYADD(H.holo_calls, src)
 
 	if(!dialed_holopads.len)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -370,9 +370,6 @@ Possible to do for anyone motivated enough:
 			if(force_answer_call && world.time > (HC.call_start_time + (HOLOPAD_MAX_DIAL_TIME / 2)))
 				HC.Answer(src)
 				break
-			if(HC.head_call && !secure)
-				HC.Answer(src)
-				break
 			if(outgoing_call)
 				HC.Disconnect(src)//can't answer calls while calling
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the ability for heads of staff to automatically connect to other ships' holopads, since that feature is not wanted on a server like Shiptest.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Added security and stops bad actors from trolling other people or otherwise gleaning information they shouldn't.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Heads of staff will no longer instantly connect to other holopads when calling them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
