### PR TITLE
[Fix] Vendors Are No Longer Free

### DIFF
--- a/_maps/shuttles/pirate/pirate_default.dmm
+++ b/_maps/shuttles/pirate/pirate_default.dmm
@@ -733,9 +733,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bH" = (
-/obj/machinery/vending/boozeomat/all_access{
-	onstation = 0
-	},
+/obj/machinery/vending/boozeomat/all_access,
 /obj/effect/turf_decal/corner/bar,
 /obj/effect/turf_decal/corner/bar{
 	dir = 1

--- a/_maps/shuttles/shiptest/pirate_libertatia.dmm
+++ b/_maps/shuttles/shiptest/pirate_libertatia.dmm
@@ -740,9 +740,7 @@
 /turf/open/floor/pod/light,
 /area/ship/crew)
 "wZ" = (
-/obj/machinery/vending/boozeomat/all_access{
-	onstation = 0
-	},
+/obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew)
 "xv" = (

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -142,14 +142,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/extra_price = 50
 	///Whether our age check is currently functional
 	var/age_restrictions = TRUE
-	/**
-	* Is this item on station or not
-	*
-	* if it doesn't originate from off-station during mapload, everything is free
-	*/
-	var/onstation = TRUE //if it doesn't originate from off-station during mapload, everything is free
-	///A variable to change on a per instance basis on the map that allows the instance to force cost and ID requirements
-	var/onstation_override = FALSE //change this on the object on the map to override the onstation check. DO NOT APPLY THIS GLOBALLY.
 
 	///ID's that can load this vending machine wtih refills
 	var/list/canload_access_list
@@ -172,17 +164,11 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/obj/item/radio/Radio
 
 /obj/item/circuitboard
-	///determines if the circuit board originated from a vendor off station or not.
-	var/onstation = TRUE
 
 /**
 	* Initialize the vending machine
 	*
 	* Builds the vending machine inventory, sets up slogans and other such misc work
-	*
-	* This also sets the onstation var to:
-	* * FALSE - if the machine was maploaded on a zlevel that doesn't pass the is_station_level check
-	* * TRUE - all other cases
 	*/
 /obj/machinery/vending/Initialize(mapload)
 	var/build_inv = FALSE
@@ -203,13 +189,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	last_slogan = world.time + rand(0, slogan_delay)
 	power_change()
 
-	onstation = FALSE
-	if(circuit)
-		circuit.onstation = onstation //sync up the circuit so the pricing schema is carried over if it's reconstructed.
-	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
-		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
-	if(onstation_override) //overrides the checks if true.
-		onstation = TRUE
 	Radio = new /obj/item/radio(src)
 	Radio.listening = 0
 
@@ -691,7 +670,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 /obj/machinery/vending/ui_static_data(mob/user)
 	. = list()
-	.["onstation"] = onstation
 	.["miningvendor"] = mining_point_vendor
 	.["department"] = payment_department
 	.["product_records"] = list()
@@ -788,7 +766,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				flick(icon_deny,src)
 				vend_ready = TRUE
 				return
-			if(onstation && ishuman(usr))
+			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				var/obj/item/card/id/C = H.get_idcard(TRUE)
 

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -130,23 +130,22 @@ export const Vending = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
-        {<Section title="User">
-            {user && (
-              <Box>
-                Welcome, <b>{user.name}</b>,
-                {' '}
-                <b>{user.job || 'Unemployed'}</b>!
-                <br />
-                Your balance is <b>{miningvendor ? user.points || 0 : user.cash || 0} {miningvendor ? "points" : "credits"}</b>.
-              </Box>
-            ) || (
-              <Box color="light-grey">
-                No registered ID card!<br />
-                Please contact your local HoP!
-              </Box>
-            )}
-          </Section>
-        }
+        <Section title="User">
+          {user && (
+            <Box>
+              Welcome, <b>{user.name}</b>,
+              {' '}
+              <b>{user.job || 'Unemployed'}</b>!
+              <br />
+              Your balance is <b>{miningvendor ? user.points || 0 : user.cash || 0} {miningvendor ? "points" : "credits"}</b>.
+            </Box>
+          ) || (
+            <Box color="light-grey">
+              No registered ID card!<br />
+              Please contact your local HoP!
+            </Box>
+          )}
+        </Section>
         <Section title="Products">
           <Table>
             {inventory.map(product => (

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -12,13 +12,11 @@ const VendingRow = (props, context) => {
   } = props;
   const {
     miningvendor,
-    onstation,
     department,
     user,
   } = data;
   const free = (
-    !onstation
-    || product.price === 0
+    product.price === 0
     || (
       !product.premium
       && department
@@ -99,7 +97,6 @@ export const Vending = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     user,
-    onstation,
     miningvendor,
     product_records = [],
     coin_records = [],
@@ -133,8 +130,7 @@ export const Vending = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
-        {!!onstation && (
-          <Section title="User">
+        {<Section title="User">
             {user && (
               <Box>
                 Welcome, <b>{user.name}</b>,
@@ -150,7 +146,7 @@ export const Vending = (props, context) => {
               </Box>
             )}
           </Section>
-        )}
+        }
         <Section title="Products">
           <Table>
             {inventory.map(product => (


### PR DESCRIPTION
## About The Pull Request

All items in both types of vendors (creds and mining points) were free.  This was due to a onstation check in the base vendor type.  If a vendor was not on the station z level, all items would be free.  I removed this check and the references to its result in the tgui js.

Overrides to onstation had to be removed from some of the map files.

## Why It's Good For The Game

Bugfix #368

## Changelog
:cl:
fix: Vendors are no longer free
/:cl:
