### PR TITLE
Fix three hanging references to mobs

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -103,6 +103,12 @@
 	QDEL_NULL(language_holder)
 	return ..()
 
+/datum/mind/proc/handle_mob_deletion(mob/living/deleted_mob)
+	if (current == deleted_mob)
+		current = null
+	if (original_character == deleted_mob)
+		original_character = null
+
 /datum/mind/proc/get_language_holder()
 	if(!language_holder)
 		language_holder = new (src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -175,6 +175,9 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 	QDEL_NULL(orbit_menu)
 	QDEL_NULL(spawners_menu)
+
+	remove_data_huds()
+
 	return ..()
 
 /*

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -184,6 +184,9 @@
 	if(path_hud)
 		QDEL_NULL(path_hud)
 		path_hud = null
+	if(data_hud_type)
+		var/datum/atom_hud/datahud = GLOB.huds[data_hud_type]
+		datahud.remove_hud_from(src)
 	GLOB.bots_list -= src
 	if(paicard)
 		ejectpai()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -37,6 +37,8 @@
 	qdel(hud_used)
 	QDEL_LIST(client_colours)
 	ghostize()
+	if(mind)
+		mind.handle_mob_deletion(src)
 	return ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes three (technically two or actually five depending on how you look at it) references left to mobs after they're qdeleted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This SHOULD fix the harddels for observers and bots, and *maybe* humans, but I'm not so sure about the last one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->