### PR TITLE
Fixes silicons being able to teleport items out of certain computers/machines

### DIFF
--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -107,10 +107,13 @@
   *	* obj/item/reagent_containers/new_beaker	-	The new beaker that the user wants to put into the device
   */
 /obj/item/storage/portable_chem_mixer/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.forceMove(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -294,10 +294,13 @@
 	replace_beaker(user)
 
 /obj/machinery/icecream_vat/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.forceMove(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -51,7 +51,7 @@
 	if(stored_card)
 		to_chat(user, "<span class='notice'>You remove [stored_card] from [src].</span>")
 		locked = FALSE
-		if(user)
+		if(user && Adjacent(user) && !issiliconoradminghost(user))
 			user.put_in_hands(stored_card)
 		else
 			stored_card.forceMove(drop_location())

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -53,7 +53,7 @@
 		to_chat(user, "<span class='warning'>There is no power cell connected to \the [src].</span>")
 		return FALSE
 	else
-		if(user)
+		if(user && Adjacent(user) && !issiliconoradminghost(user))
 			user.put_in_hands(battery)
 			to_chat(user, "<span class='notice'>You detach \the [battery] from \the [src].</span>")
 		else

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -83,7 +83,7 @@
 
 	var/ejected = 0
 	if(stored_card && (!slot || slot == 1))
-		if(user)
+		if(user && Adjacent(user) && !issiliconoradminghost(user))
 			user.put_in_hands(stored_card)
 		else
 			stored_card.forceMove(drop_location())
@@ -91,7 +91,7 @@
 		ejected++
 
 	if(stored_card2 && (!slot || slot == 2))
-		if(user)
+		if(user && Adjacent(user) && !issiliconoradminghost(user))
 			user.put_in_hands(stored_card2)
 		else
 			stored_card2.forceMove(drop_location())

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -392,6 +392,7 @@
 			user.put_in_hands(beaker)
 		else
 			beaker.forceMove(get_turf(src))
+		beaker = null
 	if(new_beaker)
 		beaker = new_beaker
 	update_icon()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -385,11 +385,13 @@
 	powerefficiency = round(newpowereff, 0.01)
 
 /obj/machinery/chem_dispenser/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
-		beaker = null
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.forceMove(get_turf(src))
 	if(new_beaker)
 		beaker = new_beaker
 	update_icon()

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -36,10 +36,13 @@
 	replace_beaker(user)
 
 /obj/machinery/chem_heater/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.forceMove(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -132,10 +132,13 @@
 	replace_beaker(user)
 
 /obj/machinery/chem_master/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.forceMove(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -109,13 +109,13 @@
 		icon_state = "juicer0"
 
 /obj/machinery/reagentgrinder/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user)
+	if(!user || !can_interact(user))
 		return FALSE
 	if(beaker)
-		if(can_interact(user))
+		if(Adjacent(src, user) && !issiliconoradminghost(user))
 			user.put_in_hands(beaker)
 		else
-			beaker.drop_location(get_turf(src))
+			beaker.forceMove(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes chemmasters, chem dispensers, chem heaters, reagent grinders, and modular consoles not checking whether someone is actually adjacent when putting an item in their hands, leading to cyborgs and AIs being able to teleport stuff. I also added a special check for adjacent silicons, since they don't have hands.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Magic ID/intellicard/beaker teleportation bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes a few instances where silicons could teleport stuff out of machines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
