### PR TITLE
Adds utility closets to sheetcrafting

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -38,7 +38,13 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		)),
 	null, \
 	new/datum/stack_recipe("rack parts", /obj/item/rack_parts), \
-	new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe_list("closets", list(
+		new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("emergency closet", /obj/structure/closet/emcloset/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("fire-safety closet", /obj/structure/closet/firecloset/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("tool closet", /obj/structure/closet/toolcloset/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("radiation closet", /obj/structure/closet/radiation/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE)
+		)),
 	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -20,6 +20,9 @@
 /obj/structure/closet/emcloset/anchored
 	anchored = TRUE
 
+/obj/structure/closet/emcloset/empty
+	populate = FALSE
+
 /obj/structure/closet/emcloset/PopulateContents()
 	..()
 
@@ -61,6 +64,9 @@
 	desc = "It's a storage unit for fire-fighting supplies."
 	icon_state = "fire"
 
+/obj/structure/closet/firecloset/empty
+	populate = FALSE
+
 /obj/structure/closet/firecloset/PopulateContents()
 	..()
 
@@ -86,6 +92,9 @@
 	desc = "It's a storage unit for tools."
 	icon_state = "eng"
 	icon_door = "eng_tool"
+
+/obj/structure/closet/toolcloset/empty
+	populate = FALSE
 
 /obj/structure/closet/toolcloset/PopulateContents()
 	..()
@@ -129,6 +138,9 @@
 	desc = "It's a storage unit for rad-protective suits."
 	icon_state = "eng"
 	icon_door = "eng_rad"
+
+/obj/structure/closet/radiation/empty
+	populate = FALSE
 
 /obj/structure/closet/radiation/PopulateContents()
 	..()


### PR DESCRIPTION
## About The Pull Request
Added empty subtypes to a few utility-type closets (emergency, fire, tool, radiation). These are craftable in the iron sheet crafting menu, alongside the existing closet, in a 'closets' category.

## Why It's Good For The Game
Allows you to create slightly nicer-looking or themed storage options from raw materials, as opposed to needing to somehow find a non-generic closet somewhere else.

## Changelog
:cl:
add: Utility closets (fire-safety, emergency, tool, and radiation) are now craftable. Make them using iron, like the normal closet.
tweak: Moved the generic closet to a 'closets' category in the sheetcrafting menu, alongside the new utility closets.
/:cl: