### PR TITLE
Replace incorrect calls to Destroy with qdel(src)

### DIFF
--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -28,7 +28,7 @@
 	if(..())
 		return
 	if(linked_radio)
-		linked_radio.Destroy()
+		qdel(linked_radio)
 
 /datum/mutation/human/antenna/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()

--- a/code/game/objects/items/shuttle_creator.dm
+++ b/code/game/objects/items/shuttle_creator.dm
@@ -154,8 +154,8 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	var/invertedDir = REVERSE_DIR(portDirection)
 	if(!portDirection || !invertedDir)
 		to_chat(usr, "<span class='warning'>Shuttle creation aborted, docking airlock must be on an external wall. Please select a new airlock.</span>")
-		port.Destroy()
-		stationary_port.Destroy()
+		qdel(port, TRUE)
+		qdel(stationary_port, TRUE)
 		target_ship = null
 		return FALSE
 	port.dir = invertedDir
@@ -163,8 +163,8 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 
 	if(!calculate_bounds(port))
 		to_chat(usr, "<span class='warning'>Bluespace calculations failed, please select a new airlock.</span>")
-		port.Destroy()
-		stationary_port.Destroy()
+		qdel(port, TRUE)
+		qdel(stationary_port, TRUE)
 		target_ship = null
 		return FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -154,7 +154,7 @@
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message("<span class='notice'>[src] grows up into [L].</span>")
-	Destroy()
+	qdel(src)
 
 //Gutlunch udder
 /obj/item/udder/gutlunch


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces incorrect calls to `src.Destroy()` with `qdel(src)`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Never call Destroy() directly outside of certain things like the internals of SSgarbage or `client/Del()`.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->