### PR TITLE
Minor Rachnid Fixes

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -454,6 +454,7 @@ ROUNDSTART_RACES ipc
 ROUNDSTART_RACES felinid
 #ROUNDSTART_RACES squid
 ROUNDSTART_RACES kepori
+ROUNDSTART_RACES rachnid
 
 ## Races that are better than humans in some ways, but worse in others
 ROUNDSTART_RACES ethereal

--- a/whitesands/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/whitesands/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_INIT(spider_last, world.file2list("strings/names/spider_last.txt"))
 	sexes = 0
 	say_mod = "chitters"
 	default_color = "00FF00"
-	species_traits = list(LIPS, NOEYESPRITES, NO_UNDERWEAR)
+	species_traits = list(LIPS, NOEYESPRITES, NO_UNDERWEAR, MUTCOLORS_PARTSONLY)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	mutant_bodyparts = list("spider_legs", "spider_spinneret", "spider_mandibles")
 	default_features = list("spider_legs" = "Plain", "spider_spinneret" = "Plain", "spider_mandibles" = "Plain")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes rachnids an actually selectable roundstart race on freshly-cloned repos, and lets them actually select their mutcolours.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rachnid players have mentioned their annoyance at not being able to select their mutcolour previously, so, this was the easy fix for it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Rachnids can now actually select their mutcolours properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
