### PR TITLE
Adds the ability for APC Powercords to drain energy off Ethereals

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -111,49 +111,89 @@
 	icon_state = "wire1"
 
 /obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	if(!istype(target, /obj/machinery/power/apc) || !ishuman(user) || !proximity_flag)
+	if((!istype(target, /obj/machinery/power/apc) && !isethereal(target)) || !ishuman(user) || !proximity_flag)
 		return ..()
 	user.changeNext_move(CLICK_CD_MELEE)
-	var/obj/machinery/power/apc/A = target
 	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/stomach/cell/cell = H.internal_organs_slot["stomach"]
-	if(!cell)
-		to_chat(H, "<span class='warning'>You try to siphon energy from the [A], but your power cell is gone!</span>")
+	var/obj/item/organ/stomach/cell/battery = H.getorganslot(ORGAN_SLOT_STOMACH)
+	if(!battery)
+		to_chat(H, "<span class='warning'>You try to siphon energy from \the [target], but your power cell is gone!</span>")
 		return
 
-	if(A.cell && A.cell.charge > 0)
-		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
-			to_chat(user, "<span class='warning'>You are already fully charged!</span>")
+	if(istype(H) && H.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
+		to_chat(user, "<span class='warning'>You are already fully charged!</span>")
+		return
+
+	if(istype(target, /obj/machinery/power/apc))
+		var/obj/machinery/power/apc/A = target
+		if(A.cell && A.cell.charge > A.cell.maxcharge/4)
+			powerdraw_loop(A, H, TRUE)
 			return
 		else
-			powerdraw_loop(A, H)
+			to_chat(user, "<span class='warning'>There is not enough charge to draw from that APC.</span>")
 			return
 
-	to_chat(user, "<span class='warning'>There is no charge to draw from that APC.</span>")
-
-/obj/item/apc_powercord/proc/powerdraw_loop(obj/machinery/power/apc/A, mob/living/carbon/human/H)
-	H.visible_message("<span class='notice'>[H] inserts a power connector into the [A].</span>", "<span class='notice'>You begin to draw power from the [A].</span>")
-	while(do_after(H, 10, target = A))
-		if(loc != H)
-			to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
-			break
-		if(A.cell.charge == 0)
-			to_chat(H, "<span class='warning'>The [A] doesn't have enough charge to spare.</span>")
-			break
-		A.charging = 1
-		if(A.cell.charge >= 500)
-			H.nutrition += 50
-			A.cell.charge -= 250
-			to_chat(H, "<span class='notice'>You siphon off some of the stored charge for your own use.</span>")
+	if(isethereal(target))
+		var/mob/living/carbon/human/target_ethereal = target
+		var/obj/item/organ/stomach/ethereal/eth_stomach = target_ethereal.getorganslot(ORGAN_SLOT_STOMACH)
+		if(target_ethereal.nutrition > 0 && eth_stomach)
+			powerdraw_loop(eth_stomach, H, FALSE)
+			return
 		else
-			H.nutrition += A.cell.charge/10
-			A.cell.charge = 0
-			to_chat(H, "<span class='notice'>You siphon off as much as the [A] can spare.</span>")
-			break
-		if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
-			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
-			break
-	H.visible_message("<span class='notice'>[H] unplugs from the [A].</span>", "<span class='notice'>You unplug from the [A].</span>")
+			to_chat(user, "<span class='warning'>There is not enough charge to draw from that being!</span>")
+			return
+
+/obj/item/apc_powercord/proc/powerdraw_loop(atom/target, mob/living/carbon/human/H, apc_target)
+	H.visible_message("<span class='notice'>[H] inserts a power connector into the [target].</span>", "<span class='notice'>You begin to draw power from the [target].</span>")
+	var/obj/item/organ/stomach/cell/battery = H.getorganslot(ORGAN_SLOT_STOMACH)
+	if(apc_target)
+		var/obj/machinery/power/apc/A = target
+		if(!istype(A))
+			return
+		while(do_after(H, 10, target = A))
+			if(loc != H)
+				to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
+				break
+			if(A.cell.charge == 0)
+				to_chat(H, "<span class='warning'>The [A] doesn't have enough charge to spare.</span>")
+				break
+			A.charging = 1
+			if(A.cell.charge >= 500)
+				H.nutrition += 50
+				A.cell.charge -= 250
+				to_chat(H, "<span class='notice'>You siphon off some of the stored charge for your own use.</span>")
+			else
+				H.nutrition += A.cell.charge/10
+				A.cell.charge = 0
+				to_chat(H, "<span class='notice'>You siphon off as much as the [A] can spare.</span>")
+				break
+			if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
+				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+				break
+	else
+		var/obj/item/organ/stomach/ethereal/A = target
+		if(!istype(A))
+			return
+		var/siphon_amt
+		while(do_after(H, 10, target = A.owner))
+			if(!battery)
+				to_chat(H, "<span class='warning'>You need a battery to recharge!</span>")
+				break
+			if(loc != H)
+				to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
+				break
+			if(A.crystal_charge == 0)
+				to_chat(H, "<span class='warning'>[A] is completely drained!</span>")
+				break
+			siphon_amt = A.crystal_charge <= 8 ? A.crystal_charge : 8
+			A.adjust_charge(-1 * siphon_amt)
+			H.nutrition += (siphon_amt * 5)
+			if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
+				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+				break
+
+	H.visible_message("<span class='notice'>[H] unplugs from the [target].</span>", "<span class='notice'>You unplug from the [target].</span>")
+	return
 
 /datum/species/ipc/spec_life(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
APC Powercords (IPC's powercord implant) can drain energy off ethereals at a rate of 1:5.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Literal energy beings, smh/

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: IPCs can drain energy off Ethereals with their powercord.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
