### PR TITLE
Ship limit

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -226,7 +226,8 @@ SUBSYSTEM_DEF(mapping)
 		if(isnum(data["cost"]))
 			S.cost = data["cost"]
 			ship_purchase_list["[S.name] ([S.cost] [CONFIG_GET(string/metacurrency_name)]s)"] = S
-
+		if(isnum(data["limit"]))
+			S.limit = data["limit"]
 		shuttle_templates[S.file_name] = S
 		map_templates[S.file_name] = S
 		if(isnum(data["roundstart"]) && data["roundstart"])

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,6 +11,7 @@
 	var/port_x_offset
 	var/port_y_offset
 
+	var/limit
 	var/cost
 	var/short_name
 	var/list/job_slots

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -354,6 +354,14 @@
 		if(SSdbcore.IsConnected() && usr.client.get_metabalance() < template.cost)
 			alert(src, "You have insufficient metabalance to cover this purchase! (Price: [template.cost])")
 			return
+		if(template.limit)
+			var/count = 0
+			for(var/obj/structure/overmap/ship/simulated/X in SSovermap.simulated_ships)
+				if(X.source_template == template)
+					count++
+					if(template.limit <= count)
+						alert(src, "The ship limit of [template.limit] has been reached this round.")
+						return
 		close_spawn_windows()
 		to_chat(usr, "<span class='danger'>Your [template.name] is being prepared. Please be patient!</span>")
 		var/obj/docking_port/mobile/target = SSshuttle.load_template(template)


### PR DESCRIPTION
Adds an optional ship limit option in the config

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability for mappers to limit the amount ship types they want
Example:

	"map_path": "_maps/shuttles/shiptest/pill_black.dmm",
	"map_id": "pill_black",
	"limit": 2,
	"job_slots": {
		"Prisoner": 3

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There were complains of the pill ship over taking the manifest with 6 or even more ships. This should solve the issue and can also be used on other ships or even gimmick ships.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ship can be limited in the config file. Optional.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
