### PR TITLE
Replaces /datum/status_effect/crusher_damage with /datum/component/crusher_damage

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -105,8 +105,6 @@
 
 #define STATUS_EFFECT_SIGILMARK /datum/status_effect/sigil_mark
 
-#define STATUS_EFFECT_CRUSHERDAMAGETRACKING /datum/status_effect/crusher_damage //tracks total kinetic crusher damage on a target
-
 #define STATUS_EFFECT_SYPHONMARK /datum/status_effect/syphon_mark //tracks kills for the KA death syphon module
 
 #define STATUS_EFFECT_INLOVE /datum/status_effect/in_love //Displays you as being in love with someone else, and makes hearts appear around them.

--- a/code/datums/components/crusher_damage.dm
+++ b/code/datums/components/crusher_damage.dm
@@ -1,0 +1,2 @@
+/datum/component/crusher_damage //tracks the damage dealt to this mob by kinetic crushers
+	var/total_damage = 0

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -10,13 +10,6 @@
 	if(owner.stat < stat_allowed)
 		qdel(src)
 
-/datum/status_effect/crusher_damage //tracks the damage dealt to this mob by kinetic crushers
-	id = "crusher_damage"
-	duration = -1
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = null
-	var/total_damage = 0
-
 /datum/status_effect/syphon_mark
 	id = "syphon_mark"
 	duration = 50

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -82,15 +82,14 @@
 		to_chat(user, "<span class='warning'>[src] is too heavy to use with one hand! You fumble and drop everything.</span>")
 		user.drop_all_held_items()
 		return
-	var/datum/status_effect/crusher_damage/C = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	var/datum/component/crusher_damage/crusher_damage = target.GetComponent( /datum/component/crusher_damage )
 	var/target_health = target.health
 	..()
-	for(var/t in trophies)
+	for(var/obj/item/crusher_trophy/trophy in trophies)
 		if(!QDELETED(target))
-			var/obj/item/crusher_trophy/T = t
-			T.on_melee_hit(target, user)
-	if(!QDELETED(C) && !QDELETED(target))
-		C.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
+			trophy.on_melee_hit(target, user)
+	if(!QDELETED(crusher_damage) && !QDELETED(target))
+		crusher_damage.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
 
 /obj/item/kinetic_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	. = ..()
@@ -118,25 +117,24 @@
 		var/datum/status_effect/crusher_mark/CM = L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)
 		if(!CM || CM.hammer_synced != src || !L.remove_status_effect(STATUS_EFFECT_CRUSHERMARK))
 			return
-		var/datum/status_effect/crusher_damage/C = L.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+		var/datum/component/crusher_damage/crusher_damage = L.GetComponent( /datum/component/crusher_damage )
 		var/target_health = L.health
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_mark_detonation(target, user)
+		for(var/obj/item/crusher_trophy/trophy in trophies)
+			trophy.on_mark_detonation(target, user)
 		if(!QDELETED(L))
-			if(!QDELETED(C))
-				C.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
+			if(!QDELETED(crusher_damage))
+				crusher_damage.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
 			new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
 			var/backstab_dir = get_dir(user, L)
 			var/def_check = L.getarmor(type = "bomb")
 			if((user.dir & backstab_dir) && (L.dir & backstab_dir))
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
+				if(!QDELETED(crusher_damage))
+					crusher_damage.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
 				L.apply_damage(detonation_damage + backstab_bonus, BRUTE, blocked = def_check)
 				playsound(user, 'sound/weapons/kenetic_accel.ogg', 100, TRUE) //Seriously who spelled it wrong
 			else
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage
+				if(!QDELETED(crusher_damage))
+					crusher_damage.total_damage += detonation_damage
 				L.apply_damage(detonation_damage, BRUTE, blocked = def_check)
 
 /obj/item/kinetic_crusher/proc/Recharge()
@@ -843,15 +841,14 @@
 		to_chat(user, "<span class='warning'>[src] is too heavy to use with one hand! You fumble and drop everything.</span>")
 		user.drop_all_held_items()
 		return
-	var/datum/status_effect/crusher_damage/C = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	var/datum/component/crusher_damage/crusher_damage = target.GetComponent( /datum/component/crusher_damage )
 	var/target_health = target.health
 	..()
-	for(var/t in trophies)
+	for(var/obj/item/crusher_trophy/trophy in trophies)
 		if(!QDELETED(target))
-			var/obj/item/crusher_trophy/T = t
-			T.on_melee_hit(target, user)
-	if(!QDELETED(C) && !QDELETED(target))
-		C.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
+			trophy.on_melee_hit(target, user)
+	if(!QDELETED(crusher_damage) && !QDELETED(target))
+		crusher_damage.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
 
 /obj/item/syndie_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	. = ..()
@@ -879,25 +876,24 @@
 		var/datum/status_effect/crusher_mark/CM = L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)
 		if(!CM || CM.hammer_synced != src || !L.remove_status_effect(STATUS_EFFECT_CRUSHERMARK))
 			return
-		var/datum/status_effect/crusher_damage/C = L.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+		var/datum/component/crusher_damage/crusher_damage = L.GetComponent( /datum/component/crusher_damage )
 		var/target_health = L.health
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_mark_detonation(target, user)
+		for(var/obj/item/crusher_trophy/trophy in trophies)
+			trophy.on_mark_detonation(target, user)
 		if(!QDELETED(L))
-			if(!QDELETED(C))
-				C.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
+			if(!QDELETED(crusher_damage))
+				crusher_damage.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
 			new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
 			var/backstab_dir = get_dir(user, L)
 			var/def_check = L.getarmor(type = "bomb")
 			if((user.dir & backstab_dir) && (L.dir & backstab_dir))
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
+				if(!QDELETED(crusher_damage))
+					crusher_damage.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item
 				L.apply_damage(detonation_damage + backstab_bonus, BRUTE, blocked = def_check)
 				playsound(user, 'sound/weapons/kenetic_accel.ogg', 100, TRUE) //Seriously who spelled it wrong
 			else
-				if(!QDELETED(C))
-					C.total_damage += detonation_damage
+				if(!QDELETED(crusher_damage))
+					crusher_damage.total_damage += detonation_damage
 				L.apply_damage(detonation_damage, BRUTE, blocked = def_check)
 
 /obj/item/syndie_crusher/proc/Recharge()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -46,7 +46,7 @@
 	. = ..()
 	if(gps_name && true_spawn)
 		AddComponent(/datum/component/gps, gps_name)
-	apply_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	AddComponent(/datum/component/crusher_damage)
 	ADD_TRAIT(src, TRAIT_NO_TELEPORT, MEGAFAUNA_TRAIT)
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	for(var/action_type in attack_action_types)
@@ -71,9 +71,9 @@
 	if(health > 0)
 		return
 	else
-		var/datum/status_effect/crusher_damage/C = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+		var/datum/component/crusher_damage/crusher_damage = GetComponent( /datum/component/crusher_damage )
 		var/crusher_kill = FALSE
-		if(C && crusher_loot && C.total_damage >= maxHealth * 0.6)
+		if(crusher_damage && crusher_loot && crusher_damage.total_damage >= maxHealth * 0.6)
 			spawn_crusher_loot()
 			crusher_kill = TRUE
 		if(true_spawn && !(flags_1 & ADMIN_SPAWNED_1))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -32,7 +32,7 @@
 		stack_trace("Invalid type [armor.type] found in .armor during /mob/living/simple_animal/hostile/asteroid Initialize()")		//WS edit begin - Whitesands
 
 	. = ..()
-	apply_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	AddComponent(/datum/component/crusher_damage)
 
 /mob/living/simple_animal/hostile/asteroid/Aggro()
 	..()
@@ -70,8 +70,8 @@
 
 /mob/living/simple_animal/hostile/asteroid/death(gibbed)
 	SSblackbox.record_feedback("tally", "mobs_killed_mining", 1, type)
-	var/datum/status_effect/crusher_damage/C = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-	if(C && crusher_loot && prob((C.total_damage/maxHealth) * crusher_drop_mod)) //on average, you'll need to kill 4 creatures before getting the item
+	var/datum/component/crusher_damage/crusher_damage = GetComponent( /datum/component/crusher_damage )
+	if(crusher_damage && crusher_loot && prob((crusher_damage.total_damage/maxHealth) * crusher_drop_mod)) //on average, you'll need to kill 4 creatures before getting the item
 		spawn_crusher_loot()
 	..(gibbed)
 

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -440,6 +440,7 @@
 #include "code\datums\components\connect_loc_behalf.dm"
 #include "code\datums\components\construction.dm"
 #include "code\datums\components\creamed.dm"
+#include "code\datums\components\crusher_damage.dm"
 #include "code\datums\components\deadchat_control.dm"
 #include "code\datums\components\decal.dm"
 #include "code\datums\components\dejavu.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces status_effect/crusher_damage with component/crusher_damage

## Why It's Good For The Game

Theoretically better performance for the same functionality, although I'm not sure if a component was the right choice considering it's so tiny now. I verified crusher trophies were still dropping correctly afterwards. 

## Changelog
:cl:
fix: Replaced /datum/status_effect/crusher_damage with /datum/component/crusher_damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
