### PR TITLE
Stops multi-z transparency breaking when copying turfs (fixes plastic floors on shuttles)

### DIFF
--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -1,5 +1,6 @@
 /datum/element/turf_z_transparency
 	var/show_bottom_level = FALSE
+	var/turf/our_turf
 
 ///This proc sets up the signals to handle updating viscontents when turfs above/below update. Handle plane and layer here too so that they don't cover other obs/turfs in Dream Maker
 /datum/element/turf_z_transparency/Attach(datum/target, show_bottom_level = TRUE)
@@ -7,7 +8,7 @@
 	if(!isturf(target))
 		return ELEMENT_INCOMPATIBLE
 
-	var/turf/our_turf = target
+	our_turf = target
 
 	src.show_bottom_level = show_bottom_level
 
@@ -26,8 +27,8 @@
 	. = ..()
 	var/turf/our_turf = source
 	our_turf.vis_contents.len = 0
-	UnregisterSignal(target, COMSIG_TURF_MULTIZ_DEL)
-	UnregisterSignal(target, COMSIG_TURF_MULTIZ_NEW)
+	UnregisterSignal(our_turf, COMSIG_TURF_MULTIZ_DEL)
+	UnregisterSignal(our_turf, COMSIG_TURF_MULTIZ_NEW)
 	REMOVE_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
 
 ///Updates the viscontents or underlays below this tile.

--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -14,8 +14,8 @@
 	our_turf.plane = OPENSPACE_PLANE
 	our_turf.layer = OPENSPACE_LAYER
 
-	RegisterSignal(target, COMSIG_TURF_MULTIZ_DEL, .proc/on_multiz_turf_del)
-	RegisterSignal(target, COMSIG_TURF_MULTIZ_NEW, .proc/on_multiz_turf_new)
+	RegisterSignal(target, COMSIG_TURF_MULTIZ_DEL, .proc/on_multiz_turf_del, TRUE)
+	RegisterSignal(target, COMSIG_TURF_MULTIZ_NEW, .proc/on_multiz_turf_new, TRUE)
 
 	ADD_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
 
@@ -26,6 +26,8 @@
 	. = ..()
 	var/turf/our_turf = source
 	our_turf.vis_contents.len = 0
+	UnregisterSignal(target, COMSIG_TURF_MULTIZ_DEL)
+	UnregisterSignal(target, COMSIG_TURF_MULTIZ_NEW)
 	REMOVE_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
 
 ///Updates the viscontents or underlays below this tile.

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -12,8 +12,8 @@ Simple datum which is instanced once per type and is used for every object of sa
 	var/id = "mat"
 	///Base color of the material, is used for greyscale. Item isn't changed in color if this is null.
 	var/color
-	///Base alpha of the material, is used for greyscale icons.
-	var/alpha
+	///Base alpha of the material, is used for greyscale icons and transparency.
+	var/alpha = 255
 	///Materials "Traits". its a map of key = category | Value = Bool. Used to define what it can be used for
 	var/list/categories = list()
 	///The type of sheet this material creates. This should be replaced as soon as possible by greyscale sheets
@@ -52,7 +52,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 	if(material_flags & MATERIAL_COLOR) //Prevent changing things with pre-set colors, to keep colored toolboxes their looks for example
 		if(color) //Do we have a custom color?
 			source.add_atom_colour(color, FIXED_COLOUR_PRIORITY)
-		if(alpha)
+		if(alpha != 255)
 			source.alpha = alpha
 		if(texture_layer_icon_state)
 			ADD_KEEP_TOGETHER(source, MATERIAL_SOURCE(src))
@@ -60,6 +60,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 
 	if(alpha < 255)
 		source.opacity = FALSE
+
 	if(material_flags & MATERIAL_ADD_PREFIX)
 		source.name = "[name] [source.name]"
 
@@ -147,7 +148,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 		o.throwforce = initial(o.throwforce)
 
 /datum/material/proc/on_removed_turf(turf/T, amount, material_flags)
-	if(alpha)
+	if(alpha != 255)
 		RemoveElement(/datum/element/turf_z_transparency, FALSE)
 
 /** Returns the composition of this material.

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -39,12 +39,12 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /turf/open/copyTurf(turf/T, copy_air = FALSE)
 	. = ..()
-	if (isopenturf(T))
+	if(isopenturf(T))
 		var/datum/component/wet_floor/slip = GetComponent(/datum/component/wet_floor)
 		if(slip)
 			var/datum/component/wet_floor/WF = T.AddComponent(/datum/component/wet_floor)
 			WF.InheritComponent(slip)
-		if (copy_air)
+		if(copy_air)
 			var/turf/open/openTurf = T
 			openTurf.air.copy_from(air)
 

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -167,7 +167,6 @@
 	icon_state = "plastic"
 	thermal_conductivity = 0.1
 	heat_capacity = 900
-	custom_materials = list(/datum/material/plastic=500)
 	floor_tile = /obj/item/stack/tile/plastic
 	broken_states = list("plastic-damaged1","plastic-damaged2")
 


### PR DESCRIPTION
## About The Pull Request

Makes the turf_z_transparency element actually clean up its signals when detached, sets the default alpha of material data to 255, and removes plastic floors' material datum.

## Why It's Good For The Game

No more random (ship)test failures, no more runtimes.

## Changelog
:cl:
fix: Fixed plastic plating causing crashes.
code: Minor improvement to turf transparency element
code: Tweaked material datum opacity usage
/:cl: