### PR TITLE
Limits grouped runtimes shown, Adds missing HREF token

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -319,7 +319,7 @@ Versioning
 
 	var/datum/DBQuery/query_report_death = SSdbcore.NewQuery({"
 		INSERT INTO [format_table_name("death")] (pod, x_coord, y_coord, z_coord, mapname, server_ip, server_port, round_id, tod, job, special, name, byondkey, laname, lakey, bruteloss, fireloss, brainloss, oxyloss, toxloss, cloneloss, staminaloss, last_words, suicide)
-		VALUES (:pod, :x_coord, :y_coord, :z_coord, :map, INET_ATON(:internet_address), :port, :round_id, :time, :job, :special, :name, :key, :laname, :lakey, :brute, :fire, :brain, :oxy, :tox, :clone, :stamina, :last_words, :suicide)
+		VALUES (:pod, :x_coord, :y_coord, :z_coord, INET_ATON(:internet_address), :port, :round_id, :time, :job, :special, :name, :key, :laname, :lakey, :brute, :fire, :brain, :oxy, :tox, :clone, :stamina, :last_words, :suicide)
 	"}, list(
 		"name" = L.real_name,
 		"key" = L.ckey,

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -36,7 +36,7 @@
 			if(!target)
 				to_chat(usr, "<span class='warning'>The object you tried to expose to [C] no longer exists (nulled or hard-deled)</span>", confidential = TRUE)
 				return
-			message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=[REF(target)]'>VV window</a>")
+			message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;[HrefToken(TRUE)];datumrefresh=[REF(target)]'>VV window</a>")
 			log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [target]")
 			to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window", confidential = TRUE)
 			C.debug_variables(target)

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -90,7 +90,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 
 	else
 		html += "[make_link("organized", null)] | linear<hr>"
-		for (var/datum/error_viewer/error_entry/error_entry in errors)
+		for (var/datum/error_viewer/error_entry/error_entry as anything in errors)
 			html += "[error_entry.make_link(null, src, 1)]<br>"
 
 	browse_to(user, html)
@@ -141,8 +141,10 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		back_to = GLOB.error_cache
 
 	var/html = build_header(back_to)
-	for (var/datum/error_viewer/error_entry/error_entry in errors)
+	for (var/i in 1 to min(length(errors), 1000))
+		var/datum/error_viewer/error_entry/error_entry = errors[i]
 		html += "[error_entry.make_link(null, src)]<br>"
+	html += "<i>Limited to the first 1000 errors</i>"
 
 	browse_to(user, html)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Limits the amount of runtimes shown in a group to 1000. Linear view still may hang it, I'll limit that too if needed. Also adds a missing href token to the "show VV to player" verb.

## Why It's Good For The Game
No more accidentally hanging the server for *everyone* just to view runtimes.

## Changelog
:cl:
fix: Viewing a huge list of grouped runtimes should no longer hang the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
