### PR TITLE
Disable Atmospherics during Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,6 @@ code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
 
 # tool-generated files
 check_regex_output.txt
+
+# vsc ionide cache
+.ionide/symbolCache.db

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -125,6 +125,10 @@ SUBSYSTEM_DEF(air)
 	fix_corrupted_atmos()
 
 /datum/controller/subsystem/air/fire(resumed = 0)
+#ifdef CITESTING
+	return
+#endif
+
 	var/timer = TICK_USAGE_REAL
 
 	if(currentpart == SSAIR_REBUILD_PIPENETS)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -30,6 +30,9 @@
 	update = air.react(src)
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/base)
+#ifdef CITESTING
+	return
+#endif
 	var/volume = 0
 	if(istype(base, /obj/machinery/atmospherics/pipe))
 		var/obj/machinery/atmospherics/pipe/E = base

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -88,6 +88,9 @@
 	other_airs |= returned_airs
 
 /datum/pipeline/proc/addMember(obj/machinery/atmospherics/A, obj/machinery/atmospherics/N)
+#ifdef CITESTING
+	return
+#endif
 	if(istype(A, /obj/machinery/atmospherics/pipe))
 		var/obj/machinery/atmospherics/pipe/P = A
 		if(P.parent)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -107,6 +107,9 @@
 		addMachineryMember(A)
 
 /datum/pipeline/proc/merge(datum/pipeline/E)
+#ifdef CITESTING
+	return
+#endif
 	if(E == src)
 		return
 	air.set_volume(air.return_volume() + E.air.return_volume())


### PR DESCRIPTION
Atmospherics is nothing except headaches during Unit Tests; until an actual solution for the constant runtimes during unit tests can be found I'm disabling it entirely.