### PR TITLE
Hotfix for new_player failing to GC on observe.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -101,6 +101,12 @@
 	if(islist(antag_datums))
 		QDEL_LIST(antag_datums)
 	QDEL_NULL(language_holder)
+	enslaved_to = null
+	soulOwner = null
+	martial_art = null
+	current = null
+	original_character = null
+	leave_all_antag_huds()
 	return ..()
 
 /datum/mind/proc/handle_mob_deletion(mob/deleted_mob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clears some references that aren't properly cleared on mind qdel. This is why `/mob/dead/new_player`s would fail to GC when you observe from the lobby.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fewer harddels, better game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->