### PR TITLE
Makes wideband intercoms work

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -155,6 +155,7 @@
 	independent = TRUE
 	frequency = FREQ_WIDEBAND
 	freqlock = TRUE
+	freerange = TRUE
 
 /obj/item/radio/intercom/wideband/unscrewed
 	unscrewed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wideband intercoms are no longer reset to the FREQ_MAX
Don't know what caused the bug in the first place, but it seems to be working now.
closes #1105
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fixes are always good

## Changelog
:cl:
fix: A pirate wideband radio jamming station has been taken taken down by a group of unidentified ships. One of them seemed to be a Minuteman Carina-class ship, however Minuteman spokesperson denies Minuteman involvement in this operation (Fixed wideband intercoms)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
