### PR TITLE
fixes a single space tile on the skipper

### DIFF
--- a/_maps/shuttles/shiptest/ntsv_skipper.dmm
+++ b/_maps/shuttles/shiptest/ntsv_skipper.dmm
@@ -1308,9 +1308,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"pR" = (
-/turf/open/space/basic,
-/area/ship/engineering/engine)
 "pZ" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
@@ -4596,7 +4593,7 @@ mD
 SU
 ov
 ov
-pR
+ov
 ov
 ov
 GF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
empty space tile on the skipper roundstart right next to the cryopods, quite possibly my fault.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
oops + roundstart death bad + ratio + my bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes a hole in the map ntsv_skipper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
