### PR TITLE
Stop ghosts interacting with helm console

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -115,7 +115,10 @@
 		current_ship.helms |= src
 
 /obj/machinery/computer/helm/ui_interact(mob/living/user, datum/tgui/ui)
-	// Update UI
+	var/user_ref = REF(user)
+	if(!isliving(user))
+		return
+
 	if(!current_ship && !reload_ship())
 		return
 
@@ -130,14 +133,9 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		var/user_ref = REF(user)
-		var/is_living = isliving(user)
-		// Ghosts shouldn't count towards concurrent users, which produces
-		// an audible terminal_on click.
-		if(is_living)
-			concurrent_users += user_ref
+		concurrent_users += user_ref
 		// Turn on the console
-		if(length(concurrent_users) == 1 && is_living)
+		if(length(concurrent_users) == 1)
 			playsound(src, 'sound/machines/terminal_on.ogg', 25, FALSE)
 			use_power(active_power_usage)
 		// Register map objects

--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -115,7 +115,6 @@
 		current_ship.helms |= src
 
 /obj/machinery/computer/helm/ui_interact(mob/living/user, datum/tgui/ui)
-	var/user_ref = REF(user)
 	if(!isliving(user))
 		return
 
@@ -133,6 +132,7 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
+		var/user_ref = REF(user)
 		concurrent_users += user_ref
 		// Turn on the console
 		if(length(concurrent_users) == 1)


### PR DESCRIPTION
## About The Pull Request

Moves an isliving check up a bit so that ghosts cant spam the chat with messages (when the ship is locked)

## Why It's Good For The Game

No haunted ship

## Changelog
:cl:
fix: fixed haunted ship helm console by not allowing ghosts to interact
/:cl: