### PR TITLE
Fixes Plumbing Bottle Spam

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -71,12 +71,12 @@
 			P.name = trim("[product_name] bottle")
 			stored_products += P
 	if(stored_products.len)
-		var/pill_amount = 0
-		for(var/obj/item/reagent_containers/pill/P in loc)
-			pill_amount++
-			if(pill_amount >= max_floor_products) //too much so just stop
+		var/container_amount = 0
+		for(var/obj/item/reagent_containers/container in loc)
+			container_amount++
+			if(container_amount >= max_floor_products) //too much so just stop
 				break
-		if(pill_amount < max_floor_products)
+		if(container_amount < max_floor_products)
 			var/atom/movable/AM = stored_products[1] //AM because forceMove is all we need
 			stored_products -= AM
 			AM.forceMove(drop_location())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**I HATE PLUMBING CODE, WHY IS THIS ALL IN PROCES-** *ahem*

Makes it so you can't spam patches and bottles with the pill factory to the point the game crashes for all clients in the nearby area, including admins trying to fix the problem.

Fixes: #466

## Why It's Good For The Game
Powerpoint mode is fun but should be relegated to an admin-only feature.

## Changelog
:cl:
fix: You can no longer spam out infinite patches and bottles with the plumbing pill factory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
