### PR TITLE
Adds speaker option to mining scanners

### DIFF
--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -1,6 +1,6 @@
 /**********************Mining Scanners**********************/
 /obj/item/mining_scanner
-	desc = "A scanner that checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations."
+	desc = "A scanner that checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations.\nIt has a speaker that can be toggled with <b>alt+click</b>"
 	name = "manual mining scanner"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "mining1"
@@ -12,14 +12,20 @@
 	slot_flags = ITEM_SLOT_BELT
 	var/cooldown = 35
 	var/current_cooldown = 0
+	var/speaker = TRUE // Speaker that plays a sound when pulsed.
+
+/obj/item/mining_scanner/AltClick(mob/user)
+	speaker = !speaker
+	to_chat(user, "<span class='notice'>You toggle [src]'s speaker to [speaker ? "<b>ON</b>" : "<b>OFF</b>"].</span>")
 
 /obj/item/mining_scanner/attack_self(mob/user)
 	if(!user.client)
 		return
 	if(current_cooldown <= world.time)
 		current_cooldown = world.time + cooldown
-		playsound(src, 'sound/effects/ping.ogg', 20)
 		mineral_scan_pulse(get_turf(user))
+		if(speaker)
+			playsound(src, 'sound/effects/ping.ogg', 20)
 
 //Debug item to identify all ore spread quickly
 /obj/item/mining_scanner/admin
@@ -31,7 +37,7 @@
 	qdel(src)
 
 /obj/item/t_scanner/adv_mining_scanner
-	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations. This one has an extended range."
+	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations. This one has an extended range.\nIt has a speaker that can be toggled with <b>alt+click</b>"
 	name = "advanced automatic mining scanner"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "mining0"
@@ -45,6 +51,11 @@
 	var/cooldown = 35
 	var/current_cooldown = 0
 	var/range = 7
+	var/speaker = FALSE // Speaker that plays a sound when pulsed.
+
+/obj/item/t_scanner/adv_mining_scanner/AltClick(mob/user)
+	speaker = !speaker
+	to_chat(user, "<span class='notice'>You toggle [src]'s speaker to [speaker ? "<b>ON</b>" : "<b>OFF</b>"].</span>")
 
 /obj/item/t_scanner/adv_mining_scanner/cyborg/Initialize()
 	. = ..()
@@ -52,7 +63,7 @@
 
 /obj/item/t_scanner/adv_mining_scanner/lesser
 	name = "automatic mining scanner"
-	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations."
+	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations.\nIt has a speaker that can be toggled with <b>alt+click</b>"
 	range = 4
 	cooldown = 50
 
@@ -61,7 +72,8 @@
 		current_cooldown = world.time + cooldown
 		var/turf/t = get_turf(src)
 		mineral_scan_pulse(t, range)
-		playsound(src, 'sound/effects/ping.ogg', 20)
+		if(speaker)
+			playsound(src, 'sound/effects/ping.ogg', 20)
 
 /proc/mineral_scan_pulse(turf/T, range = world.view)
 	var/list/minerals = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR adds a speaker option to the mining scanners so you can change on whenever it should make sounds when pulsing and also disables the speaker by default on the automatic scanners while keeping it on for the manual scanners.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
While the sound is kind of neat for immersion, it can and will eventually get annoying after hours of mining, this PR allows you to make the mining scanner shush it whenever you want it to.

## Changelog
:cl:Hardly
add: Mining scanners now have a speaker option.
tweak: Automatic mining scanners have their speakers set to off by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
