### PR TITLE
Makes the Statio.3-class unbuyable

### DIFF
--- a/_maps/configs/statio.json
+++ b/_maps/configs/statio.json
@@ -35,6 +35,5 @@
 		"Security Officer": 4,
 		"Cyborg": 2,
 		"Assistant": 30
-	},
-	"cost": 100000
+	}
 }


### PR DESCRIPTION
## About The Pull Request
Randomly errors upon loading, possibly causing unit test hangs, as well as likely causing issues in production. I haven't seen this bought without admin intervention anyways, and it's still admin-spawnable, so get over it.

## Why It's Good For The Game
Isn't really, just feels like it's a risk not worth having at the moment. After we fix whatever bug causes it, I will be more than happy to bring it back.

## Changelog
:cl:
del: For the time being, the Statio.3-class vessel has been discontinued from civilian markets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
