### PR TITLE
Bubble tweaks

### DIFF
--- a/_maps/configs/bubble_b.json
+++ b/_maps/configs/bubble_b.json
@@ -1,0 +1,19 @@
+{
+	"map_name": "Bubble-class Type B Colonial Ship",
+	"map_short_name": "Bubble-class (B)",
+	"map_path": "_maps/shuttles/shiptest/sgv_bubble_b.dmm",
+	"map_id": "sgv_bubble_b",
+	"prefix": "SGV",
+	"job_slots": {
+		"Captain": {
+			"outfit": "/datum/outfit/job/captain/solgov",
+			"officer": true,
+			"slots": 1
+		},
+		"Scientist": 1,
+		"Station Engineer": 1,
+		"Shaft Miner": 1,
+		"Assistant": 3
+	},
+	"cost": 500
+}

--- a/_maps/shuttles/shiptest/ntsv_bubble.dmm
+++ b/_maps/shuttles/shiptest/ntsv_bubble.dmm
@@ -84,14 +84,14 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "gg" = (
-/obj/machinery/computer/autopilot{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/corner/blue/three_quarters{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/frame/computer{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "gl" = (

--- a/_maps/shuttles/shiptest/sgv_bubble_b.dmm
+++ b/_maps/shuttles/shiptest/sgv_bubble_b.dmm
@@ -80,11 +80,11 @@
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "gg" = (
-/obj/machinery/computer/autopilot{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/frame/computer{
+	dir = 8
+	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "gl" = (
@@ -109,7 +109,8 @@
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "hh" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "hs" = (
@@ -351,6 +352,9 @@
 /obj/machinery/holopad/emergency/command,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
+"vx" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo)
 "vz" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -460,6 +464,9 @@
 	},
 /turf/open/floor/plating,
 /area/ship/external)
+"yb" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/maintenance/aft)
 "zy" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/starboard)
@@ -871,6 +878,9 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
+"Tt" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
 "TP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -902,7 +912,7 @@
 /area/ship/engineering)
 "Vt" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
 "Vy" = (
 /obj/item/kirbyplants/random,
@@ -1149,7 +1159,7 @@ VB
 VB
 VB
 Ob
-Ob
+yb
 mJ
 xu
 ef
@@ -1157,7 +1167,7 @@ mZ
 jI
 MW
 VA
-Ob
+yb
 Ob
 VB
 VB
@@ -1261,11 +1271,11 @@ VB
 (10,1,1) = {"
 VB
 gl
+Tt
 VQ
 VQ
 VQ
-VQ
-VQ
+Tt
 ZD
 HK
 ST
@@ -1337,11 +1347,11 @@ MJ
 (14,1,1) = {"
 VB
 VB
-mV
+vx
 mV
 mV
 oI
-mV
+vx
 CP
 rS
 CP

--- a/_maps/shuttles/shiptest/sgv_bubble_b.dmm
+++ b/_maps/shuttles/shiptest/sgv_bubble_b.dmm
@@ -37,18 +37,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/yellow{
-	dir = 4
-	},
 /obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "cV" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "ec" = (
 /obj/structure/fans/tiny,
@@ -80,19 +77,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/corner/purple/border,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "gg" = (
 /obj/machinery/computer/autopilot{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/corner/blue/three_quarters{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "gl" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -101,9 +94,6 @@
 /turf/open/floor/plating,
 /area/ship/external)
 "gz" = (
-/obj/effect/turf_decal/corner/brown{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -116,7 +106,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "hh" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -139,16 +129,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/blue/three_quarters,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "jl" = (
-/obj/effect/turf_decal/corner/yellow/border,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "jr" = (
 /obj/item/bedsheet/dorms,
@@ -161,10 +149,7 @@
 /area/ship/crew/dorm)
 "ju" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/corner/brown/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "jI" = (
 /obj/structure/cable{
@@ -192,31 +177,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/corner/blue/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "kn" = (
 /obj/machinery/ore_silo,
 /obj/item/multitool,
-/obj/effect/turf_decal/corner/brown/half{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "kt" = (
 /obj/machinery/vending/clothing,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "kW" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/autolathe,
-/obj/effect/turf_decal/corner/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "ln" = (
 /obj/machinery/power/terminal{
@@ -231,7 +207,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "mJ" = (
 /obj/machinery/power/terminal{
@@ -243,13 +219,13 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "mV" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -270,22 +246,22 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "ny" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/frame/machine,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "nH" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/science)
 "nS" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "op" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/port)
 "os" = (
 /obj/machinery/door/airlock{
@@ -296,8 +272,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/corner/green/mono,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm)
 "oI" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -326,20 +301,14 @@
 /obj/item/stack/sheet/metal/five,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/stack/sheet/glass,
-/obj/effect/turf_decal/corner/purple{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "rK" = (
 /obj/structure/sign/poster/official/build{
 	pixel_y = 32
 	},
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/corner/green/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "rS" = (
 /obj/machinery/door/airlock/command/glass,
@@ -349,8 +318,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "sO" = (
 /obj/machinery/door/airlock/mining/glass,
@@ -361,8 +329,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/brown/mono,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "sV" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -372,7 +339,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/aft)
 "uE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -382,7 +349,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad/emergency/command,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "vz" = (
 /obj/machinery/power/smes/engineering,
@@ -393,7 +360,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "vB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -402,7 +369,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "vI" = (
 /obj/structure/cable{
@@ -410,17 +377,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "vR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/science)
 "vY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "wy" = (
 /obj/structure/cable{
@@ -430,11 +397,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/suit_storage_unit/independent/mining,
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/solgov,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "wH" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -458,17 +422,14 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "wU" = (
-/obj/effect/turf_decal/corner/brown/half{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "bubbledoors";
 	name = "Blast Door Control";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/suit_storage_unit/independent/mining,
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/solgov,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "xm" = (
 /obj/structure/chair/comfy/shuttle{
@@ -485,7 +446,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/captain,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "xu" = (
 /obj/structure/cable{
@@ -500,15 +461,12 @@
 /turf/open/floor/plating,
 /area/ship/external)
 "zy" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/starboard)
 "Am" = (
 /obj/structure/frame/machine,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/corner/purple{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "AC" = (
 /obj/structure/cable{
@@ -521,7 +479,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "AR" = (
 /obj/machinery/door/airlock/external,
@@ -537,17 +495,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "CP" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "Dj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "DL" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -562,10 +520,7 @@
 /obj/structure/sign/departments/cargo{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/corner/brown/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "FF" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -610,7 +565,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "GD" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -633,7 +588,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "HS" = (
 /obj/structure/cable{
@@ -641,10 +596,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/effect/turf_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "If" = (
 /obj/structure/cable{
@@ -690,7 +642,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "IL" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -706,7 +658,7 @@
 /area/ship/engineering)
 "Je" = (
 /obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "Js" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -728,10 +680,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/corner/brown{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "JG" = (
 /obj/structure/fans/tiny,
@@ -753,7 +702,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "Kh" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -770,7 +719,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "Ls" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -794,7 +743,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "MJ" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "ML" = (
 /obj/machinery/cryopod{
@@ -803,7 +752,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "MW" = (
 /obj/effect/landmark/start/assistant,
@@ -819,20 +768,17 @@
 /turf/open/floor/plating,
 /area/ship/external)
 "Ob" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/aft)
 "OD" = (
 /obj/structure/frame/machine,
-/obj/effect/turf_decal/corner/purple/three_quarters{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "OY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "Pa" = (
 /obj/machinery/door/airlock/research/glass,
@@ -841,8 +787,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/corner/purple/mono,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/science)
 "PM" = (
 /obj/structure/cable{
@@ -853,26 +798,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/corner/green/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "QH" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/corner/yellow/border,
-/obj/effect/turf_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "Rk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "Rz" = (
 /obj/structure/cable{
@@ -885,7 +823,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "RO" = (
 /obj/structure/cable{
@@ -896,13 +834,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "Sx" = (
 /obj/structure/closet/crate,
@@ -913,7 +845,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "SC" = (
 /obj/structure/frame/computer{
@@ -926,34 +858,24 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/corner/purple{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "ST" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/corner/purple/border,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "Tr" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/corner/green/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "TP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/orange,
 /area/ship/engineering)
 "Ul" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -976,12 +898,11 @@
 /area/ship/engineering)
 "Ve" = (
 /obj/machinery/door/airlock/engineering/glass,
-/obj/effect/turf_decal/corner/yellow/mono,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Vt" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "Vy" = (
 /obj/item/kirbyplants/random,
@@ -995,7 +916,7 @@
 /obj/item/radio/intercom/wideband{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "VA" = (
 /obj/machinery/power/terminal{
@@ -1010,14 +931,11 @@
 /turf/template_noop,
 /area/space)
 "VI" = (
-/obj/effect/turf_decal/corner/brown{
-	dir = 1
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/red,
 /area/ship/cargo)
 "VO" = (
 /obj/structure/table/wood,
@@ -1033,15 +951,12 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "VQ" = (
-/turf/closed/wall,
+/turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm)
 "WB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
-/obj/effect/turf_decal/corner/purple{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "WN" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -1061,7 +976,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)
 "XG" = (
 /obj/structure/cable{
@@ -1108,15 +1023,13 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/corner/purple/border,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "YA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/purple/border,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "ZB" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -1133,10 +1046,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/green/border{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 "ZM" = (
 /obj/structure/cable{
@@ -1147,7 +1057,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "ZQ" = (
 /obj/machinery/door/airlock/external,
@@ -1163,7 +1073,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/nanoweave/purple,
 /area/ship/science)
 "ZZ" = (
 /obj/structure/cable{
@@ -1174,7 +1084,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/carpet/nanoweave/beige,
 /area/ship/hallway/central)
 
 (1,1,1) = {"


### PR DESCRIPTION
## About The Pull Request

Tweaks the bubble class (originally by @unit0016) a bit.

![Screenshot_2532](https://user-images.githubusercontent.com/58402542/155510080-2277edd6-0e21-44bf-b1d1-fb5c6befa156.png)

- Brings it a bit up with baytile standards
- Makes the suit storage units indie
- Adds some carpet
- Replaces the RCD in the crate with a ARCD and combat RCD
- Adds 50 plasteel to the crate
![Screenshot_2533](https://user-images.githubusercontent.com/58402542/155510512-340a24e4-abbb-4d57-8610-f75735d6d42b.png)

In addition, this adds the Bubble B which is... exactly the same thing, but with a solgov coat of paint. So exactly what B type ships should be.
Design heavily inspired by @fighterslam 's design
![Screenshot_2534](https://user-images.githubusercontent.com/58402542/155510300-080067f6-5a02-4883-bfd8-a72f5b618660.png)


## Why It's Good For The Game
Hopefully this makes people actually want to colonize with the bubbles

## Changelog
:cl:
add: Bubble B
balance: Several tweaks to the bubble class, including 2 special RCDs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
