### PR TITLE
Makes augment manipulators (de)constructable

### DIFF
--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -3,7 +3,7 @@
 	desc = "A machine for custom fitting augmentations, with in-built spraypainter."
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pdapainter"
-	circuit = /obj/item/circuitboard/machine/mechfab
+	circuit = /obj/item/circuitboard/machine/aug_manipulator
 	density = TRUE
 	obj_integrity = 200
 	max_integrity = 200
@@ -55,7 +55,7 @@
 		update_icon()
 
 /obj/machinery/aug_manipulator/attackby(obj/item/O, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "pdapainter", "pdapainter-broken", O)) //placeholder, get a sprite monkey to make an actual sprite, I can't be asked.
+	if(default_deconstruction_screwdriver(user, "pdapainter-broken", "pdapainter", O)) //placeholder, get a sprite monkey to make an actual sprite, I can't be asked.
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -3,6 +3,7 @@
 	desc = "A machine for custom fitting augmentations, with in-built spraypainter."
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pdapainter"
+	circuit = /obj/item/circuitboard/machine/mechfab
 	density = TRUE
 	obj_integrity = 200
 	max_integrity = 200
@@ -54,9 +55,14 @@
 		update_icon()
 
 /obj/machinery/aug_manipulator/attackby(obj/item/O, mob/user, params)
+	if(default_deconstruction_screwdriver(user, "pdapainter", "pdapainter-broken", O)) //placeholder, get a sprite monkey to make an actual sprite, I can't be asked.
+		return TRUE
+
+	if(default_deconstruction_crowbar(O))
+		return TRUE
+
 	if(default_unfasten_wrench(user, O))
 		power_change()
-		return
 
 	else if(istype(O, /obj/item/bodypart))
 		var/obj/item/bodypart/B = O

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -63,7 +63,7 @@
 
 	if(default_unfasten_wrench(user, O))
 		power_change()
-
+		return TRUE
 	else if(istype(O, /obj/item/bodypart))
 		var/obj/item/bodypart/B = O
 		if(IS_ORGANIC_LIMB(B))

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -884,6 +884,14 @@ WS End */
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stack/sheet/glass = 1)
 
+/obj/item/circuitboard/machine/aug_manipulator
+	name = "Augment Manipulator (Machine Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/aug_manipulator
+	req_components = list(
+		/obj/item/airlock_painter = 1,
+		/obj/item/stack/sheet/glass = 1)
+
 /obj/item/circuitboard/machine/monkey_recycler
 	name = "Monkey Recycler (Machine Board)"
 	icon_state = "science"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -307,6 +307,14 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/cyborgrecharger
+	name = "Machine Design (Augment Manipulator Board)"
+	desc = "The circuit board for an Augment Manipulator."
+	id = "augmanipulator"
+	build_path = /obj/item/circuitboard/machine/aug_manipulator
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/nanite_chamber
 	name = "Machine Design (Nanite Chamber Board)"
 	desc = "The circuit board for a Nanite Chamber."

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -307,7 +307,7 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/cyborgrecharger
+/datum/design/board/augmanipulator
 	name = "Machine Design (Augment Manipulator Board)"
 	desc = "The circuit board for an Augment Manipulator."
 	id = "augmanipulator"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -37,7 +37,7 @@
 	display_name = "Cyborg Construction"
 	description = "Sapient robots with preloaded tool modules and programmable laws."
 	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
-					"cyborgrecharger", "borg_upgrade_restart", "borg_upgrade_rename")
+					"cyborgrecharger", "borg_upgrade_restart", "borg_upgrade_rename", "augmanipulator")
 
 /datum/techweb_node/mech
 	id = "mecha"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

Adds the board to cyborg tech, which is default.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Them being irreplacable is bad.
I don't see how them being a constructable machine is a bad thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: mc_meiler
tweak: Augment manipulators are deconstructable
add: Added augment manipulator circuit boards to default technologies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
