### PR TITLE
Kicking around the runtime viewer, again

### DIFF
--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -51,7 +51,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 
 	. = ""
 
-	if (istype(back_to))
+	if(istype(back_to))
 		. += back_to.make_link("<b>&lt;&lt;&lt;</b>", null, linear)
 
 	. += "[make_link("Refresh")]<br><br>"
@@ -62,13 +62,13 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 
 /datum/error_viewer/proc/make_link(linktext, datum/error_viewer/back_to, linear)
 	var/back_to_param = ""
-	if (!linktext)
+	if(!linktext)
 		linktext = name
 
-	if (istype(back_to))
+	if(istype(back_to))
 		back_to_param = ";viewruntime_backto=[REF(back_to)]"
 
-	if (linear)
+	if(linear)
 		back_to_param += ";viewruntime_linear=1"
 
 	return "<a href='?_src_=holder;[HrefToken()];viewruntime=[REF(src)][back_to_param]'>[linktext]</a>"
@@ -81,27 +81,28 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 /datum/error_viewer/error_cache/show_to(user, datum/error_viewer/back_to, linear)
 	var/html = build_header()
 	html += "<b>[GLOB.total_runtimes]</b> runtimes, <b>[GLOB.total_runtimes_skipped]</b> skipped<br><br>"
-	if (!linear)
+	if(!linear)
 		html += "organized | [make_link("linear", null, 1)]<hr>"
 		var/datum/error_viewer/error_source/error_source
-		for (var/erroruid in error_sources)
+		for(var/erroruid in error_sources)
 			error_source = error_sources[erroruid]
 			html += "[error_source.make_link("([length(error_source.errors)] errors) [error_source.name]", src)]<br>"
 
 	else
 		html += "[make_link("organized", null)] | linear<hr>"
-		for (var/datum/error_viewer/error_entry/error_entry as anything in errors)
+		for(var/datum/error_viewer/error_entry/error_entry as anything in errors)
 			html += "[error_entry.make_link(null, src, 1)]<br>"
+			CHECK_TICK //you're going to be sitting here aaaaaaaaaaaaaaall day
 
 	browse_to(user, html)
 
 /datum/error_viewer/error_cache/proc/log_error(exception/e, list/desclines, skip_count)
-	if (!istype(e))
+	if(!istype(e))
 		return // Abnormal exception, don't even bother
 
 	var/erroruid = "[e.file][e.line]"
 	var/datum/error_viewer/error_source/error_source = error_sources[erroruid]
-	if (!error_source)
+	if(!error_source)
 		error_source = new(e)
 		error_sources[erroruid] = error_source
 
@@ -109,12 +110,12 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 	error_entry.error_source = error_source
 	errors += error_entry
 	error_source.errors += error_entry
-	if (skip_count)
+	if(skip_count)
 		return // Skip notifying admins about skipped errors.
 
 	// Show the error to admins with debug messages turned on, but only if one
 	//  from the same source hasn't been shown too recently
-	if (error_source.next_message_at <= world.time)
+	if(error_source.next_message_at <= world.time)
 		var/const/viewtext = "\[view]" // Nesting these in other brackets went poorly
 		//log_debug("Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b> [error_entry.make_link(viewtext)]")
 		var/err_msg_delay
@@ -130,34 +131,32 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 	var/next_message_at = 0
 
 /datum/error_viewer/error_source/New(exception/e)
-	if (!istype(e))
+	if(!istype(e))
 		name = "\[[time_stamp()]] Uncaught exceptions"
 		return
 
 	name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b>"
 
 /datum/error_viewer/error_source/show_to(user, datum/error_viewer/back_to, linear)
-	if (!istype(back_to))
+	if(!istype(back_to))
 		back_to = GLOB.error_cache
 
 	var/html = build_header(back_to)
-	for (var/i in 1 to min(length(errors), 1000))
-		var/datum/error_viewer/error_entry/error_entry = errors[i]
+	for(var/datum/error_viewer/error_entry/error_entry as anything in errors)
 		html += "[error_entry.make_link(null, src)]<br>"
-	html += "<i>Limited to the first 1000 errors</i>"
+		CHECK_TICK
 
 	browse_to(user, html)
 
 /datum/error_viewer/error_entry
 	var/datum/error_viewer/error_source/error_source
-	var/exception/exc
 	var/desc = ""
 	var/usr_ref
 	var/turf/usr_loc
 	var/is_skip_count
 
 /datum/error_viewer/error_entry/New(exception/e, list/desclines, skip_count)
-	if (!istype(e))
+	if(!istype(e))
 		name = "<b>\[[time_stamp()]]</b> Uncaught exception: <b>[html_encode(e.name)]</b>"
 		return
 
@@ -167,27 +166,26 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		return
 
 	name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b>"
-	exc = e
-	if (istype(desclines))
-		for (var/line in desclines)
+	if(istype(desclines))
+		for(var/line in desclines)
 			// There's probably a better way to do this than non-breaking spaces...
 			desc += "<span class='runtime_line'>[html_encode(line)]</span><br>"
 
-	if (usr)
+	if(usr)
 		usr_ref = "[REF(usr)]"
 		usr_loc = get_turf(usr)
 
 /datum/error_viewer/error_entry/show_to(user, datum/error_viewer/back_to, linear)
-	if (!istype(back_to))
+	if(!istype(back_to))
 		back_to = error_source
 
 	var/html = build_header(back_to, linear)
 	html += "[name]<div class='runtime'>[desc]</div>"
-	if (usr_ref)
+	if(usr_ref)
 		html += "<br><b>usr</b>: <a href='?_src_=vars;[HrefToken()];Vars=[usr_ref]'>VV</a>"
 		html += " <a href='?_src_=holder;[HrefToken()];adminplayeropts=[usr_ref]'>PP</a>"
 		html += " <a href='?_src_=holder;[HrefToken()];adminplayerobservefollow=[usr_ref]'>Follow</a>"
-		if (istype(usr_loc))
+		if(istype(usr_loc))
 			html += "<br><b>usr.loc</b>: <a href='?_src_=vars;[HrefToken()];Vars=[REF(usr_loc)]'>VV</a>"
 			html += " <a href='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a few `CHECK_TICK`s to the runtime viewer so that it doesn't lock up the entire bloody game. Also removes the 1000 runtime limit since I think that caused us to lose some important ones. *Also* reformats the file a bit since I'm sick of looking at `if (condition)`

## Why It's Good For The Game
Doesn't lag the game for everyone to the point of it hanging, but also allows coders to actually view all runtimes. Hopefully

## Changelog
:cl:
admin: The runtime viewer shouldn't hang the server for like 30 seconds anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
