### PR TITLE
Osprey console fix

### DIFF
--- a/_maps/shuttles/shiptest/ntsv_osprey.dmm
+++ b/_maps/shuttles/shiptest/ntsv_osprey.dmm
@@ -2984,7 +2984,7 @@
 /obj/item/circuitboard/machine/protolathe/department/science{
 	pixel_y = -5
 	},
-/obj/item/circuitboard/computer/research,
+/obj/item/circuitboard/computer/rdconsole,
 /obj/item/circuitboard/machine/rdserver{
 	pixel_y = 5
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the computer boards in Osprey's science lab so it can actually build an R&D console. Initially had a research monitor board by accident.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Replaced research monitor board on Osprey with rnd console board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
