### PR TITLE
Icemoon Icevault Patch

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_corporate_rejects.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_corporate_rejects.dmm
@@ -377,6 +377,11 @@
 	name = "Jack";
 	real_name = "Glorious Jonathon"
 	},
+/mob/living/simple_animal/hostile/cult_demon/greater{
+	faction = list("DeserterNT");
+	name = "Jack";
+	real_name = "Glorious Jonathon"
+	},
 /turf/open/floor/vault,
 /area/ruin/unpowered/corprejectvault)
 "jF" = (
@@ -1636,6 +1641,7 @@
 /obj/item/poster/random_official,
 /obj/item/poster/random_official,
 /obj/structure/table/glass,
+/obj/item/slimepotion/slime/sentience,
 /turf/open/floor/vault,
 /area/ruin/unpowered/corprejectvault)
 "KF" = (
@@ -1645,10 +1651,10 @@
 /turf/open/floor/vault,
 /area/ruin/unpowered/corprejectvault)
 "Lo" = (
-/mob/living/simple_animal/slaughter/laughter{
+/mob/living/simple_animal/hostile/cult_demon{
 	faction = list("DeserterNT");
 	name = "Jill";
-	real_name = "Funny Janie"
+	real_name = "Jolly Janie"
 	},
 /turf/open/floor/vault,
 /area/ruin/unpowered/corprejectvault)
@@ -1708,7 +1714,6 @@
 /obj/item/stack/sheet/mineral/gold/twenty,
 /obj/item/stack/sheet/mineral/runite/ten,
 /obj/item/toy/figure/captain,
-/obj/item/slimepotion/slime/sentience,
 /obj/item/organ/cyberimp/brain/anti_stun,
 /obj/item/disk/design_disk/adv/knight_gear,
 /turf/open/floor/vault,
@@ -1725,10 +1730,6 @@
 "Mc" = (
 /obj/structure/table/glass,
 /obj/item/gun_voucher,
-/obj/item/clothing/suit/armor/riot/knight/blue{
-	desc = "Only the finest smiths can work runite. Requiring 40 Defence to wield, it provides the best protection for f2p.";
-	name = "Runite Armor"
-	},
 /turf/open/floor/vault,
 /area/ruin/unpowered/corprejectvault)
 "Mh" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a small patch to fix a couple of unforeseen issues with the Icevault ruin.
- Moves the sentience potion to the table. (didn't spawn in the safe)
- Replaced Slaughter and Laughter demon with a hostilemob Slaugther and lesser demon. (old ones didn't have an AI)
- Removed the fake runite armor. (you can make real runite armor with the smithing disk)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I got to see the Icemoon NT vault tested on a live testmerge and found that these small kinks need to be ironed out. Just a maintenance fix for minor issues.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Phoaly
tweak: Tweaked the NT Deserter Vault Ruin on the Icemoon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
