### PR TITLE
Improves dying breath

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -359,8 +359,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 
 	if (length(last_whisper))
+		living_owner.dying_breath("[last_whisper]")
 		living_owner.say("#[last_whisper]")
-
 	living_owner.succumb(whispered = length(last_whisper) > 0)
 
 //ALIENS

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -414,5 +414,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	. = ..()
 
 /mob/living/proc/dying_breath(message)
-	for(var/mob/M in viewers())
-		M.play_screen_text("<i>[message]")
+	for(var/mob/M in viewers(world.view +1))
+		if(M.can_hear())
+			M.play_screen_text("<i>[message]")

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -414,6 +414,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	. = ..()
 
 /mob/living/proc/dying_breath(message)
-	for(var/mob/M in viewers(world.view +1))
+	for(var/mob/M in viewers(get_turf(src)))
 		if(M.can_hear())
 			M.play_screen_text("<i>[message]")

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 				return
 		if(HARD_CRIT)
 			if(!(message_mods[WHISPER_MODE] || message_mods[MODE_CHANGELING] || message_mods[MODE_ALIEN]))
-				return
+				message_mods[WHISPER_MODE] = MODE_WHISPER_CRIT
 		if(DEAD)
 			say_dead(original_message)
 			return
@@ -152,14 +152,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		log_message(message_mods[MODE_CUSTOM_SAY_EMOTE], LOG_RADIO_EMOTE)
 
 	if(!message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
-		if(message_mods[WHISPER_MODE] == MODE_WHISPER)
+		if(message_mods[WHISPER_MODE])
 			if(saymode || message_mods[RADIO_EXTENSION]) //no radio while in crit
 				saymode = null
 				message_mods -= RADIO_EXTENSION
 			message_range = 1
-			message_mods[WHISPER_MODE] = MODE_WHISPER
 			src.log_talk(message, LOG_WHISPER, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
-			if(stat == HARD_CRIT)
+			if(stat == HARD_CRIT) //This is cheaper than checking for MODE_WHISPER_CRIT message mod
 				var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 				// If we cut our message short, abruptly end it with a-..
 				var/message_len = length_char(message)
@@ -222,6 +221,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(succumbed)
 		succumb(1)
 		to_chat(src, compose_message(src, language, message, , spans, message_mods))
+		dying_breath(message)
 
 	return 1
 
@@ -412,3 +412,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(get_minds && mind)
 		return mind.get_language_holder()
 	. = ..()
+
+/mob/living/proc/dying_breath(message)
+	for(var/mob/M in viewers())
+		M.play_screen_text("<i>[message]")

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -414,6 +414,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	. = ..()
 
 /mob/living/proc/dying_breath(message)
-	for(var/mob/M in viewers(get_turf(src)))
+	for(var/mob/M in get_hearers_in_view(7, src))
 		if(M.can_hear())
 			M.play_screen_text("<i>[message]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You no longer need to manually whisper in Hard Crit to trigger a Dying Breath, you can now just use `say` (Succumb button still works too!).

Dying Breaths are now displayed as italicized screentext for all viewers, dramatic!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Deaths are more impactful and dramatic, woo!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Last Words are now displayed as screen text to nearby players.
tweak: You can now "talk" while in Hard Crit
tweak: Talking in hardcrit instantly kills you, but triggers Last Words.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
