### PR TITLE
Adds Jukebox Song Location to Jukebox Readme

### DIFF
--- a/config/jukebox_music/README.txt
+++ b/config/jukebox_music/README.txt
@@ -13,3 +13,5 @@ Every sound you add must have a unique name. Avoid using the plus sign "+" and t
 Sound names must be in the format of [song name]+[length in deciseconds]+[beat in deciseconds]+[song ID number].ogg
 
 A three minute song title "SS13" that lasted 3 minutes would have a file name SS13+1800+5+1.ogg
+
+Songs must be inside config/jukebox_music/sounds to be loaded


### PR DESCRIPTION
## About The Pull Request

The config/jukebox_music directory has an example song file, but this doesn't load because it's in the wrong directory.  The jukebox music files need to be in config/jukebox_music/sounds.

I am unable to move the example song to that location, because that folder is ignored by git if created.  My workaround is to simply add a line stating the required location to the jukebox's readme file.

## Why It's Good For The Game

Makes jukebox song setup less confusing.

## Changelog
:cl:
server: made the jukebox readme more clear
/:cl:
