### PR TITLE
Helm console power usage fix?

### DIFF
--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -119,3 +119,5 @@
 	name = "Integrated NTNet Quantum Relay"
 	use_power = NO_POWER_USE
 	circuit = null
+	active_power_usage = 0
+	idle_power_usage = 0


### PR DESCRIPTION

## About The Pull Request

So the helm draws like... 10kW. That's kinda a shitton of power. It does this because SOMEONE crammed an entire fucking NTNet relay into it, and for some reason, it still draws power when it looks like they went through the effort of atleast trying to make it not draw power. So I kinda just set the subtype it uses to have 0 on both power draws. Because, you know, that probably works if what they did before didn't.

## Why It's Good For The Game

the helm killing your ships power is Bad

## Changelog
:cl:
fix: The helm console no longer draws 10kW for little reason. Probably.
/:cl:
