### PR TITLE
Update Ghostize and Re-Enter Corpse to check for a mob being in NullSpace

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -284,6 +284,7 @@ Works together with spawning an observer, noted above.
 			ghost.client.init_verbs()
 			if(!can_reenter_corpse)	// Disassociates observer mind from the body mind
 				ghost.mind = null
+				key = null
 			return ghost
 
 /*
@@ -343,7 +344,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Re-enter Corpse"
 	if(!client)
 		return
-	if(!mind || QDELETED(mind.current))
+	if(!mind || QDELETED(mind.current) || mind.current.loc == null)
 		to_chat(src, "<span class='warning'>You have no body.</span>")
 		return
 	if(!can_reenter_corpse)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -274,6 +274,14 @@ Works together with spawning an observer, noted above.
 */
 
 /mob/proc/ghostize(can_reenter_corpse = TRUE)
+	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list)
+		if(!ghost.mind || !ghost.can_reenter_corpse)
+			continue
+		if(ghost.mind == mind)
+			SStgui.on_transfer(src, ghost)
+			if(!can_reenter_corpse)
+				ghost.mind = null
+				key = null
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -282,6 +282,7 @@ Works together with spawning an observer, noted above.
 			if(!can_reenter_corpse)
 				ghost.mind = null
 				key = null
+			return ghost
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When a dead body has ghostize called on it with the re-enterable flag set to false, if they are already a ghost it doesnt update correctly; which can cause issues when the ghost attempts to re-enter their body, which is is NullSpace (bad).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Server has a heartattack attempting to render nullspace, because it isnt intended to be rendered. Lets prevent that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ghostize and Re-Enter respect nullspace/existing ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
