### PR TITLE
Makes movement_force based on thrust capacity

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_crash_cult.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_crash_cult.dmm
@@ -1,176 +1,37 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ad" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
+"as" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"ax" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"bi" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"bp" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"bU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"cl" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/obj/item/bedsheet/cult,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"cp" = (
-/obj/structure/table,
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/megaphone{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"cE" = (
+"aH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/cult/friendly,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"cW" = (
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"cY" = (
-/obj/effect/decal/cleanable/blood/innards,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"dz" = (
-/obj/effect/turf_decal/corner/brown,
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
-/obj/structure/rack,
-/obj/item/pickaxe/emergency,
-/obj/item/pickaxe/emergency,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"dF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"dK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"ev" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/construct/proteon/hostile,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"eC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/cult/friendly,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"eY" = (
-/mob/living/simple_animal/hostile/construct/proteon/hostile,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"fe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/holopad/emergency/command{
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"hq" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/brute,
-/obj/effect/turf_decal/corner/blue,
 /obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"hG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating,
+"aS" = (
+/obj/structure/marker_beacon,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"bl" = (
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"hV" = (
+"bC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -179,93 +40,76 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"hX" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
+"cb" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"hY" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"ir" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plating,
+"cg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/closed/wall/mineral/cult,
 /area/ruin/unpowered)
-"ix" = (
-/obj/machinery/processor,
+"ct" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/green{
+/obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"iz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"iE" = (
-/obj/effect/decal/cleanable/blood/tracks{
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"iJ" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor5";
-	pixel_x = -2
+"cD" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"iV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
 	dir = 8
-	},
-/obj/machinery/light/broken,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"jn" = (
-/turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
-"jt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"jG" = (
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"jI" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"cZ" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/corner/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/obj/item/bedsheet/cult,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"dh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"jM" = (
+"dj" = (
+/obj/machinery/computer/crew,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ej" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ex" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
@@ -274,80 +118,26 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"kb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/corner/green,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"kk" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+"eE" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/corner/blue{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/construct/proteon/hostile,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"kr" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
-"ku" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
+/obj/effect/turf_decal/corner/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/brown,
-/turf/open/floor/plasteel/cult,
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
-"lE" = (
-/obj/item/ectoplasm,
-/obj/effect/decal/cleanable/dirt/dust,
+"eK" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"lQ" = (
-/obj/machinery/door/airlock/mining,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"mo" = (
-/obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid,
 /area/overmap_encounter/planetoid/rockplanet/explored)
-"mR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"nb" = (
+"eX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
@@ -360,319 +150,71 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"nG" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plasteel/cult,
+"eZ" = (
+/obj/structure/healingfountain,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
-"nP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters"
+"fg" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"fE" = (
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"hm" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"nU" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"oc" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"oC" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"pN" = (
+"hs" = (
+/obj/structure/chair,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"pR" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"pV" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
+/obj/effect/turf_decal/corner/green{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"pW" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"qf" = (
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"qm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/item/radio/intercom/wideband{
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"qR" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"rO" = (
-/obj/machinery/computer/crew,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"sr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"su" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"ti" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"tl" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"tE" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"uO" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/corner/green{
 	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"uP" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"vl" = (
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
 	},
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"vm" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"vE" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"vS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
+"hw" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"xg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"xk" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor5";
-	pixel_x = -2
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"xz" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"xP" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/unpowered)
-"ya" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"ye" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"yf" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"yL" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
-"yS" = (
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"yZ" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/corner/brown,
-/obj/effect/turf_decal/corner/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/item/electronics/apc,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"zn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"zz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"zM" = (
-/mob/living/simple_animal/hostile/construct/proteon/hostile,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"hD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"zR" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows"
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Ag" = (
-/obj/item/pickaxe/rusted,
-/obj/effect/gibspawner/human/bodypartless,
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"BT" = (
+"ig" = (
 /obj/structure/constructshell,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -682,154 +224,58 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"Ck" = (
-/obj/machinery/computer/monitor{
+"in" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
 	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Cx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"Cz" = (
+"iK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"CP" = (
-/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Dd" = (
-/obj/structure/marker_beacon,
+"jU" = (
+/obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid,
 /area/overmap_encounter/planetoid/rockplanet/explored)
-"Df" = (
+"kj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"kr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Dr" = (
-/obj/structure/marker_beacon,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"Dy" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"DK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor5";
-	pixel_x = -2
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Er" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
-"EZ" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows"
-	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Fi" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
+"kE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/unpowered)
-"Fk" = (
-/obj/effect/rune/narsie,
-/mob/living/simple_animal/hostile/construct/juggernaut/hostile{
-	loot = list(/obj/item/ectoplasm, /obj/item/nullrod/armblade/tentacle)
-	},
-/obj/structure/sacrificealtar,
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor5";
-	pixel_x = -2
-	},
-/obj/effect/decal/cleanable/blood/gibs/core,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"FX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Gc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"Gs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"GF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/construct/wraith/hostile{
-	loot = list(/obj/item/ectoplasm, /obj/item/rod_of_asclepius)
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"GJ" = (
+"kF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -842,214 +288,28 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"GM" = (
-/obj/structure/healingfountain,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Hc" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows"
+"li" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"HH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Ie" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Ir" = (
-/obj/structure/sign/warning/longtermwaste{
-	name = "long term ...  warning sign"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
-"IF" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/obj/item/kitchen/knife{
-	pixel_x = 16
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 8
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/corner/green,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"IN" = (
-/obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/corner/green,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"IT" = (
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"IY" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
-"JY" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/item/storage/firstaid/o2,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/item/defibrillator/loaded,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"KJ" = (
-/obj/structure/table,
-/obj/item/radio/off{
-	pixel_x = 6;
-	pixel_y = 14
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/door{
-	id = "whiteship_windows";
-	name = "Windows Blast Door Control";
-	pixel_x = -22;
-	pixel_y = -6
-	},
-/obj/machinery/button/door{
-	id = "whiteship_bridge";
-	name = "Bridge Blast Door Control";
-	pixel_x = -22;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/obj/item/areaeditor/shuttle,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Lo" = (
-/turf/closed/mineral/random/asteroid/rockplanet,
+/turf/open/floor/plating/asteroid,
 /area/overmap_encounter/planetoid/rockplanet/explored)
-"LB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"LN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"LP" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/cult/friendly,
-/turf/open/floor/plasteel,
-/area/ruin/unpowered)
-"LV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/brown,
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Mf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Mq" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Mz" = (
+"lu" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5";
 	pixel_x = -2
 	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"MQ" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/ruin/unpowered)
-"MT" = (
+"lF" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/green{
-	dir = 4
+/obj/item/flashlight/glowstick/red{
+	on = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"NM" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"NO" = (
+"lG" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/corner/blue{
@@ -1063,77 +323,16 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Og" = (
+"lZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/cult/friendly,
-/obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
-/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"Os" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"OJ" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green,
-/obj/item/bedsheet/cult,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Pi" = (
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"PY" = (
-/obj/structure/flora/rock,
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"Qb" = (
-/obj/machinery/light/broken,
-/obj/effect/turf_decal/corner/blue,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Qg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Ql" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
-"Qt" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"QB" = (
+"mq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -10;
@@ -1168,17 +367,51 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"QT" = (
+"mx" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"QU" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/body,
-/obj/effect/decal/cleanable/blood/tracks,
+"my" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"Rk" = (
+"nv" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/unpowered)
+"nX" = (
+/obj/machinery/door/airlock/mining,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"ou" = (
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"oA" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"oG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
 	},
@@ -1188,13 +421,410 @@
 /obj/machinery/door/airlock/cult/friendly,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"SI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"qg" = (
+/mob/living/simple_animal/hostile/construct/artificer/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/necromantic_stone)
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"qi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/construct/wraith/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/rod_of_asclepius)
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"qS" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/item/electronics/apc,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"rf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"rB" = (
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"TL" = (
+"rH" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"sA" = (
+/obj/docking_port/mobile{
+	callTime = 250;
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 11;
+	height = 17;
+	launch_status = 0;
+	name = "Salvage Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 33
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"sN" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"sX" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"sY" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"tc" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"tX" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"ua" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"ul" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"uo" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"uU" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/item/kitchen/knife{
+	pixel_x = 16
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"va" = (
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"vJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"vO" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"vT" = (
+/obj/structure/table,
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/megaphone{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wn" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"ww" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"wB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/radio/intercom/wideband{
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wG" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"wH" = (
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"wM" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"xb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"xo" = (
+/obj/item/ectoplasm,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"xt" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"xD" = (
+/turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"xI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"xT" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/gun/energy/laser/retro,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"xY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"yb" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"yq" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"zd" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"zF" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"zP" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Ao" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/corner/green,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Aw" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Ax" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/cult/friendly,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Ba" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Bf" = (
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"Bz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"BC" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/corner/brown{
@@ -1209,13 +839,146 @@
 /obj/effect/turf_decal/corner/brown,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"TP" = (
+"BV" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"BW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/corner/brown,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"BX" = (
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 14
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood,
+/obj/machinery/button/door{
+	id = "whiteship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -22;
+	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "whiteship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -22;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/item/areaeditor/shuttle,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Ud" = (
+"Cm" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Dc" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Dj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Dr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/titanium,
+/area/ruin/unpowered)
+"Ez" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"EQ" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Fa" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Fe" = (
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Fn" = (
+/obj/structure/marker_beacon,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"Gz" = (
+/obj/effect/rune/narsie,
+/mob/living/simple_animal/hostile/construct/juggernaut/hostile{
+	loot = list(/obj/item/ectoplasm, /obj/item/nullrod/armblade/tentacle)
+	},
+/obj/structure/sacrificealtar,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"GW" = (
 /obj/effect/turf_decal/corner/blue,
 /obj/effect/turf_decal/corner/blue{
 	dir = 8
@@ -1225,54 +988,47 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Uz" = (
-/obj/structure/chair{
-	dir = 8
+"Hl" = (
+/obj/effect/turf_decal/corner/brown,
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"UT" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/retro,
-/obj/effect/turf_decal/corner/blue{
+"Hm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"VG" = (
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"VP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/turf_decal/corner/blue{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"We" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/unpowered)
-"Wf" = (
-/mob/living/simple_animal/hostile/construct/artificer/hostile{
-	loot = list(/obj/item/ectoplasm, /obj/item/necromantic_stone)
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Wl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Ht" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/blue,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Wn" = (
+"Hx" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"HD" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"HE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1280,30 +1036,126 @@
 /obj/structure/marker_beacon,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"WM" = (
+"HW" = (
 /obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/healthanalyzer,
+/obj/item/storage/firstaid/o2,
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/blue,
 /obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/blue{
 	dir = 1
 	},
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"If" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"II" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/brown,
+/obj/item/flashlight/glowstick/red{
+	on = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"IO" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"IU" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/corner/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/brown,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Jh" = (
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Jq" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"JE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"JX" = (
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
 /obj/effect/turf_decal/corner/blue,
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"WR" = (
+"Ka" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"KH" = (
 /obj/item/chainsaw,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Xr" = (
+"KV" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Lq" = (
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Lz" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/green,
+/obj/effect/turf_decal/corner/green{
+	dir = 8
+	},
+/obj/item/bedsheet/cult,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"LK" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
 	pixel_x = -3;
@@ -1329,595 +1181,755 @@
 /obj/effect/turf_decal/corner/green,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Xt" = (
-/obj/machinery/hydroponics/constructable,
+"Mn" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/corner/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Xu" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/green{
-	dir = 1
-	},
-/obj/item/flashlight/glowstick/red{
-	on = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"XJ" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_bridge"
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"Ya" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
-"Yv" = (
-/obj/structure/marker_beacon,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plating/asteroid,
-/area/overmap_encounter/planetoid/rockplanet/explored)
-"Yw" = (
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Nr" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Nt" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/unpowered)
+"On" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/corner/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/corner/brown{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"Zp" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt/dust,
+"OB" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/corner/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"PU" = (
+/obj/item/pickaxe/rusted,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"QK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Rc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/effect/turf_decal/corner/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/green{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Rq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Ru" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5";
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"RA" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"Sm" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/corner/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Sq" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"SC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Tn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"TR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Us" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"UA" = (
+/obj/structure/sign/warning/longtermwaste{
+	name = "long term ...  warning sign"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ruin/unpowered)
+"UE" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Vz" = (
+/mob/living/simple_animal/hostile/construct/proteon/hostile,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"ZQ" = (
-/turf/closed/wall/mineral/cult,
+"VV" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"VX" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Wh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Wm" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Xh" = (
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/corner/green,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Xs" = (
+/obj/effect/turf_decal/corner/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"XI" = (
+/turf/closed/mineral/random/asteroid/rockplanet,
+/area/overmap_encounter/planetoid/rockplanet/explored)
+"XN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"XV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/holopad/emergency/command{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Yp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"Zg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/unpowered)
+"Zm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/corner/blue,
+/obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
-jG
-jG
-jG
-Dd
-mo
-jG
-jG
-jn
-cE
-eC
-Ir
-jG
-PY
-jG
-Dd
-jG
-jG
-jG
+Bf
+Bf
+Bf
+RA
+jU
+Bf
+Bf
+Nt
+Dj
+Ax
+UA
+Bf
+Us
+Bf
+RA
+Bf
+Bf
+Bf
 "}
 (2,1,1) = {"
-jn
-jn
-ZQ
-ZQ
-ZQ
-jn
-mo
-zR
-Wn
-WR
-zR
-jG
-jn
-jn
-jn
-jn
-jn
-jn
+Nt
+Nt
+xD
+xD
+xD
+Nt
+jU
+EQ
+HE
+KH
+EQ
+Bf
+Nt
+Nt
+Nt
+Nt
+Nt
+Nt
 "}
 (3,1,1) = {"
-ZQ
-Wf
-HH
-yS
-ir
-jn
-jG
-zR
-lE
-Wl
-zR
-jG
-yL
-Xt
-bi
-uO
-kb
-ZQ
+xD
+qg
+dh
+wH
+lF
+Nt
+Bf
+EQ
+xo
+xb
+EQ
+Bf
+Dr
+yb
+rH
+Sm
+Ao
+xD
 "}
 (4,1,1) = {"
-ZQ
-Pi
-HH
-BT
-HH
-ZQ
-jG
-zR
-Gs
-Wl
-zR
-jG
-ZQ
-Mq
-LB
-TP
-IN
-ZQ
+xD
+Jh
+dh
+ig
+dh
+xD
+Bf
+EQ
+SC
+xb
+EQ
+Bf
+xD
+OB
+Hm
+XN
+Xh
+xD
 "}
 (5,1,1) = {"
-Er
-ax
-Pi
-xk
-xg
-IY
-jG
-jn
-Cx
-pN
-jn
-jG
-ZQ
-Dy
-Os
-nU
-Qt
-zR
+cg
+JE
+Jh
+Jq
+TR
+vJ
+Bf
+Nt
+Mn
+Ba
+Nt
+Bf
+xD
+sY
+VV
+vO
+oA
+EQ
 "}
 (6,1,1) = {"
-Ya
-Mz
-Pi
-cY
-Wl
-Ql
-ZQ
-xP
-We
-QT
-xP
-zR
-ZQ
-Zp
-QB
-hG
-IF
-zR
+wM
+ww
+Jh
+Lq
+xb
+If
+xD
+nv
+IO
+Rq
+nv
+EQ
+xD
+hs
+mq
+tc
+uU
+EQ
 "}
 (7,1,1) = {"
-EZ
-GM
-Fk
-QU
-pW
-zn
-uP
-Og
-hY
-Pi
-nP
-Pi
-bU
-dF
-Uz
-yf
-ix
-zR
+HD
+eZ
+Gz
+BV
+Hx
+Ka
+ua
+kj
+zF
+Jh
+kE
+Jh
+lZ
+Rc
+cb
+KV
+sN
+EQ
 "}
 (8,1,1) = {"
-Hc
-Pi
-Pi
-iJ
-Pi
-Fi
-zR
-ZQ
-su
-TP
-xP
-zR
-ZQ
-Xu
-SI
-eY
-Xr
-zR
+zd
+Jh
+Jh
+lu
+Jh
+Zg
+EQ
+xD
+iK
+XN
+nv
+EQ
+xD
+xt
+Yp
+bl
+LK
+EQ
 "}
 (9,1,1) = {"
-jn
-HH
-Pi
-HH
-DK
-jn
-jG
-ZQ
-We
-Pi
-jn
-jG
-jn
-yS
-iz
-Wl
-VG
-zR
+Nt
+dh
+Jh
+dh
+Ru
+Nt
+Bf
+xD
+IO
+Jh
+Nt
+Bf
+Nt
+wH
+kr
+xb
+va
+EQ
 "}
 (10,1,1) = {"
-ZQ
-yS
-yf
-eY
-CP
-ZQ
-jG
-zR
-iE
-QT
-zR
-jG
-jn
-OJ
-oc
-MT
-cl
-jn
+xD
+wH
+KV
+bl
+Sq
+xD
+Bf
+EQ
+Wm
+Rq
+EQ
+Bf
+Nt
+cZ
+wn
+ej
+Lz
+Nt
 "}
 (11,1,1) = {"
-ZQ
-jn
-ZQ
-jn
-jn
-ZQ
-jG
-zR
-mR
-Qg
-zR
-jG
-jn
-ZQ
-ZQ
-jn
-jn
-jn
+xD
+Nt
+xD
+Nt
+Nt
+xD
+Bf
+EQ
+xI
+hD
+EQ
+Bf
+Nt
+xD
+xD
+Nt
+Nt
+Nt
 "}
 (12,1,1) = {"
-jG
-jG
-jG
-Dd
-jG
-qf
-jG
-ZQ
-We
-yf
-zR
-jG
-jG
-jG
-Dd
-jG
-jG
-jG
+Bf
+Bf
+Bf
+RA
+Bf
+ou
+Bf
+xD
+IO
+KV
+EQ
+Bf
+Bf
+Bf
+RA
+Bf
+Bf
+Bf
 "}
 (13,1,1) = {"
-ZQ
-ZQ
-jn
-jn
-ZQ
-ZQ
-jG
-ZQ
-nG
-pN
-zR
-jG
-jn
-jn
-jn
-ZQ
-ZQ
-ZQ
+xD
+xD
+Nt
+Nt
+xD
+xD
+Bf
+xD
+zP
+Ba
+EQ
+Bf
+Nt
+Nt
+Nt
+xD
+xD
+xD
 "}
 (14,1,1) = {"
-ZQ
-ku
-LV
-Yw
-yZ
-jn
-jG
-jn
-iE
-HH
-jn
-jG
-ZQ
-NO
-cW
-ti
-hq
-zR
+xD
+IU
+II
+mx
+qS
+Nt
+Bf
+Nt
+Wm
+dh
+Nt
+Bf
+xD
+lG
+fE
+Xs
+Fa
+EQ
 "}
 (15,1,1) = {"
-xP
-zR
-Wl
-ad
-dz
-jn
-zR
-xP
-We
-Wl
-xP
-ZQ
-ZQ
-vl
-Qb
-ZQ
-zR
-xP
+nv
+EQ
+xb
+On
+Hl
+Nt
+EQ
+nv
+IO
+xb
+nv
+xD
+xD
+tX
+rB
+xD
+EQ
+nv
 "}
 (16,1,1) = {"
-MQ
-jt
-jI
-FX
-ya
-lQ
-Pi
-Rk
-Cx
-HH
-hV
-Pi
-zz
-GJ
-Ie
-bp
-nb
-LP
+sA
+Bz
+hw
+ul
+BW
+nX
+Jh
+oG
+Mn
+dh
+bC
+Jh
+wt
+kF
+Wh
+Dc
+eX
+uo
 "}
 (17,1,1) = {"
-xP
-zR
-LN
-Df
-ev
-ZQ
-zR
-xP
-zM
-HH
-ZQ
-zR
-xP
-kk
-iV
-jn
-zR
-xP
+nv
+EQ
+Tn
+rf
+Aw
+xD
+EQ
+nv
+Vz
+dh
+xD
+EQ
+nv
+Cm
+Zm
+Nt
+EQ
+nv
 "}
 (18,1,1) = {"
-jn
-TL
-sr
-IT
-vE
-jn
-jG
-jn
-jM
-vm
-kr
-hX
-jn
-xz
-VP
-pR
-JY
-zR
+Nt
+BC
+my
+Fe
+cD
+Nt
+Bf
+Nt
+ex
+Nr
+yq
+li
+Nt
+eE
+wh
+VX
+HW
+EQ
 "}
 (19,1,1) = {"
-jn
-jn
-zR
-zR
-jn
-jn
-jG
-ZQ
-We
-QT
-jn
-oC
-jn
-jn
-zR
-zR
-jn
-jn
+Nt
+Nt
+EQ
+EQ
+Nt
+Nt
+Bf
+xD
+IO
+Rq
+Nt
+eK
+Nt
+Nt
+EQ
+EQ
+Nt
+Nt
 "}
 (20,1,1) = {"
-jG
-jG
-jG
-jG
-Dd
-jG
-jG
-ZQ
-Cx
-Pi
-jn
-Cz
-Dr
-hX
-jG
-jG
-jG
-Lo
+Bf
+Bf
+Bf
+Bf
+RA
+Bf
+Bf
+xD
+Mn
+Jh
+Nt
+xY
+aS
+li
+Bf
+Bf
+Bf
+XI
 "}
 (21,1,1) = {"
-Lo
-jG
-PY
-jG
-jG
-jG
-ZQ
-ZQ
-ye
-dK
-xP
-ZQ
-PY
-oC
-qf
-Lo
-Lo
-Lo
+XI
+Bf
+Us
+Bf
+Bf
+Bf
+xD
+xD
+QK
+hm
+nv
+xD
+Us
+eK
+ou
+XI
+XI
+XI
 "}
 (22,1,1) = {"
-Lo
-jG
-jG
-mo
-jG
-jn
-ZQ
-KJ
-vS
-NM
-WM
-ZQ
-ZQ
-oC
-Lo
-Lo
-Lo
-Lo
+XI
+Bf
+Bf
+jU
+Bf
+Nt
+xD
+BX
+aH
+in
+fg
+xD
+xD
+eK
+XI
+XI
+XI
+XI
 "}
 (23,1,1) = {"
-Lo
-Lo
-jG
-Dd
-jG
-XJ
-pV
-qm
-GF
-fe
-Gc
-tE
-XJ
-Yv
-Ag
-jG
-Dd
-jG
+XI
+XI
+Bf
+RA
+Bf
+as
+sX
+wB
+qi
+XV
+Ez
+UE
+as
+Fn
+PU
+Bf
+RA
+Bf
 "}
 (24,1,1) = {"
-Lo
-Lo
-jG
-qf
-jG
-XJ
-rO
-qR
-yf
-QT
-tl
-Mf
-ZQ
-jG
-mo
-Lo
-Lo
-jG
+XI
+XI
+Bf
+ou
+Bf
+as
+dj
+wG
+KV
+Rq
+Ht
+ct
+xD
+Bf
+jU
+XI
+XI
+Bf
 "}
 (25,1,1) = {"
-Lo
-Lo
-Lo
-jG
-jG
-XJ
-XJ
-Ck
-cp
-UT
-Ud
-ZQ
-ZQ
-jG
-Lo
-Lo
-Lo
-Lo
+XI
+XI
+XI
+Bf
+Bf
+as
+as
+JX
+vT
+xT
+GW
+xD
+xD
+Bf
+XI
+XI
+XI
+XI
 "}
 (26,1,1) = {"
-Lo
-Lo
-Lo
-Lo
-jG
-jG
-XJ
-XJ
-XJ
-XJ
-ZQ
-ZQ
-jG
-jG
-jG
-jG
-Lo
-Lo
+XI
+XI
+XI
+XI
+Bf
+Bf
+as
+as
+as
+as
+xD
+xD
+Bf
+Bf
+Bf
+Bf
+XI
+XI
 "}

--- a/_maps/shuttles/pirate/pirate_default.dmm
+++ b/_maps/shuttles/pirate/pirate_default.dmm
@@ -630,32 +630,6 @@
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/wood,
 /area/shuttle/pirate)
-"bt" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/melee/transforming/energy/sword/saber/pirate{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/melee/transforming/energy/sword/saber/pirate{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/melee/transforming/energy/sword/saber/pirate{
-	pixel_x = 13;
-	pixel_y = 6
-	},
-/turf/open/floor/pod/light,
-/area/shuttle/pirate)
 "bu" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -862,29 +836,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"ce" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "piratestarboardexternal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/docking_port/mobile/pirate{
-	dwidth = 11;
-	height = 16;
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Pirate Ship";
-	port_direction = 2;
-	width = 17
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -1251,6 +1202,28 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/pirate)
+"SE" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "piratestarboardexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/docking_port/mobile/pirate{
+	dwidth = 11;
+	height = 16;
+	launch_status = 0;
+	name = "Pirate Ship";
+	port_direction = 2;
+	width = 17
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
 "Ur" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
@@ -1259,6 +1232,32 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/shuttle/pirate)
+"UL" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/melee/transforming/energy/sword/saber/pirate{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/melee/transforming/energy/sword/saber/pirate{
+	pixel_x = 13;
+	pixel_y = 6
+	},
+/turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "Xk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1442,7 +1441,7 @@ ad
 ah
 an
 aj
-bt
+UL
 gY
 bI
 aj
@@ -1486,7 +1485,7 @@ Gk
 aS
 bZ
 bo
-ce
+SE
 "}
 (13,1,1) = {"
 af

--- a/_maps/shuttles/ruin/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin/ruin_caravan_victim.dmm
@@ -1353,7 +1353,6 @@
 	dwidth = 5;
 	height = 11;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Small Freighter";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/ruin/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin/ruin_pirate_cutter.dmm
@@ -1054,7 +1054,6 @@
 	dir = 2;
 	dwidth = 14;
 	height = 13;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Pirate Cutter";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/shiptest/whiteship_box.dmm
+++ b/_maps/shuttles/shiptest/whiteship_box.dmm
@@ -14,7 +14,6 @@
 	callTime = 250;
 	dir = 2;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Hospital Ship";
 	port_direction = 8;
 	preferred_direction = 4

--- a/_maps/shuttles/shiptest/whiteship_delta.dmm
+++ b/_maps/shuttles/shiptest/whiteship_delta.dmm
@@ -33,7 +33,6 @@
 	callTime = 250;
 	dir = 2;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Frigate";
 	port_direction = 8;
 	preferred_direction = 4

--- a/_maps/shuttles/shiptest/whiteship_kilo.dmm
+++ b/_maps/shuttles/shiptest/whiteship_kilo.dmm
@@ -2174,7 +2174,6 @@
 	dwidth = 13;
 	height = 13;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/shiptest/whiteship_meta.dmm
+++ b/_maps/shuttles/shiptest/whiteship_meta.dmm
@@ -39,7 +39,6 @@
 	dwidth = 11;
 	height = 17;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/shiptest/whiteship_midway.dmm
+++ b/_maps/shuttles/shiptest/whiteship_midway.dmm
@@ -2312,7 +2312,6 @@
 	dwidth = 11;
 	height = 17;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/shiptest/whiteship_pubby.dmm
+++ b/_maps/shuttles/shiptest/whiteship_pubby.dmm
@@ -1,4 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aw" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "aQ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -20,6 +32,28 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
+/area/ship/cargo)
+"ba" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/docking_port/mobile{
+	callTime = 250;
+	dir = 2;
+	dwidth = 11;
+	height = 12;
+	launch_status = 0;
+	name = "White Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 24
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "bn" = (
 /obj/machinery/airalarm/directional/east,
@@ -69,17 +103,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"dj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "dt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -111,6 +134,23 @@
 "eL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
+"eU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "fh" = (
 /obj/machinery/door/poddoor{
 	id = "whiteship_bridge"
@@ -121,6 +161,14 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
+"fo" = (
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "ge" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -180,6 +228,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"ia" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "iF" = (
 /obj/machinery/button/door{
 	id = "pubbywspodse";
@@ -217,27 +276,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/bridge)
-"jd" = (
-/turf/open/floor/engine/hull,
-/area/template_noop)
-"jJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/wideband{
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "jO" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -264,6 +302,9 @@
 "jV" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
+"kq" = (
+/turf/open/floor/engine/hull,
+/area/template_noop)
 "kw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/shuttle{
@@ -272,21 +313,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"kT" = (
-/obj/machinery/door/airlock/titanium,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering)
 "kW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -296,19 +322,6 @@
 	name = "Engine Access"
 	},
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"kZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "engine fuel pump"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -325,6 +338,19 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"lc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "lp" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -332,6 +358,27 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ls" = (
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"lT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -356,6 +403,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"nh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "nr" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/box,
@@ -438,33 +499,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/bridge)
-"rX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/tank/air,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"sr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
 "sx" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -531,6 +565,24 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"tW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/wideband{
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "tX" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -552,6 +604,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"vR" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
+/turf/open/floor/engine/hull,
+/area/template_noop)
 "wl" = (
 /obj/machinery/button/door{
 	id = "pubbywspodne";
@@ -576,14 +632,15 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"wR" = (
+"wL" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -600,54 +657,47 @@
 	},
 /turf/open/floor/plating,
 /area/ship/bridge)
+"xj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "xo" = (
 /obj/machinery/door/airlock/titanium,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"xC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
-/turf/open/floor/engine/hull,
-/area/template_noop)
-"xM" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+"xN" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"xV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "yn" = (
 /obj/effect/turf_decal/industrial/stand_clear,
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
-"yt" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "yv" = (
 /obj/machinery/door/window/eastright,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -682,23 +732,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"BD" = (
+"yT" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"zb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
+"zD" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "engine fuel pump"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"BF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "BN" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/box,
@@ -717,6 +777,21 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/ship/engineering)
+"Cz" = (
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "DL" = (
 /obj/structure/window/reinforced{
@@ -754,29 +829,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
-"Fp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/holopad/emergency/command,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
-"Gh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"Fc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "engine fuel pump"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "Gn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -824,19 +889,17 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"Ja" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"Jh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "JU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -852,6 +915,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
+"KW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/emergency/command,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "La" = (
 /obj/machinery/door/window/eastleft,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -863,15 +935,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
-"Ls" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "LU" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -891,23 +954,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"My" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
+"MK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
 "Nk" = (
 /obj/structure/window/reinforced,
@@ -956,16 +1005,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"Ow" = (
+"OQ" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Pa" = (
@@ -990,18 +1037,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
-/area/ship/cargo)
-"Ql" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "QO" = (
 /obj/structure/window/reinforced{
@@ -1089,29 +1124,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"TA" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
-	callTime = 250;
-	dir = 2;
-	dwidth = 11;
-	height = 12;
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "White Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 24
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
 "TC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -1129,14 +1141,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"Uh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+"Uj" = (
+/obj/machinery/power/shuttle/engine/electric{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -1147,13 +1157,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
-"Us" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"VH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -1172,16 +1182,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"Wb" = (
-/obj/effect/turf_decal/industrial/caution,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ship/engineering)
 "WG" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1236,14 +1236,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
-"Yu" = (
-/obj/effect/turf_decal/industrial/caution,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ship/engineering)
 "Yw" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1310,12 +1302,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"Zo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ship/cargo)
 "Zv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -1328,18 +1314,31 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ship/cargo)
+"ZT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "engine fuel pump"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 
 (1,1,1) = {"
 qx
 qx
-Ls
-yt
+Uj
+yT
 qx
 qx
 qx
 qx
-yt
-Ls
+yT
+Uj
 qx
 qx
 "}
@@ -1403,29 +1402,29 @@ qx
 qx
 eL
 Yw
-Uh
+lT
 WW
 YC
 Oq
 WW
 YK
-wR
+ia
 eL
 qx
 "}
 (7,1,1) = {"
-xC
-BF
-rX
-kZ
-Yu
-Ow
-Us
-Wb
-BD
-xV
+vR
+MK
+VH
+ZT
+fo
+wL
+OQ
+ls
+Fc
+Jh
 eL
-jd
+kq
 "}
 (8,1,1) = {"
 WW
@@ -1433,7 +1432,7 @@ eL
 qi
 DT
 bn
-My
+xj
 wB
 aQ
 ID
@@ -1447,7 +1446,7 @@ eL
 Rj
 Rj
 WW
-kT
+Cz
 xo
 WW
 Rj
@@ -1461,7 +1460,7 @@ nS
 Zz
 Zz
 Zm
-Gh
+nh
 Hx
 yy
 Zz
@@ -1475,7 +1474,7 @@ Ku
 tE
 YF
 Mp
-Gh
+nh
 Hx
 BN
 tE
@@ -1489,7 +1488,7 @@ Ku
 Qe
 LU
 jO
-Gh
+nh
 Hx
 hX
 Qe
@@ -1503,7 +1502,7 @@ PS
 Zz
 Lg
 WG
-Ql
+aw
 GW
 aR
 WN
@@ -1517,7 +1516,7 @@ No
 No
 Es
 Hx
-Gh
+nh
 Hx
 Hx
 wv
@@ -1526,12 +1525,12 @@ No
 No
 "}
 (15,1,1) = {"
-TA
+ba
 Hx
 sX
 Hx
-Zo
-Ja
+zb
+lc
 NO
 Hx
 Hx
@@ -1545,7 +1544,7 @@ No
 No
 La
 Hx
-Gh
+nh
 Hx
 Hx
 yv
@@ -1559,7 +1558,7 @@ PS
 Zz
 Lg
 sx
-Ql
+aw
 GW
 nr
 WN
@@ -1573,7 +1572,7 @@ Ku
 tE
 Rd
 VN
-Gh
+nh
 Hx
 nG
 tE
@@ -1587,7 +1586,7 @@ Ku
 Qe
 LU
 Ix
-Gh
+nh
 Hx
 ow
 Qe
@@ -1601,7 +1600,7 @@ PS
 wl
 Uo
 QO
-sr
+eU
 Hx
 Nk
 Uo
@@ -1615,7 +1614,7 @@ Xl
 If
 If
 If
-xM
+zD
 gr
 If
 If
@@ -1629,9 +1628,9 @@ If
 If
 qy
 na
-jJ
-Fp
-dj
+tW
+KW
+xN
 TC
 If
 If

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -99,6 +99,8 @@
   * * dock_to_use - The [/obj/docking_port/mobile] to dock to.
   */
 /obj/structure/overmap/ship/simulated/proc/dock(obj/structure/overmap/to_dock, obj/docking_port/stationary/dock_to_use)
+	refresh_engines()
+	shuttle.movement_force = list("KNOCKDOWN" = FLOOR(est_thrust / 50, 1), "THROW" = FLOOR(est_thrust / 200, 1))
 	shuttle.request(dock_to_use)
 
 	priority_announce("Beginning docking procedures. Completion in [(shuttle.callTime + 1 SECONDS)/10] seconds.", "Docking Announcement", sender_override = name, zlevel = shuttle.get_virtual_z_level())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes snowflake movement_force vars from ships, makes movement force calculated based on the amount of total thrust the ship has. Should it be based on mass too? Probably, but that's too expensive in my opinion to calculate everytime, and not consistent enough to calculate once and forget about.

## Why It's Good For The Game
Makes having fewer engines (e.g. on smaller ships) actually have an upside.

## Changelog
:cl:
tweak: Makes movement_force based on total thrust. This means that ships with a lot of thrusters will stun and possibly even throw, while smaller ships may just not stun at all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
