### PR TITLE
copyTurf() Audit

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -35,6 +35,10 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		T.update_atom_colour()
 	if(T.dir != dir)
 		T.setDir(dir)
+	if(T.smoothing_flags != smoothing_flags)
+		T.smoothing_flags
+		QUEUE_SMOOTH(target)
+		QUEUE_SMOOTH_NEIGHBORS(target)
 	return T
 
 /turf/open/copyTurf(turf/T, copy_air = FALSE)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(T.dir != dir)
 		T.setDir(dir)
 	if(T.smoothing_flags != smoothing_flags)
-		T.smoothing_flags
+		T.smoothing_flags = smoothing_flags
 		QUEUE_SMOOTH(T)
 		QUEUE_SMOOTH_NEIGHBORS(T)
 	return T

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -37,8 +37,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		T.setDir(dir)
 	if(T.smoothing_flags != smoothing_flags)
 		T.smoothing_flags
-		QUEUE_SMOOTH(target)
-		QUEUE_SMOOTH_NEIGHBORS(target)
+		QUEUE_SMOOTH(T)
+		QUEUE_SMOOTH_NEIGHBORS(T)
 	return T
 
 /turf/open/copyTurf(turf/T, copy_air = FALSE)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -551,6 +551,16 @@
 	ScrapeAway(null, flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 
+/turf/closed/mineral/gibtonite/copyTurf(turf/closed/mineral/gibtonite/T, copy_air, flags)
+	. = ..()
+	if(T.det_time != det_time)
+		T.det_time = det_time
+	if(T.stage != stage)
+		T.stage = stage //you cannot escape the consequences of your actions
+	if(T.activated_ckey != activated_ckey)
+		T.activated_ckey = activated_ckey
+	if(T.activated_name != activated_name)
+		T.activated_name = activated_name
 
 /turf/closed/mineral/gibtonite/volcanic
 	environment_type = "basalt"

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -4,8 +4,6 @@
 	icon_state = ""
 	smoothing_flags = SMOOTH_BITMASK
 	canSmoothWith = null
-	var/last_event = 0
-	var/active = null
 
 /turf/closed/wall/mineral/gold
 	name = "gold wall"
@@ -76,6 +74,8 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
+	var/last_event = 0
+	var/active = null
 
 /turf/closed/wall/mineral/uranium/proc/radiate()
 	if(!active)
@@ -88,6 +88,10 @@
 			active = null
 			return
 	return
+
+/turf/closed/wall/mineral/uranium/copyTurf(turf/closed/wall/mineral/uranium/T, copy_air, flags)
+	. = ..()
+	T.last_event = last_event
 
 /turf/closed/wall/mineral/uranium/attack_hand(mob/user)
 	radiate()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -43,3 +43,8 @@
 	else //edit, not sure how else to get it to work
 		I.play_tool_sound(src, 80)
 		return ScrapeAway(1, CHANGETURF_INHERIT_AIR) //edit, this doesnt work unless its like this
+
+/turf/open/floor/plating/catwalk_floor/copyTurf(turf/open/floor/plating/catwalk_floor/T, copy_air)
+	. = ..()
+	if(T.covered != covered)
+		T.covered = covered

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -40,6 +40,12 @@
 		icon_state = "[icon_normal]off"
 		set_light(0)
 
+/turf/open/floor/circuit/copyTurf(turf/open/floor/circuit/T, copy_air)
+	. = ..()
+	if(T.on != on)
+		T.on = on
+		T.update_icon()
+
 /turf/open/floor/circuit/off
 	icon_state = "bcircuitoff"
 	on = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This probably won't ever affect the game in practice, ever. But it's the thought that counts!

Basically- **ALL TURFS WHICH HAVE VARIABLES THAT CAN CHANGE IN GAME SHOULD HAVE A copyTurf() IMPLEMENTATION WHICH COPIES THESE VARS!** This is so the turfs are properly copied instead of reset to their initial variables. (This is fine for turfs which have vars but the vars are only changed per type, as the type will have the var set already.)

## Why It's Good For The Game
Honestly it won't do anything? If a turf with more functionality is added and these practices are followed, it'll be good since it works properly.

## Changelog
:cl:
code: Ensures turf copying is consistent.
fix: Changed smoothing flags will now carry over when moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
