### PR TITLE
Fixes loadout tablets being useless and empty

### DIFF
--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -67,7 +67,7 @@
 
 /datum/gear/tablet
 	display_name = "tablet computer"
-	path = /obj/item/modular_computer/tablet
+	path = /obj/item/modular_computer/tablet/preset/cheap
 
 /datum/gear/pen
 	display_name = "pen, black"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the tablet computer that the loadout menu gives you at roundstart from an empty tablet frame to the cheapest possible functional tablet instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
why the hell does it just give a useless frame right now? you can't do anything with the frame unless you have r&d or one of those hyper-specific vendors. let me use my damn computer. ????????????????????????????????
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Space Radioshack got new tablets in stock, so you can select actual functional ones in your loadout as opposed to the completely useless empty display tablets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
