### PR TITLE
Goliaths can be fed cactus fruit again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -41,7 +41,7 @@
 	var/pre_attack_icon = "Goliath_preattack"
 	var/tentacle_type = /obj/effect/temp_visual/goliath_tentacle
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide)
-	food_type = list(/obj/item/reagent_containers/food/snacks/meat)		// Omnivorous
+	food_type = list(/obj/item/reagent_containers/food/snacks/meat, /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit, /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf)		// Omnivorous
 	tame_chance = 0
 	bonus_tame_chance = 10
 	search_objects = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
goliaths were at some point changed so they can only be handfed meat slabs, it used to be cactus fruit. this PR makes it so they can be handfed meat slabs, cactus fruit, and mushroom leaves

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
im not sure why the change was made initially to begin with, goliaths were noted to be omnivores in a comment next to them only being able to be fed meat, also im mad because i tried to tame a goliath and it didnt work because it was chanfed to be not cactus fruit 👿 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: goliaths can be handfed cactus fruit once more (they can still be fed meat) (also they can be fed mushroom leaves)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
