### PR TITLE
Removes borer spawn on metis

### DIFF
--- a/_maps/shuttles/shiptest/metis.dmm
+++ b/_maps/shuttles/shiptest/metis.dmm
@@ -3877,12 +3877,6 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/mob/living/simple_animal/borer{
-	borer_alert = "Become a neutered cortical borer? (Warning, You can no longer be cloned!)";
-	is_team_borer = 0;
-	name = "neutered cortical borer";
-	pixel_x = -1
-	},
 /obj/item/radio{
 	broadcasting = 1;
 	pixel_x = 11;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The borer spawn on the Metis was intended to be a non-antag, non-reproducing borer. Borers do not lose the ability to reproduce when the is_team_borer variable is false, and so are able to create new borers, which have the var set to TRUE by default. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roundstart antags on shiptests bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Just like in the novel '1984' by george orwell, roundstart borers are no more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
