### PR TITLE
Automatic Respawn Timers

### DIFF
--- a/code/_globalvars/lists/client.dm
+++ b/code/_globalvars/lists/client.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_EMPTY(classic_keybinding_list_by_key)
 GLOBAL_LIST_EMPTY(hotkey_keybinding_list_by_key)
 GLOBAL_LIST_EMPTY(keybindings_by_name)
+GLOBAL_LIST_EMPTY(respawn_timers)
 
 // This is a mapping from JS keys to Byond - ref: https://keycode.info/
 GLOBAL_LIST_INIT(_kbMap, list(

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -68,8 +68,6 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
-	/// Assosciative list of clients who want to respawn and their world.time at which they will be allowed to do so.
-	var/list/respawn_timer = list()
 
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	load_mode()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -189,3 +189,6 @@
 
 	/// If the client is currently under the restrictions of the interview system
 	var/interviewee = FALSE
+
+	/// Client-based respawn timer using timeofday.
+	var/timeofdeath

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -189,6 +189,3 @@
 
 	/// If the client is currently under the restrictions of the interview system
 	var/interviewee = FALSE
-
-	/// Client-based respawn timer using timeofday.
-	var/timeofdeath

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -28,7 +28,6 @@
 
 	client.playtitlemusic()
 
-	SSticker.respawn_timer[client] = FALSE
 
 	// Check if user should be added to interview queue
 	if (!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -51,7 +51,8 @@
 	set_stat(DEAD)
 	unset_machine()
 	timeofdeath = world.time
-	GLOB.respawn_timers[client?.ckey] = world.timeofday
+	if(ckey)
+		GLOB.respawn_timers[client?.ckey] = world.timeofday
 	tod = station_time_timestamp()
 	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -51,6 +51,7 @@
 	set_stat(DEAD)
 	unset_machine()
 	timeofdeath = world.time
+	client?.timeofdeath = world.timeofday
 	tod = station_time_timestamp()
 	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -51,7 +51,7 @@
 	set_stat(DEAD)
 	unset_machine()
 	timeofdeath = world.time
-	client?.timeofdeath = world.timeofday
+	GLOB.respawn_timers[client?.ckey] = world.timeofday
 	tod = station_time_timestamp()
 	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -716,13 +716,18 @@
 	if (CONFIG_GET(flag/norespawn) && !admin_bypass)
 		return
 
-	if(client?.timeofdeath && !admin_bypass)
-		var/time_left = client?.timeofdeath + respawn_timer - world.timeofday
+	var/usrkey = client?.ckey
+	if(!usrkey)
+		log_game("[key_name(usr)] AM failed due to disconnect.")
+
+	if(GLOB.respawn_timers[usrkey] && !admin_bypass)
+		var/time_left = GLOB.respawn_timers[usrkey] + respawn_timer - world.timeofday
 		if(time_left > 0)
 			to_chat(usr, "<span class='boldnotice'>You still have [DisplayTimeText(time_left)] left before you can respawn.</span>")
 			return
 
-	client?.timeofdeath = 0
+	GLOB.respawn_timers -= usrkey
+
 	log_game("[key_name(usr)] used abandon mob.")
 
 	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -697,28 +697,32 @@
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (CONFIG_GET(flag/norespawn))
-		return
-
-	if ((stat != DEAD || !( SSticker )))
+	if ((stat != DEAD || !( SSticker )) || !isobserver(usr))
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
 	var/respawn_timer = CONFIG_GET(number/respawn_timer)
-	if(respawn_timer)
-		if(!SSticker.respawn_timer[client])
-			to_chat(usr, "<span class='boldnotice'>You have begun your respawn timer. You will be allowed to Respawn in [DisplayTimeText(respawn_timer)]</span>")
-			SSticker.respawn_timer[client] = world.time + respawn_timer
+	if(!respawn_timer)
+		return
+
+	var/admin_bypass = FALSE
+	if(client?.holder)
+		var/poll_client = tgui_alert(usr, "Would you like to use your rank to bypass a potential respawn timer?", "Admin Alert", list("Yes", "No"))
+		if(poll_client == "Yes")
+			admin_bypass = TRUE
+			message_admins("[key_name_admin(usr)] has used admin permissions to bypass respawn restrictions.")
+			log_game("key_name(usr) used admin permissions to bypass respawn restrictions.")
+
+	if (CONFIG_GET(flag/norespawn) && !admin_bypass)
+		return
+
+	if(client?.timeofdeath && !admin_bypass)
+		var/time_left = client?.timeofdeath + respawn_timer - world.timeofday
+		if(time_left > 0)
+			to_chat(usr, "<span class='boldnotice'>You still have [DisplayTimeText(time_left)] left before you can respawn.</span>")
 			return
 
-		var/left = round(SSticker.respawn_timer[client] - world.time)
-		if(left > 0)
-			to_chat(usr, "<span class='boldnotice'>You still have [DisplayTimeText(left)] left before you can respawn.</span>")
-			return
-
-		// Their timer is up, let them through
-		SSticker.respawn_timer -= client
-
+	client?.timeofdeath = 0
 	log_game("[key_name(usr)] used abandon mob.")
 
 	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")

--- a/config/config.txt
+++ b/config/config.txt
@@ -207,7 +207,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 # DEFAULT_NO_VOTE
 
 ## disable abandon mob
-NORESPAWN
+#NORESPAWN
 
 ## disables calling del(src) on newmobs if they logout before spawnin in
 # DONT_DEL_NEWMOB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds time of death GLOB and uses that directly for respawns, bypassing the need for clients to put themselves into a wait list using SSticker. Also adds admin bypass.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I didn't know you had to manually start your respawn timer and it pissed me off.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Clients no longer need to manually start their respawn timer
add: Admins can now bypass any respawn restrictions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
