### PR TITLE
Adds a POI to the Ice Planet

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_demonlab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_demonlab.dmm
@@ -1,0 +1,1599 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ac" = (
+/obj/structure/table,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"ad" = (
+/obj/structure/table,
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/random,
+/obj/item/book/manual/wiki/engineering_construction,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"ae" = (
+/obj/structure/closet/abductor,
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/head/beret/sci,
+/obj/item/clothing/neck/tie/gay,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/under/rank/rnd/scientist,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"ao" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"at" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"au" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"ay" = (
+/mob/living/simple_animal/hostile/netherworld/blankbody{
+	faction = list("demonlab");
+	health = 200;
+	name = "???"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"aC" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"aD" = (
+/obj/item/book/granter/spell/shapechange,
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"aE" = (
+/mob/living/simple_animal/hostile/asteroid/old_demon{
+	name = ""Jefferey""
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"aH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"aI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"aK" = (
+/obj/item/skub,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"aL" = (
+/obj/structure/frame,
+/obj/item/circuitboard/machine/teleporter_station,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"aN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"aP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"aR" = (
+/obj/item/banner/engineering,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"aS" = (
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"aT" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking,
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/telescience,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"aU" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"aV" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"aX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"ba" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	icon_state = "0-2"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bb" = (
+/obj/machinery/suit_storage_unit/independent/engineering,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"bg" = (
+/mob/living/simple_animal/hostile/clown/mutant/blob{
+	faction = list("demonlab")
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bh" = (
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bi" = (
+/mob/living/simple_animal/hostile/clown/longface{
+	faction = list("demonlab")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bx" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"bM" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"bV" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"cA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/powered/demonlab)
+"cL" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"dB" = (
+/obj/structure/cable/blue{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-8"
+	},
+/mob/living/simple_animal/hostile/clown/clownhulk/honcmunculus{
+	faction = list("demonlab")
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"dX" = (
+/obj/item/circuitboard/computer/rdconsole,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"ee" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Research and Development"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/powered/demonlab)
+"eP" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"eY" = (
+/obj/structure/frame,
+/obj/item/circuitboard{
+	icon_state = "science";
+	name = "broken circuit board"
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"fo" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard{
+	icon_state = "science";
+	name = "broken circuit board"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"fv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"fz" = (
+/obj/structure/cable/blue{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"gY" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/molten_object/large,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"hk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"hN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"it" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"iL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"iY" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"jK" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/ruin/powered/demonlab)
+"jM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"kx" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"kA" = (
+/obj/structure/table,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"kF" = (
+/obj/machinery/power/smes/magical{
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
+	name = "power storage unit"
+	},
+/obj/structure/cable/blue{
+	icon_state = "0-2"
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"kU" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"lh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"lJ" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"mC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"nw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"nD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"nM" = (
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"oa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"oo" = (
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"oO" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"pi" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"pn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"pr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"pC" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"pE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"qb" = (
+/obj/machinery/photocopier,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"qg" = (
+/obj/structure/closet,
+/obj/item/wrench/combat,
+/obj/item/multitool/old,
+/obj/item/weldingtool/largetank,
+/obj/item/crowbar/power,
+/obj/item/stack/cable_coil/blue,
+/obj/item/t_scanner,
+/obj/item/crowbar/red,
+/obj/item/wirecutters,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"qr" = (
+/obj/structure/cable/blue{
+	icon_state = "1-2"
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"rD" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas/welding,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"rF" = (
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"rH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"rJ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Records and Research"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/powered/demonlab)
+"sU" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"ui" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"uC" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"uK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"uP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"vk" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"vz" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard{
+	icon_state = "science";
+	name = "broken circuit board"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"wk" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"wn" = (
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/powered/demonlab)
+"wr" = (
+/obj/item/assembly/health,
+/obj/item/assembly/igniter,
+/obj/item/assembly/flash,
+/obj/item/assembly/infra,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/shock_kit,
+/obj/item/assembly/signaler,
+/obj/item/assembly/timer,
+/obj/item/assembly/voice,
+/obj/item/electropack,
+/obj/structure/table,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"wE" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"wZ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"xo" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"xy" = (
+/mob/living/simple_animal/hostile/retaliate/clown/honkling{
+	faction = list("demonlab")
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"xF" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"xI" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"xK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/barricade/wooden,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"xM" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Upsilon Laboratory"
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"yd" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/circuitboard{
+	icon_state = "science";
+	name = "broken circuit board"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"yq" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"yt" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"yJ" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"zg" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/powered/demonlab)
+"zU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Af" = (
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Az" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"AW" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Bh" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"BN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"BY" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Ca" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"Co" = (
+/mob/living/simple_animal/hostile/netherworld/asteroid{
+	faction = list("demonlab")
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"Dc" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/item/restraints/legcuffs/beartrap{
+	armed = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Dd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"Dk" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Ec" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/powered/demonlab)
+"Fg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"Fv" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"FF" = (
+/obj/structure/cable/blue{
+	icon_state = "2-8"
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Gg" = (
+/obj/structure/table,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"GF" = (
+/obj/structure/closet/abductor,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/head/beret/sci,
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/under/rank/rnd/scientist,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Hd" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"HX" = (
+/obj/item/circuitboard/computer/teleporter,
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Ig" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"IZ" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	piping_layer = 4
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Jj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"JR" = (
+/obj/structure/cable/blue,
+/obj/machinery/power/port_gen/pacman/mrs{
+	sheet_left = 5
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"JX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Kh" = (
+/mob/living/simple_animal/hostile/netherworld/migo/asteroid{
+	faction = list("demonlab")
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"Km" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Kr" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Kw" = (
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"KQ" = (
+/obj/structure/frame,
+/obj/item/circuitboard/machine/teleporter_hub,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Lp" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Lt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"Lv" = (
+/obj/machinery/door/window,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"LK" = (
+/turf/closed/wall,
+/area/ruin/powered/demonlab)
+"My" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Dimensional Research Storage"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"NX" = (
+/obj/structure/table,
+/obj/item/gun/energy/temperature,
+/obj/item/firing_pin/clown,
+/obj/item/storage/box/contractor/fulton_extraction,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Oh" = (
+/mob/living/simple_animal/hostile/netherworld/blankbody{
+	faction = list("demonlab");
+	health = 200;
+	name = "???"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Os" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Oz" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/red/insulated,
+/obj/item/clothing/head/clownmitre,
+/obj/item/clothing/mask/gas/clown_hat,
+/obj/item/clothing/suit/chaplainsuit/clownpriest,
+/obj/item/grenade/spawnergrenade/clown_broken,
+/obj/item/megaphone/clown,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"OT" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Pt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"PK" = (
+/obj/structure/cable/blue,
+/obj/machinery/power/port_gen/pacman{
+	sheet_left = 5
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"PT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow/ecto,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Qx" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/destructive_analyzer,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Ra" = (
+/obj/item/book/granter/spell/fireball,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Rr" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Sf" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"SB" = (
+/obj/structure/table,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/cell,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"SC" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"SX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Ts" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Tv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Uk" = (
+/obj/machinery/light/broken,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Ul" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/mineral/titanium,
+/area/ruin/powered/demonlab)
+"Ur" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"Uw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Vf" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/blue,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"VC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/powered/demonlab)
+"VP" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Wc" = (
+/obj/effect/decal/cleanable/ash,
+/turf/template_noop,
+/area/template_noop)
+"Wy" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"Xo" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"Xp" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/powered/demonlab)
+"Xr" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Upsilon Laboratory"
+	},
+/obj/structure/fans/tiny,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/ruin/powered/demonlab)
+"Xv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+"Xw" = (
+/obj/structure/closet,
+/obj/item/clothing/under/rank/engineering/engineer/skirt,
+/obj/item/clothing/under/rank/engineering/engineer/hazard,
+/obj/item/holosign_creator/engineering,
+/obj/item/storage/backpack/duffelbag/engineering,
+/obj/item/toy/figure/engineer,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"XP" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Yg" = (
+/mob/living/simple_animal/hostile/clown/banana{
+	faction = list("demonlab")
+	},
+/turf/open/floor/noslip,
+/area/ruin/powered/demonlab)
+"Zn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/temperatre,
+/area/ruin/powered/demonlab)
+"Zu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/zombie{
+	faction = list("demonlab")
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/powered/demonlab)
+
+(1,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+xo
+xo
+xo
+aa
+aa
+Wc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Wc
+"}
+(2,1,1) = {"
+LK
+aI
+aI
+aI
+aI
+LK
+aa
+Wc
+aI
+LK
+Xr
+LK
+aI
+aa
+aa
+aa
+Wc
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aI
+ao
+aV
+aV
+aV
+LK
+Wc
+aa
+aI
+zg
+kU
+Ur
+aI
+aa
+aa
+Wc
+aN
+Xo
+Xo
+xI
+aa
+Wc
+aa
+"}
+(4,1,1) = {"
+aI
+aS
+aX
+oo
+wE
+LK
+aa
+aa
+aI
+Ec
+Dd
+mC
+aI
+Wc
+aa
+aa
+Lt
+LK
+LK
+LK
+LK
+LK
+LK
+"}
+(5,1,1) = {"
+aI
+aS
+Co
+cL
+wZ
+LK
+aa
+aa
+aI
+Wy
+wn
+cA
+aI
+aa
+Wc
+aa
+Lt
+LK
+ba
+Vf
+fz
+PK
+LK
+"}
+(6,1,1) = {"
+aI
+bM
+oo
+Kh
+qb
+LK
+aa
+LK
+LK
+LK
+xM
+LK
+LK
+LK
+LK
+aa
+Lt
+LK
+kF
+qr
+dB
+JR
+LK
+"}
+(7,1,1) = {"
+aI
+ac
+SC
+eP
+Bh
+LK
+LK
+LK
+rF
+kA
+Dc
+uK
+uC
+au
+jK
+Pt
+Lt
+LK
+XP
+bh
+FF
+PK
+LK
+"}
+(8,1,1) = {"
+aI
+ad
+Kh
+jM
+Ca
+cL
+aU
+LK
+AW
+Lv
+Os
+Xp
+sU
+nM
+LK
+aH
+aP
+LK
+bb
+bg
+Yg
+bh
+LK
+"}
+(9,1,1) = {"
+aI
+aT
+bV
+lh
+hk
+iL
+iL
+rJ
+xK
+xF
+Gg
+Gg
+at
+Gg
+LK
+LK
+LK
+LK
+IZ
+bh
+xy
+Uk
+LK
+"}
+(10,1,1) = {"
+aI
+aU
+Kw
+oa
+Fg
+Ul
+Ul
+LK
+wk
+Az
+Kr
+Af
+pn
+nM
+yt
+LK
+aR
+zU
+SX
+BN
+bh
+Oz
+LK
+"}
+(11,1,1) = {"
+LK
+LK
+LK
+ee
+LK
+LK
+LK
+LK
+it
+nD
+Ig
+fv
+pE
+ay
+Hd
+bx
+JX
+JX
+Tv
+pr
+bi
+yq
+LK
+"}
+(12,1,1) = {"
+aa
+LK
+pC
+oO
+pC
+Rr
+rD
+LK
+LK
+LK
+LK
+LK
+lJ
+nM
+yt
+LK
+aR
+Lp
+Xw
+qg
+vk
+eY
+LK
+"}
+(13,1,1) = {"
+aa
+LK
+ae
+Xv
+Jj
+Oh
+Sf
+NX
+wr
+SB
+pC
+LK
+LK
+LK
+LK
+LK
+LK
+LK
+LK
+LK
+VC
+LK
+LK
+"}
+(14,1,1) = {"
+aa
+LK
+GF
+rH
+Km
+yJ
+gY
+Oh
+OT
+Dk
+pC
+LK
+nw
+aC
+BY
+aK
+LK
+Wc
+aa
+aa
+Zn
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+LK
+Zu
+ui
+Uw
+bf
+PT
+hN
+Uw
+Uw
+Fv
+My
+uP
+iY
+aD
+KQ
+LK
+aa
+aa
+aa
+aa
+aa
+Wc
+"}
+(16,1,1) = {"
+aa
+LK
+yd
+dX
+Qx
+vz
+fo
+LK
+LK
+LK
+LK
+LK
+Ts
+Ra
+aE
+aL
+LK
+aa
+aa
+aa
+Wc
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+LK
+LK
+LK
+LK
+LK
+LK
+LK
+aa
+aa
+aa
+LK
+kx
+VP
+pi
+HX
+LK
+aa
+Wc
+aa
+aa
+Wc
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LK
+LK
+LK
+LK
+LK
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_demonlab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_demonlab.dmm
@@ -65,7 +65,7 @@
 /area/ruin/powered/demonlab)
 "aE" = (
 /mob/living/simple_animal/hostile/asteroid/old_demon{
-	name = ""Jefferey""
+	name = "'Jefferey'"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -32,3 +32,9 @@
 
 /area/ruin/powered/slimerancher/maints
 	name = "Slime Ranching Maints"
+
+/area/ruin/powered/demonlab
+	name = "Upsilon Research Outpost"
+	icon_state = "dk_yellow"
+	mood_bonus = -10
+	mood_message = "<span class='nicegreen'>I want to leave this place.</span>\n"

--- a/whitesands/code/datums/ruins/icemoon.dm
+++ b/whitesands/code/datums/ruins/icemoon.dm
@@ -28,3 +28,9 @@
 	id = "brazillian-lab"
 	description = "A conspicuous compound in the middle of the cold wasteland. What goodies are inside?"
 	suffix = "icemoon_underground_brazillianlab.dmm"
+
+/datum/map_template/ruin/icemoon/demonlab
+	name = "Upsilon Research Outpost"
+	id = "demonlab"
+	description = "Some abandoned research outpost"
+	suffix = "icemoon_demonlab.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Upsilon Research Laboratory to the list of Ice Planet POI's.
Possible Loot includes:
Battle Wrench
Temperature Gun (no firing pin)
Hilarious Firing Pin
Fulton Extraction Kit
Book of Cast Fireball
Book of ShapeChange
Welding Goggles and SkullMask
RND Console and Deconstructive Analyzer circuit
Teleporter Hub circuits
Funny clown items
Stuffed CLUWNE
Jaws of Life
Red Insulated Gloves
![image](https://user-images.githubusercontent.com/55075747/150036939-106dd98a-5750-4d72-8683-617800b0b12f.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Ice Planet has only a handful of poi's over every other docking area with 20 or more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Phoaly
add: Added a new POI to the Ice Planet, located at icemoon_demonlab.dmm
code: Added an AREA to code/game/area/areas/ruins/icemoon.dm
code: Added the MAPTEMPLATE to whitesands/code/datums/ruins/icemoon.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
