### PR TITLE
Toner cartridges now give iodine

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -506,6 +506,7 @@
 	name = "toner cartridge"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "tonercartridge"
+	grind_results = list(/datum/reagent/iodine = 40)
 	var/charges = 5
 	var/max_charges = 5
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Toner cartridges now give 40u iodine.

## Why It's Good For The Game

tell me why grinding fucking 2000 million photo-fucking-graphs for 2 units of fucking iodine is a good idea

## Changelog
:cl:
add: grinding toner carts give 40u iodine now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
