### PR TITLE
Adds an optional surgery step to cancel with a cautery, if the active step does not require a cautery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -102,6 +102,10 @@
 		if(S.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
 			return TRUE
 		if(tool && tool.item_flags & SURGICAL_TOOL) //Just because you used the wrong tool it doesn't mean you meant to whack the patient with it
+			if ( tool.tool_behaviour == TOOL_CAUTERY )
+				// Cancel the surgery if a cautery is used AND it's not the tool used in the next step.
+				attempt_cancel_surgery( src, tool, target, user )
+				return TRUE
 			to_chat(user, "<span class='warning'>This step requires a different tool!</span>")
 			return TRUE
 	return FALSE

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -93,7 +93,8 @@
 
 	if(S.can_cancel)
 		var/required_tool_type = TOOL_CAUTERY
-		var/obj/item/close_tool = user.get_inactive_held_item()
+		// Historically surgical drapes were used with the cautery in the inactive hand, but these drapes don't seem to exist here
+		var/obj/item/close_tool = user.get_active_held_item()
 		var/is_robotic = S.requires_bodypart_type == BODYTYPE_ROBOTIC
 
 		if(is_robotic)
@@ -102,10 +103,10 @@
 		if(iscyborg(user))
 			close_tool = locate(/obj/item/cautery) in user.held_items
 			if(!close_tool)
-				to_chat(user, "<span class='warning'>You need to equip a cautery in an inactive slot to stop [M]'s surgery!</span>")
+				to_chat(user, "<span class='warning'>You need to equip a cautery in an active slot to stop [M]'s surgery!</span>")
 				return
 		else if(!close_tool || close_tool.tool_behaviour != required_tool_type)
-			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
+			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your active hand to stop [M]'s surgery!</span>")
 			return
 
 		if(ishuman(M))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -83,8 +83,8 @@
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
 	var/selected_zone = user.zone_selected
-	to_chat(user, "<span class='notice'>You begin to cancel the [S.name].</span>")
-	if ( !do_mob( user, M, 30 ) )
+	to_chat(user, "<span class='notice'>You begin to cancel \the [S].</span>")
+	if ( !do_mob( user, M, 3 SECONDS ) )
 		return
 
 	if(S.status == 1)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -83,6 +83,9 @@
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
 	var/selected_zone = user.zone_selected
+	to_chat(user, "<span class='notice'>You begin to cancel the [S.name].</span>")
+	if ( !do_mob( user, M, 30 ) )
+		return
 
 	if(S.status == 1)
 		M.surgeries -= S


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the surgery doesn't call for a cautery and a cautery is used, the surgery can be stopped 

If the surgery step does call for a cautery, the surgery continues as normal 

If the user is holding an incorrect tool, the surgery continues to notify the tool is incorrect

## Why It's Good For The Game

Fixes surgeries being unable to be cancelled, perhaps by misclicking an operation option or not knowing enough about a specific operation 

Fixes #441 

## Changelog
:cl:
add: Adds an optional surgery step to cancel with a cautery, if the active step does not require a cautery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
