### PR TITLE
Makes jungle planets less painful

### DIFF
--- a/code/datums/mapgen/biomes/_biome.dm
+++ b/code/datums/mapgen/biomes/_biome.dm
@@ -36,11 +36,25 @@
 
 /datum/biome/jungle
 	turf_type = /turf/open/floor/plating/grass/jungle
-	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/rock/jungle, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b, /obj/structure/flora/junglebush/c, /obj/structure/flora/junglebush/large, /obj/structure/flora/rock/pile/largejungle)
-	flora_density = 40
+	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/rock/jungle, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b, /obj/structure/flora/junglebush/c, /obj/structure/flora/junglebush/large, /obj/structure/flora/rock/pile/largejungle, /obj/structure/spacevine)
+	flora_density = 50
 
 /datum/biome/jungle/deep
-	flora_density = 65
+	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/rock/jungle, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b,
+	/obj/structure/flora/junglebush/c,
+	/obj/structure/flora/junglebush/large,
+	/obj/structure/flora/rock/pile/largejungle,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine/dense,
+	/obj/structure/spacevine
+	)
+	flora_density = 90
 
 /datum/biome/wasteland
 	turf_type = /turf/open/floor/plating/dirt/jungle/wasteland

--- a/code/game/turfs/open/floor/plating/planet.dm
+++ b/code/game/turfs/open/floor/plating/planet.dm
@@ -12,6 +12,9 @@
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
+	light_range = 2
+	light_power = 0.6
+	light_color = COLOR_VERY_LIGHT_GRAY
 
 /turf/open/floor/plating/dirt/dark
 	icon_state = "greenerdirt"
@@ -21,7 +24,11 @@
 
 /turf/open/floor/plating/dirt/jungle
 	slowdown = 0.5
+	baseturfs = /turf/open/floor/plating/dirt/jungle
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	light_range = 2
+	light_power = 0.6
+	light_color = COLOR_VERY_LIGHT_GRAY
 
 /turf/open/floor/plating/dirt/jungle/dark
 	icon_state = "greenerdirt"
@@ -46,6 +53,10 @@
 	desc = "Greener on the other side."
 	icon_state = "junglegrass"
 	base_icon_state = "junglegrass"
+	baseturfs = /turf/open/floor/plating/dirt/jungle
+	light_range = 2
+	light_power = 0.6
+	light_color = COLOR_VERY_LIGHT_GRAY
 	smooth_icon = 'icons/turf/floors/junglegrass.dmi'
 
 /turf/closed/mineral/random/jungle

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -18,3 +18,6 @@
 
 /turf/open/water/jungle
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	light_range = 2
+	light_power = 0.6
+	light_color = COLOR_VERY_LIGHT_GRAY

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -543,3 +543,8 @@
 		if(("vines" in M.faction) || ("plants" in M.faction))
 			return TRUE
 	return FALSE
+
+/obj/structure/spacevine/dense
+	name = "dense space vines"
+	opacity = TRUE
+	icon_state = "Hvy1"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes jungle's cbt
baseturfs dont lead to space
it has light
in return, it spawns vines
still no fauna

## Why It's Good For The Game

jungle was so jank it wasnt even funny

## Changelog
:cl:
add: jungleplanets now can have a bunch of vines
add: jungle planets now emit light
fix: jungle turfs no longer lead to space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
