### PR TITLE
Mob Holdability Traitification

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -205,6 +205,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NICE_SHOT "nice_shot" //hnnnnnnnggggg..... you're pretty good....
 /// The holder of this trait has antennae or whatever that hurt a ton when noogied
 #define TRAIT_ANTENNAE "antennae"
+/// The holder of this trait can be picked up and held by another mob that does NOT have this trait.
+#define TRAIT_HOLDABLE "holdable"
 
 //non-mob traits
 /// Used for limb-based paralysis, where replacing the limb will fix it.

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -145,7 +145,8 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_BALD" = TRAIT_BALD,
 		"TRAIT_NOBREAK" = TRAIT_NOBREAK,			//WS edit - Whitesands
 		"TRAIT_ALLBREAK" = TRAIT_ALLBREAK,			//WS edit - Whitesands
-		"TRAIT_BADTOUCH" = TRAIT_BADTOUCH
+		"TRAIT_BADTOUCH" = TRAIT_BADTOUCH,
+		"TRAIT_HOLDABLE" = TRAIT_HOLDABLE
 
 	),
 	/obj/item/bodypart = list(

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -93,6 +93,7 @@
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
+	ADD_TRAIT(owner, TRAIT_HOLDABLE, GENETIC_MUTATION)
 	owner.transform = owner.transform.Scale(1, 0.8)
 	passtable_on(owner, GENETIC_MUTATION)
 	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
@@ -101,6 +102,7 @@
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_HOLDABLE, GENETIC_MUTATION)
 	owner.transform = owner.transform.Scale(1, 1.25)
 	passtable_off(owner, GENETIC_MUTATION)
 	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1058,7 +1058,7 @@
 		return ..()
 
 	//If they can be picked up, and we can't (prevents recursion), try to pick the target mob up as an item.
-	if(target.can_be_held && !can_be_held)
+	if(HAS_TRAIT(target, TRAIT_HOLDABLE) && !HAS_TRAIT(src, TRAIT_HOLDABLE))
 		if(target.mob_try_pickup(user))
 			return
 	//If they dragged themselves and we're currently aggressively grabbing them try to piggyback

--- a/code/modules/mob/living/carbon/human/species_types/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species_types/teshari.dm
@@ -3,6 +3,7 @@
 	id = "teshari"
 	default_color = "6060FF"
 	species_traits = list(MUTCOLORS, EYECOLOR, NO_UNDERWEAR)
+	inherent_traits = list(TRAIT_HOLDABLE)
 	mutant_bodyparts = list("teshari_feathers", "teshari_body_feathers")
 	default_features = list("mcolor" = "0F0", "wings" = "None", "teshari_feathers" = "Plain", "teshari_body_feathers" = "Plain")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/chicken
@@ -29,14 +30,6 @@
 	no_equip = list(ITEM_SLOT_BACK)
 	mutanttongue = /obj/item/organ/tongue/teshari
 	species_language_holder = /datum/language_holder/teshari
-
-/datum/species/teshari/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
-	. = ..()
-	C.can_be_held = TRUE
-
-/datum/species/teshari/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
-	. = ..()
-	C.can_be_held = FALSE
 
 /datum/species/teshari/can_equip(obj/item/I, slot, disable_warning, mob/living/carbon/human/H, bypass_equip_delay_self, swap)
 	if(slot == ITEM_SLOT_MASK)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1328,7 +1328,7 @@
 	var/mob/living/U = user
 	if(isliving(dropping))
 		var/mob/living/M = dropping
-		if(M.can_be_held && U.pulling == M)
+		if(HAS_TRAIT(M, TRAIT_HOLDABLE) && U.pulling == M)
 			M.mob_try_pickup(U)//blame kevinz
 			return//dont open the mobs inventory if you are picking them up
 	. = ..()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -141,7 +141,6 @@
 
 	var/list/obj/effect/proc_holder/abilities = list()
 
-	var/can_be_held = FALSE	//whether this can be picked up and held.
 	var/worn_slot_flags = NONE //if it can be held, can it be equipped to any slots? (think pAI's on head)
 
 	var/radiation = 0 ///If the mob is irradiated.

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -12,7 +12,6 @@
 	health = 500
 	maxHealth = 500
 	layer = BELOW_MOB_LAYER
-	can_be_held = TRUE
 	worn_slot_flags = ITEM_SLOT_HEAD
 	held_lh = 'icons/mob/pai_item_lh.dmi'
 	held_rh = 'icons/mob/pai_item_rh.dmi'
@@ -102,6 +101,7 @@
 	return ..()
 
 /mob/living/silicon/pai/Initialize()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 	var/obj/item/paicard/P = loc
 	START_PROCESSING(SSfastprocess, src)
 	GLOB.pai_list += src

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -36,15 +36,14 @@
 	var/emote_cooldown = 0
 	gold_core_spawnable = FRIENDLY_SPAWN
 	collar_type = "cat"
-	can_be_held = TRUE
 	held_state = "cat2"
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
 /mob/living/simple_animal/pet/cat/Initialize()
 	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 	add_verb(src, /mob/living/proc/toggle_resting)
-
 
 /mob/living/simple_animal/pet/cat/space
 	desc = "It's a cat... in space!"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -16,7 +16,6 @@
 	see_in_dark = 5
 	speak_chance = 1
 	turns_per_move = 10
-	can_be_held = TRUE
 	var/turns_since_scan = 0
 	var/obj/movement_target
 
@@ -138,6 +137,7 @@
 
 /mob/living/simple_animal/pet/dog/Initialize()
 	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 	var/dog_area = get_area(src)
 	for(var/obj/structure/bed/dogbed/D in dog_area)
 		if(!D.owner)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -73,7 +73,6 @@
 	dextrous_hud_type = /datum/hud/dextrous/drone
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_in_dark = 7
-	can_be_held = TRUE
 	worn_slot_flags = ITEM_SLOT_HEAD
 	held_items = list(null, null)
 	/// `TRUE` if we have picked our visual appearance, `FALSE` otherwise (default)
@@ -136,6 +135,7 @@
 		var/obj/item/I = new default_hatmask(src)
 		equip_to_slot_or_del(I, ITEM_SLOT_HEAD)
 
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
 	alert_drones(DRONE_NET_CONNECT)

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -32,7 +32,7 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/simple_animal/drone/attack_hand(mob/user)
 	if(ishuman(user))
-		if(stat == DEAD || status_flags & GODMODE || !can_be_held)
+		if(stat == DEAD || status_flags & GODMODE || !HAS_TRAIT(src, TRAIT_HOLDABLE))
 			..()
 			return
 		if(user.get_active_held_item())

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -21,10 +21,13 @@
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
 	gold_core_spawnable = FRIENDLY_SPAWN
-	can_be_held = TRUE
 	held_state = "fox"
 
 	footstep_type = FOOTSTEP_MOB_CLAW
+
+/mob/living/simple_animal/pet/fox/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 
 //Captain fox
 /mob/living/simple_animal/pet/fox/Renault

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -54,11 +54,11 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	var/full = FALSE //WS Edit
 	var/eating = FALSE //WS Edit
 	var/cheesed = FALSE //WS Edit
-	can_be_held = TRUE
 	held_state = "mouse_gray"
 
 /mob/living/simple_animal/mouse/Initialize()
 	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 	AddComponent(/datum/component/squeak, list('sound/effects/mousesqueek.ogg'=1), 100, extrarange = SHORT_RANGE_SOUND_EXTRARANGE) //as quiet as a mouse or whatever
 	if(!body_color)
 		body_color = pick( list("brown","gray","white") )

--- a/whitesands/code/modules/mob/living/simple_animal/friendly/turtle.dm
+++ b/whitesands/code/modules/mob/living/simple_animal/friendly/turtle.dm
@@ -26,12 +26,15 @@
 	maxHealth = 2500
 	speed = 4
 	glide_size = 2
-	can_be_held = TRUE
 	chat_color = "#E7D26F"
 	footstep_type = FOOTSTEP_MOB_CLAW
 
 	var/turtle_hide_max = 25 //The time spent hiding in its shell
 	var/turtle_hide_dur = 25 //Same as above, this is the var that physically counts down
+
+/mob/living/simple_animal/turtle/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 
 /mob/living/simple_animal/turtle/handle_automated_movement()
 	if(!isturf(src.loc) || !(mobility_flags & MOBILITY_MOVE) || buckled)


### PR DESCRIPTION
## About The Pull Request
Makes it so you can pick up and punt dwarves into space. It's been a long time coming.

Also makes it so that mob holdability is based on a trait, so isn't fucky when, say, a kepi gains and then loses the dwarfism trait, making them unholdable. 

Also, finally, makes it so that kepi can't hold other kepi, and other such things that will go poorly. Sorry, but it had to happen.

## Why It's Good For The Game
I want to punt nine out of ten dwarves that I meet ingame into space. I can finally make that happen.

## Changelog
:cl:
tweak: Kepori can no longer pick up other kepori.
tweak: Dwarves are now holdable.
fix: Minor holdability weirdness hopefully removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
