### PR TITLE
Boyardee updates 2

### DIFF
--- a/_maps/configs/diner.json
+++ b/_maps/configs/diner.json
@@ -1,5 +1,7 @@
 {
 	"map_name": "Boyardee-class Entertainment Vessel",
+	"prefix": "ISV",
+	"namelists": ["GENERAL", "MERCANTILE"],
 	"map_short_name": "Boyardee-class",
 	"map_path": "_maps/shuttles/shiptest/bar_ship.dmm",
 	"map_id": "bar_ship",
@@ -7,7 +9,11 @@
 		"Bartender": 1,
 		"Cook": 5,
 		"Botanist": 2,
-		"Janitor": 1
+		"Janitor": 1,
+		"Waiter": {
+			"outfit": "/datum/outfit/job/assistant/waiter",
+"slots": 2
+			}
 	},
 	"cost": 750
 }

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -203,14 +203,6 @@
 "dH" = (
 /turf/closed/wall/r_wall,
 /area/ship/maintenance)
-"dJ" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/vending/hydronutrients,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/hydroponics)
 "dM" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm{
@@ -226,11 +218,6 @@
 /obj/effect/turf_decal/box,
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/dark,
-/area/ship/crew/canteen)
-"dO" = (
-/obj/structure/table/reinforced,
-/obj/item/paicard,
-/turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "dQ" = (
 /obj/machinery/light{
@@ -987,6 +974,11 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"vP" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "vZ" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1165,6 +1157,11 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
+/area/ship/crew/canteen)
+"zO" = (
+/obj/structure/table/reinforced,
+/obj/item/paicard,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "zP" = (
 /obj/machinery/icecream_vat,
@@ -1465,12 +1462,6 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall,
 /area/ship/maintenance)
-"DI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/mono,
-/area/ship/bridge)
 "DK" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "internal airlock"
@@ -1642,21 +1633,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"FS" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "FU" = (
 /obj/machinery/power/smes/engineering,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -1752,11 +1728,6 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
-/area/ship/crew/hydroponics)
-"Ie" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "In" = (
 /obj/structure/table/reinforced,
@@ -2050,6 +2021,12 @@
 "NM" = (
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
+"Os" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/bridge)
 "Ow" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -2525,6 +2502,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"WV" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/vending/hydronutrients,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "Xd" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -2542,6 +2527,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"Xl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Xv" = (
 /obj/item/radio/intercom{
 	pixel_x = 27
@@ -2969,7 +2969,7 @@ dl
 MI
 hk
 sp
-dO
+zO
 NM
 NM
 Hs
@@ -3160,14 +3160,14 @@ Ag
 px
 Dd
 Lj
-DI
+Os
 Mp
 Sf
 Lj
 dM
 TD
-Ie
-dJ
+vP
+WV
 Eo
 TD
 vZ
@@ -3181,7 +3181,7 @@ vZ
 of
 of
 lG
-FS
+Xl
 ph
 ph
 Ng

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -1124,7 +1124,7 @@
 /obj/structure/bed/nest{
 	color = "#FFFF00";
 	desc = "It's a pile of soft, loose hay shaped like a nest.";
-	name = "Chicken Nest"
+	name = "chicken nest"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -1800,7 +1800,9 @@
 /turf/closed/wall,
 /area/ship/crew/canteen)
 "Jg" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/hydroponics/constructable{
+	layer = 2
+	},
 /obj/machinery/firealarm{
 	pixel_y = -28
 	},
@@ -1934,6 +1936,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/machinery/jukebox,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Mj" = (

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -36,6 +36,12 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/box,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
 "bQ" = (
@@ -197,6 +203,14 @@
 "dH" = (
 /turf/closed/wall/r_wall,
 /area/ship/maintenance)
+"dJ" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/vending/hydronutrients,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "dM" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm{
@@ -212,6 +226,11 @@
 /obj/effect/turf_decal/box,
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/dark,
+/area/ship/crew/canteen)
+"dO" = (
+/obj/structure/table/reinforced,
+/obj/item/paicard,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "dQ" = (
 /obj/machinery/light{
@@ -241,15 +260,17 @@
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen)
 "ep" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/corner/blue{
 	dir = 8
+	},
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -360,6 +381,7 @@
 /area/ship/crew/hydroponics)
 "ie" = (
 /obj/machinery/advanced_airlock_controller{
+	locked = 0;
 	pixel_x = 24
 	},
 /obj/structure/chair,
@@ -895,7 +917,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/clothing,
 /turf/open/floor/wood,
 /area/ship/crew)
 "up" = (
@@ -990,6 +1012,9 @@
 /area/ship/cargo)
 "wm" = (
 /obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "wn" = (
@@ -1093,6 +1118,16 @@
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
 	},
+/mob/living/simple_animal/chicken{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	desc = "A regular chicken, nothing weird about this one .";
+	name = "Cluckens"
+	},
+/obj/structure/bed/nest{
+	color = #FFFF00;
+	desc = "It's a pile of soft, loose hay shaped like a nest.";
+	name = "Chicken Nest"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "yW" = (
@@ -1132,6 +1167,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "zP" = (
+/obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/freezer,
 /area/ship/storage)
 "zQ" = (
@@ -1210,7 +1246,6 @@
 /obj/effect/turf_decal/corner/blue{
 	dir = 8
 	},
-/obj/item/paicard,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "AT" = (
@@ -1430,8 +1465,16 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall,
 /area/ship/maintenance)
+"DI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/bridge)
 "DK" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	name = "internal airlock"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -1492,22 +1535,11 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/canteen)
 "Eo" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics/skirt,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
 /obj/effect/turf_decal/corner/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "Ex" = (
@@ -1547,7 +1579,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/icecream_vat,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1606,12 +1637,26 @@
 /turf/closed/wall,
 /area/ship/bridge)
 "FR" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"FS" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "FU" = (
 /obj/machinery/power/smes/engineering,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -1708,6 +1753,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
+"Ie" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "In" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -1782,6 +1832,11 @@
 	},
 /obj/effect/turf_decal/corner/neutral{
 	dir = 4
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	layer = 2.04;
+	pixel_x = -12
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
@@ -2016,13 +2071,13 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "OJ" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/corner/blue{
+	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -2068,6 +2123,11 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/structure/closet/wall/white{
+	dir = 8;
+	name = "First Aid";
+	pixel_x = 31
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
 "PL" = (
@@ -2093,6 +2153,9 @@
 "Qc" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono,
 /area/ship/bridge)
 "Qn" = (
@@ -2215,6 +2278,9 @@
 /obj/machinery/reagentgrinder,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
@@ -2401,19 +2467,9 @@
 /area/ship/crew)
 "Vm" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/reagent_containers/glass/bottle/nutrient/rh{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/machinery/smartfridge/disks,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "Vo" = (
@@ -2431,13 +2487,26 @@
 /turf/open/floor/plating,
 /area/ship/maintenance)
 "Wv" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/clothing/under/rank/civilian/hydroponics/skirt,
+/obj/item/clothing/under/rank/civilian/hydroponics/skirt,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
 /obj/item/hatchet,
 /obj/item/hatchet,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "WH" = (
@@ -2457,9 +2526,11 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
 "Xd" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2521,7 +2592,9 @@
 /turf/open/floor/wood,
 /area/ship/crew)
 "ZH" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	name = "internal airlock"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "ZI" = (
@@ -2896,7 +2969,7 @@ dl
 MI
 hk
 sp
-ng
+dO
 NM
 NM
 Hs
@@ -3087,14 +3160,14 @@ Ag
 px
 Dd
 Lj
-Sf
+DI
 Mp
 Sf
 Lj
 dM
 TD
-TD
-TD
+Ie
+dJ
 Eo
 TD
 vZ
@@ -3108,13 +3181,13 @@ vZ
 of
 of
 lG
-ph
+FS
 ph
 ph
 Ng
 of
 of
-vZ
+TD
 TD
 DZ
 TD

--- a/_maps/shuttles/shiptest/bar_ship.dmm
+++ b/_maps/shuttles/shiptest/bar_ship.dmm
@@ -25,6 +25,12 @@
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
 /area/ship/storage)
+"bB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ship/bridge)
 "bM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/closet/secure_closet/freezer/meat/open,
@@ -974,11 +980,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"vP" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/hydroponics)
 "vZ" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1024,6 +1025,11 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
+"wO" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "xh" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
@@ -1116,7 +1122,7 @@
 	name = "Cluckens"
 	},
 /obj/structure/bed/nest{
-	color = #FFFF00;
+	color = "#FFFF00";
 	desc = "It's a pile of soft, loose hay shaped like a nest.";
 	name = "Chicken Nest"
 	},
@@ -1157,11 +1163,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
-/area/ship/crew/canteen)
-"zO" = (
-/obj/structure/table/reinforced,
-/obj/item/paicard,
-/turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "zP" = (
 /obj/machinery/icecream_vat,
@@ -1718,6 +1719,11 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance)
+"HN" = (
+/obj/structure/table/reinforced,
+/obj/item/paicard,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "HY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1868,6 +1874,14 @@
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/bridge)
+"Kl" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/vending/hydronutrients,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/hydroponics)
 "KJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -2018,15 +2032,24 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
-"NM" = (
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen)
-"Os" = (
+"NB" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/neutral{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"NM" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/canteen)
 "Ow" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -2502,14 +2525,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"WV" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/vending/hydronutrients,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/hydroponics)
 "Xd" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -2527,21 +2542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
-"Xl" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "Xv" = (
 /obj/item/radio/intercom{
 	pixel_x = 27
@@ -2969,7 +2969,7 @@ dl
 MI
 hk
 sp
-zO
+HN
 NM
 NM
 Hs
@@ -3160,14 +3160,14 @@ Ag
 px
 Dd
 Lj
-Os
+bB
 Mp
 Sf
 Lj
 dM
 TD
-vP
-WV
+wO
+Kl
 Eo
 TD
 vZ
@@ -3181,7 +3181,7 @@ vZ
 of
 of
 lG
-Xl
+NB
 ph
 ph
 Ng

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -157,3 +157,11 @@ Assistant
 	uniform = /obj/item/clothing/under/rank/prisoner
 	shoes = /obj/item/clothing/shoes/sneakers/orange
 	accessory = /obj/item/clothing/accessory/armband/deputy
+
+/datum/outfit/job/assistant/waiter
+	name = "Assistant (Waiter)"
+
+	uniform = /obj/item/clothing/under/suit/waiter
+	shoes = /obj/item/clothing/shoes/laceup
+	ears = /obj/item/radio/headset/headset_srv
+	gloves = /obj/item/clothing/gloves/color/white


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another update to the Boyardee class 

- Meat fridge has extra meat
- Added a nutrivend
- Replaced the two empty monitors in the bridge with a civilian mod console and a power monitor
- Added a clothesmate
- Added a totally normal pet chicken and a totally normal strawbed for her
- Moved ice-cream vat to the cold room (why would you store your icecream right next to the engines?)
- PAI card moved from ontop of the helm to the bar
- Renamed external airlocks to make setting up the AAC easier
- AAC starts unlocked
- Added a sink inside of botany
- Added a completely normal chicken

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I love but boyardee but it needs a little love, this update mostly makes it easier to produce food 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Small tweaks around the Boyardee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
