### PR TITLE
Changes all Instances of 'Aluminum' to 'Aluminium'

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -1,6 +1,6 @@
 // Foam
 // Similar to smoke, but slower and mobs absorb its reagent through their exposed skin.
-#define ALUMINUM_FOAM 1
+#define ALUMINIUM_FOAM 1
 #define IRON_FOAM 2
 #define RESIN_FOAM 3
 
@@ -69,7 +69,7 @@
 
 /obj/effect/particle_effect/foam/metal
 	name = "aluminium foam"
-	metal = ALUMINUM_FOAM
+	metal = ALUMINIUM_FOAM
 	icon_state = "mfoam"
 	slippery_foam = FALSE
 
@@ -106,7 +106,7 @@
 /obj/effect/particle_effect/foam/proc/kill_foam()
 	STOP_PROCESSING(SSfastprocess, src)
 	switch(metal)
-		if(ALUMINUM_FOAM)
+		if(ALUMINIUM_FOAM)
 			new /obj/structure/foamedmetal(get_turf(src))
 		if(IRON_FOAM)
 			new /obj/structure/foamedmetal/iron(get_turf(src))
@@ -328,6 +328,6 @@
 		for(var/obj/item/Item in O)
 			Item.extinguish()
 
-#undef ALUMINUM_FOAM
+#undef ALUMINIUM_FOAM
 #undef IRON_FOAM
 #undef RESIN_FOAM

--- a/whitesands/code/datums/ruins/space.dm
+++ b/whitesands/code/datums/ruins/space.dm
@@ -33,7 +33,7 @@
 	id = "transport18"
 	suffix = "transport18.dmm"
 	name = "Booze Cruise"
-	description = "A freighter, damaged beyond repair and surrounded by a cloud of aluminum and... beer foam?"
+	description = "A freighter, damaged beyond repair and surrounded by a cloud of aluminium and... beer foam?"
 
 /datum/map_template/ruin/space/fueldepot
 	id = "fueldepot"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Keeps everything consistent. Everything is JUST Aluminium.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency is bliss!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changes descriptions and instances with 'Aluminum' to be 'Aluminium' instead for consistency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
