### PR TITLE
Independent Hardsuit Refactor

### DIFF
--- a/_maps/shuttles/shiptest/amogus_sus.dmm
+++ b/_maps/shuttles/shiptest/amogus_sus.dmm
@@ -229,8 +229,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/box,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "dh" = (
@@ -387,10 +387,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
-"ex" = (
-/obj/structure/tank_dispenser,
-/turf/open/floor/plasteel,
-/area/ship/engineering/atmospherics)
 "eJ" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/public/glass,
@@ -846,8 +842,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "jh" = (
-/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/independent/engineering,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "jm" = (
@@ -3271,11 +3267,13 @@
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
 "LB" = (
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/hooded/survivor,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "LO" = (
@@ -3916,8 +3914,8 @@
 /area/ship/hallway/fore)
 "SJ" = (
 /obj/machinery/light/small,
-/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/independent/engineering,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "SU" = (
@@ -4512,6 +4510,10 @@
 "Yu" = (
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
+"YM" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering)
 "YN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5072,7 +5074,7 @@ Us
 xu
 tt
 vP
-vP
+YM
 DO
 dl
 dl
@@ -5641,7 +5643,7 @@ iP
 iV
 CL
 HC
-ex
+DA
 HB
 DA
 HX

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -901,6 +901,17 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew)
+"tP" = (
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "tR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1555,7 +1566,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "EH" = (
@@ -2990,7 +3001,7 @@ as
 cp
 nc
 DB
-EF
+tP
 FN
 np
 bQ

--- a/_maps/shuttles/shiptest/cargotide.dmm
+++ b/_maps/shuttles/shiptest/cargotide.dmm
@@ -1140,8 +1140,11 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 9
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/gloves/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/suit/hooded/explorer,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/central)
 "HP" = (
@@ -1292,8 +1295,8 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/central)
 "NW" = (

--- a/_maps/shuttles/shiptest/chapel.dmm
+++ b/_maps/shuttles/shiptest/chapel.dmm
@@ -171,6 +171,7 @@
 	},
 /obj/item/pickaxe/rusted,
 /obj/item/clothing/head/hardhat/mining,
+/obj/item/gps,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "cC" = (
@@ -349,7 +350,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "fy" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -671,7 +673,7 @@
 	name = "Privacy Shutters Control";
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "kH" = (
 /obj/structure/table/reinforced,
@@ -708,10 +710,10 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/carpet/nanoweave/blue,
@@ -750,7 +752,6 @@
 /obj/item/storage/box/rubbershot,
 /obj/item/key/displaycase,
 /obj/item/soulstone/anybody/chaplain,
-/obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor,
 /obj/item/megaphone,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/chapel/office)
@@ -1908,6 +1909,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/head/welding,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Af" = (
@@ -2113,6 +2115,9 @@
 "Cy" = (
 /obj/structure/cable{
 	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/chapel/office)
@@ -2396,7 +2401,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "HE" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -2514,7 +2519,7 @@
 /obj/machinery/meter{
 	name = "exterior atmosphere flow meter"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ship/engineering/atmospherics)
 "JJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2568,8 +2573,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/chapel/office)
@@ -2699,13 +2704,13 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/meter/atmos/distro_loop,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Lp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Lq" = (
 /obj/structure/railing/corner,
@@ -2818,7 +2823,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Nm" = (
 /turf/open/floor/plasteel/dark,
@@ -3254,12 +3259,8 @@
 	},
 /turf/open/floor/wood,
 /area/ship/medical)
-"Sa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
-/area/ship/engineering/atmospherics)
 "Se" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Sg" = (
 /obj/structure/cable{
@@ -3719,9 +3720,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/breath,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/crew/chapel/office)
 "Wk" = (
@@ -3954,6 +3956,7 @@
 /area/ship/engineering/atmospherics)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Yx" = (
@@ -5171,8 +5174,8 @@ Ss
 CS
 Hz
 MO
-Sa
-Sa
+yp
+yp
 VD
 Yp
 yp

--- a/_maps/shuttles/shiptest/hightide.dmm
+++ b/_maps/shuttles/shiptest/hightide.dmm
@@ -27,8 +27,8 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "bg" = (
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "bn" = (
@@ -185,6 +185,13 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
+"hh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/fore)
 "hy" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/glitter,
@@ -1414,7 +1421,7 @@ ob
 cQ
 lQ
 po
-LV
+hh
 vK
 vK
 jr

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -10,7 +10,6 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "aT" = (
-/obj/machinery/suit_storage_unit/open,
 /obj/item/clothing/suit/space/hardsuit/combatmedic,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/sechailer,
@@ -19,6 +18,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/suit_storage_unit/inherit,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bl" = (
@@ -48,11 +48,11 @@
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bC" = (
-/obj/machinery/suit_storage_unit/open,
 /obj/item/clothing/suit/space/hardsuit/combatmedic,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/suit_storage_unit/inherit,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bX" = (
@@ -1832,7 +1832,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "SH" = (
-/obj/machinery/suit_storage_unit/open,
 /obj/item/clothing/suit/space/hardsuit/combatmedic,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/sechailer,
@@ -1840,6 +1839,7 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/suit_storage_unit/inherit,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "SI" = (

--- a/_maps/shuttles/shiptest/isv_roberts.dmm
+++ b/_maps/shuttles/shiptest/isv_roberts.dmm
@@ -312,7 +312,7 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "vf" = (
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "vj" = (
@@ -754,7 +754,7 @@
 	name = "Blast Door Control";
 	pixel_y = -24
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Ub" = (

--- a/_maps/shuttles/shiptest/pirate_libertatia.dmm
+++ b/_maps/shuttles/shiptest/pirate_libertatia.dmm
@@ -388,19 +388,12 @@
 	dir = 8;
 	pixel_y = 12
 	},
-/obj/item/clothing/suit/space/orange,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/clothing/head/helmet/space,
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/closet/wall/red{
-	dir = 4;
-	name = "suit locker";
-	pixel_x = -28;
-	req_one_access_txt = "1"
-	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/swat,
+/obj/item/tank/jetpack/carbondioxide,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "pA" = (

--- a/_maps/shuttles/shiptest/wright.dmm
+++ b/_maps/shuttles/shiptest/wright.dmm
@@ -1495,7 +1495,7 @@
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/office)
 "Mv" = (
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/independent/mining/eva,
 /turf/open/floor/plating,
 /area/ship/crew/office)
 "MI" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refactors a bunch of independent ships to use the independent EVA suit variants added in #455, namely:

- Shetland
- Boyardee
- TrunkTide
- Shepherd
- HighTide
- Li Tieguai
- Tide
- Libertatia
- Wright

Class ships have had their suit selection adjusted.

In the event this somehow causes another line-ending blood curse to hex the repo I apologise in advance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency and more widespread use of new content.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Independent ships now stock independent hardsuits to avoid copyright infringement with NT.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
