### PR TITLE
Species Tracking Adjustment

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -298,15 +298,14 @@
 
 	SSticker.minds += character.mind
 	character.client.init_verbs() // init verbs for the late join
-	var/mob/living/carbon/human/humanc
-	if(ishuman(character))
-		humanc = character	//Let's retypecast the var to be human,
 
-	if(humanc)	//These procs all expect humans
+	if(ishuman(character))	//These procs all expect humans
+		var/mob/living/carbon/human/humanc = character
 		ship.manifest_inject(humanc, client, job)
 		GLOB.data_core.manifest_inject(humanc, client)
 		AnnounceArrival(humanc, job.title, ship)
 		AddEmploymentContract(humanc)
+		SSblackbox.record_feedback("tally", "species_spawned", 1, humanc.dna.species.name)
 
 		if(GLOB.highlander)
 			to_chat(humanc, "<span class='userdanger'><i>THERE CAN BE ONLY ONE!!!</i></span>")
@@ -317,11 +316,10 @@
 			give_magic(humanc)
 		if(GLOB.curse_of_madness_triggered)
 			give_madness(humanc, GLOB.curse_of_madness_triggered)
+		if(CONFIG_GET(flag/roundstart_traits))
+			SSquirks.AssignQuirks(humanc, humanc.client, TRUE)
 
 	GLOB.joined_player_list += character.ckey
-
-	if(humanc && CONFIG_GET(flag/roundstart_traits))
-		SSquirks.AssignQuirks(humanc, humanc.client, TRUE)
 
 	log_manifest(character.mind.key, character.mind, character, TRUE)
 
@@ -358,7 +356,7 @@
 					count++
 					if(template.limit <= count)
 						alert(src, "The ship limit of [template.limit] has been reached this round.")
-						return
+						return LateChoices() //Send them back to shuttle selection
 		close_spawn_windows()
 		to_chat(usr, "<span class='danger'>Your [template.name] is being prepared. Please be patient!</span>")
 		var/datum/overmap/ship/controlled/target = new(SSovermap.get_unused_overmap_square(), template)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1264,7 +1264,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 /datum/species/proc/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	H.update_mutant_bodyparts()
-	SSblackbox.record_feedback("tally", "species_spawned", 1, name)
 
 /datum/species/proc/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == exotic_blood)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two smallish tweaks. One changes nothing functionally, it's just a re-ordering of an if statement to be more readable and efficient, and the other makes it so the `species_spawned` feedback value only gets incremented when a player late-joins instead of whenever a human is spawned with an outfit (oops).

## Why It's Good For The Game
Better tracking of species stats.

## Changelog
:cl:
tweak: Player species stat tracking now actually reflects <i>player</i> species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
