### PR TITLE
Ungibbening Part 1: Guns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -97,7 +97,9 @@
 		if(prob(100 - (magazine.ammo_count() * 5)))	//minimum probability of 70, maximum of 95
 			playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
-			user.gib()
+			user.take_bodypart_damage(0,20)
+			explosion(src, 0, 0, 1, 1)
+			user.dropItemToGround(src)
 			return 0
 	..()
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -304,7 +304,8 @@
 		playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 		to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
 		if(prob(25))
-			user.gib()
+			user.take_bodypart_damage(0,75)
+			explosion(src, 0, 0, 1, 1)
 			user.dropItemToGround(src)
 		else
 			user.take_bodypart_damage(0,50)
@@ -326,7 +327,8 @@
 		playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 		if(prob(50))
 			to_chat(user, "<span class='userdanger'>Fu-</span>")
-			user.gib()
+			user.take_bodypart_damage(100)
+			explosion(src, 0, 0, 1, 1)
 			user.dropItemToGround(src)
 		else
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face! What a surprise.</span>")
@@ -338,7 +340,7 @@
 //god fucking bless brazil
 /obj/item/gun/ballistic/shotgun/doublebarrel/brazil
 	name = "six-barreled \"TRABUCO\" shotgun"
-	desc = "Dear fucking god, what the fuck even is this!? Theres a green flag with a blue circle and a yellow diamond around it. Some text in the circle says: \"ORDEM E PROGRESSO.\""
+	desc = "Dear fucking god, what the fuck even is this!? The recoil caused by the sheer act of firing this thing would probably kill you, if the gun itself doesn't explode in your face first! Theres a green flag with a blue circle and a yellow diamond around it. Some text in the circle says: \"ORDEM E PROGRESSO.\""
 	icon_state = "shotgun_brazil"
 	icon = 'icons/obj/guns/48x32guns.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
@@ -387,8 +389,8 @@
 			Ó Pátria amada, \
 			Idolatrada, \
 			Salve! Salve!</span>")
+			user.take_bodypart_damage(0,50)
 			explosion(src, 0, 2, 4, 6, TRUE, TRUE)
-			user.gib()
 	..()
 /obj/item/gun/ballistic/shotgun/doublebarrel/brazil/death
 	name = "Force of Nature"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What started as a 5 minute fix for the TRABUCO being a deathtrap turned into a sudden but well deserved decision to clean up a lot of the things that gib players. The TRABUCO has its description actually mention the fact that it will fucking explode, and no longer gibs you when it actually does (arguably a worse fate considering you have to deal with the consequences). The compactx3 and its associated mistakes will also no longer have a chance to gib you, causing a small explosion instead. Additionally, the detectives .38 revolver will no longer have a chance to flat out fucking gib you for using the wrong ammo type either, hooray!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. The TRABUCO shouldnt be a noob trap that murders everyone who uses it.
2. Two shotgun shells going off in your hand will not completely obliterate your body, and will now just horribly maim you.
3. Its total bullshit how a wrong bullet type in a gun could completely obliterate your body, so now it will also just maim you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: TRABUCO no longer gibs you and its description actually tells you it explodes.
tweak: Compactx3 shotgun no longer gibs you, just explodes in your hand and hurts a lot.
tweak: Using the wrong bullet type in a .38 will no longer gib you, and will just explode in your hand and hurt a lot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
