### PR TITLE
Moves ash/salt garnish to crafting menu

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -935,3 +935,17 @@
 		/obj/item/paper = 1,
 		/obj/item/stack/rods = 1)
 	category = CAT_DRINK
+
+/datum/crafting_recipe/ash_garnish
+	name = "Ash Garnish"
+	result = /obj/item/garnish/ash
+	reqs = list(/datum/reagent/ash = 10)
+	time = 5
+	category = CAT_DRINK
+
+/datum/crafting_recipe/salt_garnish
+	name = "Salt Garnish"
+	result = /obj/item/garnish/salt
+	reqs = list(/datum/reagent/consumable/sodiumchloride = 10)
+	time = 5
+	category = CAT_DRINK

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -31,15 +31,6 @@
 	results = list(/datum/reagent/consumable/sodiumchloride = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1)
 
-/datum/chemical_reaction/saltsolidification
-	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 10)
-	required_temp = 600
-
-/datum/chemical_reaction/saltsolidification/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
-		new /obj/item/garnish/salt(location)
-
 /datum/chemical_reaction/plasmasolidification
 	required_reagents = list(/datum/reagent/iron = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/toxin/plasma = 20)
 	mob_react = FALSE
@@ -431,15 +422,6 @@
 	results = list(/datum/reagent/ash = 1)
 	required_reagents = list(/datum/reagent/fuel/oil = 1)
 	required_temp = 480
-
-/datum/chemical_reaction/ashsolidification
-	required_reagents = list(/datum/reagent/ash = 10)
-	required_temp = 600
-
-/datum/chemical_reaction/ashsolidification/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
-		new /obj/item/garnish/ash(location)
 
 /datum/chemical_reaction/colorful_reagent
 	results = list(/datum/reagent/colorful_reagent = 5)


### PR DESCRIPTION
## About The Pull Request
Changes the method of acquiring the ash and salt garnish items from MODtending to recipes in the crafting menu, as opposed to chemical recipes.

Fixes: #1069 

## Why It's Good For The Game
Fixes the bonfire ash conversion crash.

## Changelog
:cl:
fix: Changed ash/salt garnish to be created in the crafting menu instead of chemically.
/:cl: