### PR TITLE
Adds some admin messages to the shuttle manipulator

### DIFF
--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -33,16 +33,19 @@
 			destination = null
 			mode = SHUTTLE_IGNITING
 			setTimer(ignitionTime)
+			message_admins("[user.key] has placed [name] into Infinite Transit.")
 
 		if("Delete Shuttle")
 			if(alert(user, "Really delete [name]?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
 			jumpToNullSpace()
+			message_admins("[user.key] has deleted [name].")
 
 		if("Into The Sunset (delete & greentext 'escape')")
 			if(alert(user, "Really delete [name] and greentext escape objectives?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
 			intoTheSunset()
+			message_admins("[user.key] has deleted [name], and granted the crew greentext.")
 
 		else
 			if(options[selection])

--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -45,7 +45,7 @@
 			if(alert(user, "Really delete [name] and greentext escape objectives?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
 			intoTheSunset()
-			message_admins("[user.key] has deleted [name], and granted the crew greentext.")
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has deleted [name], and granted the crew greentext.")
 
 		else
 			if(options[selection])

--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -39,7 +39,7 @@
 			if(alert(user, "Really delete [name]?", "Delete Shuttle", "Cancel", "Really!") != "Really!")
 				return
 			jumpToNullSpace()
-			message_admins("[user.key] has deleted [name].")
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has deleted [name].")
 
 		if("Into The Sunset (delete & greentext 'escape')")
 			if(alert(user, "Really delete [name] and greentext escape objectives?", "Delete Shuttle", "Cancel", "Really!") != "Really!")

--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -33,7 +33,7 @@
 			destination = null
 			mode = SHUTTLE_IGNITING
 			setTimer(ignitionTime)
-			message_admins("[user.key] has placed [name] into Infinite Transit.")
+			message_admins("\[SHUTTLE]: [key_name_admin(user)] has placed [name] into Infinite Transit.")
 
 		if("Delete Shuttle")
 			if(alert(user, "Really delete [name]?", "Delete Shuttle", "Cancel", "Really!") != "Really!")


### PR DESCRIPTION
I added this on voidcrew, and figured it might be useful for you guys aswell

🆑
admin: The shuttle manipulator will now message admins when it is used to delete, or place a shuttle into infinite transit.
/🆑