### PR TITLE
[RIP] Stations Unnamed

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -107,7 +107,6 @@
 	force = 15
 
 /obj/item/station_charter/flag/rename_station(designation, uname, ureal_name, ukey)
-	set_station_name(designation)
 	minor_announce("[ureal_name] has designated the planet as [station_name()]", "Captain's Banner", 0)
 	log_game("[ukey] has renamed the planet as [station_name()].")
 	name = "banner of [station_name()]"


### PR DESCRIPTION
Removes the ability for Captains to rename the global station name, aka the name that is displayed in the Hub listing.
Due to recent issues regarding a certain server Lummox is now actually moderating the Hub with semi-frequency.
I do not want us to get kicked off of the Hub.