### PR TITLE
Pills created by ChemMasters will actually go into pill bottles inserted into them.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -309,6 +309,7 @@
 					/datum/component/storage)
 				if(STRB)
 					drop_threshold = STRB.max_items - bottle.contents.len
+					target_loc = bottle
 			for(var/i = 0; i < amount; i++)
 				if(i < drop_threshold)
 					P = new/obj/item/reagent_containers/pill(target_loc)


### PR DESCRIPTION
## About The Pull Request

Did you know that you can put pill bottles into ChemMasters? I didn't! However, this was useless since a bug prevented created pills from actually going into inserted pill bottles. This PR rectifies that. _Note: Does not apply to created patches._

## Why It's Good For The Game

Lets people working with ChemMasters put pills into bottles more efficiently again.

## Changelog
:cl:
fix: Fixed bug where pill bottles in ChemMasters didn't receive pills created by them.
/:cl:
