### PR TITLE
Fixes Schmiedeberg-Class Pill Press

### DIFF
--- a/_maps/shuttles/shiptest/schmiedeberg-class.dmm
+++ b/_maps/shuttles/shiptest/schmiedeberg-class.dmm
@@ -394,13 +394,14 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "kf" = (
+/obj/effect/turf_decal/corner/white/mono,
 /obj/machinery/plumbing/pill_press{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/orange/end{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/ship/medical)
 "kh" = (
 /obj/machinery/suit_storage_unit/cmo,
@@ -954,6 +955,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/corner/white/mono,
 /obj/machinery/plumbing/input{
 	dir = 8
 	},
@@ -963,7 +965,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/ship/medical)
 "CR" = (
 /obj/structure/cable{
@@ -1647,12 +1649,13 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/canteen/kitchen)
 "Vi" = (
+/obj/effect/turf_decal/corner/white/mono,
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/orange/arrow_ccw,
 /obj/effect/turf_decal/trimline/orange/arrow_cw{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/ship/medical)
 "Vu" = (
 /obj/machinery/vending/medical,


### PR DESCRIPTION
## About The Pull Request
Replaces tiles over pill press with decals instead.
![image](https://user-images.githubusercontent.com/100787466/169868464-2eb96968-c7d4-4e85-a6bb-f666e91945a7.png)


## Why It's Good For The Game
Removing the tiles over the pipes fixes the pill press for some reason. I guess fluid ducts really hate being under stuff.

## Changelog
Fixes ship


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
