### PR TITLE
Completely fixes Default input

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -31,17 +31,20 @@ SUBSYSTEM_DEF(input)
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
+			"Escape" = "Reset-Held-Keys",
 			),
 		"old_default" = list( //Unlocked Bar. Respects oldmode_keys whitelist. Full tab support. [Default]
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Ctrl+T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
 			"Ctrl+O" = "ooc",
+			"Ctrl+Escape" = "Reset-Held-Keys", //Small concession for the safety net.
 			),
 		"old_hotkeys" = list( //Unlocked Any. Supports clean switch back to unlocked. [Default]
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
+			"Escape" = "Reset-Held-Keys",
 			),
 		)
 

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(input)
 	priority = FIRE_PRIORITY_INPUT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
-	var/list/macro_set
+	var/list/macro_sets
 
 /datum/controller/subsystem/input/Initialize()
 	setup_default_macro_sets()
@@ -19,13 +19,69 @@ SUBSYSTEM_DEF(input)
 
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
-	macro_set = list(
-	"Any" = "\"KeyDown \[\[*\]\]\"",
-	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
-	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-	"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-	"Escape" = "Reset-Held-Keys",
-	)
+	var/list/static/default_macro_sets
+
+	if(default_macro_sets)
+		macro_sets = default_macro_sets
+		return
+
+	default_macro_sets = list(
+		"default" = list( //Locked Any. Reduced tab support. [Hotkey]
+			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
+			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
+			"Any" = "\"KeyDown \[\[*\]\]\"",
+			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
+			),
+		"old_default" = list( //Unlocked Bar. Respects oldmode_keys whitelist. Full tab support. [Default]
+			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
+			"Ctrl+T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
+			"Ctrl+O" = "ooc",
+			),
+		"old_hotkeys" = list( //Unlocked Any. Supports clean switch back to unlocked. [Default]
+			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
+			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
+			"Any" = "\"KeyDown \[\[*\]\]\"",
+			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
+			),
+		)
+
+	// Because i'm lazy and don't want to type all these out twice
+	var/list/old_default = default_macro_sets["old_default"]
+
+	var/list/static/oldmode_keys = list(
+		"North", "East", "South", "West",
+		"Northeast", "Southeast", "Northwest", "Southwest",
+		"Insert", "Delete", "Ctrl", "Alt",
+		"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+		)
+
+	for(var/i in 1 to oldmode_keys.len)
+		var/key = oldmode_keys[i]
+		old_default[key] = "\"KeyDown [key]\""
+		old_default["[key]+UP"] = "\"KeyUp [key]\""
+
+	var/list/static/oldmode_ctrl_override_keys = list(
+		"W" = "W", "A" = "A", "S" = "S", "D" = "D", // movement
+		"1" = "1", "2" = "2", "3" = "3", "4" = "4", // intent
+		"B" = "B", // resist
+		"E" = "E", // quick equip
+		"F" = "F", // intent left
+		"G" = "G", // intent right
+		"H" = "H", // stop pulling
+		"Q" = "Q", // drop
+		"R" = "R", // throw
+		"X" = "X", // switch hands
+		"Y" = "Y", // activate item
+		"Z" = "Z", // activate item
+		)
+
+	for(var/i in 1 to oldmode_ctrl_override_keys.len)
+		var/key = oldmode_ctrl_override_keys[i]
+		var/override = oldmode_ctrl_override_keys[key]
+		old_default["Ctrl+[key]"] = "\"KeyDown [override]\""
+		old_default["Ctrl+[key]+UP"] = "\"KeyUp [override]\""
+
+	macro_sets = default_macro_sets
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -35,8 +35,6 @@ SUBSYSTEM_DEF(input)
 			),
 		"old_default" = list( //Unlocked Bar. Respects oldmode_keys whitelist. Full tab support. [Default]
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
-			"Ctrl+O" = "ooc",
 			"Ctrl+Escape" = "Reset-Held-Keys", //Small concession for the safety net.
 			),
 		"old_hotkeys" = list( //Unlocked Any. Supports clean switch back to unlocked. [Default]

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -873,9 +873,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		// so that the visual focus indicator matches reality.
 		winset(src, null, "input.background-color=[COLOR_INPUT_DISABLED]")
 
-	else
-		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
-
 	..()
 
 /client/proc/add_verbs_from_config()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1971,7 +1971,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("hotkeys")
 					hotkeys = !hotkeys
 					if(hotkeys)
-						winset(src, null, "map.focus=true input.background-color=[COLOR_INPUT_DISABLED] mainwindow.macro=default")
+						winset(user, null, "map.focus=true input.background-color=[COLOR_INPUT_DISABLED] mainwindow.macro=default")
 					else
 						winset(user, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=old_default")
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1971,9 +1971,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("hotkeys")
 					hotkeys = !hotkeys
 					if(hotkeys)
-						winset(user, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
+						winset(src, null, "map.focus=true input.background-color=[COLOR_INPUT_DISABLED] mainwindow.macro=default")
 					else
-						winset(user, null, "input.focus=true input.background-color=[COLOR_INPUT_DISABLED]")
+						winset(user, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=old_default")
 
 				if("keybindings_capture")
 					var/datum/keybinding/kb = GLOB.keybindings_by_name[href_list["keybinding"]]

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -36,10 +36,10 @@
 		qdel(src)
 		return
 
-	//Focus Chat failsafe. Overrides movement checks to prevent WASD.
-	if(!prefs.hotkeys && length(_key) == 1 && _key != "Alt" && _key != "Ctrl" && _key != "Shift")
-		winset(src, null, "input.focus=true ; input.text=[url_encode(_key)]")
-		return
+	//Focus Chat failsafe. Overrides movement checks to prevent WASD. Should no longer be necessary.
+	// if(!prefs.hotkeys && length(_key) == 1 && _key != "Alt" && _key != "Ctrl" && _key != "Shift")
+	// 	winset(src, null, "input.focus=true ; input.text=[url_encode(_key)]")
+	// 	return
 
 	if(length(keys_held) >= HELD_KEY_BUFFER_LENGTH && !keys_held[_key])
 		keyUp(keys_held[1]) //We are going over the number of possible held keys, so let's remove the first one.

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -10,12 +10,17 @@
 
 // removes all the existing macros
 /client/proc/erase_all_macros()
+	var/list/macro_sets = params2list(winget(src, null, "macros"))
 	var/erase_output = ""
-	var/list/macro_set = params2list(winget(src, "default.*", "command")) // The third arg doesnt matter here as we're just removing them all
-	for(var/k in 1 to length(macro_set))
-		var/list/split_name = splittext(macro_set[k], ".")
-		var/macro_name = "[split_name[1]].[split_name[2]]" // [3] is "command"
-		erase_output = "[erase_output];[macro_name].parent=null"
+	for(var/i in 1 to macro_sets.len)
+		var/setname = macro_sets[i]
+		if(copytext(setname, 1, 9) == "persist_") // Don't remove macro sets not handled by input. Used in input_box.dm by create_input_window
+			continue
+		var/list/macro_set = params2list(winget(src, "[setname].*", "command")) // The third arg doesnt matter here as we're just removing them all
+		for(var/k in 1 to macro_set.len)
+			var/list/split_name = splittext(macro_set[k], ".")
+			var/macro_name = "[split_name[1]].[split_name[2]]" // [3] is "command"
+			erase_output = "[erase_output];[macro_name].parent=null"
 	winset(src, null, erase_output)
 
 /client/proc/set_macros()
@@ -26,15 +31,20 @@
 
 	erase_all_macros()
 
-	var/list/macro_set = SSinput.macro_set
-	for(var/k in 1 to length(macro_set))
-		var/key = macro_set[k]
-		var/command = macro_set[key]
-		winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[command]")
+	var/list/macro_sets = SSinput.macro_sets
+	for(var/i in 1 to macro_sets.len)
+		var/setname = macro_sets[i]
+		if(setname != "default")
+			winclone(src, "default", setname)
+		var/list/macro_set = macro_sets[setname]
+		for(var/k in 1 to macro_set.len)
+			var/key = macro_set[k]
+			var/command = macro_set[key]
+			winset(src, "[setname]-[REF(key)]", "parent=[setname];name=[key];command=[command]")
 
-	if(prefs?.hotkeys)
-		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
+	if(prefs.hotkeys)
+		winset(src, null, "map.focus=true input.background-color=[COLOR_INPUT_DISABLED] mainwindow.macro=default")
 	else
-		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_DISABLED]")
+		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=old_default")
 
 	update_special_keybinds()

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -12,8 +12,7 @@
 /client/proc/erase_all_macros()
 	var/list/macro_sets = params2list(winget(src, null, "macros"))
 	var/erase_output = ""
-	for(var/i in 1 to macro_sets.len)
-		var/setname = macro_sets[i]
+	for(var/setname in macro_sets)
 		if(copytext(setname, 1, 9) == "persist_") // Don't remove macro sets not handled by input. Used in input_box.dm by create_input_window
 			continue
 		var/list/macro_set = params2list(winget(src, "[setname].*", "command")) // The third arg doesnt matter here as we're just removing them all
@@ -32,13 +31,11 @@
 	erase_all_macros()
 
 	var/list/macro_sets = SSinput.macro_sets
-	for(var/i in 1 to macro_sets.len)
-		var/setname = macro_sets[i]
+	for(var/setname in macro_sets)
 		if(setname != "default")
 			winclone(src, "default", setname)
 		var/list/macro_set = macro_sets[setname]
-		for(var/k in 1 to macro_set.len)
-			var/key = macro_set[k]
+		for(var/key in macro_set)
 			var/command = macro_set[key]
 			winset(src, "[setname]-[REF(key)]", "parent=[setname];name=[key];command=[command]")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Partial revert of some weird changes made as part of tgstation/tgstation#47003. These changes resulted in legacy input behaving unexpectedly and generally being pretty broken.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes legacy/default/focuschat/pipis mode function as expected instead of stapled to a bit of jank related to use of `Any` macros.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: Non-hotkey/default/pipis input mode has had it's support code fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
