### PR TITLE
adjusts overmap encounter docking port placement

### DIFF
--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -288,8 +288,8 @@ SUBSYSTEM_DEF(overmap)
 
 	// locates the first dock in the bottom left, accounting for padding and the border
 	var/turf/primary_docking_turf = locate(
-		vlevel.low_x+RESERVE_DOCK_DEFAULT_PADDING+1 + vlevel.reserved_margin,
-		vlevel.low_y+RESERVE_DOCK_DEFAULT_PADDING+1 + vlevel.reserved_margin,
+		vlevel.low_x+RESERVE_DOCK_DEFAULT_PADDING + vlevel.reserved_margin,
+		vlevel.low_y+RESERVE_DOCK_DEFAULT_PADDING + vlevel.reserved_margin,
 		vlevel.z_value
 		)
 	// now we need to offset to account for the first dock
@@ -323,14 +323,14 @@ SUBSYSTEM_DEF(overmap)
 		// no ruin, so we can make more docks upward
 		var/turf/tertiary_docking_turf = locate(
 			primary_docking_turf.x,
-			primary_docking_turf.y+RESERVE_DOCK_MAX_SIZE_LONG+RESERVE_DOCK_DEFAULT_PADDING,
+			primary_docking_turf.y+RESERVE_DOCK_MAX_SIZE_SHORT+RESERVE_DOCK_DEFAULT_PADDING,
 			primary_docking_turf.z
 			)
 		// rinse and repeat
 		var/turf/quaternary_docking_turf = locate(
-			primary_docking_turf.x+RESERVE_DOCK_MAX_SIZE_LONG+RESERVE_DOCK_DEFAULT_PADDING,
-			primary_docking_turf.y+RESERVE_DOCK_MAX_SIZE_LONG+RESERVE_DOCK_DEFAULT_PADDING,
-			primary_docking_turf.z
+			secondary_docking_turf.x,
+			secondary_docking_turf.y+RESERVE_DOCK_MAX_SIZE_SHORT+RESERVE_DOCK_DEFAULT_PADDING,
+			secondary_docking_turf.z
 			)
 
 		var/obj/docking_port/stationary/tertiary_dock = new(tertiary_docking_turf)


### PR DESCRIPTION
## About The Pull Request

adjusts the spacing and placement of docking ports on overmap encounters, particularly empty space encounters. it's a bit difficult to explain in words so i made some pictures to help -- the image represents the full 127x127 virtual level, with a 3-tile border on all sides making a 121x121 tile usable space. the docking port areas are the colored rectangles inside that square. the lines connecting the docking ports are spacings -- if two lines have the same color, they have the same spacing.

docking ports on dynamic encounters used to be placed like this (the upper two docking areas only appear in empty space):
![base](https://user-images.githubusercontent.com/53132901/172585351-c5a17e4c-d5a9-49d3-a956-edec7ac6585d.png)

now they're placed like this:
![new](https://user-images.githubusercontent.com/53132901/172585405-143b9b03-a4ee-42fd-af5f-2ca1c48c543c.png)

this shouldn't break or intersect with any ruins, i think

## Why It's Good For The Game

even spacing on each side was my original intention when i wrote the code for placing docking ports on encounters, and i think it's better if the ships in empty space are more closely packed with one another. it lets people get to each other easier (and it also opens up more space for builds on my 0.1 outposts)

## Changelog
:cl:
tweak: Overmap encounter docking port placement has been tweaked to be slightly more consistent.
/:cl:
