### PR TITLE
Manifestoro: The ReAwakening

### DIFF
--- a/whitesands/code/game/machinery/cryopod.dm
+++ b/whitesands/code/game/machinery/cryopod.dm
@@ -316,6 +316,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			announce_rank = G.fields["rank"]
 			qdel(G)
 
+	// Regardless of what ship you spawned in you need to be removed from it.
+	// This covers scenarios where you spawn in one ship but cryo in another.
+	for(var/obj/structure/overmap/ship/simulated/sim_ship as anything in SSovermap.simulated_ships)
+		sim_ship.manifest -= mob_occupant.real_name
+
 	//Make an announcement and log the person entering storage.
 	if(control_computer)
 		control_computer.frozen_crew += "[mob_occupant.real_name]"


### PR DESCRIPTION
Fixes a long standing issue where people who cryo weren't removed from their ships manifest.

## Changelog
:cl:
fix: People who cryo are now correctly removed from their ships manifest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
