### PR TITLE
Minor Refactor of Shuttle Loading Code

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -270,6 +270,8 @@ SUBSYSTEM_DEF(shuttle)
   * * destination_port - The port the newly loaded shuttle will be sent to after being fully spawned in. If you want to have a transit dock be created, use [proc/load_template] instead. Should NOT be null.
   **/
 /datum/controller/subsystem/shuttle/proc/action_load(datum/map_template/shuttle/loading_template, obj/docking_port/stationary/destination_port)
+	if(!destination_port)
+		CRASH("No destination port specified for shuttle load, aborting.")
 	var/obj/docking_port/mobile/new_shuttle = load_template(loading_template, FALSE)
 	var/result = new_shuttle.canDock(destination_port)
 	if((result != SHUTTLE_CAN_DOCK))

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -305,6 +305,10 @@ SUBSYSTEM_DEF(shuttle)
 	new_shuttle.current_ship.set_ship_name(to_replace.name)
 	new_shuttle.current_ship.forceMove(to_replace.current_ship.loc) //Overmap location
 
+	if(istype(old_shuttle_location, /obj/docking_port/stationary/transit))
+		to_replace.assigned_transit = null
+		new_shuttle.assigned_transit = old_shuttle_location
+
 	to_replace.jumpToNullSpace() //This will destroy the old shuttle
 	new_shuttle.initiate_docking(old_shuttle_location) //This will spawn the new shuttle
 	return new_shuttle

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -322,12 +322,14 @@ SUBSYSTEM_DEF(shuttle)
   **/
 /datum/controller/subsystem/shuttle/proc/load_template(datum/map_template/shuttle/template, spawn_transit = TRUE)
 	. = FALSE
-	var/datum/turf_reservation/reservation = SSmapping.request_dynamic_reservation(template.width, template.height)
-	if(!reservation)
-		CRASH("failed to reserve an area for shuttle template loading")
-	reservation.fill_in(turf_type = /turf/open/space/transit/south)
+	var/loading_mapzone = SSmapping.create_map_zone("Shuttle Loading Zone")
+	var/datum/virtual_level/loading_zone = SSmapping.create_virtual_level("[template.name] Loading Level", list(ZTRAIT_RESERVED = TRUE), loading_mapzone, template.width, template.height, ALLOCATION_FREE)
 
-	var/turf/BL = TURF_FROM_COORDS_LIST(reservation.bottom_left_coords)
+	if(!loading_zone)
+		CRASH("failed to reserve an area for shuttle template loading")
+	loading_zone.fill_in(turf_type = /turf/open/space/transit/south)
+
+	var/turf/BL = locate(loading_zone.low_x, loading_zone.low_y, loading_zone.z_value)
 	template.load(BL, centered = FALSE, register = FALSE)
 
 	var/affected = template.get_affected_turfs(BL, centered=FALSE)
@@ -373,7 +375,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	new_shuttle.initiate_docking(transit_dock)
 	new_shuttle.linkup(transit_dock)
-	QDEL_NULL(reservation)
+	QDEL_NULL(loading_zone)
 
 	//Everything fine
 	template.post_load(new_shuttle)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -38,15 +38,6 @@ SUBSYSTEM_DEF(shuttle)
 	/// Stops ALL shuttles from being able to move
 	var/lockdown = FALSE
 
-	/// The shuttle manipulator's currently selected shuttle
-	var/datum/map_template/shuttle/selected
-	/// The shuttle manipulator's currently loaded preview shuttle
-	var/obj/docking_port/mobile/preview_shuttle
-	/// The template of the shuttle manipulator's currently loaded preview shuttle
-	var/datum/map_template/shuttle/preview_template
-	/// The mapzone that the preview shuttle is loaded into
-	var/datum/map_zone/preview_mapzone
-
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)
 
@@ -235,12 +226,6 @@ SUBSYSTEM_DEF(shuttle)
 	ordernum = SSshuttle.ordernum
 	lockdown = SSshuttle.lockdown
 
-	selected = SSshuttle.selected
-
-	preview_shuttle = SSshuttle.preview_shuttle
-	preview_template = SSshuttle.preview_template
-	preview_mapzone = SSshuttle.preview_mapzone
-
 /datum/controller/subsystem/shuttle/proc/is_in_shuttle_bounds(atom/A)
 	var/area/param_area = get_area(A)
 	if(istype(param_area, /area/ship))
@@ -282,98 +267,69 @@ SUBSYSTEM_DEF(shuttle)
   * spawned at a generated transit doc. Doing this is how most ships are loaded.
   *
   * * loading_template - The shuttle map template to load. Can NOT be null.
-  * * destination_port - The port the newly loaded shuttle will be sent to after being fully spawned in. Can be null, and will create a transit port if so.
-  * * old_shuttle - The shuttle the newly loaded shuttle will replace(?).
+  * * destination_port - The port the newly loaded shuttle will be sent to after being fully spawned in. If you want to have a transit dock be created, use [proc/load_template] instead. Should NOT be null.
   **/
-/datum/controller/subsystem/shuttle/proc/action_load(datum/map_template/shuttle/loading_template, obj/docking_port/stationary/destination_port = null, obj/docking_port/mobile/old_shuttle = null)
-	// Check for an existing preview
-	if(preview_shuttle && (loading_template != preview_template))
-		preview_shuttle.jumpToNullSpace()
-		preview_shuttle = null
-		preview_template = null
-		QDEL_NULL(preview_mapzone)
+/datum/controller/subsystem/shuttle/proc/action_load(datum/map_template/shuttle/loading_template, obj/docking_port/stationary/destination_port)
+	var/obj/docking_port/mobile/new_shuttle = load_template(loading_template, FALSE)
+	var/result = new_shuttle.canDock(destination_port)
+	if((result != SHUTTLE_CAN_DOCK))
+		WARNING("Template shuttle [new_shuttle] cannot dock at [destination_port] ([result]).")
+		new_shuttle.jumpToNullSpace()
+		return
+	new_shuttle.initiate_docking(destination_port)
 
-	if(!preview_shuttle)
-		if(load_template(loading_template))
-			preview_shuttle.linkup(destination_port)
-		preview_template = loading_template
+/**
+  * This proc replaces the given shuttle with a fresh new one spawned from a template.
+  * spawned at a generated transit doc. Doing this is how most ships are loaded.
+  *
+  * Hopefully this doesn't need to be used, it's a last resort for admin-coders at best,
+  * but I wanted to preserve the functionality of old action_load() in case it was needed.
+  *
+  * * to_replace - The shuttle to replace. Should NOT be null.
+  * * replacement - The shuttle map template to load in place of the old shuttle. Can NOT be null.
+  **/
+/datum/controller/subsystem/shuttle/proc/replace_shuttle(obj/docking_port/mobile/to_replace, datum/map_template/shuttle/replacement)
+	if(!to_replace || !replacement)
+		return
+	var/obj/docking_port/mobile/new_shuttle = load_template(replacement, FALSE)
+	var/obj/docking_port/stationary/old_shuttle_location = to_replace.get_docked()
+	var/result = new_shuttle.canDock(old_shuttle_location)
 
-	// get the existing shuttle information, if any
-	var/timer = 0
-	var/mode = SHUTTLE_IDLE
-	var/obj/docking_port/stationary/D
-
-	if(istype(destination_port))
-		D = destination_port
-	else if(old_shuttle)
-		timer = old_shuttle.timer
-		mode = old_shuttle.mode
-		D = old_shuttle.get_docked()
-
-	if(!D)
-		D = generate_transit_dock(preview_shuttle)
-
-	if(!D)
-		CRASH("No dock found/could be created for preview shuttle ([preview_template.name]), aborting.")
-
-	var/result = preview_shuttle.canDock(D)
-	// truthy value means that it cannot dock for some reason
-	// but we can ignore the someone else docked error because we'll
-	// be moving into their place shortly
-	if((result != SHUTTLE_CAN_DOCK) && (result != SHUTTLE_SOMEONE_ELSE_DOCKED))
-		WARNING("Template shuttle [preview_shuttle] cannot dock at [D] ([result]).")
-		preview_shuttle.jumpToNullSpace()
+	if((result != SHUTTLE_CAN_DOCK) && (result != SHUTTLE_SOMEONE_ELSE_DOCKED)) //Someone else /IS/ docked, the old shuttle!
+		WARNING("Template shuttle [new_shuttle] cannot dock at [old_shuttle_location] ([result]).")
+		new_shuttle.jumpToNullSpace()
 		return
 
-	if(old_shuttle)
-		old_shuttle.jumpToNullSpace()
+	new_shuttle.timer = to_replace.timer //Copy some vars from the old shuttle
+	new_shuttle.mode = to_replace.mode
+	new_shuttle.current_ship.set_ship_name(to_replace.name)
+	new_shuttle.current_ship.forceMove(to_replace.current_ship.loc) //Overmap location
 
-	var/list/force_memory = preview_shuttle.movement_force
-	preview_shuttle.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
-	preview_shuttle.initiate_docking(D)
-	preview_shuttle.movement_force = force_memory
+	to_replace.jumpToNullSpace() //This will destroy the old shuttle
+	new_shuttle.initiate_docking(old_shuttle_location) //This will spawn the new shuttle
+	return new_shuttle
 
-	. = preview_shuttle
-
-	// Shuttle state involves a mode and a timer based on world.time, so
-	// plugging the existing shuttles old values in works fine.
-	preview_shuttle.timer = timer
-	preview_shuttle.mode = mode
-
-	preview_shuttle.register()
-
-	preview_shuttle.reset_air()
-
-	// TODO indicate to the user that success happened, rather than just
-	// blanking the modification tab
-	preview_shuttle = null
-	preview_template = null
-	selected = null
-
-	preview_mapzone.clear_reservation() //Is this safe? Docking CHECK_TICK's and this should happen on the same thread, so theoritically this wouldn't happen until docking has been finished? Maybe?
-	QDEL_NULL(preview_mapzone)
-
-/// Internal template loading proc. Do not call, instead use [/datum/controller/subsystem/shuttle/proc/action_load]
-/datum/controller/subsystem/shuttle/proc/load_template(datum/map_template/shuttle/S)
-	PRIVATE_PROC(TRUE)
+/**
+  * This proc is THE proc that loads a shuttle from a specified template. Anything else should go through this
+  * in order to spawn a new shuttle.
+  *
+  * * template - The shuttle map template to load. Can NOT be null.
+  * * spawn_transit - Whether or not to send the new shuttle to a newly-generated transit dock after loading.
+  **/
+/datum/controller/subsystem/shuttle/proc/load_template(datum/map_template/shuttle/template, spawn_transit = TRUE)
 	. = FALSE
-	var/width = S.width
-	var/height = S.height
-
-	var/mapzone_name = "Preview Shuttle Zone"
-	preview_mapzone = SSmapping.create_map_zone(mapzone_name)
-	var/datum/virtual_level/vlevel = SSmapping.create_virtual_level(mapzone_name, list(ZTRAIT_RESERVED = TRUE), preview_mapzone, width, height, ALLOCATION_FREE)
-
-	if(!preview_mapzone) ///Shouldn't ever happen
+	var/datum/turf_reservation/reservation = SSmapping.request_dynamic_reservation(template.width, template.height)
+	if(!reservation)
 		CRASH("failed to reserve an area for shuttle template loading")
-	vlevel.fill_in(/turf/open/space/transit/south)
+	reservation.fill_in(turf_type = /turf/open/space/transit/south)
 
-	var/turf/BL = locate(vlevel.low_x, vlevel.low_y, vlevel.z_value)
-	S.load(BL, centered = FALSE, register = FALSE)
+	var/turf/BL = TURF_FROM_COORDS_LIST(reservation.bottom_left_coords)
+	template.load(BL, centered = FALSE, register = FALSE)
 
-	var/affected = S.get_affected_turfs(BL, centered=FALSE)
+	var/affected = template.get_affected_turfs(BL, centered=FALSE)
 
 	var/found = 0
+	var/obj/docking_port/mobile/new_shuttle
 	// Search the turfs for docking ports
 	// - We need to find the mobile docking port because that is the heart of
 	//   the shuttle.
@@ -385,13 +341,13 @@ SUBSYSTEM_DEF(shuttle)
 				found++
 				if(found > 1)
 					qdel(P, force=TRUE)
-					log_world("Map warning: Shuttle Template [S.mappath] has multiple mobile docking ports.")
+					log_world("Map warning: Shuttle Template [template.mappath] has multiple mobile docking ports.")
 				else
-					preview_shuttle = P
+					new_shuttle = P
 			if(istype(P, /obj/docking_port/stationary))
-				log_world("Map warning: Shuttle Template [S.mappath] has a stationary docking port.")
+				log_world("Map warning: Shuttle Template [template.mappath] has a stationary docking port.")
 	if(!found)
-		var/msg = "load_template(): Shuttle Template [S.mappath] has no mobile docking port. Aborting import."
+		var/msg = "load_template(): Shuttle Template [template.mappath] has no mobile docking port. Aborting import."
 		for(var/T in affected)
 			var/turf/T0 = T
 			T0.empty()
@@ -399,14 +355,28 @@ SUBSYSTEM_DEF(shuttle)
 		message_admins(msg)
 		WARNING(msg)
 		return
-	//Everything fine
-	S.post_load(preview_shuttle)
-	return TRUE
 
-/datum/controller/subsystem/shuttle/proc/unload_preview()
-	if(preview_shuttle)
-		preview_shuttle.jumpToNullSpace()
-	preview_shuttle = null
+	var/obj/docking_port/mobile/transit_dock = generate_transit_dock(new_shuttle)
+
+	if(!transit_dock)
+		CRASH("No dock found/could be created for shuttle ([template.name]), aborting.")
+
+	var/result = new_shuttle.canDock(transit_dock)
+	if((result != SHUTTLE_CAN_DOCK))
+		WARNING("Template shuttle [new_shuttle] cannot dock at [transit_dock] ([result]).")
+		new_shuttle.jumpToNullSpace()
+		return
+
+	new_shuttle.initiate_docking(transit_dock)
+	new_shuttle.linkup(transit_dock)
+	QDEL_NULL(reservation)
+
+	//Everything fine
+	template.post_load(new_shuttle)
+	new_shuttle.register()
+	new_shuttle.reset_air()
+
+	return new_shuttle
 
 /datum/controller/subsystem/shuttle/ui_state(mob/user)
 	return GLOB.admin_state
@@ -425,7 +395,6 @@ SUBSYSTEM_DEF(shuttle)
 	data["templates"] = list()
 	var/list/templates = data["templates"]
 	data["templates_tabs"] = list()
-	data["selected"] = list()
 
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
@@ -442,9 +411,6 @@ SUBSYSTEM_DEF(shuttle)
 		L["category"] = S.category
 		L["description"] = S.description
 		L["admin_notes"] = S.admin_notes
-
-		if(selected == S)
-			data["selected"] = L
 
 		templates[S.category]["templates"] += list(L)
 
@@ -487,8 +453,14 @@ SUBSYSTEM_DEF(shuttle)
 	switch(action)
 		if("select_template")
 			if(S)
-				selected = S
 				. = TRUE
+				// If successful, returns the mobile docking port
+				var/obj/docking_port/mobile/mdp = load_template(S)
+				if(mdp)
+					user.forceMove(get_turf(mdp))
+					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
+					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
+					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
 
 		if("jump_to")
 			if(params["type"] == "mobile")
@@ -515,23 +487,3 @@ SUBSYSTEM_DEF(shuttle)
 					log_admin("[key_name(usr)] fast travelled [M]")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[M.name]")
 					break
-
-		if("preview")
-			if(S)
-				. = TRUE
-				unload_preview()
-				load_template(S)
-				if(preview_shuttle)
-					preview_template = S
-					user.forceMove(get_turf(preview_shuttle))
-
-		if("load")
-			if(S)
-				. = TRUE
-				// If successful, returns the mobile docking port
-				var/obj/docking_port/mobile/mdp = action_load(S)
-				if(mdp)
-					user.forceMove(get_turf(mdp))
-					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
-					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
-					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -149,7 +149,7 @@ SUBSYSTEM_DEF(vote)
 			//WS End
 
 			if("map")
-				SSshuttle.action_load(SSmapping.maplist[.])
+				SSshuttle.load_template(SSmapping.maplist[.])
 
 	if(restart)
 		var/active_admins = FALSE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -356,7 +356,7 @@
 			return
 		close_spawn_windows()
 		to_chat(usr, "<span class='danger'>Your [template.name] is being prepared. Please be patient!</span>")
-		var/obj/docking_port/mobile/target = SSshuttle.action_load(template)
+		var/obj/docking_port/mobile/target = SSshuttle.load_template(template)
 		if(!istype(target))
 			to_chat(usr, "<span class='danger'>There was an error loading the ship (You have not been charged). Please contact admins!</span>")
 			new_player_panel()

--- a/code/modules/unit_tests/ship_placement.dm
+++ b/code/modules/unit_tests/ship_placement.dm
@@ -3,7 +3,7 @@
 	for(var/mapname as anything in SSmapping.ship_purchase_list)
 		var/datum/map_template/shuttle/map = SSmapping.ship_purchase_list[mapname]
 		try
-			SSshuttle.action_load(map)
+			SSshuttle.load_template(map)
 			// shuttle.jumpToNullSpace() //Hangs CI, so until we figure that out this should remained commented out
 		catch(var/exception/e)
 			Fail("Runtime error loading ship type ([map.name]): [e] on [e.file]:[e.line]\n[e.desc]")

--- a/tgui/packages/tgui/interfaces/ShuttleManipulator.js
+++ b/tgui/packages/tgui/interfaces/ShuttleManipulator.js
@@ -1,6 +1,7 @@
 import { map } from 'common/collections';
 import { useBackend, useLocalState } from '../backend';
 import { Button, Flex, LabeledList, Section, Table, Tabs } from '../components';
+import { ButtonConfirm } from '../components/Button';
 import { Window } from '../layouts';
 
 export const ShuttleManipulator = (props, context) => {
@@ -23,20 +24,12 @@ export const ShuttleManipulator = (props, context) => {
             onClick={() => setTab(2)}>
             Templates
           </Tabs.Tab>
-          <Tabs.Tab
-            selected={tab === 3}
-            onClick={() => setTab(3)}>
-            Modification
-          </Tabs.Tab>
         </Tabs>
         {tab === 1 && (
           <ShuttleManipulatorStatus />
         )}
         {tab === 2 && (
           <ShuttleManipulatorTemplates />
-        )}
-        {tab === 3 && (
-          <ShuttleManipulatorModification />
         )}
       </Window.Content>
     </Window>
@@ -103,7 +96,6 @@ export const ShuttleManipulatorStatus = (props, context) => {
 export const ShuttleManipulatorTemplates = (props, context) => {
   const { act, data } = useBackend(context);
   const templateObject = data.templates || {};
-  const selected = data.selected || {};
   const [
     selectedTemplateId,
     setSelectedTemplateId,
@@ -126,9 +118,6 @@ export const ShuttleManipulatorTemplates = (props, context) => {
         </Flex.Item>
         <Flex.Item grow={1} basis={0}>
           {actualTemplates.map(actualTemplate => {
-            const isSelected = (
-              actualTemplate.file_name === selected.file_name
-            );
             // Whoever made the structure being sent is an asshole
             return (
               <Section
@@ -136,9 +125,8 @@ export const ShuttleManipulatorTemplates = (props, context) => {
                 level={2}
                 key={actualTemplate.file_name}
                 buttons={(
-                  <Button
-                    content={isSelected ? 'Selected' : 'Select'}
-                    selected={isSelected}
+                  <ButtonConfirm
+                    content="Load"
                     onClick={() => act('select_template', {
                       file_name: actualTemplate.file_name,
                     })} />
@@ -164,52 +152,6 @@ export const ShuttleManipulatorTemplates = (props, context) => {
           })}
         </Flex.Item>
       </Flex>
-    </Section>
-  );
-};
-
-export const ShuttleManipulatorModification = (props, context) => {
-  const { act, data } = useBackend(context);
-  const selected = data.selected || {};
-  return (
-    <Section>
-      {selected ? (
-        <>
-          <Section
-            level={2}
-            title={selected.name}>
-            {(!!selected.description || !!selected.admin_notes) && (
-              <LabeledList>
-                {!!selected.description && (
-                  <LabeledList.Item label="Description">
-                    {selected.description}
-                  </LabeledList.Item>
-                )}
-                {!!selected.admin_notes && (
-                  <LabeledList.Item label="Admin Notes">
-                    {selected.admin_notes}
-                  </LabeledList.Item>
-                )}
-              </LabeledList>
-            )}
-          </Section>
-          <Section
-            level={2}
-            title="Status">
-            <Button
-              content="Preview"
-              onClick={() => act('preview', {
-                file_name: selected.file_name,
-              })} />
-            <Button
-              content="Load"
-              color="bad"
-              onClick={() => act('load', {
-                file_name: selected.file_name,
-              })} />
-          </Section>
-        </>
-      ) : 'No shuttle selected'}
     </Section>
   );
 };

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -170,7 +170,7 @@ SUBSYSTEM_DEF(overmap)
 /datum/controller/subsystem/overmap/proc/spawn_initial_ships()
 	var/datum/map_template/shuttle/selected_template = SSmapping.maplist[pick(SSmapping.maplist)]
 	INIT_ANNOUNCE("Loading [selected_template.name]...")
-	SSshuttle.action_load(selected_template)
+	SSshuttle.load_template(selected_template)
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_round_map_name = SSdbcore.NewQuery({"
 			UPDATE [format_table_name("round")] SET map_name = :map_name WHERE id = :round_id


### PR DESCRIPTION

## About The Pull Request
Dismantles `action_load()` in favor of splitting it into `load_template()` and two helper procs, `action_load()` and `replace_shuttle()`. Also kills the horrible preview system that caused so much pain with simultaneous loading of ships. This *SHOULD* fix a fair few bugs.

## Why It's Good For The Game
No more spawning on the wrong ship, hopefully no more unit tests being overwhelmed with stupidity.

## Changelog
:cl:
del: Removes shuttle previewing from the admin shuttle manipulator.
refactor: Shuttles now load independently, instead of through one single port specified in the shuttle subsystem for reasons beyond my comprehension.
fix: Fixed the bug where you spawn on the wrong ship (caused by people trying to create two ships at the sameish time)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
