### PR TITLE
Revamps Cryo Consoles

### DIFF
--- a/_maps/shuttles/shiptest/amogus_sus.dmm
+++ b/_maps/shuttles/shiptest/amogus_sus.dmm
@@ -345,7 +345,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3967,7 +3967,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Td" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/wood,

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -2522,7 +2522,7 @@
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "Zz" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/wood,

--- a/_maps/shuttles/shiptest/bar_ship_b.dmm
+++ b/_maps/shuttles/shiptest/bar_ship_b.dmm
@@ -2471,7 +2471,7 @@
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
 "Zz" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/carpet/nanoweave/red,

--- a/_maps/shuttles/shiptest/bogatyr.dmm
+++ b/_maps/shuttles/shiptest/bogatyr.dmm
@@ -643,7 +643,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/ship/cargo)
 "xL" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/dorm)
 "xR" = (

--- a/_maps/shuttles/shiptest/cargotide.dmm
+++ b/_maps/shuttles/shiptest/cargotide.dmm
@@ -1244,7 +1244,7 @@
 /turf/template_noop,
 /area/space)
 "Lo" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ship/crew)
@@ -1438,7 +1438,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "RR" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/shiptest/chapel.dmm
+++ b/_maps/shuttles/shiptest/chapel.dmm
@@ -484,7 +484,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "hJ" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
@@ -821,7 +821,7 @@
 	},
 /area/ship/crew/chapel/office)
 "mf" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -1851,7 +1851,7 @@
 /turf/open/floor/wood,
 /area/ship/medical)
 "zB" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
@@ -1935,7 +1935,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/chapel/office)
 "Aq" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "AA" = (

--- a/_maps/shuttles/shiptest/corp_high.dmm
+++ b/_maps/shuttles/shiptest/corp_high.dmm
@@ -2625,7 +2625,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /turf/open/floor/carpet/nanoweave/beige,
@@ -2726,7 +2726,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /turf/open/floor/carpet/nanoweave/beige,

--- a/_maps/shuttles/shiptest/engi_moth.dmm
+++ b/_maps/shuttles/shiptest/engi_moth.dmm
@@ -1318,7 +1318,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/bridge)
 "Hy" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,

--- a/_maps/shuttles/shiptest/hightide.dmm
+++ b/_maps/shuttles/shiptest/hightide.dmm
@@ -649,7 +649,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
 "yw" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1252,7 +1252,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "XU" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/item/trash/semki,

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -170,7 +170,7 @@
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "el" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{

--- a/_maps/shuttles/shiptest/isv_roberts.dmm
+++ b/_maps/shuttles/shiptest/isv_roberts.dmm
@@ -613,7 +613,7 @@
 /area/ship/maintenance/starboard)
 "Lh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod/latejoin/reskinnable{
+/obj/machinery/cryopod{
 	close_state = "crate";
 	dir = 8;
 	icon = 'goon/icons/obj/crates.dmi';

--- a/_maps/shuttles/shiptest/lamia.dmm
+++ b/_maps/shuttles/shiptest/lamia.dmm
@@ -476,7 +476,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 27
 	},
-/obj/machinery/cryopod/latejoin/reskinnable{
+/obj/machinery/cryopod{
 	close_state = "bscanner_green";
 	icon_state = "bscanner_open";
 	open_state = "bscanner_open"

--- a/_maps/shuttles/shiptest/mining_ship_all.dmm
+++ b/_maps/shuttles/shiptest/mining_ship_all.dmm
@@ -313,7 +313,7 @@
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "hv" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/ntsv_bubble.dmm
+++ b/_maps/shuttles/shiptest/ntsv_bubble.dmm
@@ -256,7 +256,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "nr" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -784,7 +784,7 @@
 /turf/closed/wall,
 /area/ship/engineering)
 "ML" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/shiptest/ntsv_skipper.dmm
+++ b/_maps/shuttles/shiptest/ntsv_skipper.dmm
@@ -1958,7 +1958,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "zs" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /turf/open/floor/wood,
 /area/ship/crew)
 "zy" = (
@@ -2655,7 +2655,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/machinery/light/small{
 	dir = 4
 	},

--- a/_maps/shuttles/shiptest/pirate_libertatia.dmm
+++ b/_maps/shuttles/shiptest/pirate_libertatia.dmm
@@ -1069,7 +1069,7 @@
 /turf/open/floor/pod/light,
 /area/ship/crew)
 "EG" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/structure/curtain/bounty,

--- a/_maps/shuttles/shiptest/rigger.dmm
+++ b/_maps/shuttles/shiptest/rigger.dmm
@@ -1111,7 +1111,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "pY" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/airalarm/all_access{
@@ -2333,7 +2333,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "Dr" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/rigger_b.dmm
+++ b/_maps/shuttles/shiptest/rigger_b.dmm
@@ -1197,7 +1197,7 @@
 /turf/open/floor/wood,
 /area/ship/crew)
 "pY" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/airalarm/all_access{
@@ -2345,7 +2345,7 @@
 /turf/open/floor/carpet/nanoweave/purple,
 /area/ship/crew/canteen)
 "Dr" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/rigger_c.dmm
+++ b/_maps/shuttles/shiptest/rigger_c.dmm
@@ -2603,7 +2603,7 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "Dr" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/scrapper.dmm
+++ b/_maps/shuttles/shiptest/scrapper.dmm
@@ -3464,7 +3464,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "NT" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/structure/sign/poster/official/no_erp{

--- a/_maps/shuttles/shiptest/scrapperb.dmm
+++ b/_maps/shuttles/shiptest/scrapperb.dmm
@@ -3615,7 +3615,7 @@
 /turf/open/floor/engine/hull,
 /area/ship/external)
 "SO" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/machinery/light/dim{
 	dir = 4
 	},

--- a/_maps/shuttles/shiptest/solar_class.dmm
+++ b/_maps/shuttles/shiptest/solar_class.dmm
@@ -1257,7 +1257,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway)
 "yM" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/warning{

--- a/_maps/shuttles/shiptest/solgov_carina.dmm
+++ b/_maps/shuttles/shiptest/solgov_carina.dmm
@@ -1178,7 +1178,7 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sM" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -2017,7 +2017,7 @@
 /turf/open/floor/eighties,
 /area/ship/crew/dorm)
 "yn" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
@@ -2227,7 +2227,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "zZ" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -2584,7 +2584,7 @@
 /turf/open/floor/eighties,
 /area/ship/crew/dorm)
 "CO" = (
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /turf/open/floor/eighties,
 /area/ship/crew/dorm)
 "CQ" = (

--- a/_maps/shuttles/shiptest/solgov_liberty.dmm
+++ b/_maps/shuttles/shiptest/solgov_liberty.dmm
@@ -1052,7 +1052,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "EG" = (
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/structure/curtain/bounty,

--- a/_maps/shuttles/shiptest/whiteship_box.dmm
+++ b/_maps/shuttles/shiptest/whiteship_box.dmm
@@ -1267,7 +1267,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "cY" = (

--- a/_maps/shuttles/shiptest/whiteship_delta.dmm
+++ b/_maps/shuttles/shiptest/whiteship_delta.dmm
@@ -112,7 +112,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 8
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/whiteship_kilo.dmm
+++ b/_maps/shuttles/shiptest/whiteship_kilo.dmm
@@ -630,7 +630,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},

--- a/_maps/shuttles/shiptest/whiteship_meta.dmm
+++ b/_maps/shuttles/shiptest/whiteship_meta.dmm
@@ -829,7 +829,7 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 8
 	},
 /obj/machinery/computer/cryopod{

--- a/_maps/shuttles/shiptest/whiteship_midway.dmm
+++ b/_maps/shuttles/shiptest/whiteship_midway.dmm
@@ -1092,7 +1092,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/green,
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 8
 	},
 /obj/machinery/computer/cryopod{
@@ -2216,7 +2216,7 @@
 /obj/effect/turf_decal/corner/green{
 	dir = 4
 	},
-/obj/machinery/cryopod/latejoin{
+/obj/machinery/cryopod{
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/shiptest/whiteship_pubby.dmm
+++ b/_maps/shuttles/shiptest/whiteship_pubby.dmm
@@ -1062,7 +1062,7 @@
 "TC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod/latejoin,
+/obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},

--- a/_maps/shuttles/shiptest/wright.dmm
+++ b/_maps/shuttles/shiptest/wright.dmm
@@ -558,7 +558,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "mW" = (
-/obj/machinery/cryopod/latejoin/reskinnable{
+/obj/machinery/cryopod{
 	close_state = "sleeper_clockwork";
 	dir = 4;
 	icon_state = "sleeper_clockwork-open";
@@ -1386,7 +1386,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "Kg" = (
-/obj/machinery/cryopod/latejoin/reskinnable{
+/obj/machinery/cryopod{
 	close_state = "sleeper_clockwork";
 	dir = 8;
 	icon_state = "sleeper_clockwork-open";

--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -36,7 +36,7 @@ standards:
   - exactly: [22, 'world<< uses', 'world[ \t]*<<']
   - exactly: [0, 'world.log<< uses', 'world.log[ \t]*<<']
 
-  - exactly: [306, 'non-bitwise << uses', '(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)']
+  - exactly: [303, 'non-bitwise << uses', '(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)']
   - exactly: [0, 'incorrect indentations', '^(?:  +)(?!\*)']
   - exactly: [0, 'superflous whitespace', '[ \t]+$']
   - exactly: [36, 'mixed indentation', '^( +\t+|\t+ +)']

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -253,6 +253,7 @@ SUBSYSTEM_DEF(mapping)
 					job_slot = new /datum/job(job, job_outfit)
 					job_slot.wiki_page = value["wiki_page"]
 					job_slot.exp_requirements = value["exp_requirements"]
+					job_slot.officer = value["officer"]
 					slots = value["slots"]
 
 				if(!job_slot || !slots)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -62,6 +62,9 @@
 	///Levels unlocked at roundstart in physiology
 	var/list/roundstart_experience
 
+	///Basically determines whether or not more of the job can be opened.
+	var/officer = FALSE
+
 /datum/job/New(new_title, datum/outfit/new_outfit)
 	if(new_title)
 		title = new_title

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -11,6 +11,7 @@
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_COMMAND
+	officer = TRUE
 	wiki_page = "Captain"
 
 	outfit = /datum/outfit/job/captain

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -12,6 +12,7 @@
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
+	officer = TRUE
 	wiki_page = "Chief_Medical_Officer"
 
 	outfit = /datum/outfit/job/cmo

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ddddff"
 	minimal_player_age = 10
 	exp_requirements = 180
+	officer = TRUE
 	wiki_page = "Head_of_Personnel" //WS Edit - Wikilinks/Warning
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SERVICE

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ffdddd"
 	minimal_player_age = 14
 	exp_requirements = 300
+	officer = TRUE
 	wiki_page = "Head_of_Security" //WS Edit - Wikilinks/Warning
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -7,6 +7,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
 	wiki_page = "Quartermaster" //WS Edit - Wikilinks/Warning
+	officer = TRUE
 	exp_type_department = EXP_TYPE_SUPPLY // This is so the jobs menu can work properly
 
 	outfit = /datum/outfit/job/quartermaster

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -12,6 +12,7 @@
 	exp_type_department = EXP_TYPE_SCIENCE
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	officer = TRUE
 	wiki_page = "Research_Director" //WS Edit - Wikilinks/Warning
 
 	outfit = /datum/outfit/job/rd

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -10,6 +10,7 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	officer = TRUE
 	wiki_page = "Space_Law" //WS Edit - Wikilinks/Warning
 
 	outfit = /datum/outfit/job/warden

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -339,7 +339,7 @@
 	var/list/shuttle_choices = list("Purchase ship..." = "Purchase") //Dummy for purchase option
 
 	for(var/obj/structure/overmap/ship/simulated/S in SSovermap.overmap_objects)
-		if(length(S.shuttle.spawn_points) < 1)
+		if((length(S.shuttle.spawn_points) < 1) || !S.join_allowed)
 			continue
 		shuttle_choices[S.name + " ([S.shuttle.source_template.short_name ? S.shuttle.source_template.short_name : "Unknown-class"])"] = S //Try to get the class name
 
@@ -368,11 +368,20 @@
 			new_player_panel()
 		return
 
+	if(selected_ship.memo)
+		var/memo_accept = tgui_alert(src, "Current ship memo: [selected_ship.memo]", "[selected_ship.name] Memo", list("OK", "Cancel"))
+		if(memo_accept == "Cancel")
+			return LateChoices() //Send them back to shuttle selection
+
 	var/list/job_choices = list()
 	for(var/datum/job/job as anything in selected_ship.job_slots)
 		if(selected_ship.job_slots[job] < 1)
 			continue
 		job_choices["[job.title] ([selected_ship.job_slots[job]] positions)"] = job
+
+	if(!length(job_choices))
+		to_chat(usr, "<span class='danger'>There are no jobs available on this ship!</span>")
+		return LateChoices() //Send them back to shuttle selection
 
 	var/datum/job/selected_job = job_choices[tgui_input_list(src, "Select job.", "Welcome, [client.prefs.real_name].", job_choices)]
 	if(!selected_job)

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -8,6 +8,12 @@
 	var/list/manifest = list()
 	///Shipwide bank account
 	var/datum/bank_account/ship/ship_account
+	///Whether or not new players are allowed to join the ship
+	var/join_allowed = TRUE
+	///Short memo of the ship shown to new joins
+	var/memo = ""
+	///Time that next job slot change can occur
+	var/job_slot_adjustment_cooldown = 0
 
 /obj/structure/overmap/ship/simulated/Initialize(mapload, obj/docking_port/mobile/_shuttle)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/CryoStorageConsole.js
+++ b/tgui/packages/tgui/interfaces/CryoStorageConsole.js
@@ -1,0 +1,158 @@
+import { useBackend, useLocalState } from '../backend';
+import { Button, LabeledList, Section, Table, Tabs, Dimmer, NoticeBox, Divider } from '../components';
+import { ButtonInput } from '../components/Button';
+import { TableCell, TableRow } from '../components/Table';
+import { Window } from '../layouts';
+
+export const CryoStorageConsole = (props, context) => {
+  return (
+    <Window
+      width={450}
+      height={620}
+      resizable>
+      <Window.Content scrollable>
+        <CryoStorageConsoleContent />
+      </Window.Content>
+    </Window>
+  );
+};
+
+export const CryoStorageConsoleContent = (props, context) => {
+  const { act, data } = useBackend(context);
+  const [tab, setTab] = useLocalState(context, 'tab', 1);
+  const {
+    stored = [],
+    jobs = [],
+    memo,
+    hasItems,
+    awakening,
+    allowItems,
+    cooldown = 1,
+  } = data;
+  return (
+    <Section
+      title={"Cryo Management"}
+      buttons={(
+        <Tabs>
+          <Tabs.Tab
+            selected={tab === 1}
+            onClick={() => setTab(1)}>
+            Management
+          </Tabs.Tab>
+          <Tabs.Tab
+            selected={tab === 2}
+            onClick={() => setTab(2)}>
+            Storage Log
+          </Tabs.Tab>
+        </Tabs>
+      )}>
+      {tab === 1 && (
+        <>
+          <LabeledList>
+            <LabeledList.Item label="Eject Item">
+              <Button
+                content={allowItems ? "Disable" : "Enable"}
+                icon={allowItems ? "ban" : "check"}
+                color={allowItems ? "bad" : "good"}
+                onClick={() => act('toggleStorage')} />
+              <Button
+                content="Eject one"
+                icon="eject"
+                disabled={!hasItems}
+                onClick={() => act('items')} />
+              <Button
+                content="Eject all"
+                icon="eject"
+                color="bad"
+                disabled={!hasItems}
+                onClick={() => act('allItems')} />
+            </LabeledList.Item>
+            <LabeledList.Item label="Awakening Settings">
+              <Button
+                content={awakening ? "Disable" : "Enable"}
+                icon="bed"
+                color={awakening ? "bad" : "good"}
+                onClick={() => act('toggleAwakening')} />
+              <Button.Input
+                content="Set Memo"
+                currentValue={memo}
+                onCommit={(e, value) => act('setMemo', {
+                  newName: value,
+                })} />
+            </LabeledList.Item>
+          </LabeledList>
+          <Divider />
+          {cooldown > 0 && (
+            <div className="NoticeBox">
+              {"On Cooldown: " + (cooldown / 10) + "s"}
+            </div>
+            )}
+          <Table>
+            <Table.Row header>
+              <Table.Cell>
+                Job Name
+              </Table.Cell>
+              <Table.Cell>
+                Slots
+              </Table.Cell>
+            </Table.Row>
+            {jobs.map(job => (
+              <Table.Row>
+                <Table.Cell key={job.name}>
+                  {job.name}
+                </Table.Cell>
+                <TableCell>
+                  <Button
+                    content="+"
+                    disabled={cooldown > 0 || job.slots >= job.max}
+                    onClick={() => act('adjustJobSlot', {
+                      toAdjust: job.ref,
+                      delta: 1,
+                    })} />
+                   {job.slots}
+                  <Button
+                    content="-"
+                    disabled={cooldown > 0 || job.slots <= 0}
+                    onClick={() => act('adjustJobSlot', {
+                      toAdjust: job.ref,
+                      delta: -1,
+                    })} />
+                </TableCell>
+              </Table.Row>
+            ))}
+          </Table>
+        </>
+      )}
+      {tab === 2 && (
+        <Table>
+          <Table.Row header>
+            <Table.Cell>
+              Time Frozen
+            </Table.Cell>
+            <Table.Cell>
+              Name
+            </Table.Cell>
+            <Table.Cell>
+              Occupation
+            </Table.Cell>
+          </Table.Row>
+          {stored.map(storedPerson => (
+            <Table.Row
+              key={storedPerson.name}
+              className="candystripe">
+              <Table.Cell>
+                {storedPerson.time}
+              </Table.Cell>
+              <Table.Cell>
+                {storedPerson.name}
+              </Table.Cell>
+              <Table.Cell>
+                {storedPerson.rank}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table>
+      )}
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/CryoStorageConsole.js
+++ b/tgui/packages/tgui/interfaces/CryoStorageConsole.js
@@ -86,7 +86,7 @@ export const CryoStorageConsoleContent = (props, context) => {
             <div className="NoticeBox">
               {"On Cooldown: " + (cooldown / 10) + "s"}
             </div>
-            )}
+          )}
           <Table>
             <Table.Row header>
               <Table.Cell>
@@ -97,8 +97,8 @@ export const CryoStorageConsoleContent = (props, context) => {
               </Table.Cell>
             </Table.Row>
             {jobs.map(job => (
-              <Table.Row>
-                <Table.Cell key={job.name}>
+              <Table.Row key={job.name}>
+                <Table.Cell>
                   {job.name}
                 </Table.Cell>
                 <TableCell>
@@ -109,7 +109,7 @@ export const CryoStorageConsoleContent = (props, context) => {
                       toAdjust: job.ref,
                       delta: 1,
                     })} />
-                   {job.slots}
+                  {job.slots}
                   <Button
                     content="-"
                     disabled={cooldown > 0 || job.slots <= 0}

--- a/whitesands/code/game/machinery/cryopod.dm
+++ b/whitesands/code/game/machinery/cryopod.dm
@@ -1,3 +1,5 @@
+#define DEFAULT_JOB_SLOT_ADJUSTMENT_COOLDOWN 2 MINUTES
+
 /*
  * Cryogenic refrigeration unit. Basically a despawner.
  * Stealing a lot of concepts/code from sleepers due to massive laziness.
@@ -16,17 +18,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	icon_state = "cellconsole_1"
 	// circuit = /obj/item/circuitboard/cryopodcontrol
 	density = FALSE
-	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
 	req_one_access = list(ACCESS_HEADS, ACCESS_ARMORY) //Heads of staff or the warden can go here to claim recover items from their department that people went were cryodormed with.
-	var/mode = null
 
-	//Used for logging people entering cryosleep and important items they are carrying.
+	/// Used for logging people entering cryosleep and important items they are carrying. Shows crew members.
 	var/list/frozen_crew = list()
+	/// Used for logging people entering cryosleep and important items they are carrying. Shows items.
 	var/list/frozen_items = list()
 
-	var/storage_type = "crewmembers"
-	var/storage_name = "Cryogenic Oversight Control"
+	/// Whether or not to store items from people going into cryosleep.
 	var/allow_items = TRUE
+	/// The ship object representing the ship that this console is on.
+	var/obj/docking_port/mobile/linked_ship
 
 /obj/machinery/computer/cryopod/Initialize()
 	. = ..()
@@ -34,99 +36,116 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/computer/cryopod/Destroy()
 	GLOB.cryopod_computers -= src
-	..()
+	return ..()
 
-/obj/machinery/computer/cryopod/attack_ai()
-	attack_hand()
+/obj/machinery/computer/cryopod/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override)
+	. = ..()
+	linked_ship = port
 
-/obj/machinery/computer/cryopod/attack_hand(mob/user = usr)
-	if(machine_stat & (NOPOWER|BROKEN))
-		return
+/obj/machinery/computer/cryopod/ui_interact(mob/user, datum/tgui/ui)
+	. = ..()
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CryoStorageConsole", name)
+		ui.open()
 
-	user.set_machine(src)
-	add_fingerprint(user)
-
-	var/dat
-
-	dat += "<hr/><br/><b>[storage_name]</b><br/>"
-	dat += "<i>Welcome, [user.real_name].</i><br/><br/><hr/>"
-	dat += "<a href='?src=[REF(src)];log=1'>View storage log</a>.<br>"
-	if(allow_items)
-		dat += "<a href='?src=[REF(src)];view=1'>View objects</a>.<br>"
-		dat += "<a href='?src=[REF(src)];item=1'>Recover object</a>.<br>"
-		dat += "<a href='?src=[REF(src)];allitems=1'>Recover all objects</a>.<br>"
-
-	user << browse(dat, "window=cryopod_console")
-	onclose(user, "cryopod_console")
-
-/obj/machinery/computer/cryopod/Topic(href, href_list)
+/obj/machinery/computer/cryopod/ui_act(action, list/params)
 	if(..())
-		return 1
-
+		return TRUE
 	var/mob/user = usr
 
 	add_fingerprint(user)
 
-	if(href_list["log"])
+	switch(action)
+		if("items")
+			if(!allow_items)
+				return
 
-		var/dat = "<b>Recently stored [storage_type]</b><br/><hr/><br/>"
-		for(var/person in frozen_crew)
-			dat += "[person]<br/>"
-		dat += "<hr/>"
+			if(!allowed(user))
+				to_chat(user, "<span class='warning'>Access Denied.</span>")
+				return
 
-		user << browse(dat, "window=cryolog")
+			if(frozen_items.len == 0)
+				to_chat(user, "<span class='notice'>There is nothing to recover from storage.</span>")
+				return
 
-	if(href_list["view"])
-		if(!allow_items) return
+			var/obj/item/I = tgui_input_list(user, "Select an item to recover.", name, frozen_items)
 
-		var/dat = "<b>Recently stored objects</b><br/><hr/><br/>"
-		for(var/obj/item/I in frozen_items)
-			dat += "[I.name]<br/>"
-		dat += "<hr/>"
+			visible_message("<span class='notice'>The console beeps happily as it disgorges \the [I].</span>")
 
-		user << browse(dat, "window=cryoitems")
-
-	else if(href_list["item"])
-		if(!allowed(user))
-			to_chat(user, "<span class='warning'>Access Denied.</span>")
-			return
-		if(!allow_items) return
-
-		if(frozen_items.len == 0)
-			to_chat(user, "<span class='notice'>There is nothing to recover from storage.</span>")
-			return
-
-		var/obj/item/I = input(user, "Please choose which object to retrieve.","Object recovery",null) as null|anything in frozen_items
-		if(!I)
-			return
-
-		if(!(I in frozen_items))
-			to_chat(user, "<span class='notice'>\The [I] is no longer in storage.</span>")
-			return
-
-		visible_message("<span class='notice'>The console beeps happily as it disgorges \the [I].</span>")
-
-		I.forceMove(get_turf(src))
-		frozen_items -= I
-
-	else if(href_list["allitems"])
-		if(!allowed(user))
-			to_chat(user, "<span class='warning'>Access Denied.</span>")
-			return
-		if(!allow_items) return
-
-		if(frozen_items.len == 0)
-			to_chat(user, "<span class='notice'>There is nothing to recover from storage.</span>")
-			return
-
-		visible_message("<span class='notice'>The console beeps happily as it disgorges the desired objects.</span>")
-
-		for(var/obj/item/I in frozen_items)
 			I.forceMove(get_turf(src))
 			frozen_items -= I
+			return
 
-	updateUsrDialog()
-	return
+		if("allItems")
+			if(!allow_items)
+				return
+
+			if(!allowed(user))
+				to_chat(user, "<span class='warning'>Access Denied.</span>")
+				return
+
+			if(frozen_items.len == 0)
+				to_chat(user, "<span class='notice'>There is nothing to recover from storage.</span>")
+				return
+
+			visible_message("<span class='notice'>The console beeps happily as it disgorges the desired objects.</span>")
+
+			for(var/obj/item/I as anything in frozen_items)
+				I.forceMove(get_turf(src))
+				frozen_items -= I
+			update_static_data(user)
+			return
+
+		if("toggleStorage")
+			allow_items = !allow_items
+			return
+
+		if("toggleAwakening")
+			linked_ship.current_ship.join_allowed = !linked_ship.current_ship.join_allowed
+			return
+
+		if("setMemo")
+			if(!("newName" in params) || params["newName"] == linked_ship.current_ship.memo)
+				return
+			linked_ship.current_ship.memo = params["newName"]
+			return
+
+		if("adjustJobSlot")
+			if(!("toAdjust" in params) || !("delta" in params) || !COOLDOWN_FINISHED(linked_ship.current_ship, job_slot_adjustment_cooldown))
+				return
+			var/datum/job/target_job = locate(params["toAdjust"])
+			if(!target_job)
+				return
+			if(linked_ship.current_ship.job_slots[target_job] + params["delta"] < 0 || linked_ship.current_ship.job_slots[target_job] + params["delta"] > 4)
+				return
+			linked_ship.current_ship.job_slots[target_job] += params["delta"]
+			linked_ship.current_ship.job_slot_adjustment_cooldown = world.time + DEFAULT_JOB_SLOT_ADJUSTMENT_COOLDOWN
+			update_static_data(user)
+			return
+
+/obj/machinery/computer/cryopod/ui_data(mob/user)
+	. = list()
+	.["allowItems"] = allow_items
+	.["awakening"] = linked_ship.current_ship.join_allowed
+	.["cooldown"] = linked_ship.current_ship.job_slot_adjustment_cooldown - world.time
+	.["memo"] = linked_ship.current_ship.memo
+
+/obj/machinery/computer/cryopod/ui_static_data(mob/user)
+	. = list()
+	.["jobs"] = list()
+	for(var/datum/job/J as anything in linked_ship.current_ship.job_slots)
+		if(J.officer)
+			continue
+		.["jobs"] += list(list(
+			name = J.title,
+			slots = linked_ship.current_ship.job_slots[J],
+			ref = REF(J),
+			max = linked_ship.source_template.job_slots[J] * 2
+		))
+
+	.["hasItems"] = length(frozen_items) > 0
+	.["stored"] = frozen_crew
 
 //Cryopods themselves.
 /obj/machinery/cryopod
@@ -141,10 +160,13 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	/// Time until the human inside is despawned. Reduced to 10% of this if player manually enters cryo.
 	var/time_till_despawn = 5 MINUTES
 
-	var/obj/machinery/computer/cryopod/control_computer
+	/// The linked control computer.
+	var/datum/weakref/control_computer
+
+	/// The last time the "no control computer" message was sent to admins.
 	var/last_no_computer_message = 0
 
-	// These items are preserved when the process() despawn proc occurs.
+	/// These items are preserved when the process() despawn proc occurs.
 	var/static/list/preserve_items = list(
 		/obj/item/hand_tele,
 		/obj/item/card/id/captains_spare,
@@ -167,24 +189,33 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		/obj/item/documents,
 		/obj/item/nuke_core_container
 	)
-	// These items will NOT be preserved
-	var/static/list/do_not_preserve_items = list (
-		/obj/item/mmi/posibrain
-	)
+
+	var/static/list/preserve_items_typecache
+
+	var/open_state = "cryopod-open"
+	var/close_state = "cryopod"
+	var/obj/docking_port/mobile/linked_ship
 
 /obj/machinery/cryopod/Initialize()
 	..()
+	if(!preserve_items_typecache)
+		preserve_items_typecache = typecacheof(preserve_items)
+	icon_state = open_state
 	return INITIALIZE_HINT_LATELOAD //Gotta populate the cryopod computer GLOB first
+
+/obj/machinery/cryopod/Destroy()
+	linked_ship?.spawn_points -= src
+	return ..()
 
 /obj/machinery/cryopod/LateInitialize()
 	update_icon()
 	find_control_computer()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent = FALSE)
-	for(var/M in GLOB.cryopod_computers)
-		var/obj/machinery/computer/cryopod/C = M
+	control_computer = null
+	for(var/obj/machinery/computer/cryopod/C as anything in GLOB.cryopod_computers)
 		if(get_area(C) == get_area(src))
-			control_computer = C
+			control_computer = WEAKREF(C)
 			break
 
 	// Don't send messages unless we *need* the computer, and less than five minutes have passed since last time we messaged
@@ -193,14 +224,14 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		message_admins("Cryopod in [get_area(src)] could not find control computer!")
 		last_no_computer_message = world.time
 
-	return control_computer != null
+	return !isnull(control_computer)
 
 /obj/machinery/cryopod/JoinPlayerHere(mob/M, buckle)
 	. = ..()
 	close_machine(M, TRUE)
 
 /obj/machinery/cryopod/close_machine(mob/user, exiting = FALSE)
-	if(!control_computer)
+	if(isnull(control_computer.resolve()))
 		find_control_computer(TRUE)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
 		..(user)
@@ -208,17 +239,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			var/mob/living/carbon/C = user
 			C.SetSleeping(50)
 			to_chat(occupant, "<span class='boldnotice'>You begin to wake from cryosleep...</span>")
-			icon_state = "cryopod"
+			icon_state = close_state
 			return
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 		addtimer(CALLBACK(src, .proc/try_despawn_occupant, mob_occupant), mob_occupant.client ? time_till_despawn * 0.1 : time_till_despawn) // If they're logged in, reduce the timer
-	icon_state = "cryopod"
+	icon_state = close_state
 
 /obj/machinery/cryopod/open_machine()
 	..()
-	icon_state = "cryopod-open"
+	icon_state = open_state
 	density = TRUE
 	name = initial(name)
 
@@ -240,7 +271,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 
 	if(!mob_occupant.client) //Occupant's client isn't present
-		if(!control_computer)
+		if(isnull(control_computer.resolve()))
 			find_control_computer(urgent = TRUE)//better hope you found it this time
 
 		despawn_occupant()
@@ -294,11 +325,15 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
 
-	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
-		//Handle job slot/tater cleanup.
-		if(LAZYLEN(mob_occupant.mind.objectives))
-			mob_occupant.mind.objectives.Cut()
-			mob_occupant.mind.special_role = null
+	if(linked_ship)
+		if(mob_occupant.job in linked_ship.current_ship.job_slots)
+			linked_ship.current_ship.job_slots[mob_occupant.job]++
+
+		if(mob_occupant.mind && mob_occupant.mind.assigned_role)
+			//Handle job slot/tater cleanup.
+			if(LAZYLEN(mob_occupant.mind.objectives))
+				mob_occupant.mind.objectives.Cut()
+				mob_occupant.mind.special_role = null
 
 	// Delete them from datacore.
 
@@ -319,30 +354,37 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	for(var/obj/structure/overmap/ship/simulated/sim_ship as anything in SSovermap.simulated_ships)
 		sim_ship.manifest -= mob_occupant.real_name
 
+	var/obj/machinery/computer/cryopod/control_computer_obj = control_computer.resolve()
+
 	//Make an announcement and log the person entering storage.
-	if(control_computer)
-		control_computer.frozen_crew += "[mob_occupant.real_name]"
+	if(control_computer_obj)
+		var/list/frozen_details = list()
+		frozen_details["name"] = "[mob_occupant.real_name]"
+		frozen_details["rank"] = announce_rank || "[mob_occupant.job]"
+		frozen_details["time"] = gameTimestamp()
+
+		control_computer_obj.frozen_crew += list(frozen_details)
 
 	if(GLOB.announcement_systems.len)
 		var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
 		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, list())
 		visible_message("<span class='notice'>\The [src] hums and hisses as it moves [mob_occupant.real_name] into storage.</span>")
 
+	var/list/all_mob_contents = mob_occupant.GetAllContents()
 
-	for(var/obj/item/W in mob_occupant.GetAllContents())
-		if(W.loc.loc && (( W.loc.loc == loc ) || (W.loc.loc == control_computer)))
+	for(var/obj/item/W as anything in all_mob_contents)
+		if(W.loc.loc && (( W.loc.loc == loc ) || (W.loc.loc == control_computer_obj)))
 			continue//means we already moved whatever this thing was in
 			//I'm a professional, okay
 			//what the fuck are you on rn and can I have some
-		for(var/T in preserve_items)
-			if(istype(W, T))
-				if(control_computer && control_computer.allow_items)
-					control_computer.frozen_items += W
-					mob_occupant.transferItemToLoc(W, control_computer, TRUE)
-				else
-					mob_occupant.transferItemToLoc(W, loc, TRUE)
+		if(is_type_in_typecache(W, preserve_items_typecache))
+			if(control_computer_obj && control_computer_obj.allow_items)
+				control_computer_obj.frozen_items += W
+				mob_occupant.transferItemToLoc(W, control_computer_obj, TRUE)
+			else
+				mob_occupant.transferItemToLoc(W, loc, TRUE)
 
-	for(var/obj/item/W in mob_occupant.GetAllContents())
+	for(var/obj/item/W as anything in all_mob_contents)
 		qdel(W)//because we moved all items to preserve away
 		//and yes, this totally deletes their bodyparts one by one, I just couldn't bother
 
@@ -406,53 +448,9 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	message_admins("[key_name_admin(target)] entered a stasis pod. (<A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 	add_fingerprint(target)
 
-/obj/machinery/cryopod/latejoin
-	var/obj/docking_port/mobile/linked_ship
-
-/obj/machinery/cryopod/latejoin/despawn_occupant()
-	if(!linked_ship)
-		return ..()
-	var/mob/living/mob_occupant = occupant
-	if(mob_occupant.job in linked_ship.current_ship.job_slots)
-		linked_ship.current_ship.job_slots[mob_occupant.job]++
-	return ..()
-
-/obj/machinery/cryopod/latejoin/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override)
+/obj/machinery/cryopod/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override)
 	. = ..()
 	linked_ship = port
 	linked_ship.spawn_points += src
 
-/obj/machinery/cryopod/latejoin/Destroy()
-	linked_ship?.spawn_points -= src
-	. = ..()
-
-/obj/machinery/cryopod/latejoin/reskinnable
-	var/open_state = "cryopod-open"
-	var/close_state = "cryopod"
-
-/obj/machinery/cryopod/latejoin/reskinnable/Initialize()
-	..()
-	icon_state = open_state
-
-/obj/machinery/cryopod/latejoin/reskinnable/close_machine(mob/user, exiting = FALSE)
-	if(!control_computer)
-		find_control_computer(TRUE)
-	if((isnull(user) || istype(user)) && state_open && !panel_open)
-		..(user)
-		if(exiting && istype(user, /mob/living/carbon))
-			var/mob/living/carbon/C = user
-			C.SetSleeping(50)
-			to_chat(occupant, "<span class='boldnotice'>You begin to wake from cryosleep...</span>")
-			icon_state = close_state
-			return
-		var/mob/living/mob_occupant = occupant
-		if(mob_occupant && mob_occupant.stat != DEAD)
-			to_chat(occupant, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
-		addtimer(CALLBACK(src, .proc/try_despawn_occupant, mob_occupant), mob_occupant.client ? time_till_despawn * 0.1 : time_till_despawn) // If they're logged in, reduce the timer
-	icon_state = close_state
-
-/obj/machinery/cryopod/latejoin/reskinnable/open_machine()
-	..()
-	icon_state = open_state
-	density = TRUE
-	name = initial(name)
+#undef DEFAULT_JOB_SLOT_ADJUSTMENT_COOLDOWN

--- a/whitesands/code/game/machinery/cryopod.dm
+++ b/whitesands/code/game/machinery/cryopod.dm
@@ -370,9 +370,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, list())
 		visible_message("<span class='notice'>\The [src] hums and hisses as it moves [mob_occupant.real_name] into storage.</span>")
 
-	var/list/all_mob_contents = mob_occupant.GetAllContents()
-
-	for(var/obj/item/W as anything in all_mob_contents)
+	for(var/obj/item/W as anything in mob_occupant.GetAllContents())
 		if(W.loc.loc && (( W.loc.loc == loc ) || (W.loc.loc == control_computer_obj)))
 			continue//means we already moved whatever this thing was in
 			//I'm a professional, okay
@@ -384,7 +382,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			else
 				mob_occupant.transferItemToLoc(W, loc, TRUE)
 
-	for(var/obj/item/W as anything in all_mob_contents)
+	for(var/obj/item/W as anything in mob_occupant.GetAllContents())
 		qdel(W)//because we moved all items to preserve away
 		//and yes, this totally deletes their bodyparts one by one, I just couldn't bother
 

--- a/whitesands/code/modules/jobs/job_types/solgov_rep.dm
+++ b/whitesands/code/modules/jobs/job_types/solgov_rep.dm
@@ -12,6 +12,7 @@ SolGov Representative
 	wiki_page = "Government_Attaché"
 	minimal_player_age = 7
 	exp_requirements = 180
+	officer = TRUE
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a bunch of functionality to cryogenics control consoles, not limited to setting a memo for new joins, disabling joining on your ship altogether, adjusting job slots, as well as the old item retrieval functionality, and it's all in TGUI!

## Why It's Good For The Game
Just better QoL for join configuration.

![image](https://user-images.githubusercontent.com/29362068/141887956-4a72c7ef-26c9-4bd6-8bbf-aadf42591c12.png)
*Pictured: A Dwayne-class' oversight screen*

## Changelog
:cl:
add: Cryo consoles can now control job slots, joining, and even set a memo to be displayed before new joins select your ship.
tweak: Combined latejoin/reskinnable cryopods into the main object. No need to have the plain old one anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
