### PR TITLE
Adds Wand Wresting

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -1,5 +1,5 @@
-//For use in prob()
-#define WAND_WREST_CHANCE (100/121)
+//For use in prob() to determine if an empty wand will shoot once then break.
+#define WAND_WREST_CHANCE (1/121)
 
 /obj/item/gun/magic/wand
 	name = "wand"
@@ -57,7 +57,7 @@
 	update_icon()
 
 /obj/item/gun/magic/wand/shoot_with_empty_chamber(mob/living/user)
-	if(prob(WAND_WREST_CHANCE))
+	if(prob(100*WAND_WREST_CHANCE))
 		to_chat(user,"<span class='danger'>You manage to activate [src] one last time.</span>")
 		charges++
 		recharge_newshot()
@@ -255,3 +255,4 @@
 	ammo_type = /obj/item/ammo_casing/magic/nothing
 
 
+#undef WAND_WREST_CHANCE

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -1,5 +1,5 @@
-//For use in prob(), about a 1 in 121 chance
-#define WAND_WREST_CHANCE 0.82644628
+//For use in prob()
+#define WAND_WREST_CHANCE (100/121)
 
 /obj/item/gun/magic/wand
 	name = "wand"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -1,3 +1,6 @@
+//For use in prob(), about a 1 in 121 chance
+#define WAND_WREST_CHANCE 0.82644628
+
 /obj/item/gun/magic/wand
 	name = "wand"
 	desc = "You shouldn't have this."
@@ -9,7 +12,6 @@
 	can_charge = FALSE
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = TRUE
-	var/wrest_chance = 0.82644628 //For use in prob(), about a 1 in 121 chance
 
 /obj/item/gun/magic/wand/Initialize()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
@@ -55,8 +57,8 @@
 	update_icon()
 
 /obj/item/gun/magic/wand/shoot_with_empty_chamber(mob/living/user)
-	if(prob(wrest_chance))
-		to_chat(user,"<span class='danger'>You manage to activate [src] one last time</span>")
+	if(prob(WAND_WREST_CHANCE))
+		to_chat(user,"<span class='danger'>You manage to activate [src] one last time.</span>")
 		charges++
 		recharge_newshot()
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds Wand Wresting, when using a wand without any charges, there is a small chance (1 in 121) that the wand will fire one last time before disintegrating. That's it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rewards anyone with a empty wand if they're dedicated or desperate enough to squeeze out the last charge.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Empty wands have a rare chance to activate one last time when used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
