### PR TITLE
Add a defibrillator and fix operating computer placement in the Skipper.

### DIFF
--- a/_maps/shuttles/shiptest/ntsv_skipper.dmm
+++ b/_maps/shuttles/shiptest/ntsv_skipper.dmm
@@ -1461,13 +1461,17 @@
 /turf/open/floor/plasteel,
 /area/ship/engineering)
 "rL" = (
-/obj/structure/table/optable,
 /obj/effect/turf_decal/corner/blue{
 	dir = 9
 	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
+/obj/item/storage/box/gloves,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/belt/medical,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "rP" = (
@@ -3822,14 +3826,12 @@
 /obj/effect/turf_decal/corner/blue{
 	dir = 5
 	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/box/gloves,
-/obj/item/storage/belt/medical,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Vo" = (
@@ -3891,13 +3893,11 @@
 /turf/closed/wall/r_wall,
 /area/ship/engineering)
 "WI" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/turf_decal/corner/blue{
 	dir = 5
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "WS" = (
@@ -3985,6 +3985,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/door/window/northleft,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/plasteel,
 /area/ship/medical)
 "Yf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Title. This PR moves the surgical table and the operating computer on the Skipper to be cardinally adjacent to each other so that the operating computer actually works. Also adds a defibrillator to the medbay.

## Why It's Good For The Game

Making players able to save each other better good.

## Changelog
:cl:
tweak: Added a defibrillator to the medical area on the Skipper.
fix: The operating computer on the Skipper now works.
/:cl: