### PR TITLE
Nerfs venus human traps

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -86,9 +86,10 @@
 	ranged = TRUE
 	harm_intent_damage = 5
 	obj_damage = 60
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	melee_damage_lower = 18
+	melee_damage_upper = 18
 	a_intent = INTENT_HARM
+	ranged_cooldown_time = 45
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
@@ -103,18 +104,11 @@
 	/// How far away a plant can attach a vine to something
 	var/vine_grab_distance = 5
 	/// Whether or not this plant is ghost possessable
-	var/playable_plant = TRUE
+	var/playable_plant = FALSE
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life()
 	. = ..()
 	pull_vines()
-
-/mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()
-	. = ..()
-	if(isliving(target))
-		var/mob/living/L = target
-		if(L.stat != DEAD)
-			adjustHealth(-maxHealth * 0.1)
 
 /mob/living/simple_animal/hostile/venus_human_trap/OpenFire(atom/the_target)
 	for(var/datum/beam/B in vines)
@@ -136,7 +130,7 @@
 	vines += newVine
 	if(isliving(the_target))
 		var/mob/living/L = the_target
-		L.Paralyze(20)
+		L.Paralyze(12)
 	ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/venus_human_trap/Login()
@@ -148,6 +142,11 @@
 	if(.)
 		return
 	humanize_plant(user)
+
+/mob/living/simple_animal/hostile/venus_human_trap/Destroy()
+	for(var/datum/beam/vine as anything in vines)
+		qdel(vine) // reference is automatically deleted by remove_vine
+	return ..()
 
 /**
   * Sets a ghost to control the plant if the plant is eligible


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the amount of time a venus human trap's vine grab hardstuns, increases the cooldown on said attack, lowers damage and removes their ability to regain health on hit. Also disables the ability for ghosts to enter them at any time. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This relic of old tg kudzu was unfortunately overpowered, and needed some adjustments to allow it to be used in ruins without it just fuckin murdering players. We also don't even have kudzu incidents here, so they really don't need to be this powerful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: venus human traps have reduced stuns, damage and lose the ability to regain health on hit. the vine attack now has a longer cooldown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
