### PR TITLE
[Fix] Fixing Life Reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -400,20 +400,14 @@
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
 
-/*WS Begin - No CobbyChems
-
 /datum/chemical_reaction/life
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/C2/instabitaluri = 1, /datum/reagent/blood = 1)
-	required_temp = 374
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (hostile)") //defaults to HOSTILE_SPAWN
 
 /datum/chemical_reaction/life_friendly
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/C2/instabitaluri = 1, /datum/reagent/consumable/sugar = 1)
-	required_temp = 374
-
-WS End */
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (friendly)", FRIENDLY_SPAWN)

--- a/whitesands/code/modules/reagents/chemistry/recipes/others.dm
+++ b/whitesands/code/modules/reagents/chemistry/recipes/others.dm
@@ -1,9 +1,3 @@
-/datum/chemical_reaction/life
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)
-
-/datum/chemical_reaction/life_friendly
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
-
 /datum/chemical_reaction/cellulose_carbonization/ash		// Sub for cellulose
 	required_reagents = list(/datum/reagent/ash_fibers)
 


### PR DESCRIPTION
## About The Pull Request

When WaspStation was initially modularizing, they changed the reaction requirements for life and life_friendly.  So they moved these to the modularized folder and commented them out in their old location.  It appears when this was done, life/on_reaction() was unintentionally commented out too.

I moved the required_reagents for life and life_friendly back to the unmodularized location (because not being in the same file is confusing), and uncommented life/on_reaction().

![image](https://user-images.githubusercontent.com/7697956/137522733-a42f4a4f-0914-4014-966e-d8a398b6231d.png)

## Why It's Good For The Game

Bug fix requested by a couple people.

## Changelog
:cl:
fix: Life reaction works again
/:cl:
