### PR TITLE
Fixes Reagent Thruster Fuel Calculation

### DIFF
--- a/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -186,7 +186,7 @@
 	return thrust * true_percentage
 
 /obj/machinery/power/shuttle/engine/liquid/return_fuel()
-	var/true_percentage = 1
+	var/true_percentage = INFINITY
 	for(var/reagent in fuel_reagents)
 		true_percentage = min(reagents.get_reagent_amount(reagent) / fuel_reagents[reagent], true_percentage)
 	return reagent_amount_holder * true_percentage //Multiplies the total amount needed by the smallest percentage of any reagent in the recipe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #611 

## Changelog
:cl:
fix: Reagent thrusters now give an accurate reading instead of maxing out at 5%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
