### PR TITLE
Moderate Severity Ship Bugfixes

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -175,7 +175,7 @@
 	.["mapRef"] = current_ship.map_name
 	.["shipInfo"] = list(
 		name = current_ship.name,
-		class = current_ship.source_template.name,
+		class = current_ship.source_template?.name,
 		mass = current_ship.mass,
 		sensor_range = current_ship.sensor_range
 	)

--- a/code/modules/overmap/ships/simulated.dm
+++ b/code/modules/overmap/ships/simulated.dm
@@ -35,7 +35,7 @@
 	var/obj/structure/overmap/docked
 	///The docking port of the linked shuttle
 	var/obj/docking_port/mobile/shuttle
-	///The map template the shuttle was spawned from, if it was indeed created from a template
+	///The map template the shuttle was spawned from, if it was indeed created from a template. CAN BE NULL (ex. custom-built ships).
 	var/datum/map_template/shuttle/source_template
 
 /obj/structure/overmap/ship/simulated/Initialize(mapload, obj/docking_port/mobile/_shuttle, datum/map_template/shuttle/_source_template)

--- a/code/modules/overmap/ships/simulated_ship_data.dm
+++ b/code/modules/overmap/ships/simulated_ship_data.dm
@@ -3,7 +3,7 @@
 
 /obj/structure/overmap/ship/simulated
 	///Assoc list of remaining open job slots (job = remaining slots)
-	var/list/job_slots = list("Captain" = 1, "Assistant" = 5)
+	var/list/job_slots = list(new /datum/job/captain() = 1, new /datum/job/assistant() = 5)
 	///Manifest list of people on the ship
 	var/list/manifest = list()
 	///Shipwide bank account

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -87,10 +87,11 @@ SUBSYSTEM_DEF(overmap)
   * * Shuttle: The docking port to create an overmap object for
   */
 /datum/controller/subsystem/overmap/proc/setup_shuttle_ship(obj/docking_port/mobile/shuttle, datum/map_template/shuttle/source_template)
-	var/docked_object = shuttle.current_ship
+	var/docked_object = get_overmap_object_by_location(shuttle)
 	var/obj/structure/overmap/ship/simulated/new_ship
 	if(docked_object)
 		new_ship = new(docked_object, shuttle, source_template)
+		new_ship.state = OVERMAP_SHIP_IDLE
 	else if(is_reserved_level(shuttle))
 		new_ship = new(get_unused_overmap_square(), shuttle, source_template)
 		new_ship.state = OVERMAP_SHIP_FLYING
@@ -344,6 +345,17 @@ SUBSYSTEM_DEF(overmap)
 		if (dist < max_range && dist < ret_dist)
 			. = T
 			ret_dist = dist
+
+/**
+  * Gets the parent overmap object (e.g. the planet the atom is on) for a given atom.
+  * * source - The object you want to get the corresponding parent overmap object for.
+  */
+/datum/controller/subsystem/overmap/proc/get_overmap_object_by_location(atom/source)
+	for(var/O in overmap_objects)
+		if(istype(O, /obj/structure/overmap/dynamic))
+			var/obj/structure/overmap/dynamic/D = O
+			if(D.mapzone?.is_in_bounds(source))
+				return D
 
 /datum/controller/subsystem/overmap/Recover()
 	if(istype(SSovermap.events))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows setup_shuttle_ship() to be used on ships that are docked on planets, which both means that custom shuttles work again and admins can fix overmap tokens when they get deleted for whatever reason. Also fixes another minor bug which bluescreened the helm console UI if there wasn't a source template linked to the ship (see: custom shuttles yet again). Also fixes the default template job slots.

## Why It's Good For The Game
Allows for custom shuttle builds again as well as allows fixing a recurring bug.

## Changelog
:cl:
fix: Custom shuttles can be built again.
admin: setup_shuttle_ship() actually works to fix ships missing their overmap token once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
