### PR TITLE
Nerfs the oldcode nukie ship map for being a deathtrap.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldcodeops.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldcodeops.dmm
@@ -39,8 +39,6 @@
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/clothing/shoes/sneakers/black,
 /obj/item/storage/backpack,
-/obj/item/clothing/head/helmet/swat,
-/obj/item/clothing/suit/space/swat,
 /obj/item/clothing/under/color/black,
 /obj/item/gun/ballistic/automatic/pistol/deagle,
 /obj/structure/closet{
@@ -48,6 +46,7 @@
 	name = "strange closet"
 	},
 /obj/item/ammo_box/magazine/m50,
+/obj/item/clothing/suit/space/hardsuit/syndi/elite,
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "fO" = (
@@ -95,7 +94,6 @@
 "na" = (
 /obj/item/crowbar,
 /obj/item/stack/cable_coil,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/assembly/prox_sensor,
 /obj/structure/table/greyscale,
 /turf/open/floor/oldshuttle,
@@ -210,7 +208,6 @@
 	},
 /area/ruin/powered)
 "JB" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space/oldcode,
 /turf/open/floor/circuit,
 /area/ruin/powered)
 "KA" = (
@@ -297,7 +294,6 @@
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "Vp" = (
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/assembly/signaler,
 /obj/structure/table/greyscale,
 /turf/open/floor/oldshuttle,
@@ -310,7 +306,6 @@
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "Wm" = (
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/assembly/prox_sensor,
 /obj/structure/table/greyscale,
 /turf/open/floor/oldshuttle,
@@ -321,15 +316,13 @@
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "Xm" = (
-/obj/structure/chair/old{
-	dir = 4
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	info = "<i>Proceed with caution. This place is better than before, but still dangerous."
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/space/oldcode,
-/turf/open/floor/oldshuttle,
-/area/ruin/powered)
+/turf/template_noop,
+/area/template_noop)
 "XT" = (
 /obj/machinery/cell_charger,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/assembly/signaler,
 /obj/structure/table/greyscale,
 /turf/open/floor/oldshuttle,
@@ -422,7 +415,7 @@ iW
 iW
 iW
 Td
-zH
+iW
 iW
 iW
 iW
@@ -483,7 +476,7 @@ vk
 Td
 iW
 iW
-pM
+iW
 Td
 Td
 Td
@@ -510,7 +503,7 @@ iW
 iW
 Td
 qQ
-Xm
+fg
 fg
 fg
 fg
@@ -538,7 +531,7 @@ iW
 iW
 iW
 iW
-iW
+zH
 iW
 iW
 iW
@@ -563,7 +556,7 @@ MY
 MY
 MY
 iW
-zH
+iW
 iW
 iW
 iW
@@ -579,7 +572,7 @@ vk
 Td
 iW
 iW
-pM
+iW
 Td
 Td
 Td
@@ -634,7 +627,7 @@ vk
 vk
 vk
 FQ
-pM
+iW
 iW
 iW
 Td
@@ -656,7 +649,7 @@ vk
 vk
 vk
 vk
-vk
+Xm
 Sp
 iW
 iW
@@ -664,7 +657,7 @@ Sw
 Td
 rj
 iW
-pM
+iW
 iW
 iW
 gj

--- a/_maps/RandomRuins/SpaceRuins/oldcodeops.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldcodeops.dmm
@@ -315,12 +315,6 @@
 /obj/item/bombcore,
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
-"Xm" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	info = "<i>Proceed with caution. This place is better than before, but still dangerous."
-	},
-/turf/template_noop,
-/area/template_noop)
 "XT" = (
 /obj/machinery/cell_charger,
 /obj/item/assembly/signaler,
@@ -527,11 +521,11 @@ VQ
 iW
 Ge
 iW
-iW
-iW
-iW
-iW
 zH
+iW
+iW
+iW
+iW
 iW
 iW
 iW
@@ -649,7 +643,7 @@ vk
 vk
 vk
 vk
-Xm
+vk
 Sp
 iW
 iW

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -316,6 +316,8 @@
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword/space/oldcode
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 	icon = 'whitesands/icons/mob/simple_human.dmi'
 	icon_state = "oldcode_syndicate_csaber"
 	icon_living = "oldcode_syndicate_csaber"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the amount of damage that oldcode sword mobs did from 30 to 20. They already get armor penetration and free space movement alongside this damage, so the change is justified. Also reduces the density of mobs in the ruin to hopefully lower the amount of people this ruin murders.
![image](https://user-images.githubusercontent.com/95449138/172773081-a9db5979-26cb-4bf6-bd8d-710f3511d9b0.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ruins should not be merciless deathtraps for players, and this ruin definitely fell under that category for me at least. Most players would approach this ruin in a mining hardsuit, look in the first room, and proceed to get mulched (or severely injured) by the oldcode esword mob with 30 melee damage and armor penetration that would lurk in the airlock. In all of my time observing and playing, I have never seen a crew make it past the first two rooms without casualties. Most would die in space as what is essentially a space carp with an esword would chase them into space and murder them for looking at them the wrong way.

If only we could avoid the sin that is what remains of tgs "antag balance" in our antagless codebase. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: decreased the oldcode sword mob's damage from 30 to 20
tweak: decreased the amount of mobs in oldcodeops.dmm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
