### PR TITLE
Probably Fix CI

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -128,6 +128,9 @@ SUBSYSTEM_DEF(air)
 	fix_corrupted_atmos()
 
 /datum/controller/subsystem/air/fire(resumed = 0)
+	if(map_loading)
+		pause()
+		return
 
 	var/timer = TICK_USAGE_REAL
 
@@ -506,9 +509,11 @@ SUBSYSTEM_DEF(air)
 
 /datum/controller/subsystem/air/StartLoadingMap()
 	map_loading = TRUE
+	state = SS_PAUSED
 
 /datum/controller/subsystem/air/StopLoadingMap()
 	map_loading = FALSE
+	state = SS_RUNNING
 
 /datum/controller/subsystem/air/proc/setup_allturfs()
 	var/list/turfs_to_init = block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz))

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -245,7 +245,7 @@ GLOBAL_VAR(restart_counter)
 	#ifdef UNIT_TESTS
 	FinishTestRun()
 	return
-	#endif
+	#else
 
 	if(TgsAvailable())
 		var/do_hard_reboot
@@ -272,6 +272,8 @@ GLOBAL_VAR(restart_counter)
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
 	AUXTOOLS_SHUTDOWN(AUXMOS)
 	..()
+
+	#endif // #ifdef UNIT_TESTS
 
 /world/Del()
 	shutdown_logging() // makes sure the thread is closed before end, else we terminate

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -67,6 +67,7 @@
 		else
 			SSair.atmos_machinery += src
 	SetInitDirections()
+	SSair.add_to_rebuild_queue(src)
 
 /obj/machinery/atmospherics/Destroy()
 	for(var/i in 1 to device_type)

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -49,6 +49,13 @@
 /obj/machinery/atmospherics/pipe/return_air()
 	if(air_temporary)
 		return air_temporary
+	if(!parent)
+		SSair.process_rebuilds()
+		if(!parent)
+			stack_trace("parent still null after SSair rebuild")
+			rebuild_pipes()
+			if(!parent)
+				CRASH("parent still null after manual rebuild.")
 	return parent.air
 
 /obj/machinery/atmospherics/pipe/return_analyzable_air()

--- a/code/modules/unit_tests/reagent_mod_expose.dm
+++ b/code/modules/unit_tests/reagent_mod_expose.dm
@@ -56,3 +56,4 @@
 
 /datum/unit_test/reagent_mob_expose/Destroy()
 	SSmobs.ignite()
+	return ..()


### PR DESCRIPTION
Forces all atmos machinery to add themselves to the rebuild queue on SSair upon creation, as sometimes SSair would blindly miss them for no obvious reason.