### PR TITLE
Superpill (Pill-Class derivative)

### DIFF
--- a/_maps/configs/superpill.json
+++ b/_maps/configs/superpill.json
@@ -1,0 +1,11 @@
+{
+	"map_name": "Pill Class-R(adioactive) Execution Device",
+	"prefix": null,
+	"namelists": ["PILLS"],
+	"map_short_name": "Superpill-class",
+	"map_path": "_maps/shuttles/shiptest/pill_super.dmm",
+	"map_id": "pill_super",
+	"job_slots": {
+		"Prisoner": 3
+	}
+}

--- a/_maps/shuttles/shiptest/pill_super.dmm
+++ b/_maps/shuttles/shiptest/pill_super.dmm
@@ -60,15 +60,25 @@
 /turf/open/floor/plating/rust,
 /area/ship/storage)
 "i" = (
-/obj/machinery/power/supermatter_crystal,
+/obj/machinery/power/supermatter_crystal{
+	layer = 3.4
+	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	filter_types = list("co2","bz","o2","plasma","water_vapor","nob","no2","tritium","freon","miasma","pluox","stim")
 	},
-/obj/structure/window/spawner,
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner/east,
-/obj/structure/window/spawner/north,
+/obj/structure/window/spawner{
+	pixel_y = -5
+	},
+/obj/structure/window/spawner/west{
+	pixel_x = -5
+	},
+/obj/structure/window/spawner/east{
+	pixel_x = 5
+	},
+/obj/structure/window/spawner/north{
+	pixel_y = 5
+	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2o=28, n2=72;TEMP=7"
 	},

--- a/_maps/shuttles/shiptest/pill_super.dmm
+++ b/_maps/shuttles/shiptest/pill_super.dmm
@@ -1,0 +1,280 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer4{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"b" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"c" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	layer = 3;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer1{
+	dir = 9
+	},
+/obj/docking_port,
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"f" = (
+/obj/machinery/power/emitter/welded{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 4;
+	layer = 3
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer1{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"i" = (
+/obj/machinery/power/supermatter_crystal,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	filter_types = list("co2","bz","o2","plasma","water_vapor","nob","no2","tritium","freon","miasma","pluox","stim")
+	},
+/obj/structure/window/spawner,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/turf/open/floor/plating{
+	initial_gas_mix = "n2o=28, n2=72;TEMP=7"
+	},
+/area/ship/storage)
+"l" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer4{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"m" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w{
+	layer = 3
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"q" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -6
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/radio/intercom/wideband{
+	dir = 4;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
+"x" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"z" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/syndicatebomb/self_destruct{
+	minimum_timer = 180;
+	name = "Alternative Bluespace Jump Device";
+	timer_set = 180
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2,
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+"A" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/structure/bed,
+/obj/machinery/computer/helm{
+	density = 0;
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/machinery/light/floor,
+/obj/structure/fans/tiny,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 5
+	},
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 8;
+	launch_status = 0
+	},
+/obj/item/storage/toolbox/mechanical/old,
+/obj/item/circuitboard/machine/autolathe,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/pickaxe/improvised,
+/obj/item/pickaxe/improvised,
+/obj/item/pickaxe/improvised,
+/mob/living/carbon/human/species/moth{
+	name = "Life-size Moth Plushie";
+	real_name = "Life-Size Moth Plushie"
+	},
+/obj/item/bedsheet/black,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/areaeditor/shuttle,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/machinery/door/window,
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
+/obj/item/clothing/suit/space/orange,
+/obj/item/gun/energy/e_gun/mini{
+	name = "engine ignition key"
+	},
+/obj/item/analyzer,
+/obj/item/multitool,
+/obj/machinery/holopad,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/storage/cans/sixbeer,
+/obj/item/reagent_containers/food/snacks/jellysandwich,
+/obj/item/storage/firstaid/regular,
+/obj/item/toy/plush/among,
+/obj/item/gps/mining,
+/obj/item/kirbyplants/dead,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
+"R" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w{
+	layer = 3
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w,
+/obj/structure/catwalk,
+/turf/open/floor/plating/rust,
+/area/ship/storage)
+
+(1,1,1) = {"
+l
+z
+a
+"}
+(2,1,1) = {"
+x
+q
+b
+"}
+(3,1,1) = {"
+f
+A
+c
+"}
+(4,1,1) = {"
+i
+R
+m
+"}

--- a/_maps/shuttles/shiptest/pill_super.dmm
+++ b/_maps/shuttles/shiptest/pill_super.dmm
@@ -60,24 +60,26 @@
 /turf/open/floor/plating/rust,
 /area/ship/storage)
 "i" = (
-/obj/machinery/power/supermatter_crystal{
-	layer = 3.4
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	filter_types = list("co2","bz","o2","plasma","water_vapor","nob","no2","tritium","freon","miasma","pluox","stim")
 	},
-/obj/structure/window/spawner{
-	pixel_y = -5
+/obj/machinery/power/supermatter_crystal/shard,
+/obj/structure/window/plasma/reinforced/spawner{
+	pixel_y = -7
 	},
-/obj/structure/window/spawner/west{
-	pixel_x = -5
+/obj/structure/window/plasma/reinforced/spawner/east{
+	pixel_x = 7
 	},
-/obj/structure/window/spawner/east{
-	pixel_x = 5
+/obj/structure/window/plasma/reinforced/spawner/north{
+	pixel_y = 7
 	},
-/obj/structure/window/spawner/north{
-	pixel_y = 5
+/obj/structure/window/plasma/reinforced/spawner/west{
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w{
+	layer = 3
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2o=28, n2=72;TEMP=7"
@@ -235,7 +237,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1,
 /obj/item/clothing/suit/space/orange,
 /obj/item/gun/energy/e_gun/mini{
-	name = "engine ignition key"
+	name = "engine ignition device"
 	},
 /obj/item/analyzer,
 /obj/item/multitool,
@@ -252,9 +254,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "R" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w{
-	layer = 3
-	},
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -265,6 +264,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer4,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w,
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer2,
 /turf/open/floor/plating/rust,
 /area/ship/storage)
 


### PR DESCRIPTION
## About The Pull Request

Adds the _'Pill Class-R(adioactive) Execution Device'_, a long-ranged SM-powered modification to the well-known and beloved Pill class pod.

![superpill](https://user-images.githubusercontent.com/72716882/168697230-48aedc03-c92b-4a04-a823-825f5d1069cd.gif)

Video proof of function/tutorial
[![Superpill](http://img.youtube.com/vi/nN5oRB5wMtE/0.jpg)](http://www.youtube.com/watch?v=nN5oRB5wMtE "Superpill")

## Why It's Good For The Game

Adds a small ship with a comparable size to the sugarcube (4x3 vs 6x12, only an 83% difference) with an interesting engine mechanic.


## Changelog
:cl:
add: Superpill
change: Stopped the sneaky little git of a crystal from sliding under the glass level
/:cl:

