### PR TITLE
Makes Expulsion Thrusters Require Fuel, Regarding Issue #867

### DIFF
--- a/whitesands/code/game/machinery/shuttle/shuttle_heater.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_heater.dm
@@ -128,7 +128,7 @@
 		return
 	if(!gas_type)
 		var/datum/gas_mixture/removed = air_contents.remove(amount)
-		return removed.return_volume()
+		return removed.total_moles()
 	else
 		var/starting_amt = air_contents.get_moles(gas_type)
 		air_contents.adjust_moles(gas_type, -amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes return_volume() to total_moles(), making expulsion thrusters no longer work without fuel.
![image](https://user-images.githubusercontent.com/95449138/159137962-c080e21e-7a4f-4768-a008-8edc3f199921.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
troll physics bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: makes expulsion thrusters require fuel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
