### PR TITLE
Kugel wiring fix, filters default to their intended gases

### DIFF
--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -146,10 +146,10 @@
 /area/ship/engineering/engine)
 "ed" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "4-6"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -205,10 +205,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -225,7 +221,11 @@
 /area/ship/engineering/atmospherics)
 "fQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 8
+	dir = 8;
+	filter_type = n2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9-10"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -300,9 +300,6 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/electrical)
 "ja" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -310,6 +307,9 @@
 	dir = 6
 	},
 /obj/machinery/holopad/emergency/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "jq" = (
@@ -638,7 +638,8 @@
 /area/ship/bridge)
 "qU" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
+	dir = 4;
+	filter_type = plasma
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -763,6 +764,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "vg" = (

--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -146,10 +146,7 @@
 /area/ship/engineering/engine)
 "ed" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -175,6 +172,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -205,10 +205,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -226,6 +222,9 @@
 "fQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -300,9 +299,6 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/electrical)
 "ja" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -310,6 +306,9 @@
 	dir = 6
 	},
 /obj/machinery/holopad/emergency/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "jq" = (
@@ -763,6 +762,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "vg" = (

--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -222,7 +222,7 @@
 "fQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
-	filter_type = n2
+	filter_type = "n2"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "9-10"
@@ -639,7 +639,7 @@
 "qU" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
-	filter_type = plasma
+	filter_type = "plasma"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"

--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -146,10 +146,10 @@
 /area/ship/engineering/engine)
 "ed" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-6"
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -205,6 +205,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -221,11 +225,7 @@
 /area/ship/engineering/atmospherics)
 "fQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 8;
-	filter_type = n2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9-10"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -300,6 +300,9 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/electrical)
 "ja" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -307,9 +310,6 @@
 	dir = 6
 	},
 /obj/machinery/holopad/emergency/engineering,
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "jq" = (
@@ -638,8 +638,7 @@
 /area/ship/bridge)
 "qU" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = plasma
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -764,9 +763,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "vg" = (

--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -148,6 +148,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-6"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "ee" = (
@@ -172,9 +175,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -221,10 +221,11 @@
 /area/ship/engineering/atmospherics)
 "fQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 8
+	dir = 8;
+	filter_type = n2
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-10"
+	icon_state = "9-10"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -637,7 +638,8 @@
 /area/ship/bridge)
 "qU" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
+	dir = 4;
+	filter_type = plasma
 	},
 /obj/structure/cable{
 	icon_state = "2-4"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Kugel wiring was fucked up at round start, with wires missing from underneath a door and the SMESes being wired to themselves once you managed to fix said door, due to the emitter being cringe.
![image](https://user-images.githubusercontent.com/32314478/138040129-fc935deb-22b5-43e4-aea7-47dd05960fc5.png)
Previously the wirenets connected underneath the emitter. Now it goes around!
The filters on Kugel's starting supermatter cooling have been set to what gas they're supposed to be set to, also. This wasn't entirely necessary but, shit, it's like this on any other server with a supermatter, so why not.

By the way, I went into this to partially fix the wires, and to partially fix the apparently bugged input pipes on the atmospherics harvesting system. As it turns out, these literally weren't even bugged. All you need to do to get them to work is to turn them on on these consoles. 
![image](https://user-images.githubusercontent.com/32314478/138040376-ad894df7-945d-4cd7-86d2-ecd4967efdc6.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix man good
make it easier for people to quickly grasp a novel supermatter pipenet in order to prevent fucky wuckies
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Kugelblitz wiring fixed
tweak: Kugel's supermatter filters now default to being set to filter the gases they are supposed to filter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
