### PR TITLE
Adds material requirement for floor painter

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1152,6 +1152,7 @@
 	name = "Floor Painter"
 	id = "floor_painter"
 	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 200, /datum/material/glass = 50)
 	build_path = /obj/item/floor_painter
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SERVICE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds material requirement for floor painter so you can actually print it now.
fixes #1103
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/22380218/170885419-fa0d9be4-6efd-443e-aeb6-c614bd89e193.png)
AHAHAHAHA I LOVE PRINTING MY FLOOR PAINTERS
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: An update of autolathe software is now ready for download. This update fixes a glitch that was blocking printing of floor painters (you can now actually print floor painters and don't have to do anything).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
