### PR TITLE
Fixes some bullet-related bugs.

### DIFF
--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -9,4 +9,4 @@ GLOBAL_LIST_INIT(typecache_living, typecacheof(/mob/living))
 
 GLOBAL_LIST_INIT(typecache_stack, typecacheof(/obj/item/stack))
 
-GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure)))
+GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure, /obj/mecha)))

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -9,4 +9,4 @@ GLOBAL_LIST_INIT(typecache_living, typecacheof(/mob/living))
 
 GLOBAL_LIST_INIT(typecache_stack, typecacheof(/obj/item/stack))
 
-GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure, /obj/mecha)))
+GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure, /obj/mecha, /obj/spacepod)))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -334,7 +334,7 @@
 	// Here's hoping it doesn't stay like this for years before we finish conversion to step_
 	var/atom/firstbump
 	var/canPassSelf = CanPass(mover, src)
-	if(canPassSelf || (mover.movement_type & PHASING))
+	if(canPassSelf || (mover.movement_type & PHASING) || (mover.pass_flags & pass_flags_self))
 		for(var/i in contents)
 			if(QDELETED(mover))
 				return FALSE		//We were deleted, do not attempt to proceed with movement.
@@ -356,7 +356,7 @@
 		firstbump = src
 	if(firstbump)
 		mover.Bump(firstbump)
-		return (mover.movement_type & PHASING)
+		return (mover.movement_type & PHASING) || (mover.pass_flags & pass_flags_self) // If they can phase through us, let them in. If not, don't.
 	return TRUE
 
 /turf/Exit(atom/movable/mover, atom/newloc)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -434,8 +434,8 @@
 		var/mob/living/M = pick(considering)
 		return M.lowest_buckled_mob()
 	considering.len = 0
-	// 3. objs/mechs
-	possible = typecache_filter_list(T, GLOB.typecache_machine_or_structure) + typecache_filter_list(T, typecacheof(/obj/mecha))	// because why are items ever dense?
+	// 3. objs
+	possible = typecache_filter_list(T, GLOB.typecache_machine_or_structure)	// because why are items ever dense?
 	for(var/i in possible)
 		if(!can_hit_target(i, i == original, TRUE))
 			continue

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -434,8 +434,8 @@
 		var/mob/living/M = pick(considering)
 		return M.lowest_buckled_mob()
 	considering.len = 0
-	// 3. objs
-	possible = typecache_filter_list(T, GLOB.typecache_machine_or_structure)	// because why are items ever dense?
+	// 3. objs/mechs
+	possible = typecache_filter_list(T, GLOB.typecache_machine_or_structure) + typecache_filter_list(T, typecacheof(/obj/mecha))	// because why are items ever dense?
 	for(var/i in possible)
 		if(!can_hit_target(i, i == original, TRUE))
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
So when bullets try to hit objects, they try to pick a target from any structures or machinery on the tile they're hitting.

The problem with this is that mechs aren't machines or structures. When a bullet tries to hit them, it'll just ignore the mech and keep bumping up against it until the bullet times out.

This PR fixes that by adding mechs to the list of objects that can get hit by a bullet.

I fixed spacepods the same way.

Fixing X-ray lasers was done by adding pass flag handling to turfs, since it apparently didn't have that before despite the fact that closed turf pass flags exist. 

closes #343

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Combat mechs shouldn't be immune to bullets.

## Changelog
:cl:
fix: Mechs can get hit by bullets again.
fix: Spacepods can get hit by bullets again.
fix: X-ray lasers can go through walls now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
