### PR TITLE
Fixes Join menu-breaking bug

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -311,7 +311,8 @@ SUBSYSTEM_DEF(shuttle)
 	loading_zone.fill_in(turf_type = /turf/open/space/transit/south)
 
 	var/turf/BL = locate(loading_zone.low_x, loading_zone.low_y, loading_zone.z_value)
-	template.load(BL, centered = FALSE, register = FALSE)
+	if(!template.load(BL, centered = FALSE, register = FALSE))
+		return
 
 	var/affected = template.get_affected_turfs(BL, centered=FALSE)
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -357,7 +357,7 @@
 		close_spawn_windows()
 		to_chat(usr, "<span class='danger'>Your [template.name] is being prepared. Please be patient!</span>")
 		var/datum/overmap/ship/controlled/target = new(SSovermap.get_unused_overmap_square(), template)
-		if(!istype(target))
+		if(!target?.shuttle_port)
 			to_chat(usr, "<span class='danger'>There was an error loading the ship. Please contact admins!</span>")
 			new_player_panel()
 			return

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -65,6 +65,9 @@
 		job_slots = source_template.job_slots?.Copy()
 		if(create_shuttle)
 			shuttle_port = SSshuttle.load_template(creation_template, src)
+			if(!shuttle_port) //Loading failed, if the shuttle is supposed to be created, we need to delete ourselves.
+				qdel(src) // Can't return INITIALIZE_HINT_QDEL here since this isn't ACTUAL initialisation. Considering changing the name of the proc.
+				return
 			calculate_mass()
 			refresh_engines()
 
@@ -80,7 +83,8 @@
 	SSovermap.controlled_ships -= src
 	if(!QDELETED(shuttle_port))
 		shuttle_port.intoTheSunset()
-	QDEL_NULL(ship_account)
+	if(!QDELETED(ship_account))
+		QDEL_NULL(ship_account)
 	return ..()
 
 /datum/overmap/ship/controlled/get_jump_to_turf()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title and better description in [#important-dev](https://discord.com/channels/837744059291533392/867456723400785931/977437305801420830). Basically just makes sure that the shuttle actually loads before letting the datum finish creating itself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The join menu is... very important to the game, and it breaking spontaneously is not a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The join menu should no longer break randomly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
