### PR TITLE
Fixes some emotes not checking if they should continue on overrides

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -68,6 +68,8 @@
 
 /datum/emote/spin/run_emote(mob/user, params ,  type_override, intentional)
 	. = ..()
+	if(!.)
+		return
 	if(HAS_TRAIT(user, ORBITED_TRAIT))
 		user.spin(40, 2)
 	else

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -116,6 +116,8 @@
 
 /datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return
 	var/obj/item/circlegame/N = new(user)
 	if(user.put_in_hands(N))
 		to_chat(user, "<span class='notice'>You make a circle with your hand.</span>")

--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -28,6 +28,8 @@
 
 /datum/emote/slime/mood/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return
 	var/mob/living/simple_animal/slime/S = user
 	S.mood = mood
 	S.regenerate_icons()


### PR DESCRIPTION
Co-authored-by: Mark Suckerberg <MarkSuckerberg@users.noreply.github.com>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #968
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seemingly, people are rolling in their graves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: SandPoot, Mark Suckerberg
fix: Dead people are no longer rolling in their graves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
