### PR TITLE
Minor Planetgen Fixes/Tweaks

### DIFF
--- a/code/modules/overmap/dynamic_events.dm
+++ b/code/modules/overmap/dynamic_events.dm
@@ -65,12 +65,12 @@
 /obj/structure/overmap/dynamic/proc/choose_level_type()
 	var/chosen
 	if(!probabilities)
-		probabilities = list(DYNAMIC_WORLD_LAVA = length(SSmapping.lava_ruins_templates),
-		DYNAMIC_WORLD_ICE = length(SSmapping.ice_ruins_templates),
-		DYNAMIC_WORLD_JUNGLE = length(SSmapping.jungle_ruins_templates),
-		DYNAMIC_WORLD_SAND = length(SSmapping.sand_ruins_templates),
-		DYNAMIC_WORLD_SPACERUIN = length(SSmapping.space_ruins_templates),
-		DYNAMIC_WORLD_ROCKPLANET = length(SSmapping.rock_ruins_templates),
+		probabilities = list(DYNAMIC_WORLD_LAVA = min(length(SSmapping.lava_ruins_templates), 20),
+		DYNAMIC_WORLD_ICE = min(length(SSmapping.ice_ruins_templates), 20),
+		DYNAMIC_WORLD_JUNGLE = min(length(SSmapping.jungle_ruins_templates), 20),
+		DYNAMIC_WORLD_SAND = min(length(SSmapping.sand_ruins_templates), 20),
+		DYNAMIC_WORLD_SPACERUIN = min(length(SSmapping.space_ruins_templates), 20),
+		DYNAMIC_WORLD_ROCKPLANET = min(length(SSmapping.rock_ruins_templates), 20),
 		//DYNAMIC_WORLD_REEBE = 1, //very rare because of major lack of skil //TODO, make removing no teleport not break things, then it can be reenabled
 		DYNAMIC_WORLD_ASTEROID = 30)
 
@@ -126,7 +126,7 @@
 		if(DYNAMIC_WORLD_SPACERUIN)
 			name = "weak energy signal"
 			desc = "A very weak energy signal emenating from space."
-			planet = FALSE
+			planet = DYNAMIC_WORLD_SPACERUIN
 			icon_state = "strange_event"
 			color = null
 			mass = 0 //Space doesn't weigh anything


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes ruins not spawning at energy signals like they were supposed to, and also adds minimums to the encounter type probabilities values to ensure they all get at least some chance of spawning.

This has brought to my attention that it may POSSIBLY be nice to refactor planets into datums so that mapgen/area/ruin lists/turfs/probabilities can be combined together unlike the current way with code strewn out over multiple files linked only by defines.

Fixes: #625

## Why It's Good For The Game
It's kind of nice to actually be able to have ruins spawn when they should.

## Changelog
:cl:
fix: Ruins spawn at weak energy signals again.
tweak: Planet type selection probability now has minimums for planets that are linked to the amount of ruins the planets have.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
