### PR TITLE
Fixes circlegame issue

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -752,7 +752,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/circlegame/Destroy()
 	var/mob/owner = loc
 	if(!istype(owner))
-		return
+		return ..()
 	UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
 	. = ..()
 

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -112,6 +112,7 @@
 	key = "circle"
 	key_third_person = "circles"
 	hands_use_check = TRUE
+	mob_type_allowed_typecache = list(/mob/living/carbon)
 
 /datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -126,6 +127,7 @@
 	key = "slap"
 	key_third_person = "slaps"
 	hands_use_check = TRUE
+	mob_type_allowed_typecache = list(/mob/living/carbon)
 
 /datum/emote/living/carbon/slap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability for ghosts to spawn in indestructible (even by admins!) circled hands. This not only makes the hands destructible, but also limits the emotes to carbons, as they should be.

Fixes: #531
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It gets annoying
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ghosts can no longer rain circlehands down on the living
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
