### PR TITLE
Add: Species Locks for Ship Models

### DIFF
--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -46,7 +46,7 @@
 		"allowed_species": {
 			"title": "Allowed Species",
 			"type": "array",
-			"description": "The species allowed to buy and join this class of ship. Is ignored when empty.",
+			"description": "The species allowed to buy and join this class of ship. Is ignored when empty."
 		},
 		"job_slots": {
 			"title": "Job Slots",

--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -46,7 +46,11 @@
 		"allowed_species": {
 			"title": "Allowed Species",
 			"type": "array",
-			"description": "The species allowed to buy and join this class of ship. Is ignored when empty."
+			"description": "The species allowed to buy and join this class of ship. Is ignored when empty.",
+			"items": {
+				"type": "string",
+				"pattern": "^\/datum\/species\/(.+)$"
+			}
 		},
 		"job_slots": {
 			"title": "Job Slots",

--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -43,6 +43,11 @@
 			"type": "string",
 			"description": "The ID of the ship class. Deprecated, code uses map_path instead."
 		},
+		"allowed_species": {
+			"title": "Allowed Species",
+			"type": "array",
+			"description": "The species allowed to buy and join this class of ship. Is ignored when empty."
+		},
 		"job_slots": {
 			"title": "Job Slots",
 			"description": "A list of job slots that this ship class will have when placed. The First Slot will always be the 'captain' that the purchaser becomes.",

--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -47,10 +47,6 @@
 			"title": "Allowed Species",
 			"type": "array",
 			"description": "The species allowed to buy and join this class of ship. Is ignored when empty.",
-			"items": {
-				"type": "string",
-				"pattern": "^\/datum\/species\/(.+)$"
-			}
 		},
 		"job_slots": {
 			"title": "Job Slots",

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -250,6 +250,15 @@ SUBSYSTEM_DEF(mapping)
 		if(islist(data["namelists"]))
 			S.name_categories = data["namelists"]
 
+		S.allowed_species = list()
+		if(islist(data["allowed_species"]))
+			var/list/allowed_species_list = data["allowed_species"]
+			for(var/species in allowed_species_list)
+				if(ispath(text2path(species), /datum/species) && species != "/datum/species")
+					S.allowed_species.Add(text2path(species))
+				else
+					stack_trace("Invalid species! [species] on [S.name]'s config! Skipping.")
+
 		S.job_slots = list()
 		var/list/job_slot_list = data["job_slots"]
 		for(var/job in job_slot_list)
@@ -275,6 +284,7 @@ SUBSYSTEM_DEF(mapping)
 				continue
 
 			S.job_slots[job_slot] = slots
+
 		if(isnum(data["cost"]))
 			S.cost = data["cost"]
 			ship_purchase_list["[S.name] ([S.cost] [CONFIG_GET(string/metacurrency_name)]s)"] = S

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -254,7 +254,7 @@ SUBSYSTEM_DEF(mapping)
 		if(islist(data["allowed_species"]))
 			var/list/allowed_species_list = data["allowed_species"]
 			for(var/species in allowed_species_list)
-				if(ispath(text2path(species), /datum/species) && species != "/datum/species")
+				if(ispath(text2path(species), /datum/species)) // forbidding the parent type is done by the schema
 					S.allowed_species.Add(text2path(species))
 				else
 					stack_trace("Invalid species! [species] on [S.name]'s config! Skipping.")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -254,8 +254,8 @@ SUBSYSTEM_DEF(mapping)
 		if(islist(data["allowed_species"]))
 			var/list/allowed_species_list = data["allowed_species"]
 			for(var/species in allowed_species_list)
-				if(ispath(text2path(species), /datum/species)) // forbidding the parent type is done by the schema
-					S.allowed_species.Add(text2path(species))
+				if(species in GLOB.species_list) // forbidding the parent type is done by the schema
+					S.allowed_species.Add(GLOB.species_list[species])
 				else
 					stack_trace("Invalid species! [species] on [S.name]'s config! Skipping.")
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -14,7 +14,9 @@
 	var/cost
 	var/short_name
 	var/list/job_slots
+	var/list/allowed_species
 	var/list/name_categories = list("GENERAL")
+
 	var/prefix = "SV"
 
 /datum/map_template/shuttle/proc/prerequisites_met()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -354,6 +354,10 @@
 		if(SSdbcore.IsConnected() && usr.client.get_metabalance() < template.cost)
 			alert(src, "You have insufficient metabalance to cover this purchase! (Price: [template.cost])")
 			return
+		if(template.allowed_species.len > 0)
+			if(!(client.prefs.pref_species.type in template.allowed_species))
+				alert(src, "This species is unable to purchase this model of ship!")
+				return
 		close_spawn_windows()
 		to_chat(usr, "<span class='danger'>Your [template.name] is being prepared. Please be patient!</span>")
 		var/obj/docking_port/mobile/target = SSshuttle.action_load(template)
@@ -367,6 +371,11 @@
 			to_chat(usr, "<span class='danger'>Ship spawned, but you were unable to be spawned. You can likely try to spawn in the ship through joining normally, but if not, please contact an admin.</span>")
 			new_player_panel()
 		return
+
+	if(selected_ship.allowed_species.len > 0)
+		if(!(client.prefs.pref_species.type in selected_ship.allowed_species))
+			alert(src, "This species is unable to join this model of ship!")
+			return
 
 	if(selected_ship.memo)
 		var/memo_accept = tgui_alert(src, "Current ship memo: [selected_ship.memo]", "[selected_ship.name] Memo", list("OK", "Cancel"))

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -4,6 +4,8 @@
 /obj/structure/overmap/ship/simulated
 	///Assoc list of remaining open job slots (job = remaining slots)
 	var/list/job_slots = list("Captain" = 1, "Assistant" = 5)
+	///List of species allowed to join this ship (empty means no restriction)
+	var/list/allowed_species = list()
 	///Manifest list of people on the ship
 	var/list/manifest = list()
 	///Shipwide bank account
@@ -18,6 +20,7 @@
 /obj/structure/overmap/ship/simulated/Initialize(mapload, obj/docking_port/mobile/_shuttle, datum/map_template/shuttle/_source_template)
 	. = ..()
 	job_slots = _source_template.job_slots.Copy()
+	allowed_species = _source_template.allowed_species.Copy()
 	ship_account = new(name, 7500)
 
 /**


### PR DESCRIPTION
## About The Pull Request

Adds allowed_species as a optional field in the ship config json files.  If it exists, only the species (one or multiple) on this list can join that model of ship.  If it doesn't exist, any species can join it.

This field is documented in the ship_config_schema.

The allowed_species list starts (or doesn't) in the ship config json.  In load_ship_templates(), the mapping subsystem removes any invalid species from the list (and reports it), then loads it into a shuttle template.  Simulated ships copy the allowed_species list when initialized.  If the list isn't empty, a new player's species will be checked against it before being able to buy or join a specific ship.  If the list is empty, no check is preformed.

Example usage:
![image](https://user-images.githubusercontent.com/7697956/147886103-53a491e0-3919-4d4c-a720-53c8b0e5da99.png)

Unable to purchase/join alerts:
![image](https://user-images.githubusercontent.com/7697956/147886135-7884bd11-9dd4-4514-bfec-201e64b10ca2.png)
![image](https://user-images.githubusercontent.com/7697956/147886127-c23b8a8c-0d9b-4ee7-8743-9401ade9d2d7.png)

## Why It's Good For The Game

Allows for species-specialized ships, such as a Plasmaman ship with plasma atmos.

Requested in https://github.com/shiptest-ss13/Shiptest/issues/253

## Changelog
:cl:
add: Ability to species lock ship models
/:cl:
