### PR TITLE
Fixes reflector rotation by shuttles

### DIFF
--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -82,7 +82,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 /obj/structure/reflector/shuttleRotate(rotation, params)
 	. = ..()
-	setAngle(rotation_angle += rotation)
+	setAngle(SIMPLIFY_DEGREES(rotation_angle += rotation))
 
 /************************************Machine rotate procs************************************/
 

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -80,6 +80,10 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	params &= ~ROTATE_OFFSET
 	return ..()
 
+/obj/structure/reflector/shuttleRotate(rotation, params)
+	. = ..()
+	setAngle(rotation_angle += rotation)
+
 /************************************Machine rotate procs************************************/
 
 /obj/machinery/atmospherics/shuttleRotate(rotation, params)

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -82,7 +82,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 /obj/structure/reflector/shuttleRotate(rotation, params)
 	. = ..()
-	setAngle(SIMPLIFY_DEGREES(rotation_angle += rotation))
+	setAngle(SIMPLIFY_DEGREES(rotation_angle + rotation))
 
 /************************************Machine rotate procs************************************/
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR fixes reflectors not rotating when a shuttle takes off/lands. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having to re-rotate the reflectors in an SM setup every time the ship decides to move is annoying.

closes #710 

## Changelog
:cl:
fix: Reflectors on shuttles rotate properly now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
