### PR TITLE
QoL additions for engineering

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -4,6 +4,7 @@
 	icon_state = "pipe_d"
 	desc = "Dispenses countless types of pipes. Very useful if you need pipes."
 	density = TRUE
+	circuit = /obj/item/circuitboard/machine/pipedispenser
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_OFFLINE
 	var/wait = 0
 	var/piping_layer = PIPING_LAYER_DEFAULT
@@ -85,6 +86,15 @@
 
 	return TRUE
 
+/obj/machinery/pipedispenser/screwdriver_act(mob/user, obj/item/I)
+	panel_open = !panel_open
+	I.play_tool_sound(src)
+	to_chat(user, "<span class='notice'>You [panel_open?"open":"close"] the panel on [src].</span>")
+	return TRUE
+
+/obj/machinery/pipedispenser/crowbar_act(mob/living/user, obj/item/I)
+	default_deconstruction_crowbar(I)
+	return TRUE
 
 /obj/machinery/pipedispenser/disposal
 	name = "disposal pipe dispenser"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -377,6 +377,14 @@
 #undef PATH_FREEZER
 #undef PATH_HEATER
 
+/obj/item/circuitboard/machine/pipedispenser
+	name = "Pipe dispenser (Machine Board)"
+	icon_state = "engineering"
+	build_path = /obj/machinery/pipedispenser
+	req_components = list(
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stock_parts/matter_bin = 1)
+
 //Generic
 
 /obj/item/circuitboard/machine/circuit_imprinter

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1194,6 +1194,32 @@
 		/obj/item/stock_parts/matter_bin = 3)
 	generate_items_inside(items_inside,src)
 
+/obj/item/storage/box/stockparts/t2
+	name = "box of T2 stock parts"
+	desc = "Contains a variety of advanced stock parts."
+
+/obj/item/storage/box/stockparts/t2/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stock_parts/capacitor/adv = 3,
+		/obj/item/stock_parts/scanning_module/adv = 3,
+		/obj/item/stock_parts/manipulator/nano = 3,
+		/obj/item/stock_parts/micro_laser/high = 3,
+		/obj/item/stock_parts/matter_bin/adv = 3)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/box/stockparts/t3
+	name = "box of T3 stock parts"
+	desc = "Contains a variety of super stock parts."
+
+/obj/item/storage/box/stockparts/t3/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stock_parts/capacitor/super = 3,
+		/obj/item/stock_parts/scanning_module/phasic = 3,
+		/obj/item/stock_parts/manipulator/pico = 3,
+		/obj/item/stock_parts/micro_laser/ultra = 3,
+		/obj/item/stock_parts/matter_bin/super = 3)
+	generate_items_inside(items_inside,src)
+
 /obj/item/storage/box/stockparts/deluxe
 	name = "box of deluxe stock parts"
 	desc = "Contains a variety of deluxe stock parts."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1229,7 +1229,7 @@
 
 /datum/supply_pack/materials/plasma
 	name = "Plasma Canister"
-	desc = "Contains a canister of Plasma. Handy when no synthetization or plasma-rich atmospheres are aviable"
+	desc = "Contains a canister of Plasma. Handy when no synthetization or plasma-rich atmospheres are available."
 	cost = 4000
 	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
 	crate_name = "Plasma canister crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1122,6 +1122,23 @@
 	crate_name = "tesla generator crate"
 	dangerous = TRUE
 
+/datum/supply_pack/engine/teg
+	name = "Thermoelectric generator Crate"
+	desc = "Turn heat into electricity! Make atmosia great again."
+	cost = 5000
+	contains = list(/obj/item/circuitboard/machine/generator,
+					/obj/item/circuitboard/machine/circulator,
+					/obj/item/circuitboard/machine/circulator)
+	crate_name = "thermoelectric generator crate"
+
+/datum/supply_pack/engine/thermomachine
+	name = "Thermomachine Crate"
+	desc = "Freeze or heat your air."
+	cost = 2000
+	contains = list(/obj/item/circuitboard/machine/thermomachine,
+					/obj/item/circuitboard/machine/thermomachine)
+	crate_name = "thermomachine crate"
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Canisters & Materials ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1208,6 +1225,14 @@
 	cost = 3000
 	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 	crate_name = "carbon dioxide canister crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/materials/plasma
+	name = "Plasma Canister"
+	desc = "Contains a canister of Plasma. Handy when no synthetization or plasma-rich atmospheres are aviable"
+	cost = 4000
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	crate_name = "Plasma canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/materials/foamtank
@@ -1509,6 +1534,20 @@
 	cost = 1000
 	contains = list(/obj/item/storage/part_replacer/cargo)
 	crate_name = "\improper RPED crate"
+
+/datum/supply_pack/science/t2
+	name = "T2 parts crate"
+	desc = "An advanced parts order offering 3 each tier 2 components with only a 2,000,000% price increase!"
+	cost = 20000 // 100 plasma sheets worth
+	contains = list(/obj/item/storage/box/stockparts/t2)
+	crate_name = "\improper T2 parts crate"
+
+/datum/supply_pack/science/t3
+	name = "T3 parts crate"
+	desc = "A deluxe parts order offering 3 each tier 3 components with only a 6e13% price increase!"
+	cost = 60000 // 300 plasma sheets worth
+	contains = list(/obj/item/storage/box/stockparts/t3)
+	crate_name = "\improper T3 parts crate"
 
 /datum/supply_pack/science/shieldwalls
 	name = "Shield Generator Crate"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -513,6 +513,8 @@
 					backpack_contents += pick(list(/obj/item/slime_extract/grey = 1, /obj/item/slime_scanner = 1, /obj/item/resonator/upgraded = 1, /obj/item/gps = 1, /obj/item/fulton_core = 2, /obj/item/extraction_pack = 3, /obj/item/stack/sheet/mineral/plasma/twenty = 3, /obj/item/stack/marker_beacon/ten = 3, /obj/item/mining_scanner = 2, /obj/item/extinguisher/mini = 3, /obj/item/flashlight/seclite=3, /obj/item/research_notes/loot/medium = 3, /obj/item/stack/sheet/metal/fifty = 3, /obj/item/research_notes/loot/big = 1))
 				if(prob(5))
 					backpack_contents += list(/obj/item/storage/box/rndboards)
+				if(prob(20))
+					backpack_contents += pick(list(/obj/item/storage/box/stockparts/basic = 4, /obj/item/storage/box/stockparts/t2 = 3, /obj/item/storage/box/stockparts/t3 = 2, /obj/item/storage/box/stockparts/deluxe = 1))
 			if(prob(30))
 				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 2, /obj/item/clothing/glasses/hud/health = 2, /obj/item/clothing/glasses/hud/diagnostic =2, /obj/item/clothing/glasses/science = 2, /obj/item/clothing/glasses/welding = 2, /obj/item/clothing/glasses/night = 1))
 			if(prob(10))

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -280,7 +280,7 @@
 	id = "rdserver"
 	build_type = AUTOLATHE | IMPRINTER
 	build_path = /obj/item/circuitboard/machine/rdserver
-	category = list("Research Machinery", "initial", "Equipment")
+	category = list("Research Machinery", "initial", "Equipment", "Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/mechfab

--- a/whitesands/code/modules/research/designs/autolathe_designs.dm
+++ b/whitesands/code/modules/research/designs/autolathe_designs.dm
@@ -15,3 +15,11 @@
 	materials = list(/datum/material/iron = 20000)
 	build_path = /obj/item/ammo_box/magazine/zip_ammo_9mm
 	category = list("hacked", "Security")
+
+/datum/design/pipedispenser
+	name = "Pipe Dispenser (Machine Board)"
+	id = "pipedispenser"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/glass = 500)
+	build_path = /obj/item/circuitboard/machine/pipedispenser
+	category = list("initial", "Machinery")


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The following things can be ordered now:
Plasma canister for 4000
TEG set boards for 5000
2 Freezer boards for 2000
T2 parts 3 each for 20000
T3 parts 3 each for 60000

Server RnD board and Pipe dispenser board is now sorted in the Machinery tab in the autolathe

Pipe dispenser are now constructable


## Why It's Good For The Game

As an engineer I find myself often very bottle necked in the ability to do things like constructing an SM or wanting to do fusion/atmos magic. I would always have to hope that there is a ship to ship interaction happening (Which very few captains seek out even when suggested) and have the other ship cooperate or have the necessary equipment. This luck dependency makes it just a mere luck investment or a huge time sink. 

An orderable plasma canister was added because not every atmosphere has plasma and bugging the captain about moving to another planet can be pretty annoying for the whole crew. With it being base component for a lot of atmos magic it should hopefully encourage players to do some gas reactions. So far I have never seen anyone do it.

This too helps mix things up. I am always sad to see that my engineering option right now is just "Hey set up the AM" which is just a 3x3 box that magically produces 200kW with no active tweaking or management. 

Likewise I have seen very little use of T2 or T3 parts. Either everything is just T1 or T4. Hopefully this makes T2 and T3 somewhat more common used. To make things even more interesting, Golems can drop T4 parts rarely. Making components management somewhat of a more thought intensive matter with the limited amount you get. Priotise your gear!

Making the pipe dispenser constructable with simple tech will allow people to repair/expand their atmos and I consider it to be a bare necessity since the alternative is the RPD which requires some pretty advanced RnD making this a very simple early stage solution. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: TEG boards, freezer boards, plasma, T2 and T3 parts can be ordered on the express console.
add: Pipe dispenser boards can now be printed at an autolathe. Can now also be constructed/deconstructed.
balance: Golems can drop part boxes including T4
fix: RnD server board added to machinery category in the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
