### PR TITLE
Makes the ak47 and NT-AK not fit on the belt slot

### DIFF
--- a/whitesands/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/whitesands/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -106,7 +106,7 @@
 	mag_display = TRUE
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = null
+	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/ak47
 
 /obj/item/gun/ballistic/automatic/ak47/nt

--- a/whitesands/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/whitesands/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -106,6 +106,7 @@
 	mag_display = TRUE
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = null
 	mag_type = /obj/item/ammo_box/magazine/ak47
 
 /obj/item/gun/ballistic/automatic/ak47/nt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the ak47 and subtypes fit on the back instead of the belt slot

## Why It's Good For The Game

I fucking missed this and never fixed it until now 

## Changelog
:cl:
fix: ak47 no longer fits in the belt slot, but fits on backs like they are supposed to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
