### PR TITLE
Removing the skip delay on AACs

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -95,7 +95,7 @@
 	var/scan_on_late_init = FALSE
 	var/depressurization_margin = 10 // use a lower value to reduce cross-contamination
 	var/overlays_hash = null
-	var/skip_delay = 300
+	var/skip_delay = 10
 	var/skip_timer = 0
 	var/is_skipping = FALSE
 
@@ -106,7 +106,7 @@
 /obj/machinery/advanced_airlock_controller/lavaland
 	exterior_pressure = WARNING_LOW_PRESSURE + 10
 	depressurization_margin = ONE_ATMOSPHERE
-	skip_delay = 30
+	skip_delay = 10
 
 /obj/machinery/advanced_airlock_controller/mix_chamber
 	depressurization_margin = 0.15 // The minimum - We really don't want contamination.
@@ -129,12 +129,12 @@
 	qdel(wires)
 	wires = null
 	cut_links()
-	SSair.stop_processing_machine(src)
+	SSair.atmos_machinery -= src
 	return ..()
 
 /obj/machinery/advanced_airlock_controller/Initialize(mapload)
 	. = ..()
-	SSair.start_processing_machine(src)
+	SSair.atmos_machinery += src
 	scan_on_late_init = mapload
 	if(mapload && (. != INITIALIZE_HINT_QDEL))
 		return INITIALIZE_HINT_LATELOAD

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -129,12 +129,12 @@
 	qdel(wires)
 	wires = null
 	cut_links()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	return ..()
 
 /obj/machinery/advanced_airlock_controller/Initialize(mapload)
 	. = ..()
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	scan_on_late_init = mapload
 	if(mapload && (. != INITIALIZE_HINT_QDEL))
 		return INITIALIZE_HINT_LATELOAD


### PR DESCRIPTION
## About The Pull Request

AACs are disliked due to their slow speed and having a delay on skipping it provides no practical benefit really as skipping the re- or depressurization is a shiptester's choice in the end.

## Why It's Good For The Game

Makes AACs more user-friendly

## Changelog
:cl:
del: Removed AAC skip delay
/:cl: