### PR TITLE
Fixes Digitigrade Characters Bypassing Being Paraplegic

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -281,7 +281,7 @@
 		return FALSE
 	. = TRUE
 	moveToNullspace()
-	owner = C
+	set_owner(C)
 	C.add_bodypart(src)
 	if(held_index)
 		if(held_index > C.hand_bodyparts.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, the set_owner() proc which dealt with the paraplegic quirk  was bypassed except in the instance that the leg was created when the player was first created, which, digitigrade legs are swapped out *after* this. The code the code the code the code.

Fixes: #501 

## Why It's Good For The Game
Makes the quirk actually function as intended, prevents players from getting free trait points.

## Changelog
:cl:
fix: Digitigrade characters with the paraplegic quirk no longer start being able to walk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
