### PR TITLE
Fix farm map

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_camp_farm.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_camp_farm.dmm
@@ -3,15 +3,15 @@
 /obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "b" = (
 /obj/structure/fence/door/opened,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "c" = (
 /obj/structure/fence,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "d" = (
 /obj/machinery/light,
@@ -142,7 +142,7 @@
 /area/whitesands/surface/outdoors)
 "v" = (
 /obj/structure/fence/cut/large,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "w" = (
 /obj/machinery/light,
@@ -150,7 +150,7 @@
 /area/whitesands/surface/outdoors)
 "z" = (
 /obj/structure/fence/cut/medium,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "A" = (
 /obj/structure/chair/plastic{
@@ -181,7 +181,7 @@
 /obj/structure/fence/cut/large{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "F" = (
 /obj/machinery/biogenerator,
@@ -229,17 +229,17 @@
 /area/whitesands/surface/outdoors)
 "M" = (
 /obj/structure/fence/post,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "N" = (
 /obj/structure/fence/post{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "O" = (
 /obj/structure/fence/corner,
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "P" = (
 /mob/living/simple_animal/hostile/asteroid/goliath/beast{
@@ -285,7 +285,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 "V" = (
 /obj/structure/closet/wardrobe/botanist,
@@ -325,7 +325,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/open/floor/plating/asteroid/whitesands/dried,
 /area/whitesands/surface/outdoors)
 
 (1,1,1) = {"


### PR DESCRIPTION
## About The Pull Request

Fixes #911 where for some reason space tiles were left under the fences of the farm. Now they are replaced by sand tiles

## Why It's Good For The Game

remove random spess

## Changelog
:cl:
fix: Removed random space tiles on the whitesands farm ruin
/:cl:
