### PR TITLE
Uh Oh Yuh Oh Hightide-Class Had The Wrong Boards

### DIFF
--- a/_maps/shuttles/shiptest/hightide.dmm
+++ b/_maps/shuttles/shiptest/hightide.dmm
@@ -668,9 +668,9 @@
 	},
 /obj/item/circuitboard/machine/rdserver,
 /obj/effect/spawner/lootdrop/maintenance/five,
-/obj/item/circuitboard/computer/research,
 /obj/item/circuitboard/machine/circuit_imprinter,
 /obj/item/circuitboard/machine/destructive_analyzer,
+/obj/item/circuitboard/computer/rdconsole,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "xt" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I fucked up and put the wrong computer board in the hightide rnd locker, this fixes that, speedmerge
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mapper Moment
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: hightide-class rnd console board is back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
