### PR TITLE
Possibly Fixes Shuttle Engine (real and fake) Harddel Issues

### DIFF
--- a/_maps/shuttles/shiptest/carrier.dmm
+++ b/_maps/shuttles/shiptest/carrier.dmm
@@ -86,7 +86,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "bt" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -449,7 +449,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
@@ -832,7 +832,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
@@ -939,7 +939,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/construction)
 "oA" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1356,7 +1356,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/science/robotics)
 "uy" = (
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1528,7 +1528,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
@@ -1551,7 +1551,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/construction)
 "xg" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -1688,7 +1688,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
@@ -1864,7 +1864,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/electrical)
 "BX" = (
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2008,7 +2008,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
@@ -2052,7 +2052,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/obj/structure/shuttle/engine/platform/corner{
+/obj/structure/shuttle/platform/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
@@ -2312,7 +2312,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/science/robotics)
 "Jj" = (
-/obj/structure/shuttle/engine/platform,
+/obj/structure/shuttle/platform,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -2364,7 +2364,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
@@ -2420,7 +2420,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/construction)
 "Ki" = (
-/obj/structure/shuttle/engine/platform,
+/obj/structure/shuttle/platform,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -2457,7 +2457,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "Ll" = (
-/obj/structure/shuttle/engine/platform,
+/obj/structure/shuttle/platform,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -2488,7 +2488,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
@@ -2573,7 +2573,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/construction)
 "Nm" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
@@ -2602,7 +2602,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
 "NN" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2755,7 +2755,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
 	},
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 6
 	},
 /turf/open/floor/plasteel/tech,
@@ -2981,7 +2981,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/obj/structure/shuttle/engine/platform/corner,
+/obj/structure/shuttle/platform/corner,
 /turf/open/floor/plasteel/tech,
 /area/ship/construction)
 "Tz" = (
@@ -3046,7 +3046,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
@@ -3132,7 +3132,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/central)
 "Vp" = (
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -3222,7 +3222,7 @@
 /area/ship/bridge)
 "WO" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/structure/shuttle/engine/platform{
+/obj/structure/shuttle/platform{
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech,

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -55,7 +55,6 @@
 			if(I.use_tool(src, user, ENGINE_WELDTIME, volume=50))
 				state = ENGINE_WELDED
 				to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
-				alter_engine_power(engine_power, src)
 
 		if(ENGINE_WELDED)
 			if(!I.tool_start_check(user, amount=0))
@@ -68,22 +67,7 @@
 			if(I.use_tool(src, user, ENGINE_WELDTIME, volume=50))
 				state = ENGINE_WRENCHED
 				to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
-				alter_engine_power(-engine_power, src)
 	return TRUE
-
-/obj/structure/shuttle/engine/Destroy()
-	if(state == ENGINE_WELDED)
-		alter_engine_power(-engine_power, src)
-	. = ..()
-
-//Propagates the change to the shuttle.
-/obj/structure/shuttle/engine/proc/alter_engine_power(mod)
-	if(mod == 0)
-		return
-	if(SSshuttle.is_in_shuttle_bounds(src))
-		var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
-		if(M)
-			M.alter_engines(mod, src)
 
 /obj/structure/shuttle/engine/heater
 	name = "engine heater"
@@ -91,14 +75,13 @@
 	desc = "Directs energy into compressed particles in order to power engines."
 	engine_power = 0 // todo make these into 2x1 parts
 
-/obj/structure/shuttle/engine/platform
+/obj/structure/shuttle/platform
 	name = "engine platform"
 	icon_state = "platform"
 	desc = "A platform for engine components."
-	engine_power = 0
 	pass_flags_self = PASSPLATFORM
 
-/obj/structure/shuttle/engine/platform/corner
+/obj/structure/shuttle/platform/corner
 	icon_state = "platform_corner"
 
 /obj/structure/shuttle/engine/propulsion

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -15,7 +15,6 @@
 	desc = "A bluespace engine used to make shuttles move."
 	density = TRUE
 	anchored = TRUE
-	var/engine_power = 1
 	var/state = ENGINE_WELDED //welding shmelding
 
 //Ugh this is a lot of copypasta from emitters, welding need some boilerplate reduction
@@ -73,7 +72,6 @@
 	name = "engine heater"
 	icon_state = "heater"
 	desc = "Directs energy into compressed particles in order to power engines."
-	engine_power = 0 // todo make these into 2x1 parts
 
 /obj/structure/shuttle/platform
 	name = "engine platform"

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
@@ -63,7 +63,11 @@
 	update_icon_state()
 	var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
 	if(M)
-		M.engine_list += src
+		M.engine_list |= src
+
+/obj/machinery/power/shuttle/engine/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	. = ..()
+	port.engine_list |= src
 
 /obj/machinery/power/shuttle/engine/Destroy()
 	. = ..()

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
@@ -61,11 +61,15 @@
 /obj/machinery/power/shuttle/engine/Initialize()
 	. = ..()
 	update_icon_state()
-	alter_engine_power(0.5)
+	var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
+	if(M)
+		M.engine_list += src
 
 /obj/machinery/power/shuttle/engine/Destroy()
 	. = ..()
-	alter_engine_power(-0.5)
+	var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
+	if(M)
+		M.engine_list -= src
 
 /obj/machinery/power/shuttle/engine/on_construction()
 	. = ..()
@@ -76,12 +80,3 @@
 	if(do_after(user, MIN_TOOL_SOUND_DELAY, target=src))
 		enabled = !enabled
 		to_chat(user, "<span class='notice'>You [enabled ? "enable" : "disable"] [src].")
-
-///Propagates the change to the shuttle.
-/obj/machinery/power/shuttle/engine/proc/alter_engine_power(mod)
-	if(mod == 0)
-		return
-	if(SSshuttle.is_in_shuttle_bounds(src))
-		var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
-		if(M)
-			M.alter_engines(mod, src)

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
@@ -70,10 +70,10 @@
 	port.engine_list |= src
 
 /obj/machinery/power/shuttle/engine/Destroy()
-	. = ..()
 	var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
 	if(M)
 		M.engine_list -= src
+	return ..()
 
 /obj/machinery/power/shuttle/engine/on_construction()
 	. = ..()

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine.dm
@@ -61,9 +61,6 @@
 /obj/machinery/power/shuttle/engine/Initialize()
 	. = ..()
 	update_icon_state()
-	var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(src)
-	if(M)
-		M.engine_list |= src
 
 /obj/machinery/power/shuttle/engine/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	. = ..()

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -23,21 +23,27 @@
 
 /obj/machinery/power/shuttle/engine/fueled/burn_engine(percentage = 100)
 	..()
-	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater.resolve()
+	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater?.resolve()
+	if(!resolved_heater)
+		return
 	if(heat_creation)
 		heat_engine()
 	var/to_use = fuel_use * (percentage / 100)
-	return resolved_heater?.consume_fuel(to_use, fuel_type) / to_use * thrust //This proc returns how much was actually burned, so let's use that and multiply it by the thrust to get all the thrust we CAN give.
+	return resolved_heater.consume_fuel(to_use, fuel_type) / to_use * thrust //This proc returns how much was actually burned, so let's use that and multiply it by the thrust to get all the thrust we CAN give.
 
 /obj/machinery/power/shuttle/engine/fueled/return_fuel()
 	. = ..()
-	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater.resolve()
-	return resolved_heater?.return_gas(fuel_type)
+	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater?.resolve()
+	if(!resolved_heater)
+		return
+	return resolved_heater.return_gas(fuel_type)
 
 /obj/machinery/power/shuttle/engine/fueled/return_fuel_cap()
 	. = ..()
-	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater.resolve()
-	return resolved_heater?.return_gas_capacity()
+	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater?.resolve()
+	if(!resolved_heater)
+		return
+	return resolved_heater.return_gas_capacity()
 
 /obj/machinery/power/shuttle/engine/fueled/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title or changelog, seems to work in testing

## Why It's Good For The Game
Harddels are one of the worst things bogging us down right now

## Changelog
:cl:
fix: Shuttle engines no longer are forced to harddel.
tweak: Makes "fake" shuttle engines even less functional than they already were. Consider removing completely in the future?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
