### PR TITLE
More ship name sanitization and administration

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -190,12 +190,16 @@
 
 	switch(action) // Universal topics
 		if("rename_ship")
-			if(!("newName" in params) || params["newName"] == current_ship.name)
+			var/new_name = params["newName"]
+			if(!new_name)
 				return
-			if(reject_bad_text(params["newName"], MAX_CHARTER_LEN))
+			new_name = trim(new_name)
+			if (!length(new_name) || new_name == current_ship.name)
+				return
+			if(!reject_bad_text(new_name, MAX_CHARTER_LEN))
 				say("Error: Replacement designation rejected by system.")
 				return
-			if(!current_ship.set_ship_name(params["newName"]))
+			if(!current_ship.set_ship_name(new_name))
 				say("Error: [COOLDOWN_TIMELEFT(current_ship, rename_cooldown)/10] seconds until ship designation can be changed..")
 			update_static_data(usr, ui)
 			return

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -301,6 +301,7 @@
 		return
 	if(name != initial(name))
 		priority_announce("The [name] has been renamed to the [new_name].", "Docking Announcement", sender_override = new_name, zlevel = shuttle.virtual_z())
+	message_admins("[key_name_admin(usr)] renamned vessel '[name]' to '[new_name]'")
 	name = new_name
 	shuttle.name = new_name
 	if(!ignore_cooldown)


### PR DESCRIPTION
## About The Pull Request

> Orders from the Management, shiptesters. Recent events has promoted revokation of the 2nd amendment to your ship labour freedoms and rights. From this point and on, renaming your vessels is a privilege and with that comes regulations on how you are allowed to call your evaluation period ships.

- Sanitize whitespace from left and right sides of text
- Makes sure the sanity check added #663 works on all cases
- Ship renaming are now logged to admin log

## Why It's Good For The Game

The Management will be pleased with the development.

## Changelog
:cl:
tweak: Ship renaming is now logged to admins
fix: Fixed few ship name sanitization edge cases
/:cl:
