### PR TITLE
Removes Hyena Cargo

### DIFF
--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -140,6 +140,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "dr" = (
@@ -307,11 +308,6 @@
 /obj/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/bridge)
-"fT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/engine,
-/area/ship/cargo)
 "fV" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
@@ -368,11 +364,13 @@
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/glasses/thermal/eyepatch,
 /obj/item/clothing/head/HoS/syndicate,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/gun/ballistic/revolver,
+/obj/item/ammo_box/a357/match,
+/obj/item/ammo_box/a357/match,
 /obj/item/ammo_box/a357/match,
 /obj/item/codespeak_manual/unlimited,
 /obj/item/pen/edagger,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "hy" = (
@@ -382,13 +380,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
-"hP" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
-/area/ship/cargo)
 "ia" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -424,6 +415,7 @@
 	pixel_y = -22
 	},
 /obj/item/circuitboard/machine/protolathe/department/cargo,
+/obj/item/circuitboard/machine/rdserver,
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
 "ir" = (
@@ -485,16 +477,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "iC" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "iG" = (
 /obj/machinery/porta_turret/centcom_shuttle/ballistic{
@@ -638,25 +626,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "lg" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/outline,
+/obj/structure/closet/crate/freezer{
+	opened = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "lt" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
-	suit_type = /obj/item/clothing/suit/space/syndicate
-	},
-/obj/effect/turf_decal/industrial/outline,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "lX" = (
@@ -858,7 +836,6 @@
 /turf/open/floor/carpet/red,
 /area/ship/crew/dorm)
 "px" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/corner/red,
 /obj/effect/turf_decal/corner/red{
 	dir = 4
@@ -904,10 +881,7 @@
 /area/ship/bridge)
 "pP" = (
 /obj/effect/turf_decal/industrial/outline,
-/obj/machinery/mineral/ore_redemption{
-	dir = 1;
-	output_dir = 1
-	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "pT" = (
@@ -956,7 +930,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/start/station_engineer,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "rd" = (
@@ -1048,8 +1022,15 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/starboard)
 "sG" = (
-/obj/structure/sign/syndicate,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/hatch{
+	name = "external airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "sH" = (
 /obj/structure/cable{
@@ -1162,9 +1143,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "uf" = (
-/obj/machinery/computer/selling_pad_control{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -1173,6 +1151,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/office)
 "uk" = (
@@ -1353,7 +1334,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/start/shaft_miner,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "xQ" = (
@@ -1822,6 +1803,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
+"Fv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
+	suit_type = /obj/item/clothing/suit/space/syndicate
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
 "FA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1836,18 +1832,15 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "FQ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/plasma/reinforced,
-/obj/effect/turf_decal/industrial/stand_clear,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Gm" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/hatch{
+	name = "external airlock"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/docking_port/mobile{
 	can_move_docking_ports = 1;
@@ -1860,9 +1853,7 @@
 	preferred_direction = 4;
 	width = 28
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "external airlock"
-	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Gw" = (
@@ -1899,15 +1890,10 @@
 "GV" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/dorm)
-"Hk" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/ship/cargo)
+"HE" = (
+/obj/structure/sign/syndicate,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
 "HJ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/armory)
@@ -1949,9 +1935,12 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/port)
 "Ik" = (
-/obj/effect/turf_decal/industrial/hatch,
-/obj/machinery/selling_pad,
 /obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/mineral/ore_redemption{
+	dir = 1;
+	output_dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Iz" = (
@@ -2125,15 +2114,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
-"KM" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/ship/cargo)
 "KQ" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2217,11 +2197,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/port)
 "Ln" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Lv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -2258,12 +2235,10 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "Mp" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/outline,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "Ms" = (
 /obj/structure/bed,
@@ -2276,7 +2251,9 @@
 /area/ship/crew/dorm)
 "My" = (
 /obj/effect/turf_decal/industrial/outline,
-/obj/machinery/autolathe,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "MF" = (
@@ -2383,7 +2360,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "OJ" = (
@@ -2522,9 +2498,8 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "PT" = (
-/obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Qy" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2575,6 +2550,7 @@
 /turf/open/floor/plating,
 /area/ship/storage)
 "Rn" = (
+/obj/structure/lattice,
 /obj/machinery/porta_turret/centcom_shuttle/ballistic{
 	dir = 1;
 	name = "ship turret";
@@ -2900,17 +2876,13 @@
 /turf/open/floor/carpet/red,
 /area/ship/crew/dorm)
 "Wd" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "external airlock"
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
 "Wp" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -2969,14 +2941,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew)
 "Xj" = (
-/obj/machinery/computer/cargo/express{
-	dir = 8
-	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/crew{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/office)
 "Xz" = (
@@ -3103,8 +3075,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew)
 "YI" = (
-/obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
@@ -3112,9 +3084,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "YV" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -3147,15 +3116,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security/armory)
 "Zi" = (
-/obj/effect/turf_decal/industrial/warning{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/arrows{
 	dir = 1
 	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Zn" = (
 /obj/effect/turf_decal/industrial/outline,
@@ -3168,11 +3133,10 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "ZM" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/turf_decal/industrial/outline,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "ZR" = (
 /obj/structure/cable{
@@ -3183,6 +3147,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
@@ -3468,9 +3435,9 @@ nn
 Zb
 "}
 (15,1,1) = {"
-Zb
-nn
-YI
+Rn
+cs
+cs
 MO
 Uh
 HJ
@@ -3488,9 +3455,9 @@ nn
 Zb
 "}
 (16,1,1) = {"
-Rn
 cs
-cs
+Fv
+HE
 ZR
 BB
 DO
@@ -3508,7 +3475,7 @@ LC
 Zb
 "}
 (17,1,1) = {"
-cs
+YI
 lt
 sG
 YV
@@ -3595,8 +3562,8 @@ Dq
 rd
 Ap
 lg
-hP
-KM
+ZM
+Mp
 Zi
 bl
 si
@@ -3615,7 +3582,7 @@ WN
 sH
 Ap
 Ln
-fT
+Ln
 PT
 FQ
 zn
@@ -3636,7 +3603,7 @@ le
 Ap
 ZM
 Mp
-Hk
+Mp
 iC
 Tg
 Qy

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -35,21 +35,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"bq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline,
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
-	suit_type = /obj/item/clothing/suit/space/syndicate
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
 "bJ" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/structure/closet/secure_closet{
@@ -261,10 +246,6 @@
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
-"ey" = (
-/obj/structure/sign/syndicate,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/hallway/central)
 "fi" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/effect/turf_decal/radiation/white,
@@ -1172,8 +1153,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/machine{
-	anchored = 1
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/office)
@@ -1959,6 +1941,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
+"IK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
+	suit_type = /obj/item/clothing/suit/space/syndicate
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
 "IO" = (
 /obj/effect/turf_decal/corner/bar{
 	dir = 1
@@ -2600,6 +2597,10 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"SF" = (
+/obj/structure/sign/syndicate,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
 "SJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3458,8 +3459,8 @@ Zb
 "}
 (16,1,1) = {"
 cs
-bq
-ey
+IK
+SF
 ZR
 BB
 DO

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -130,6 +130,10 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"dc" = (
+/obj/structure/sign/syndicate,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
 "dh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -635,6 +639,8 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "lt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "lX" = (
@@ -1803,21 +1809,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
-"Fv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline,
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
-	suit_type = /obj/item/clothing/suit/space/syndicate
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
 "FA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1890,10 +1881,6 @@
 "GV" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/dorm)
-"HE" = (
-/obj/structure/sign/syndicate,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/hallway/central)
 "HJ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/armory)
@@ -2710,6 +2697,21 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"Uy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
+	suit_type = /obj/item/clothing/suit/space/syndicate
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
 "UI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3456,8 +3458,8 @@ Zb
 "}
 (16,1,1) = {"
 cs
-Fv
-HE
+Uy
+dc
 ZR
 BB
 DO

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -105,12 +105,14 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hallway/central)
 "cH" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/storage)
 "cV" = (
@@ -295,19 +297,9 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "fL" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/cargo/office)
-"fR" = (
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters{
-	id = "wreckerwindows";
-	name = "blast shutters"
-	},
-/obj/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
-/area/ship/bridge)
 "fV" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
@@ -517,14 +509,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/dorm)
 "jt" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
-	},
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/storage)
@@ -664,8 +652,7 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/fore)
 "mX" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/crew)
 "nn" = (
@@ -751,8 +738,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "oz" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
@@ -2011,8 +1997,7 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/port)
 "JP" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/storage)
 "JS" = (
@@ -2510,8 +2495,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "QW" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
@@ -2573,8 +2557,7 @@
 /turf/open/floor/carpet/red,
 /area/ship/crew/dorm)
 "Sg" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
@@ -2672,11 +2655,10 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "TR" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/curtain/cloth/fancy{
 	name = "blood-red curtains"
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "TT" = (
@@ -2879,12 +2861,11 @@
 /turf/open/floor/carpet/red,
 /area/ship/crew/dorm)
 "Wd" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Wp" = (
@@ -3078,12 +3059,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew)
 "YI" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "wreckerwindows";
 	name = "blast shutters"
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "YV" = (
@@ -3658,7 +3638,7 @@ mL
 mL
 "}
 (26,1,1) = {"
-fR
+oz
 cf
 Ma
 ch

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -35,6 +35,21 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"bq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
+	suit_type = /obj/item/clothing/suit/space/syndicate
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
 "bJ" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/structure/closet/secure_closet{
@@ -130,10 +145,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"dc" = (
-/obj/structure/sign/syndicate,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/hallway/central)
 "dh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -250,6 +261,10 @@
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
+"ey" = (
+/obj/structure/sign/syndicate,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
 "fi" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/effect/turf_decal/radiation/white,
@@ -1345,7 +1360,7 @@
 /area/ship/storage)
 "xQ" = (
 /obj/structure/chair/sofa/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
@@ -2697,21 +2712,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"Uy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline,
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate;
-	suit_type = /obj/item/clothing/suit/space/syndicate
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
 "UI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3458,8 +3458,8 @@ Zb
 "}
 (16,1,1) = {"
 cs
-Uy
-dc
+bq
+ey
 ZR
 BB
 DO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes cargo consoles from the Hyena. Converts the former pod landing area into extra warehouse space with some loot and replaces the Foreman's cargo consoles with a crew monitor (for tracking miners) and a machine frame for the R&D server. Also improved the dynamics of the Hyena's airlock to allow dragging objects through it without getting stuck.

## Why It's Good For The Game

hyena was a bit too strong and already had plenty of equipment to do its job. Cargo just led to gun spam and caused a sharp decline in the population of the threatened "Dwayne" species.

## Changelog
:cl:
del: Removed cargo consoles on Hyena
tweak: Made Hyena's side airlock more practical to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
