### PR TITLE
Ruins Tide's aesthetic to fix Shuttle Permit issues

### DIFF
--- a/_maps/shuttles/shiptest/isv_roberts.dmm
+++ b/_maps/shuttles/shiptest/isv_roberts.dmm
@@ -881,7 +881,7 @@ Ck
 pH
 IX
 pU
-Ck
+pH
 Ck
 Ck
 Ck
@@ -892,7 +892,7 @@ Ck
 Ck
 Ck
 Ck
-Ck
+cd
 Ns
 cd
 Yo
@@ -901,7 +901,7 @@ pH
 Ab
 eR
 pH
-Ck
+Po
 Po
 zr
 zr
@@ -927,7 +927,7 @@ zm
 Ck
 "}
 (4,1,1) = {"
-Ck
+Hj
 Tp
 Oy
 Ns
@@ -1003,7 +1003,7 @@ Bs
 zm
 "}
 (8,1,1) = {"
-Ck
+Hj
 Oy
 Oy
 oC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Much of the Tide does not count as a valid area for the shuttle permit, this resolves the issue making all areas start off as valid rooms.

![image](https://user-images.githubusercontent.com/5572280/151258684-47dc3056-5065-4676-9513-5e7ebdab5c6b.png)![image](https://user-images.githubusercontent.com/5572280/151258696-efd2878b-83fc-4993-9ebb-0ea55600e5fd.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should, allegedly, cut down on Ship-Cutting Syndrome the Tide frequently suffers from due to the shuttle permit acting wacky.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Added a few corner walls to the Tide-class so its areas counts as valid rooms at roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
