### PR TITLE
[Fix] Prevent Elzu Infinite Charge from Syringes

### DIFF
--- a/_maps/shuttles/shiptest/isv_roberts.dmm
+++ b/_maps/shuttles/shiptest/isv_roberts.dmm
@@ -605,7 +605,6 @@
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/BPlus,
-/obj/item/reagent_containers/blood/ethereal,
 /obj/item/reagent_containers/blood/random,
 /obj/item/organ/ears/cat,
 /obj/item/organ/tail/cat,

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -147,7 +147,6 @@
 	new /obj/item/reagent_containers/blood/OMinus(src)
 	new /obj/item/reagent_containers/blood/OPlus(src)
 	new /obj/item/reagent_containers/blood/lizard(src)
-	new /obj/item/reagent_containers/blood/ethereal(src)
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/blood/random(src)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1286,7 +1286,7 @@
 
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
-	desc = "Contains eight different blood packs for reintroducing blood to patients."
+	desc = "Contains several different blood packs for reintroducing blood to patients."
 	cost = 1000
 	contains = list(/obj/item/reagent_containers/blood,
 					/obj/item/reagent_containers/blood,
@@ -1296,8 +1296,7 @@
 					/obj/item/reagent_containers/blood/BMinus,
 					/obj/item/reagent_containers/blood/OPlus,
 					/obj/item/reagent_containers/blood/OMinus,
-					/obj/item/reagent_containers/blood/lizard,
-					/obj/item/reagent_containers/blood/ethereal)
+					/obj/item/reagent_containers/blood/lizard)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer
 

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -1,4 +1,4 @@
-#define ETHEREAL_EMAG_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000") //WS Edit -- Multitool Color Change
+#define ETHEREAL_EMAG_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000")
 
 /datum/species/ethereal
 	name = "Elzuose"
@@ -9,12 +9,11 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal
 	mutantstomach = /obj/item/organ/stomach/ethereal
 	mutanttongue = /obj/item/organ/tongue/ethereal
-	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, AGENDER, HAIR, FACEHAIR)    //WS Edit - Gave Ethereals Beards
+	species_traits = list(DYNCOLORS, AGENDER, HAIR, FACEHAIR)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/ethereal
 	inherent_traits = list(TRAIT_NOHUNGER)
@@ -29,18 +28,16 @@
 	hair_alpha = 140
 	var/current_color
 	var/EMPeffect = FALSE
-	var/emag_effect = FALSE                          //WS Edit -- Multitool Color Change
-	var/static/unhealthy_color = rgb(237, 164, 149)  //WS Edit -- Multitool Color Change
+	var/emag_effect = FALSE
+	var/static/unhealthy_color = rgb(237, 164, 149)
 	loreblurb = "Elzuosa are an uncommon and unusual species best described as crystalline, electrically-powered plantpeople. They hail from the warm planet Kalixcis, where they evolved alongside the Sarathi. Kalixcian culture places no importance on blood-bonds, and those from it tend to consider their family anyone they are sufficiently close to, and choose their own names."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
 	var/obj/effect/dummy/lighting_obj/ethereal_light
-
 
 /datum/species/ethereal/Destroy(force)
 	if(ethereal_light)
 		QDEL_NULL(ethereal_light)
 	return ..()
-
 
 /datum/species/ethereal/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
@@ -48,19 +45,16 @@
 		return
 	var/mob/living/carbon/human/ethereal = C
 	default_color = "#[ethereal.dna.features["ethcolor"]]"
-	//WS Removal -- Multitool Color Change
 	RegisterSignal(ethereal, COMSIG_ATOM_EMAG_ACT, .proc/on_emag_act)
 	RegisterSignal(ethereal, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
-
 
 /datum/species/ethereal/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
 	UnregisterSignal(C, COMSIG_ATOM_EMAG_ACT)
 	UnregisterSignal(C, COMSIG_ATOM_EMP_ACT)
 	QDEL_NULL(ethereal_light)
 	return ..()
-
 
 /datum/species/ethereal/random_name(gender,unique,lastname)
 	if(unique)
@@ -70,23 +64,19 @@
 
 	return randname
 
-
 /datum/species/ethereal/spec_updatehealth(mob/living/carbon/human/H)
 	. = ..()
 	if(H.stat != DEAD && !EMPeffect)
-		//WS Start -- Multitool Color Change
 		if(!emag_effect)
 			current_color = health_adjusted_color(H, default_color)
 		set_ethereal_light(H, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
-		//WS End
 	else
 		ethereal_light.set_light_on(FALSE)
 		fixed_mut_color = rgb(128,128,128)
 	H.update_body()
 
-//WS Start -- Multitool Color Change
 /datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, default_color)
 	var/health_percent = max(H.health, 0) / 100
 
@@ -112,7 +102,6 @@
 	var/light_power = 1 + (1 * health_percent)
 
 	ethereal_light.set_light_range_power_color(light_range, light_power, current_color)
-//WS End
 
 /datum/species/ethereal/proc/on_emp_act(mob/living/carbon/human/H, severity)
 	EMPeffect = TRUE
@@ -125,49 +114,44 @@
 			addtimer(CALLBACK(src, .proc/stop_emp, H), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 20 seconds
 
 /datum/species/ethereal/proc/on_emag_act(mob/living/carbon/human/H, mob/user)
-	if(emag_effect)                              //WS Edit -- Multitool Color Change
+	if(emag_effect)
 		return
-	emag_effect = TRUE                           //WS Edit -- Multitool Color Change
+	emag_effect = TRUE
 	if(user)
 		to_chat(user, "<span class='notice'>You tap [H] on the back with your card.</span>")
 	H.visible_message("<span class='danger'>[H] starts flickering in an array of colors!</span>")
 	handle_emag(H)
 	addtimer(CALLBACK(src, .proc/stop_emag, H), 30 SECONDS) //Disco mode for 30 seconds! This doesn't affect the ethereal at all besides either annoying some players, or making someone look badass.
 
-
 /datum/species/ethereal/spec_life(mob/living/carbon/human/H)
 	.=..()
 	handle_charge(H)
-
 
 /datum/species/ethereal/proc/stop_emp(mob/living/carbon/human/H)
 	EMPeffect = FALSE
 	spec_updatehealth(H)
 	to_chat(H, "<span class='notice'>You feel more energized as your shine comes back.</span>")
 
-
 /datum/species/ethereal/proc/handle_emag(mob/living/carbon/human/H)
-	if(!emag_effect)                              //WS Edit -- Multitool Color Change
+	if(!emag_effect)
 		return
-	current_color = pick(ETHEREAL_EMAG_COLORS)    //WS Edit -- Multitool Color Change
+	current_color = pick(ETHEREAL_EMAG_COLORS)
 	spec_updatehealth(H)
 	addtimer(CALLBACK(src, .proc/handle_emag, H), 5) //Call ourselves every 0.5 seconds to change color
 
 /datum/species/ethereal/proc/stop_emag(mob/living/carbon/human/H)
-	emag_effect = FALSE                           //WS Edit -- Multitool Color Change
+	emag_effect = FALSE
 	spec_updatehealth(H)
 	H.visible_message("<span class='danger'>[H] stops flickering and goes back to their normal state!</span>")
 
 /datum/species/ethereal/proc/handle_charge(mob/living/carbon/human/H)
 	brutemod = 1.25
 	switch(get_charge(H))
-		//WS Begin - Display Ethereal no charge icon
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			if(get_charge(H) == ETHEREAL_CHARGE_NONE)
 				H.throw_alert("ethereal_charge", /atom/movable/screen/alert/etherealcharge, 3)
 			else
 				H.throw_alert("ethereal_charge", /atom/movable/screen/alert/etherealcharge, 2)
-			//WS End
 			if(H.health > 10.5)
 				apply_damage(0.2, TOX, null, null, H)
 			brutemod = 1.75
@@ -197,9 +181,9 @@
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		playsound(H, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
 		H.cut_overlay(overcharge)
-		tesla_zap(H, 2, (stomach.crystal_charge / ETHEREAL_CHARGE_SCALING_MULTIPLIER) * 50, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)       //WS Edit -- Ethereal Charge Scaling
+		tesla_zap(H, 2, (stomach.crystal_charge / ETHEREAL_CHARGE_SCALING_MULTIPLIER) * 50, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)
 		if(istype(stomach))
-			stomach.adjust_charge(ETHEREAL_CHARGE_FULL - stomach.crystal_charge)     //WS Edit -- Ethereal Charge Scaling
+			stomach.adjust_charge(ETHEREAL_CHARGE_FULL - stomach.crystal_charge)
 		to_chat(H, "<span class='warning'>You violently discharge energy!</span>")
 		H.visible_message("<span class='danger'>[H] violently discharges energy!</span>")
 		if(prob(10)) //chance of developing heart disease to dissuade overcharging oneself
@@ -216,7 +200,6 @@
 		return stomach.crystal_charge
 	return ETHEREAL_CHARGE_NONE
 
-//WS Start -- Multitool Color Change
 /datum/species/ethereal/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, intent, mob/living/carbon/human/H)
 	if(istype(I, /obj/item/multitool))
 		if(user.a_intent == INTENT_HARM)
@@ -243,4 +226,3 @@
 				H.visible_message("<span class='notice'>[H] modulates \his EM frequency to [new_etherealcolor].</span>")
 	else
 		. = ..()
-//WS End

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -64,10 +64,6 @@
 /obj/item/reagent_containers/blood/squid
 	blood_type = "S"
 
-/obj/item/reagent_containers/blood/ethereal
-	blood_type = "LE"
-	unique_blood = /datum/reagent/consumable/liquidelectricity
-
 /obj/item/reagent_containers/blood/universal
 	blood_type = "U"
 

--- a/whitesands/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/whitesands/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -26,6 +26,5 @@
 		/obj/item/reagent_containers/blood/OMinus = 1,
 		/obj/item/reagent_containers/blood/OPlus = 1,
 		/obj/item/reagent_containers/blood/lizard = 1,
-		/obj/item/reagent_containers/blood/ethereal = 1,
 		/obj/item/reagent_containers/blood/squid = 1,
 		/obj/item/reagent_containers/blood/random = 5)


### PR DESCRIPTION
## About The Pull Request

Explanation:

Elzu used to be able to get free charge by removing their blood (liquid electricity) with a syringe, then putting it back for 1% per unit.  This could be repeated as many times as desired, to quickly raise charge.

The best solution to this issue is to separate "Elzu blood" and "charge-giving chemical" into two different reagents.  For the time being, I've decided to give them standard blood.

I like the idea of giving them a custom blood reagent with custom blood decals.  But the blood decal code likely needs to be refactored before this is done, as it is difficult to extend currently.  This is why I am not including this at this time.

Changes:

The exotic_blood var was removed from ezlu to make them default to using standard blood.

The liquid electricity blood pack and its references were removed (was also hardcoded onto Tide-Class).

Removed modularization comments I put in ethereal.dm over a year ago, and made number of newlines consistent.

Made description of blood pack crate no longer give a specific number of packs, because it will surely continue to change.

![image](https://user-images.githubusercontent.com/7697956/147709121-327b0993-5ce2-4492-93f7-dde0d74604b5.png)

![image](https://user-images.githubusercontent.com/7697956/147709146-70e03685-7ce2-4564-8a55-9e608d0c963d.png)

## Why It's Good For The Game

Free charging was clearly unintentional.

## Changelog
:cl:
tweak: Elzu have standard blood
fix: Elzu can no longer use a syringe for free charge
/:cl:
