### PR TITLE
Shipcoin  gain 2: Coin Harder

### DIFF
--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -11,4 +11,4 @@
 /// Rewarded when you don't survive the round, but stick around till the end
 #define METACOIN_NOTSURVIVE_REWARD 25
 /// Rewarded when you are alive and active for 10 minutes
-#define METACOIN_TENMINUTELIVING_REWARD 10
+#define METACOIN_TENMINUTELIVING_REWARD 15

--- a/code/__DEFINES/~whitesands_defines/metacoin.dm
+++ b/code/__DEFINES/~whitesands_defines/metacoin.dm
@@ -5,10 +5,10 @@
 /// Rewarded when you complete a crew objective
 #define METACOIN_CO_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 150)
 /// Rewarded when you escape on the shuttle
-#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 100 : max(min(round(200 * (round_duration / 72000)), 100), 300)
+#define METACOIN_ESCAPE_REWARD(is_speed_round, round_duration) is_speed_round ? 100 : max(min(round(200 * (round_duration / 72000)), 100), 50)
 /// Rewarded when you survive the round
 #define METACOIN_SURVIVE_REWARD(is_speed_round, round_duration) is_speed_round ? 50 : max(min(round(100 * (round_duration / 72000)), 50), 150)
 /// Rewarded when you don't survive the round, but stick around till the end
-#define METACOIN_NOTSURVIVE_REWARD 30
+#define METACOIN_NOTSURVIVE_REWARD 25
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD 10

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -149,6 +149,9 @@ GLOBAL_PROTECT(exp_to_update)
 		if(mob.stat != DEAD)
 			var/rolefound = FALSE
 			play_records[EXP_TYPE_LIVING] += minutes
+
+			process_ten_minute_living()
+
 			if(announce_changes)
 				to_chat(src,"<span class='notice'>You got: [minutes] Living EXP!</span>")
 			if(mob.mind.assigned_role)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

-Shipcoins are now gained at a rate of 15 every 10 minutes, over the course of time in a round as a living entity.
-The Shipcoin reward on roundend has been reduced to 50 coins, or 25 if you do not survive but stick around to the end.

Provided you survive to the end of a round, you need to play for just under 3 hours to achieve the original 300 coin reward.

This is more or less a direct port of the original bee functionality, but this may change if more powerful coders walk me through making it a different subsystem.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Rewards time played rather than rounds, mostly slays the beast that is "I would probably keep playing but I want my 300 shipcoins, transfer vote"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: shipcoins are now gained mostly based on time played, at a rate of 1.5 per minute. The reward on round-end is now 50 coins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
