### PR TITLE
Change slime name.

### DIFF
--- a/whitesands/code/game/objects/structures/ghost_role_spawners.dm
+++ b/whitesands/code/game/objects/structures/ghost_role_spawners.dm
@@ -18,7 +18,7 @@
 	assignedrole = "Slime Rancher"
 
 /obj/effect/mob_spawn/human/slime_rancher/special(mob/living/new_spawn)
-	var/slime_name = pick("Maroon", "Funky", "Squishy", "Bubblegum", "Gummy", "Pinkie Pie", "Rainbow Dash", "Piss Brown", "Chartreuse", "Chocolate")
+	var/slime_name = pick("Maroon", "Funky", "Squishy", "Bubblegum", "Gummy", "Pinkie Pie", "Rainbow Dash", "Beatrix LeBeau", "Chartreuse", "Chocolate")
 	new_spawn.fully_replace_character_name(null,slime_name)
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn


### PR DESCRIPTION
## About The Pull Request

Changes a Slime Rancher ghost role name into something more RP friendly.

## Why It's Good For The Game

Once upon a time an admeme yelled at me for having my name as "Piss Brown" but since it was a ghost spawner role I had no control over it ;-;
Now it is in reference to the Slime Rancher's main character, Beatrix LeBeau.

## Changelog
:cl:
tweak: Changed potential slime rancher name "Piss Brown" to "Beatrix LeBeau"
/:cl:
