### PR TITLE
Hyena Tweaks

### DIFF
--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -276,6 +276,7 @@
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
 	},
+/obj/item/disk/design_disk/ammo_c10mm,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "fA" = (
@@ -2837,14 +2838,16 @@
 "VQ" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/industrial/outline,
-/obj/item/kinetic_crusher{
-	pixel_y = -4
-	},
-/obj/item/kinetic_crusher{
-	pixel_y = 4
-	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
+	},
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/syndie_crusher{
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)

--- a/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -67,5 +67,5 @@
 
 /obj/item/disk/design_disk/ammo_c10mm/Initialize()
 	. = ..()
-	var/datum/design/ammo/c10mm/C = new
-	blueprints[1] = C
+	blueprints[1] = new /datum/design/c10mm()
+``` whoops, missed this, my bad

--- a/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -60,3 +60,20 @@
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c38_box/hunting
 	category = list("Imported")
+
+/obj/item/disk/design_disk/ammo_c10mm
+	name = "Design Disk - 10mm Ammo"
+	desc = "A design disk containing the pattern for a refill box of standard 10mm ammo, used in Stechkin pistols."
+
+/obj/item/disk/design_disk/ammo_c10mm/Initialize()
+	. = ..()
+	var/datum/design/ammo/c10mm/C = new
+	blueprints[1] = C
+
+/datum/design/ammo/c10mm
+	name = "Ammo Box (10mm)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 40000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("Imported")

--- a/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -68,4 +68,3 @@
 /obj/item/disk/design_disk/ammo_c10mm/Initialize()
 	. = ..()
 	blueprints[1] = new /datum/design/c10mm()
-``` whoops, missed this, my bad

--- a/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/whitesands/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -69,11 +69,3 @@
 	. = ..()
 	var/datum/design/ammo/c10mm/C = new
 	blueprints[1] = C
-
-/datum/design/ammo/c10mm
-	name = "Ammo Box (10mm)"
-	id = "c10mm"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 40000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("Imported")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Minor tweaks to the Hyena; replaces the roundstart crushers with Syndicate cleavers and adds a design disk for 10mm ammo boxes (boxes, not magazines, so retain your roundstart mags).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Added Magnetic Cleavers and 10mm Design Disk to hyena
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
