### PR TITLE
Fixes missing wire on libertatia-class hauler

### DIFF
--- a/_maps/shuttles/shiptest/pirate_libertatia.dmm
+++ b/_maps/shuttles/shiptest/pirate_libertatia.dmm
@@ -1420,6 +1420,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/port)
 "OO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![libertaria](https://user-images.githubusercontent.com/60303391/168863156-10a7e1ab-fdc8-48cc-b324-02dd84bafcaa.png)
The libertatia was missing a wire knot beneath its port SMES.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The port SMES is now connected to the power grid.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a missing wire on the libertatia-class hauler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
