### PR TITLE
Fix several radio issues

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -60,6 +60,10 @@
 /obj/item/radio/intercom/attack_ai(mob/user)
 	interact(user)
 
+/obj/item/radio/intercom/attack_paw(mob/user)
+	return attack_hand(user)
+
+
 /obj/item/radio/intercom/attack_hand(mob/user)
 	. = ..()
 	if(.)
@@ -67,7 +71,12 @@
 	interact(user)
 
 /obj/item/radio/intercom/ui_state(mob/user)
-	return GLOB.default_state
+	if(issilicon(user)) // for silicons give default_state
+		return GLOB.default_state
+
+	return GLOB.physical_state // for other non-dexterous mobs give physical_state
+
+
 
 /obj/item/radio/intercom/can_receive(freq, map_zones)
 	if(!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -104,14 +104,14 @@
 /obj/item/radio/AltClick(mob/user)
 	if(headset)
 		. = ..()
-	else
+	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		broadcasting = !broadcasting
 		to_chat(user, "<span class='notice'>You toggle broadcasting [broadcasting ? "on" : "off"].</span>")
 
 /obj/item/radio/CtrlShiftClick(mob/user)
 	if(headset)
 		. = ..()
-	else
+	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		listening = !listening
 		to_chat(user, "<span class='notice'>You toggle speaker [listening ? "on" : "off"].</span>")
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes #806 and resolves #891 where crit players/ghosts/non-dexterous mobs could use radios and intercomms via telekinesis. It also makes monkeys able to use the radio devices in a normal manner by `attack_paw` since they can already use many more advanced items

## Why It's Good For The Game

L + monke can use radio normally + get debugged

## Changelog
:cl:
fix: fixed radio telekinesis issues
/:cl:
