### PR TITLE
[Fix] Removed Access Requirement from Disco Jukebox

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -5,7 +5,6 @@
 	icon_state = "jukebox"
 	verb_say = "states"
 	density = TRUE
-	//WS Edit - Removed Jukebox Access Requirements
 	var/active = FALSE
 	var/list/rangers = list()
 	var/stop = 0
@@ -17,7 +16,6 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(ACCESS_ENGINE)
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()
@@ -28,7 +26,6 @@
 /obj/machinery/jukebox/disco/indestructible
 	name = "radiant dance machine mark V"
 	desc = "Now redesigned with data gathered from the extensive disco and plasma research."
-	req_access = null
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1


### PR DESCRIPTION
## About The Pull Request

The disco jukebox still required engineering access to use.  I forgot to remove this as part of https://github.com/Whitesands13/Whitesands/pull/671.  This has been removed along with the access requirements references in the other jukeboxes.

## Why It's Good For The Game

BugFix: Anyone can use the disco jukebox

## Changelog
:cl:
fix: Removed access requirement from disco jukebox
/:cl:
