### PR TITLE
Pill trilogy: The sweet return of the successor

### DIFF
--- a/_maps/configs/sugarcube.json
+++ b/_maps/configs/sugarcube.json
@@ -1,0 +1,11 @@
+{
+	"map_name": "Sugarcube-Class Prison Bus Ship",
+	"map_short_name": "Sugarcube-class",
+	"map_path": "_maps/shuttles/shiptest/sugarcube.dmm",
+	"map_id": "sugarcube",
+	"limit": 2,
+	"job_slots": {
+		"Prisoner": 6
+	},
+	"cost": 100
+}

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -1,0 +1,45 @@
+"a" = (/turf/closed/wall/rust,/area/ship/storage)
+"b" = (/turf/closed/wall,/area/ship/storage)
+"c" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating,/area/ship/storage)
+"d" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/obj/effect/decal/cleanable/oil/slippery,/turf/open/floor/plating,/area/ship/storage)
+"e" = (/obj/structure/window/reinforced/spawner/east,/obj/machinery/power/shuttle/engine/electric{dir = 4},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
+"f" = (/obj/structure/cable{icon_state = "4-8"},/obj/structure/cable{icon_state = "2-4"},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/apc/auto_name/north{charging = 20000},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
+"g" = (/obj/structure/cable{icon_state = "0-8"},/obj/machinery/power/smes/shuttle/precharged,/turf/open/floor/plating,/area/ship/storage)
+"h" = (/obj/item/reagent_containers/food/snacks/rationpack,/obj/item/reagent_containers/food/snacks/rationpack,/obj/item/trash/cheesie,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/structure/closet/crate,/turf/open/floor/plating,/area/ship/storage)
+"i" = (/obj/machinery/cryopod{dir = 4},/obj/machinery/computer/cryopod{pixel_y = 32},/turf/open/floor/plating,/area/ship/storage)
+"j" = (/obj/structure/chair{dir = 4},/obj/structure/window/reinforced/spawner/west,/turf/open/floor/plating,/area/ship/storage)
+"k" = (/obj/structure/chair{dir = 4},/obj/structure/window/reinforced/spawner/west,/obj/structure/window/reinforced/spawner/east,/obj/machinery/light{dir = 1},/turf/open/floor/plating,/area/ship/storage)
+"l" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/ship/storage)
+"m" = (/obj/structure/window/reinforced/spawner/west,/obj/item/radio/intercom/wideband{pixel_y = 26},/obj/structure/chair/comfy/shuttle{dir = 4},/obj/effect/mob_spawn/human/corpse{outfit = /datum/outfit/job/security},/turf/open/floor/plating,/area/ship/storage)
+"n" = (/obj/machinery/computer/helm{dir = 8},/turf/open/floor/plating,/area/ship/storage)
+"o" = (/obj/structure/cable{icon_state = "1-2"},/turf/open/floor/plating,/area/ship/storage)
+"p" = (/obj/structure/cable{icon_state = "0-8"},/obj/machinery/power/port_gen/pacman,/obj/machinery/light/small{dir = 4},/obj/item/stack/sheet/mineral/plasma/five,/obj/machinery/power/terminal{dir = 1},/turf/open/floor/plating,/area/ship/storage)
+"q" = (/obj/effect/decal/cleanable/dirt/dust,/obj/item/trash/chips,/turf/open/floor/plating,/area/ship/storage)
+"r" = (/obj/structure/chair{dir = 4},/obj/structure/window/reinforced/spawner/west,/obj/structure/window/reinforced/spawner/east,/turf/open/floor/plating,/area/ship/storage)
+"s" = (/obj/structure/window/reinforced/spawner/west,/obj/machinery/holopad/emergency/command,/obj/effect/mob_spawn/human/corpse/assistant,/turf/open/floor/plating,/area/ship/storage)
+"t" = (/obj/item/areaeditor/shuttle,/obj/structure/table/reinforced,/turf/open/floor/plating,/area/ship/storage)
+"u" = (/obj/structure/cable{icon_state = "1-2"},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/ship/storage)
+"v" = (/obj/effect/decal/cleanable/dirt/dust,/mob/living/simple_animal/hostile/cockroach/glockroach,/turf/open/floor/plating,/area/ship/storage)
+"w" = (/obj/machinery/door/airlock/maintenance_hatch,/turf/open/floor/plating,/area/ship/storage)
+"x" = (/mob/living/simple_animal/deer{desc = "A strange looking pony? It likes sugarcubes that is for sure!"; name = "Applejack"},/turf/open/floor/plating,/area/ship/storage)
+"y" = (/turf/open/floor/plating,/area/ship/storage)
+"z" = (/obj/effect/mob_spawn/human/corpse/damaged,/turf/open/floor/plating,/area/ship/storage)
+"A" = (/obj/effect/decal/cleanable/glass,/obj/item/shard,/obj/item/shard,/obj/item/kitchen/knife/shiv,/obj/effect/mob_spawn/human/corpse/charredskeleton,/turf/open/floor/plating,/area/ship/storage)
+"B" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/telecomms/relay,/turf/open/floor/plating,/area/ship/storage)
+"C" = (/obj/structure/cable{icon_state = "1-8"},/obj/effect/decal/cleanable/dirt/dust,/obj/structure/safe/floor,/obj/item/toy/plush/among,/obj/item/clothing/suit/space/hardsuit/carp/old,/obj/item/clothing/suit/space/hardsuit/carp/old,/turf/open/floor/plating,/area/ship/storage)
+"D" = (/obj/structure/rack,/obj/item/storage/toolbox/mechanical/old,/obj/item/circuitboard/machine/autolathe,/obj/item/pickaxe/improvised,/obj/item/pickaxe/improvised,/obj/effect/spawner/lootdrop/glowstick,/obj/effect/spawner/lootdrop/glowstick,/turf/open/floor/plating,/area/ship/storage)
+"E" = (/obj/structure/chair{dir = 4},/turf/open/floor/plating,/area/ship/storage)
+"F" = (/obj/structure/chair{dir = 4},/obj/structure/window/reinforced/spawner/west,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/ship/storage)
+"G" = (/obj/structure/chair{dir = 4},/obj/structure/window/reinforced/spawner/west,/obj/structure/window/reinforced/spawner/east,/obj/machinery/light,/turf/open/floor/plating,/area/ship/storage)
+"H" = (/obj/structure/window/reinforced/spawner/west,/obj/structure/fluff/oldturret,/turf/open/floor/plating,/area/ship/storage)
+"I" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/deepcore/hub,/turf/open/floor/plating,/area/ship/storage)
+"J" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ship/storage)
+
+(1,1,1) = {"
+aaabcacbdacc
+efgbhijklmnc
+bopaqljrlstc
+auvwlxylzABc
+eCDbEjFGlHIc
+bbbacbcbJacc
+"}

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -1,7 +1,7 @@
 "a" = (/turf/closed/wall/rust,/area/ship/storage)
 "b" = (/turf/closed/wall,/area/ship/storage)
 "c" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating,/area/ship/storage)
-"d" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/obj/effect/decal/cleanable/oil/slippery,/obj/docking_port/mobile{dir = 2; launch_status = 0},/turf/open/floor/plating,/area/ship/storage)
+"d" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/obj/effect/decal/cleanable/oil/slippery,/obj/docking_port/mobile{can_move_docking_ports = 1; dir = 2; launch_status = 0; port_direction = 8; preferred_direction = 4},/turf/open/floor/plating,/area/ship/storage)
 "e" = (/obj/structure/window/reinforced/spawner/east,/obj/machinery/power/shuttle/engine/electric{dir = 4},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
 "f" = (/obj/structure/cable{icon_state = "4-8"},/obj/structure/cable{icon_state = "2-4"},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/apc/auto_name/north{charging = 20000},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
 "g" = (/obj/structure/cable{icon_state = "0-8"},/obj/machinery/power/smes/shuttle/precharged,/turf/open/floor/plating,/area/ship/storage)

--- a/_maps/shuttles/shiptest/sugarcube.dmm
+++ b/_maps/shuttles/shiptest/sugarcube.dmm
@@ -1,7 +1,7 @@
 "a" = (/turf/closed/wall/rust,/area/ship/storage)
 "b" = (/turf/closed/wall,/area/ship/storage)
 "c" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating,/area/ship/storage)
-"d" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/obj/effect/decal/cleanable/oil/slippery,/turf/open/floor/plating,/area/ship/storage)
+"d" = (/obj/structure/fans/tiny,/obj/machinery/door/airlock/external/glass,/obj/effect/decal/cleanable/oil/slippery,/obj/docking_port/mobile{dir = 2; launch_status = 0},/turf/open/floor/plating,/area/ship/storage)
 "e" = (/obj/structure/window/reinforced/spawner/east,/obj/machinery/power/shuttle/engine/electric{dir = 4},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
 "f" = (/obj/structure/cable{icon_state = "4-8"},/obj/structure/cable{icon_state = "2-4"},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/apc/auto_name/north{charging = 20000},/obj/structure/cable{icon_state = "0-4"},/turf/open/floor/plating,/area/ship/storage)
 "g" = (/obj/structure/cable{icon_state = "0-8"},/obj/machinery/power/smes/shuttle/precharged,/turf/open/floor/plating,/area/ship/storage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is an attempt to bring back the pill with its issues fixed while trying to keep its concept intact.

Ship to ship: A holopad and a wideband channel is now available
Player count: Default prisoner count is 6
Ship limit: The Sugarcube is limited to 2 ships per round (Requires #718) 

![sugarcube](https://user-images.githubusercontent.com/21098781/150725729-25a0bb0d-4e19-4afa-89b2-70c462c869a5.PNG)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The pill design philosophy unfolded shiptests potential and it was quite evident on the results. This ship should still provide the unforgiving feeling of no mistakes allowed. It should be great fun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Sugarcube Prison bus ship. The pill returns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
