### PR TITLE
quick-fixes dumb mapping mistake introduced in areas & ambience

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_fortress_of_solitide.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_fortress_of_solitide.dmm
@@ -351,9 +351,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/rust,
 /area/ruin/powered)
-"dz" = (
-/turf/template_noop,
-/area/overmap_encounter/planetoid/rockplanet)
 "dC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -800,7 +797,7 @@
 /area/ruin/powered)
 "in" = (
 /turf/template_noop,
-/area/overmap_encounter/planetoid/rockplanet/explored)
+/area/template_noop)
 "is" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
@@ -2311,7 +2308,7 @@
 "vJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/template_noop,
-/area/overmap_encounter/planetoid/rockplanet/explored)
+/area/template_noop)
 "vM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -6942,7 +6939,7 @@ ut
 Fw
 he
 xx
-dz
+in
 IA
 ll
 IA
@@ -6986,7 +6983,7 @@ Uk
 am
 Bd
 xx
-dz
+in
 IA
 IA
 IA


### PR DESCRIPTION
dumb bish accidentally coats entire fortress of solitude map in explored subtype, creates hard vacuum on rock worlds

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

:mothdonk:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

begone vacuum
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes vacuum spawning alongside the Fortress of Solitude ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
