### PR TITLE
[Fix] Vendors Are No Longer Free

### DIFF
--- a/_maps/shuttles/pirate/pirate_default.dmm
+++ b/_maps/shuttles/pirate/pirate_default.dmm
@@ -734,7 +734,7 @@
 /area/shuttle/pirate)
 "bH" = (
 /obj/machinery/vending/boozeomat/all_access{
-	onstation = 0
+	all_items_free = 1
 	},
 /obj/effect/turf_decal/corner/bar,
 /obj/effect/turf_decal/corner/bar{

--- a/_maps/shuttles/shiptest/pirate_libertatia.dmm
+++ b/_maps/shuttles/shiptest/pirate_libertatia.dmm
@@ -741,7 +741,7 @@
 /area/ship/crew)
 "wZ" = (
 /obj/machinery/vending/boozeomat/all_access{
-	onstation = 0
+	all_items_free = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -197,9 +197,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(mapload)
 		if(circuit)
 			circuit.all_items_free = all_items_free //sync up the circuit so the pricing schema is carried over if it's reconstructed.
-	else
-		if(circuit && (circuit.all_items_free != all_items_free)) //check if they're not the same to minimize the amount of edited values.
-			all_items_free = circuit.all_items_free //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
 
 	Radio = new /obj/item/radio(src)
 	Radio.listening = 0

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -166,10 +166,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/// used for narcing on underages
 	var/obj/item/radio/Radio
 
-/obj/item/circuitboard
-	///allows the circuit board to remember if items should be free.
-	var/all_items_free = FALSE
-
 /**
 	* Initialize the vending machine
 	*
@@ -193,10 +189,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	// so if slogantime is 10 minutes, it will say it at somewhere between 10 and 20 minutes after the machine is crated.
 	last_slogan = world.time + rand(0, slogan_delay)
 	power_change()
-
-	if(mapload)
-		if(circuit)
-			circuit.all_items_free = all_items_free //sync up the circuit so the pricing schema is carried over if it's reconstructed.
 
 	Radio = new /obj/item/radio(src)
 	Radio.listening = 0

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -142,14 +142,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/extra_price = 50
 	///Whether our age check is currently functional
 	var/age_restrictions = TRUE
-	/**
-	* Is this item on station or not
-	*
-	* if it doesn't originate from off-station during mapload, everything is free
-	*/
-	var/onstation = TRUE //if it doesn't originate from off-station during mapload, everything is free
-	///A variable to change on a per instance basis on the map that allows the instance to force cost and ID requirements
-	var/onstation_override = FALSE //change this on the object on the map to override the onstation check. DO NOT APPLY THIS GLOBALLY.
+
+	///A variable to change on a per instance basis on the map that allows the instance to remove cost and ID requirements
+	var/all_items_free = FALSE //change this on the object on the map. DO NOT APPLY THIS GLOBALLY.
 
 	///ID's that can load this vending machine wtih refills
 	var/list/canload_access_list
@@ -172,17 +167,13 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/obj/item/radio/Radio
 
 /obj/item/circuitboard
-	///determines if the circuit board originated from a vendor off station or not.
-	var/onstation = TRUE
+	///allows the circuit board to remember if items should be free.
+	var/all_items_free = FALSE
 
 /**
 	* Initialize the vending machine
 	*
 	* Builds the vending machine inventory, sets up slogans and other such misc work
-	*
-	* This also sets the onstation var to:
-	* * FALSE - if the machine was maploaded on a zlevel that doesn't pass the is_station_level check
-	* * TRUE - all other cases
 	*/
 /obj/machinery/vending/Initialize(mapload)
 	var/build_inv = FALSE
@@ -203,13 +194,13 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	last_slogan = world.time + rand(0, slogan_delay)
 	power_change()
 
-	onstation = FALSE
-	if(circuit)
-		circuit.onstation = onstation //sync up the circuit so the pricing schema is carried over if it's reconstructed.
-	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
-		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
-	if(onstation_override) //overrides the checks if true.
-		onstation = TRUE
+	if(mapload)
+		if(circuit)
+			circuit.all_items_free = all_items_free //sync up the circuit so the pricing schema is carried over if it's reconstructed.
+	else
+		if(circuit && (circuit.all_items_free != all_items_free)) //check if they're not the same to minimize the amount of edited values.
+			all_items_free = circuit.all_items_free //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
+
 	Radio = new /obj/item/radio(src)
 	Radio.listening = 0
 
@@ -691,7 +682,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 /obj/machinery/vending/ui_static_data(mob/user)
 	. = list()
-	.["onstation"] = onstation
+	.["all_items_free"] = all_items_free
 	.["miningvendor"] = mining_point_vendor
 	.["department"] = payment_department
 	.["product_records"] = list()
@@ -788,7 +779,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				flick(icon_deny,src)
 				vend_ready = TRUE
 				return
-			if(onstation && ishuman(usr))
+			if(!all_items_free && ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				var/obj/item/card/id/C = H.get_idcard(TRUE)
 

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -12,12 +12,12 @@ const VendingRow = (props, context) => {
   } = props;
   const {
     miningvendor,
-    onstation,
+    all_items_free,
     department,
     user,
   } = data;
   const free = (
-    !onstation
+    all_items_free
     || product.price === 0
     || (
       !product.premium
@@ -99,7 +99,7 @@ export const Vending = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     user,
-    onstation,
+    all_items_free,
     miningvendor,
     product_records = [],
     coin_records = [],
@@ -133,7 +133,7 @@ export const Vending = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
-        {!!onstation && (
+        {!all_items_free && (
           <Section title="User">
             {user && (
               <Box>


### PR DESCRIPTION
## About The Pull Request

Replacing #384

All items in both types of vendors (creds and mining points) were free. This was due to onstation always being set to false, which made all items in the vendor free.

To make the code more clear, I replaced onstation and onstation_override with all_items_free.

Vendors can be made free by setting all_items_free to 1 via a map editor or view variables.

![image](https://user-images.githubusercontent.com/7697956/140674125-eecc28fc-d072-423f-a668-2406d8b84f1d.png)

Known Issue: The circuitboard of a deconstructed vendor remembered if the vendor was free, but did not successfully pass this information back to the vendor when reconstructed.  My attempts to fix this were unsuccessful.  I removed the existing code that attempted to do this, as it would just runtime.

Workaround: If a free vendor is reconstructed and is no longer free, an admin can make it free again by setting all_items_free via view variables.

## Why It's Good For The Game

Bugfix #368

## Changelog
:cl:
fix: Vendors are no longer free
/:cl:
