### PR TITLE
Makes both ak rifles unbuyable

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -690,6 +690,7 @@
 	crate_name = "ammo crate"
 	dangerous = TRUE
 
+/*
 /datum/supply_pack/security/armory/aknt
 	name = "Nanotrasen Brand Kalashnikov Rifle Crate"
 	desc = "Contains two cheaply made reproductions of the AK-47 by Nanotrasen, the NT-AK."
@@ -725,7 +726,7 @@
 					/obj/item/ammo_box/magazine/ak47)
 	crate_name = "rifle crate"
 	dangerous = TRUE
-
+*/
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -690,43 +690,6 @@
 	crate_name = "ammo crate"
 	dangerous = TRUE
 
-/*
-/datum/supply_pack/security/armory/aknt
-	name = "Nanotrasen Brand Kalashnikov Rifle Crate"
-	desc = "Contains two cheaply made reproductions of the AK-47 by Nanotrasen, the NT-AK."
-	cost = 12000
-	contains = list(/obj/item/gun/ballistic/automatic/ak47/nt,
-					/obj/item/gun/ballistic/automatic/ak47/nt)
-	crate_name = "rifle crate"
-	dangerous = TRUE
-
-/datum/supply_pack/security/armory/akntammo
-	name = "Nanotrasen Brand Kalashnikov Ammo Crate"
-	desc = "Contains two 30 round proprietary magazines for the NT-AK."
-	cost = 5000
-	contains = list(/obj/item/ammo_box/magazine/aknt,
-					/obj/item/ammo_box/magazine/aknt)
-	crate_name = "rifle crate"
-	dangerous = TRUE
-
-/datum/supply_pack/security/armory/ak47
-	name = "Kalashnikov Rifle Crate"
-	desc = "Hello Comrade, this here is our most famous product! It is easily maintainable, and more afordable than any other rifle, yes! If product stops working, just apply tape!"
-	cost = 20000
-	contains = list(/obj/item/gun/ballistic/automatic/ak47,
-					/obj/item/gun/ballistic/automatic/ak47)
-	crate_name = "rifle crate"
-	dangerous = TRUE
-
-/datum/supply_pack/security/armory/ak47ammo
-	name = "Kalashnikov Ammo Crate"
-	desc = "You ran out of ammo? We have solution, yes! Order 2 spare magazines for the shiny rifle of yours, and continue doing, whatever you do with your rifle!"
-	cost = 7000
-	contains = list(/obj/item/ammo_box/magazine/ak47,
-					/obj/item/ammo_box/magazine/ak47)
-	crate_name = "rifle crate"
-	dangerous = TRUE
-*/
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the code that lets the ak47 and NT-AK buyable from cargo

## Why It's Good For The Game
There are a shit-ton of guns you can buy from cargo, and while you may avoid buying the AK to save money, when you are fighiting another ship, it's just more worth to buy a ak or nt ak, because even though nt-ak technicaly does around 10 less damage, the extreme firing rate just outpaces the amount of damage it does. Talk to the discord and even people that use the AK want it removed.

## Changelog
:cl:
balance: AK-47s are sold out.
balance: Additionally, NT-AKs are discontinued following record sales, but not hitting sales projections.
/:cl:
