### PR TITLE
Removes Quantum Pads from technodes, and two ruins.

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_clock.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_clock.dmm
@@ -37,10 +37,6 @@
 	},
 /turf/open/floor/bronze,
 /area/overmap_encounter/planetoid/rockplanet/explored)
-"hb" = (
-/obj/machinery/quantumpad,
-/turf/open/floor/bronze,
-/area/overmap_encounter/planetoid/rockplanet/explored)
 "hm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -125,11 +121,6 @@
 /obj/structure/trap/stun,
 /turf/open/floor/bronze,
 /area/overmap_encounter/planetoid/rockplanet/explored)
-"tg" = (
-/obj/structure/fluff/clockwork/alloy_shards,
-/obj/machinery/quantumpad,
-/turf/open/floor/bronze,
-/area/overmap_encounter/planetoid/rockplanet/explored)
 "tI" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -140,7 +131,6 @@
 /turf/open/floor/bronze,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "ur" = (
-/obj/machinery/quantumpad,
 /obj/structure/trap/damage,
 /turf/open/floor/bronze,
 /area/overmap_encounter/planetoid/rockplanet/explored)
@@ -533,7 +523,7 @@ Nr
 "}
 (11,1,1) = {"
 Qs
-tg
+lm
 Id
 Ji
 NP
@@ -567,7 +557,7 @@ OB
 "}
 (13,1,1) = {"
 Qs
-hb
+NP
 NP
 jK
 WK

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
@@ -467,7 +467,6 @@
 /area/whitesands/surface/outdoors)
 "lM" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
-/obj/machinery/quantumpad,
 /turf/open/floor/engine,
 /area/whitesands/surface/outdoors)
 "lO" = (

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -213,7 +213,7 @@
 	display_name = "Bluespace Travel"
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
-	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
+	design_ids = list("tele_station", "tele_hub", "teleconsole", "launchpad", "launchpad_console", "bluespace_pod")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request
Removes quantum pads from the research node which contains them, effectively making them unobtainable outside of adminspawn. Also removes them from two ruins, even moreso making them adminspawn only. Why a rockplanet ruin had three quantumpads lined up next to eachother is byond me, but I shot them now.

## Why It's Good For The Game
Quantum Pads currently completely invalidate the idea of ships being far away from eachother, as they can simply slap these little buggers up, and teleport to their buddies ship, even if they are as far away as possible. While this would in theory just result in very easy trading, it just results in figuratively bolting two ships together and zero trading.

## Changelog
:cl:
del: Removed Quantum Pads from research nodes. They are now admin only.
del: Removed Quantum Pads from two ruins, there is no longer three free quantum pads in a certain rockplanet ruin.
/:cl: