### PR TITLE
Remaps jungle_seedling.dmm

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_seedling.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_seedling.dmm
@@ -1,390 +1,463 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"au" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
 "cO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"ez" = (
-/obj/item/reagent_containers/food/snacks/grown/tomato/blood,
-/turf/open/floor/grass,
+/obj/machinery/door/airlock/survival_pod,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered)
+"dT" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/dirt/jungle/dark,
 /area/ruin/unpowered)
 "fj" = (
-/obj/structure/fence,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"hJ" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/grass,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "iB" = (
-/obj/structure/fence{
-	dir = 4
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "iJ" = (
-/obj/structure/flora/junglebush/c,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"lk" = (
-/obj/structure/flora/ausbushes,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"mh" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"ms" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"mt" = (
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"my" = (
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"nr" = (
-/obj/structure/fence,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"oI" = (
-/obj/structure/fence/corner{
-	dir = 5
-	},
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"pl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"pN" = (
-/obj/effect/decal/cleanable/leaper_sludge,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"rN" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
-"rZ" = (
-/obj/item/organ/eyes/night_vision/mushroom,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"tz" = (
-/obj/structure/fence/door/opened,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"uX" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"uY" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"vy" = (
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"vB" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/ruin/unpowered)
-"vY" = (
-/obj/structure/fence,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"wa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"wW" = (
-/obj/structure/flora/rock/jungle,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"xV" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"yj" = (
-/obj/structure/fence/corner,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"zG" = (
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"BS" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"Cy" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
-"Ij" = (
-/obj/item/organ/ears/penguin,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"Io" = (
-/obj/item/seeds/cocoapod/bungotree,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"ID" = (
-/obj/structure/fence{
+"iX" = (
+/obj/structure/fence/cut/large{
 	dir = 8
 	},
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"kj" = (
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/dirt/jungle/dark,
+/area/ruin/unpowered)
+"mh" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"ms" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"mt" = (
+/obj/item/storage/bag/medical,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered)
+"nW" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered)
+"pl" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/organ/cyberimp/arm/surgery,
+/obj/item/organ/eyes/night_vision/mushroom,
+/obj/item/organ/heart/cybernetic/tier3,
+/obj/item/organ/liver/dwarf,
+/obj/item/organ/liver/plasmaman,
+/obj/item/organ/tongue/robot,
+/obj/item/organ/moth_wings,
+/obj/item/organ/stomach/cybernetic/tier2,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered)
+"pN" = (
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered)
+"rN" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"rZ" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"so" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"uY" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
+"vZ" = (
+/obj/structure/fence/door,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"wa" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/dirt/jungle/dark,
+/area/ruin/unpowered)
+"wT" = (
+/obj/structure/fence/end{
+	dir = 8
+	},
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"wW" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"xV" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/dirt/jungle/wasteland,
+/area/ruin/unpowered)
+"zA" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/dirt/jungle/dark,
+/area/ruin/unpowered)
+"Ef" = (
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/water/jungle,
+/area/ruin/unpowered)
+"FT" = (
+/obj/item/scythe,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"Io" = (
+/turf/closed/mineral,
 /area/ruin/unpowered)
 "JL" = (
 /turf/open/water/jungle,
 /area/ruin/unpowered)
+"Ld" = (
+/obj/item/clothing/suit/hooded/wintercoat/medical,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered)
 "Lt" = (
-/mob/living/simple_animal/hostile/jungle/seedling{
-	health = 300;
-	maxHealth = 300
-	},
-/obj/item/ship_in_a_bottle,
-/turf/open/water/jungle,
+/turf/open/floor/plating/dirt/jungle/dark,
 /area/ruin/unpowered)
-"OK" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"Pg" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/organ/heart/cursed,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
+"Nj" = (
+/mob/living/simple_animal/bot/medbot/rockplanet,
+/obj/item/circuitboard/machine/techfab/department/medical,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered)
+"Pe" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered)
 "Py" = (
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/grass,
+/obj/structure/fence,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "Qe" = (
-/obj/effect/mob_spawn/human/corpse/cargo_tech,
-/turf/open/water/jungle,
+/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/food/snacks/salad/jungle,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "QF" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/grass,
+/obj/item/stack/rods,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"QG" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "QV" = (
-/obj/item/organ/liver/plasmaman,
-/turf/open/water/jungle,
-/area/ruin/unpowered)
-"Rg" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"RO" = (
-/turf/open/floor/grass,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/dirt/jungle/dark,
 /area/ruin/unpowered)
 "SA" = (
-/obj/structure/fence,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"SH" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/grass,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "SI" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"ST" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
+/obj/effect/turf_decal/dept/medical,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "TD" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/grass/jungle,
+/area/ruin/unpowered)
+"TM" = (
+/obj/item/cultivator/rake,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "Uv" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/jungle,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "Vf" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/organ/tongue/lizard,
-/turf/open/water/jungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/grass/jungle,
 /area/ruin/unpowered)
 "Vu" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered)
 "VB" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/ruin/unpowered)
-"WR" = (
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt/jungle,
 /area/ruin/unpowered)
+"WA" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"WR" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/dirt/jungle/wasteland,
+/area/ruin/unpowered)
 "ZE" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/open/floor/plating/dirt/jungle/wasteland,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
+SA
 ZE
+TD
+Io
 ZE
+Io
 ZE
-ZE
-mt
-pl
-mt
-mt
-mt
-ZE
-ZE
+xV
+TD
+wW
+TD
+TD
+TD
+Vf
+TD
 "}
 (2,1,1) = {"
-ZE
-ZE
-lk
-cO
+WR
+xV
+Io
+Io
+Io
+Io
+Io
+TD
 rN
-RO
-OK
-vB
-zG
-ZE
-ZE
+TD
+TD
+SA
+TD
+TD
+TD
 "}
 (3,1,1) = {"
 ZE
-mt
+Io
+Io
+WA
+WA
+Io
 WR
 SA
-vY
-nr
-SA
-SA
+wW
 TD
-mt
-ZE
+Vf
+TD
+TD
+wW
+TD
 "}
 (4,1,1) = {"
-pl
-mt
-ID
-mh
-ez
-Ij
-Py
-uX
-iB
-lk
 ZE
+ZE
+uY
+Nj
+pl
+uY
+ZE
+mh
+Py
+Py
+Py
+Py
+iB
+TD
+iJ
 "}
 (5,1,1) = {"
+TD
+ZE
+SI
+Pe
 mt
 SI
-SH
-hJ
+TD
+Uv
 Vf
-JL
+FT
 wW
-ST
-iB
-wa
-mt
+TD
+Uv
+fj
+TD
 "}
 (6,1,1) = {"
+rN
+fj
+uY
+Ld
 pN
 uY
-SH
+QF
 Uv
-BS
+SA
 Qe
-JL
-Pg
-SH
-Rg
-my
+ms
+Vf
+Uv
+TD
+TD
 "}
 (7,1,1) = {"
+SA
+TD
+nW
+cO
 cO
 Vu
-SH
-au
-JL
-Lt
+Vf
+TD
 JL
 JL
-tz
-RO
-cO
+Ef
+TD
+Uv
+TD
+TD
 "}
 (8,1,1) = {"
-mt
+fj
+TD
+Lt
+QV
+kj
 wa
-SH
+TD
 QF
 rZ
 JL
 JL
-iJ
-iB
-RO
-pN
+JL
+iX
+TD
+TD
 "}
 (9,1,1) = {"
-ZE
-mt
-SH
-RO
-SI
+iJ
+TD
+wa
+Lt
+zA
+Lt
+Uv
+TD
+TM
 ms
-QV
-xV
-iB
-vy
-pl
+JL
+JL
+Uv
+SA
+TD
 "}
 (10,1,1) = {"
-ZE
-lk
-oI
-SA
-SA
-SA
-vY
-fj
-yj
-mt
-mt
+TD
+Lt
+Lt
+Lt
+Lt
+QF
+Vf
+QG
+ms
+JL
+JL
+JL
+Uv
+TD
+iJ
 "}
 (11,1,1) = {"
-ZE
-ZE
-mt
-mt
-ST
+TD
+QV
+Lt
+Lt
+QV
+iX
+TD
+JL
+JL
+JL
+JL
+TD
+Uv
+TD
+TD
+"}
+(12,1,1) = {"
+TD
+Lt
+dT
+Lt
+TD
+TD
+TD
+JL
+JL
+JL
+JL
+wW
+Uv
+TD
+TD
+"}
+(13,1,1) = {"
+SA
+Lt
+Lt
+Lt
+wW
+TD
+QF
+TD
+JL
+JL
+so
+TD
+vZ
+TD
+TD
+"}
+(14,1,1) = {"
+TD
+Lt
+Lt
+TD
+TD
+iJ
+TD
+Vf
+TD
+wW
+TD
+TD
+wT
+TD
+TD
+"}
+(15,1,1) = {"
+TD
 VB
-Io
-lk
-Cy
-cO
-ZE
+rN
+wW
+TD
+Vf
+TD
+TD
+SA
+TD
+TD
+fj
+TD
+rN
+TD
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remaps a badly made ruin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The seedling fauna was insanely lethal and several complaints were made about the state of this ruin while it was in it. This remap serves to keep the spirit of its former self through the crate of spare organs (which hopefully shouldn't spoil due to being in an actual freezer this time) and the plant based enemies. Now with environmental storytelling! 
![image](https://user-images.githubusercontent.com/95449138/170419304-cffd541d-c074-434b-81d6-62661e96c66a.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: remapped jungle_seedling.dmm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
