### PR TITLE
Moves IPC languages to a holder, removes a hard-coded span

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -325,6 +325,12 @@ Key procs
 							/datum/language/dwarf = list(LANGUAGE_ATOM),
 							/datum/language/teceti_unified = list(LANGUAGE_ATOM))
 
+/datum/language_holder/ipc
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/machine = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/machine = list(LANGUAGE_ATOM))
+
 /datum/language_holder/moth
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/moffic = list(LANGUAGE_ATOM),

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -33,6 +33,7 @@
 	allow_numbers_in_name = TRUE
 	deathsound = "sound/voice/borg_deathsound.ogg"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+	species_language_holder = /datum/language_holder/ipc
 	loreblurb = "Integrated Positronic Chassis or \"IPC\" for short, are synthetic lifeforms composed of an Artificial \
 	Intelligence program encased in a bipedal robotic shell. They are fragile, allergic to EMPs, and the butt of endless toaster jokes. \
 	Just as easy to repair as they are to destroy, they might just get their last laugh in as you're choking on neurotoxins. Beep Boop."
@@ -63,12 +64,6 @@
 	. = ..()
 	if(change_screen)
 		change_screen.Remove(C)
-
-/datum/species/ipc/get_spans()
-	return SPAN_ROBOT
-
-/datum/species/ipc/after_equip_job(datum/job/J, mob/living/carbon/human/H)
-	H.grant_language(/datum/language/machine)
 
 /datum/species/ipc/spec_death(gibbed, mob/living/carbon/C)
 	saved_screen = C.dna.features["ipc_screen"]


### PR DESCRIPTION
## About The Pull Request

Previously, IPCs were given their EAL from a weird method, this has been moved into a language holder like all other species for consistency and because it was causing a bug where IPCs would lose their EAL seemingly at random (Stabilized green slime being an example).
The hard-coded span was removed in favor of allowing the span to come from the tongue, in this case the robotic voicebox, which IPCs get by default.

## Why It's Good For The Game

Helps fix some annoying edge-cases with losing EAL, as well with helping consistency with languages and speech.

## Changelog
:cl:
fix: IPCs should no longer lose their ability to speak EAL at random.
code: Added a language holder for IPCs, removed forced span in favor of robotic voicebox.
/:cl: