### PR TITLE
Add cryo console to Solar-class

### DIFF
--- a/_maps/shuttles/shiptest/solar_class.dmm
+++ b/_maps/shuttles/shiptest/solar_class.dmm
@@ -1516,6 +1516,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "Co" = (


### PR DESCRIPTION
## About The Pull Request

Fixes #845 as it seems the console was not there only on the solar-class. Consoles on other ships (I checked all of them) were added in #924 and other PRs.

## Why It's Good For The Game

Less bug

## Changelog
:cl:
fix: A cryo console is added to the solar-class as it should be
/:cl: