### PR TITLE
Rebalances Xenobio aspects

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -663,7 +663,7 @@ GENE SCANNER
 	to_render += "\nGrowth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]"
 	if(T.effectmod)
 		to_render += "\n<span class='notice'>Core mutation in progress: [T.effectmod]</span>\
-					  \n<span class='notice'>Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]</span>"
+					  \n<span class='notice'>Progress in core mutation: [T.applied] / [(SLIME_EXTRACT_CROSSING_REQUIRED * T.crossbreed_modifier)]</span>"
 	to_chat(user, to_render + "\n========================")
 
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -545,6 +545,11 @@
 	show_in_roundend = FALSE //These are here for admin tracking purposes only
 	you_are_greet = FALSE
 
+	chem_storage = 25
+	geneticpoints = 2
+	chem_recharge_rate = 0.5
+	dna_max = 3
+
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()
 

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -1,8 +1,8 @@
 /datum/action/changeling/fakedeath
 	name = "Reviving Stasis"
-	desc = "We fall into a stasis, allowing us to regenerate and trick our enemies. Costs 15 chemicals."
+	desc = "We fall into a stasis, allowing us to regenerate and trick our enemies. Costs 30 chemicals."
 	button_icon_state = "fake_death"
-	chemical_cost = 15
+	chemical_cost = 30
 	dna_cost = 0
 	req_dna = 1
 	req_stat = DEAD

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -706,6 +706,28 @@
 	jitteriness = 0
 	stop_sound_channel(CHANNEL_HEARTBEAT)
 
+//proc used to heal a mob, but only damage types specified.
+/mob/living/proc/specific_heal(blood_amt = 0, brute_amt = 0, fire_amt = 0, tox_amt = 0, oxy_amt = 0, clone_amt = 0, organ_amt = 0, stam_amt = 0, specific_revive = FALSE)
+	if(iscarbon(src))
+		var/mob/living/carbon/C = src
+		if(!(C.dna?.species && (NOBLOOD in C.dna.species.species_traits)))
+			C.blood_volume += (blood_amt)
+
+		for(var/i in C.internal_organs)
+			var/obj/item/organ/O = i
+			if(O.organ_flags & ORGAN_SYNTHETIC)
+				continue
+			O.applyOrganDamage(organ_amt*-1)//1 = 5 organ damage healed
+
+	if(specific_revive)
+		revive()
+
+	adjustBruteLoss(brute_amt*-1)
+	adjustFireLoss(fire_amt*-1)
+	adjustToxLoss(tox_amt*-1)
+	adjustOxyLoss(oxy_amt*-1)
+	adjustCloneLoss(clone_amt*-1)
+	adjustStaminaLoss(stam_amt*-1)
 
 //proc called by revive(), to check if we can actually ressuscitate the mob (we don't want to revive him and have him instantly die again)
 /mob/living/proc/can_be_revived()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -707,7 +707,7 @@
 	stop_sound_channel(CHANNEL_HEARTBEAT)
 
 //proc used to heal a mob, but only damage types specified.
-/mob/living/proc/specific_heal(blood_amt = 0, brute_amt = 0, fire_amt = 0, tox_amt = 0, oxy_amt = 0, clone_amt = 0, organ_amt = 0, stam_amt = 0, specific_revive = FALSE)
+/mob/living/proc/specific_heal(blood_amt = 0, brute_amt = 0, fire_amt = 0, tox_amt = 0, oxy_amt = 0, clone_amt = 0, organ_amt = 0, stam_amt = 0, specific_revive = FALSE, specific_bones = FALSE)
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 		if(!(C.dna?.species && (NOBLOOD in C.dna.species.species_traits)))
@@ -718,6 +718,10 @@
 			if(O.organ_flags & ORGAN_SYNTHETIC)
 				continue
 			O.applyOrganDamage(organ_amt*-1)//1 = 5 organ damage healed
+
+		if(specific_bones)
+			for(var/obj/item/bodypart/B in C.bodyparts)
+				B.fix_bone()
 
 	if(specific_revive)
 		revive()

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -79,6 +79,7 @@
 	///////////CORE-CROSSING CODE
 
 	var/effectmod //What core modification is being used.
+	var/crossbreed_modifier = 1 // modifies how many extracts are needed
 	var/applied = 0 //How many extracts of the modtype have been applied.
 
 
@@ -366,7 +367,7 @@
 				qdel(S)
 				applied++
 				hasFound = TRUE
-			if(applied >= SLIME_EXTRACT_CROSSING_REQUIRED)
+			if(applied >= (SLIME_EXTRACT_CROSSING_REQUIRED * crossbreed_modifier))
 				to_chat(user, "<span class='notice'>You feed the slime as many of the extracts from the bag as you can, and it mutates!</span>")
 				playsound(src, 'sound/effects/attackblob.ogg', 50, TRUE)
 				spawn_corecross()

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -5,7 +5,7 @@
 	multiplicative_slowdown = 3
 
 /datum/movespeed_modifier/status_effect/lightpink
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -0.1
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/tarfoot

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -5,7 +5,7 @@
 	multiplicative_slowdown = 3
 
 /datum/movespeed_modifier/status_effect/lightpink
-	multiplicative_slowdown = -0.1
+	multiplicative_slowdown = -0.25
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/tarfoot

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -8,7 +8,7 @@ Slimecrossing Weapons
 /obj/item/melee/arm_blade/slime
 	name = "slimy boneblade"
 	desc = "What remains of the bones in your arm. Incredibly sharp, and painful for both you and your opponents."
-	force = 15
+	force = 22.5
 	force_string = "painful"
 
 /obj/item/melee/arm_blade/slime/attack(mob/living/L, mob/user)
@@ -23,13 +23,13 @@ Slimecrossing Weapons
 	icon = 'icons/obj/slimecrossing.dmi'
 	icon_state = "rainbowknife"
 	item_state = "rainbowknife"
-	force = 15
+	force = 18
 	throwforce = 15
 	damtype = BRUTE
 
 /obj/item/kitchen/knife/rainbowknife/afterattack(atom/O, mob/user, proximity)
 	if(proximity && istype(O, /mob/living))
-		damtype = pick(BRUTE, BURN, TOX, OXY, CLONE)
+		damtype = pick(BRUTE, BURN, TOX, OXY)
 	switch(damtype)
 		if(BRUTE)
 			hitsound = 'sound/weapons/bladeslice.ogg'
@@ -43,9 +43,6 @@ Slimecrossing Weapons
 		if(OXY)
 			hitsound = 'sound/effects/space_wind.ogg'
 			attack_verb = list("suffocated","winded","vacuumed")
-		if(CLONE)
-			hitsound = 'sound/items/geiger/ext1.ogg'
-			attack_verb = list("irradiated","mutated","maligned")
 	return ..()
 
 //Adamantine shield - Chilling Adamantine

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -180,7 +180,7 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/sepia
 	colour = "sepia"
-	effect_desc = "Touching someone with it adds/removes them from a list. Activating the extract stops time for 30 seconds, and everyone on the list is immune, except the user."
+	effect_desc = "Touching someone with it adds/removes them from a list. Activating the extract stops time for 7 seconds, and everyone on the list is immune, except the user."
 	var/list/allies = list()
 
 /obj/item/slimecross/chilling/sepia/afterattack(atom/target, mob/user, proximity)
@@ -197,7 +197,7 @@ Chilling extracts:
 /obj/item/slimecross/chilling/sepia/do_effect(mob/user)
 	user.visible_message("<span class='warning'>[src] shatters, freezing time itself!</span>")
 	allies -= user //support class
-	new /obj/effect/timestop(get_turf(user), 2, 300, allies)
+	new /obj/effect/timestop(get_turf(user), 2, 70, allies)
 	..()
 
 /obj/item/slimecross/chilling/cerulean

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -40,7 +40,7 @@ Regenerative extracts:
 	var/brute_loss = (5 + (H.getBruteLoss() * 0.35))
 	var/stamina_loss = (5 + (H.getStaminaLoss() * 0.5))
 	H.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
-	H.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_atm = stamina_loss, organ_amt = 2, clone_amt = 100, blood_amt = 100)
+	H.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_amt = stamina_loss, organ_amt = 2, clone_amt = 100, blood_amt = 100)
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -9,6 +9,19 @@ Regenerative extracts:
 	effect = "regenerative"
 	icon_state = "regenerative"
 
+	var/oxy_loss = 0
+	var/tox_loss = 0
+	var/fire_loss = 0
+	var/brute_loss = 0
+	var/stamina_loss = 0
+	var/blood_loss = 100
+	var/organ_loss = 3
+	var/slime_heal_modifier = 1 //Specialised types only heal half
+	var/jelly_amount = 7.5
+	var/bone_loss = FALSE
+	var/life_loss = FALSE
+	var/slime_delay = 10
+
 /obj/item/slimecross/regenerative/proc/core_effect(mob/living/carbon/human/target, mob/user)
 	return
 /obj/item/slimecross/regenerative/proc/core_effect_before(mob/living/carbon/human/target, mob/user)
@@ -19,35 +32,40 @@ Regenerative extracts:
 	if(!prox || !isliving(target))
 		return
 	var/mob/living/H = target
-	if(H.stat == DEAD)
+	if(H.stat == DEAD && life_loss)
+		slime_delay = 200 //Reviving the dead takes a while, 20 seconds to be exact
+		to_chat(user, "<span class='warning'>You begin using the [src] to try and bring [H] back from the dead...</span>")
+	else
+		slime_delay = 10
+	if(H.stat == DEAD && !life_loss) // Won't revive the dead, except for specific extracts
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
 	if(H != user)
-		if(!do_mob(user, H, 10)) // 1 second delay
+		if(!do_mob(user, H, slime_delay)) // 1 second delay
 			return FALSE
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating some of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating some of [H.p_their()] injuries.</span>")
 	else
-		if(!do_mob(user, H, 20)) // 2 second delay
+		if(!do_mob(user, H, (slime_delay * 2))) // 2 second delay
 			return FALSE
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating some of [user.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates som of your injuries!</span>")
-	core_effect_before(H, user)
-// Slimes are good at healing clone damage, but don't heal other damage types as much. Additionally heals 10 organ damage.
-	var/oxy_loss = (5 + (H.getOxyLoss() * 0.35))
-	var/tox_loss = (5 + (H.getToxLoss() * 0.35))
-	var/fire_loss = (5 + (H.getFireLoss() * 0.35))
-	var/brute_loss = (5 + (H.getBruteLoss() * 0.35))
-	var/stamina_loss = (5 + (H.getStaminaLoss() * 0.5))
-	H.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
-	H.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_amt = stamina_loss, organ_amt = 2, clone_amt = 100, blood_amt = 100)
-	core_effect(H, user)
+			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates some of your injuries!</span>")
+// Slimes are good at healing clone damage, but don't heal other damage types as much. Additionally heals 15 organ damage.
+	core_effect_before(H, user) // can affect heal multiplier
+	oxy_loss = (12.5 + (H.getOxyLoss() * 0.4 * slime_heal_modifier))
+	tox_loss = (12.5 + (H.getToxLoss() * 0.4 * slime_heal_modifier))
+	fire_loss = (12.5 + (H.getFireLoss() * 0.4 * slime_heal_modifier))
+	brute_loss = (12.5 + (H.getBruteLoss() * 0.4 * slime_heal_modifier))
+	stamina_loss = (12.5 + (H.getStaminaLoss() * 0.5 * slime_heal_modifier))
+	core_effect(H, user) // can affect specific healing values
+	H.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,jelly_amount) // Splits the healing effect across an instant heal, and a smaller heal after.
+	H.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_amt = stamina_loss, organ_amt = organ_loss, clone_amt = 100, blood_amt = blood_loss, specific_bones = bone_loss, specific_revive = life_loss)
 	playsound(target, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)
 
 /obj/item/slimecross/regenerative/grey
 	colour = "grey" //Has no bonus effect.
-	effect_desc = "Fully heals the target and does nothing else."
+	effect_desc = "Partially heals the target and does nothing else."
 
 /obj/item/slimecross/regenerative/orange
 	colour = "orange"
@@ -60,24 +78,32 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/purple
 	colour = "purple"
-	effect_desc = "Fully heals the target and injects them with some regen jelly."
+	effect_desc = "Partially heals the target and injects them with some additional regen jelly."
 
 /obj/item/slimecross/regenerative/purple/core_effect(mob/living/target, mob/user)
-	target.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,10)
+	jelly_amount += 10
 
 /obj/item/slimecross/regenerative/blue
 	colour = "blue"
-	effect_desc = "Fully heals the target and makes the floor wet."
+	effect_desc = "Weakly heals the target, but extra effective at treating burns. Additionally makes the floor wet."
+
+/obj/item/slimecross/regenerative/blue/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.5
 
 /obj/item/slimecross/regenerative/blue/core_effect(mob/living/target, mob/user)
 	if(isturf(target.loc))
 		var/turf/open/T = get_turf(target)
 		T.MakeSlippery(TURF_WET_WATER, min_wet_time = 10, wet_time_to_add = 5)
 		target.visible_message("<span class='warning'>The milky goo in the extract gets all over the floor!</span>")
+	fire_loss = (10 + (target.getFireLoss() * 0.8))
+	jelly_amount *= 0.2
 
 /obj/item/slimecross/regenerative/metal
 	colour = "metal"
-	effect_desc = "Fully heals the target and encases the target in a locker."
+	effect_desc = "Barely heals the target, but fixes their bones .Additionally encases the target in a locker."
+
+/obj/item/slimecross/regenerative/metal/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.1
 
 /obj/item/slimecross/regenerative/metal/core_effect(mob/living/target, mob/user)
 	target.visible_message("<span class='warning'>The milky goo hardens and reshapes itself, encasing [target]!</span>")
@@ -85,10 +111,19 @@ Regenerative extracts:
 	C.name = "slimy closet"
 	C.desc = "Looking closer, it seems to be made of a sort of solid, opaque, metal-like goo."
 	target.forceMove(C)
+	bone_loss = TRUE
+	jelly_amount *= 0.2
 
 /obj/item/slimecross/regenerative/yellow
 	colour = "yellow"
-	effect_desc = "Fully heals the target and fully recharges a single item on the target."
+	effect_desc = "Partially heals the target, can revive the dead. additionally Partially recharges a single item on the target."
+	life_loss = TRUE //Will revive the dead. Heals normally unless target is dead, in which case it heals less.
+
+/obj/item/slimecross/regenerative/yellow/core_effect_before(mob/living/target, mob/user)
+	if(target.stat == DEAD)
+		slime_heal_modifier = 0.1
+	else
+		slime_heal_modifier = 0.75 //discourages spamming these to revive a target, combine with other cores
 
 /obj/item/slimecross/regenerative/yellow/core_effect(mob/living/target, mob/user)
 	var/list/batteries = list()
@@ -99,10 +134,15 @@ Regenerative extracts:
 		var/obj/item/stock_parts/cell/ToCharge = pick(batteries)
 		ToCharge.charge = ToCharge.maxcharge
 		to_chat(target, "<span class='notice'>You feel a strange electrical pulse, and one of your electrical items was recharged.</span>")
+	if(target.stat == DEAD)
+		blood_loss = 50
+		organ_loss = 2
+		jelly_amount *= 0.2
+		target.visible_message("<span class='warning'>The [src] sparks as it tries to revive [target]!</span>")
 
 /obj/item/slimecross/regenerative/darkpurple
 	colour = "dark purple"
-	effect_desc = "Fully heals the target and gives them purple clothing if they are naked."
+	effect_desc = "Partially heals the target and gives them purple clothing if they are naked."
 
 /obj/item/slimecross/regenerative/darkpurple/core_effect(mob/living/target, mob/user)
 	var/equipped = 0
@@ -115,7 +155,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/darkblue
 	colour = "dark blue"
-	effect_desc = "Fully heals the target and fireproofs their clothes."
+	effect_desc = "Partially heals the target and fireproofs their clothes."
 
 /obj/item/slimecross/regenerative/darkblue/core_effect(mob/living/target, mob/user)
 	if(!ishuman(target))
@@ -143,7 +183,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/silver
 	colour = "silver"
-	effect_desc = "Fully heals the target and makes their belly feel round and full."
+	effect_desc = "Partially heals the target and makes their belly feel round and full."
 
 /obj/item/slimecross/regenerative/silver/core_effect(mob/living/target, mob/user)
 	target.set_nutrition(NUTRITION_LEVEL_FULL - 1)
@@ -151,7 +191,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/bluespace
 	colour = "bluespace"
-	effect_desc = "Fully heals the target and teleports them to where this core was created."
+	effect_desc = "Partially heals the target and teleports them to where this core was created."
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
@@ -166,7 +206,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"
-	effect_desc = "Fully heals the target and stops time."
+	effect_desc = "Partially heals the target and stops time."
 
 /obj/item/slimecross/regenerative/sepia/core_effect_before(mob/living/target, mob/user)
 	to_chat(target, "<span class=notice>You try to forget how you feel.</span>")
@@ -174,7 +214,10 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/cerulean
 	colour = "cerulean"
-	effect_desc = "Fully heals the target and makes a second regenerative core with no special effects."
+	effect_desc = "Slightly heals the target, but provides a boost of oxygen for a while. Additionally makes a second regenerative core with no special effects."
+
+/obj/item/slimecross/regenerative/cerulean/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.5
 
 /obj/item/slimecross/regenerative/cerulean/core_effect(mob/living/target, mob/user)
 	src.forceMove(user.loc)
@@ -182,11 +225,13 @@ Regenerative extracts:
 	X.name = name
 	X.desc = desc
 	user.put_in_active_hand(X)
+	oxy_loss = 150
+	target.reagents.add_reagent(/datum/reagent/medicine/salbutamol,15) //Similar to the luminescent effect, lets you breathe without oxygen for a while.
 	to_chat(user, "<span class='notice'>Some of the milky goo congeals in your hand!</span>")
 
 /obj/item/slimecross/regenerative/pyrite
 	colour = "pyrite"
-	effect_desc = "Fully heals and randomly colors the target."
+	effect_desc = "Partially heals and randomly colors the target."
 
 /obj/item/slimecross/regenerative/pyrite/core_effect(mob/living/target, mob/user)
 	target.visible_message("<span class='warning'>The milky goo coating [target] leaves [target.p_them()] a different color!</span>")
@@ -194,15 +239,22 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/red
 	colour = "red"
-	effect_desc = "Fully heals the target and injects them with some ephedrine."
+	effect_desc = "Slightly heals the target and injects them with a lot of blood, what a rush!"
+
+/obj/item/slimecross/regenerative/red/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.5
 
 /obj/item/slimecross/regenerative/red/core_effect(mob/living/target, mob/user)
 	to_chat(target, "<span class='notice'>You feel... <i>faster.</i></span>")
 	target.reagents.add_reagent(/datum/reagent/medicine/ephedrine,3)
+	blood_loss += 700
 
 /obj/item/slimecross/regenerative/green
 	colour = "green"
-	effect_desc = "Fully heals the target and changes the spieces or color of a slime or jellyperson."
+	effect_desc = "Weakly heals the target, but fixes their organs .Additionally changes the spieces or color of a slime or jellyperson."
+
+/obj/item/slimecross/regenerative/green/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.5
 
 /obj/item/slimecross/regenerative/green/core_effect(mob/living/target, mob/user)
 	if(isslime(target))
@@ -211,11 +263,12 @@ Regenerative extracts:
 		S.random_colour()
 	if(isjellyperson(target))
 		target.reagents.add_reagent(/datum/reagent/mutationtoxin/jelly,5)
+	organ_loss += 17
 
 
 /obj/item/slimecross/regenerative/pink
 	colour = "pink"
-	effect_desc = "Fully heals the target and injects them with some krokodil."
+	effect_desc = "Partially heals the target and injects them with some krokodil."
 
 /obj/item/slimecross/regenerative/pink/core_effect(mob/living/target, mob/user)
 	to_chat(target, "<span class='notice'>You feel more calm.</span>")
@@ -223,7 +276,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/gold
 	colour = "gold"
-	effect_desc = "Fully heals the target and produces a random coin."
+	effect_desc = "Partially heals the target and produces a random coin."
 
 /obj/item/slimecross/regenerative/gold/core_effect(mob/living/target, mob/user)
 	var/newcoin = pick(/obj/item/coin/silver, /obj/item/coin/iron, /obj/item/coin/gold, /obj/item/coin/diamond, /obj/item/coin/plasma, /obj/item/coin/uranium)
@@ -233,7 +286,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/oil
 	colour = "oil"
-	effect_desc = "Fully heals the target and flashes everyone in sight."
+	effect_desc = "Partially heals the target and flashes everyone in sight."
 
 /obj/item/slimecross/regenerative/oil/core_effect(mob/living/target, mob/user)
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
@@ -242,7 +295,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/black
 	colour = "black"
-	effect_desc = "Fully heals the target and creates a duplicate of them, that drops dead soon after."
+	effect_desc = "Partially heals the target and creates a duplicate of them, that drops dead soon after."
 
 /obj/item/slimecross/regenerative/black/core_effect_before(mob/living/target, mob/user)
 	var/dummytype = target.type
@@ -261,7 +314,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/lightpink
 	colour = "light pink"
-	effect_desc = "Fully heals the target and also heals the user."
+	effect_desc = "Partially heals the target and also heals the user."
 
 // Doesn't heal the user as much as the target
 /obj/item/slimecross/regenerative/lightpink/core_effect(mob/living/target, mob/user)
@@ -270,25 +323,30 @@ Regenerative extracts:
 	if(target == user)
 		return
 	var/mob/living/U = user
-	var/oxy_loss = (5 + (U.getOxyLoss() * 0.2))
-	var/tox_loss = (5 + (U.getToxLoss() * 0.2))
-	var/fire_loss = (5 + (U.getFireLoss() * 0.2))
-	var/brute_loss = (5 + (U.getBruteLoss() * 0.2))
-	var/stamina_loss = (5 + (U.getStaminaLoss() * 0.35))
-	U.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
+	var/oxy_loss = (10 + (U.getOxyLoss() * 0.3))
+	var/tox_loss = (10 + (U.getToxLoss() * 0.3))
+	var/fire_loss = (10 + (U.getFireLoss() * 0.3))
+	var/brute_loss = (10 + (U.getBruteLoss() * 0.3))
+	var/stamina_loss = (10 + (U.getStaminaLoss() * 0.35))
+	U.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,10) // Splits the healing effect across an instant heal, and a smaller heal after.
 	U.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_amt = stamina_loss, organ_amt = 2, clone_amt = 100)
 	to_chat(U, "<span class='notice'>Some of the milky goo sprays onto you, as well!</span>")
 
 /obj/item/slimecross/regenerative/adamantine
 	colour = "adamantine"
-	effect_desc = "Fully heals the target and boosts their armor."
+	effect_desc = "weakly heals the target, but extra effective at treating brute trauma. Additionally boosts their armor."
+
+/obj/item/slimecross/regenerative/adamantine/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.3
 
 /obj/item/slimecross/regenerative/adamantine/core_effect(mob/living/target, mob/user) //WIP - Find out why this doesn't work.
 	target.apply_status_effect(STATUS_EFFECT_SLIMESKIN)
+	brute_loss = (10 + (target.getBruteLoss() * 0.65)) //most common damage type, let's not go overboard
+	jelly_amount *= 0.5
 
 /obj/item/slimecross/regenerative/rainbow
 	colour = "rainbow"
-	effect_desc = "Fully heals the target and temporarily makes them immortal, but pacifistic."
+	effect_desc = "Partially heals the target and temporarily makes them immortal, but pacifistic."
 
 /obj/item/slimecross/regenerative/rainbow/core_effect(mob/living/target, mob/user)
 	target.apply_status_effect(STATUS_EFFECT_RAINBOWPROTECTION)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -46,7 +46,7 @@ Regenerative extracts:
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating some of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating some of [H.p_their()] injuries.</span>")
 	else
-		if(!do_mob(user, H, (slime_delay * 2))) // 2 second delay
+		if(!do_mob(user, H, (slime_delay * 1.5))) // 1.5 second delay
 			return FALSE
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating some of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates some of your injuries!</span>")
@@ -78,9 +78,13 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/purple
 	colour = "purple"
-	effect_desc = "Partially heals the target and injects them with some additional regen jelly."
+	effect_desc = "Weakly heals the target, but treats toxin damage especially well. Additionally injects them with some additional regen jelly."
+
+/obj/item/slimecross/regenerative/purple/core_effect_before(mob/living/target, mob/user)
+	slime_heal_modifier = 0.75
 
 /obj/item/slimecross/regenerative/purple/core_effect(mob/living/target, mob/user)
+	tox_loss = (10 + (target.getBruteLoss() * 0.8))
 	jelly_amount += 10
 
 /obj/item/slimecross/regenerative/blue
@@ -121,7 +125,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/yellow/core_effect_before(mob/living/target, mob/user)
 	if(target.stat == DEAD)
-		slime_heal_modifier = 0.1
+		slime_heal_modifier = 0.1 //use surgery to fix wounds
 	else
 		slime_heal_modifier = 0.75 //discourages spamming these to revive a target, combine with other cores
 
@@ -135,8 +139,8 @@ Regenerative extracts:
 		ToCharge.charge = ToCharge.maxcharge
 		to_chat(target, "<span class='notice'>You feel a strange electrical pulse, and one of your electrical items was recharged.</span>")
 	if(target.stat == DEAD)
-		blood_loss = 50
-		organ_loss = 2
+		blood_loss = 100
+		organ_loss = 30 // More effective at fixing organs if the target is dead
 		jelly_amount *= 0.2
 		target.visible_message("<span class='warning'>The [src] sparks as it tries to revive [target]!</span>")
 

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -25,13 +25,13 @@ Regenerative extracts:
 	if(H != user)
 		if(!do_mob(user, H, 10)) // 1 second delay
 			return FALSE
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
+		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating some of [H.p_their()] injuries!</span>",
+			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating some of [H.p_their()] injuries.</span>")
 	else
 		if(!do_mob(user, H, 20)) // 2 second delay
 			return FALSE
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
+		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating some of [user.p_their()] injuries!</span>",
+			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates som of your injuries!</span>")
 	core_effect_before(H, user)
 // Slimes are good at healing clone damage, but don't heal other damage types as much. Additionally heals 10 organ damage.
 	var/oxy_loss = (5 + (H.getOxyLoss() * 0.35))

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -276,7 +276,7 @@ Regenerative extracts:
 	var/brute_loss = (5 + (U.getBruteLoss() * 0.2))
 	var/stamina_loss = (5 + (U.getStaminaLoss() * 0.35))
 	U.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
-	U.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_atm = stamina_loss, organ_amt = 2, clone_amt = 100)
+	U.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_amt = stamina_loss, organ_amt = 2, clone_amt = 100)
 	to_chat(U, "<span class='notice'>Some of the milky goo sprays onto you, as well!</span>")
 
 /obj/item/slimecross/regenerative/adamantine

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -23,13 +23,24 @@ Regenerative extracts:
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
 	if(H != user)
+		if(!do_mob(user, H, 10)) // 1 second delay
+			return FALSE
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
 	else
+		if(!do_mob(user, H, 20)) // 2 second delay
+			return FALSE
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)
-	H.revive(full_heal = TRUE, admin_revive = FALSE)
+// Slimes are good at healing clone damage, but don't heal other damage types as much. Additionally heals 10 organ damage.
+	var/oxy_loss = (5 + (H.getOxyLoss() * 0.35))
+	var/tox_loss = (5 + (H.getToxLoss() * 0.35))
+	var/fire_loss = (5 + (H.getFireLoss() * 0.35))
+	var/brute_loss = (5 + (H.getBruteLoss() * 0.35))
+	var/stamina_loss = (5 + (H.getStaminaLoss() * 0.5))
+	H.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
+	H.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_atm = stamina_loss, organ_amt = 2, clone_amt = 100, blood_amt = 100)
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)
@@ -252,13 +263,20 @@ Regenerative extracts:
 	colour = "light pink"
 	effect_desc = "Fully heals the target and also heals the user."
 
+// Doesn't heal the user as much as the target
 /obj/item/slimecross/regenerative/lightpink/core_effect(mob/living/target, mob/user)
 	if(!isliving(user))
 		return
 	if(target == user)
 		return
 	var/mob/living/U = user
-	U.revive(full_heal = TRUE, admin_revive = FALSE)
+	var/oxy_loss = (5 + (U.getOxyLoss() * 0.2))
+	var/tox_loss = (5 + (U.getToxLoss() * 0.2))
+	var/fire_loss = (5 + (U.getFireLoss() * 0.2))
+	var/brute_loss = (5 + (U.getBruteLoss() * 0.2))
+	var/stamina_loss = (5 + (U.getStaminaLoss() * 0.35))
+	U.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,5) // Splits the healing effect across an instant heal, and a smaller heal after.
+	U.specific_heal(brute_amt = brute_loss, fire_amt = fire_loss, tox_amt = tox_loss, oxy_amt = oxy_loss, stam_atm = stamina_loss, organ_amt = 2, clone_amt = 100)
 	to_chat(U, "<span class='notice'>Some of the milky goo sprays onto you, as well!</span>")
 
 /obj/item/slimecross/regenerative/adamantine

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -201,7 +201,7 @@
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
 	effectmod = "regenerative"
-	crossbreed_modifier = 0.5
+	crossbreed_modifier = 0.3
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
 	research = SLIME_RESEARCH_TIER_1
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -880,7 +880,7 @@
 
 /obj/item/slimepotion/speed
 	name = "slime speed potion"
-	desc = "A potent chemical mix that will remove the slowdown from any item."
+	desc = "A potent chemical mix that will reduce the slowdown from any item."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potyellow"
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -893,10 +893,10 @@
 		return
 	if(isitem(C))
 		var/obj/item/I = C
-		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown <= 0.25 || I.obj_flags & IMMUTABLE_SLOW)
 			to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 			return ..()
-		I.slowdown = 0
+		I.slowdown = 0.25
 
 	if(istype(C, /obj/vehicle))
 		var/obj/vehicle/V = C

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -14,6 +14,7 @@
 	var/Uses = 1 ///uses before it goes inert
 	var/qdel_timer = null ///deletion timer, for delayed reactions
 	var/effectmod ///Which type of crossbred
+	var/crossbreed_modifier = 1 //Modifies how many extracts are needed to cross a core.
 	var/list/activate_reagents = list() ///Reagents required for activation
 	var/recurring = FALSE
 	var/research ///Research point value for slime cores. These are defines stored in [/__DEFINES/research] - the actual values are updated there.
@@ -78,13 +79,14 @@
 
 	if(!M.effectmod)
 		M.effectmod = effectmod
+		M.crossbreed_modifier = crossbreed_modifier
 
 	M.applied++
 	qdel(src)
 	to_chat(user, "<span class='notice'>You feed the slime [src], [M.applied == 1 ? "starting to mutate its core." : "further mutating its core."]</span>")
 	playsound(M, 'sound/effects/attackblob.ogg', 50, TRUE)
 
-	if(M.applied >= SLIME_EXTRACT_CROSSING_REQUIRED)
+	if(M.applied >= (SLIME_EXTRACT_CROSSING_REQUIRED * crossbreed_modifier))
 		M.spawn_corecross()
 
 /obj/item/slime_extract/grey
@@ -199,6 +201,7 @@
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
 	effectmod = "regenerative"
+	crossbreed_modifier = 0.5
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
 	research = SLIME_RESEARCH_TIER_1
 
@@ -264,6 +267,7 @@
 	name = "yellow slime extract"
 	icon_state = "yellow slime extract"
 	effectmod = "charged"
+	crossbreed_modifier = 0.8
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
 	research = SLIME_RESEARCH_TIER_2
 
@@ -546,6 +550,7 @@
 	name = "pyrite slime extract"
 	icon_state = "pyrite slime extract"
 	effectmod = "prismatic"
+	crossbreed_modifier = 0.5
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
 	research = SLIME_RESEARCH_TIER_3
 


### PR DESCRIPTION
## About The Pull Request
**NOTE - THIS IS NOT A REWORK, THESE ARE BANDAID FIXES TO CURB THE POWER LEVEL OF XENOBIO** 

Mostly nerfs stuff that's far too powerful in xenobio currently. 
Contains a couple small buffs too, mainly to underused stuff that's meant to be more than just a gimmick.
Also nerfs xenoling significantly. It's a fun feature, but it's currently way, way too strong. This also nerfs normal changeling a little, but those aren't really used that much to begin with, and they're still really good.

**FEEL FREE TO SUGGEST MORE NERFS, BUT KEEP THEM SIMPLE**

## Why It's Good For The Game

Xenobio trivializes many aspects of the game and is notoriously used for powergaming as a result. This should bring the strength of a couple outliers more in line with the power of other departments.

The reason I'm buffing slime armblade and rainbow knife, is because they're mostly just gimmicky, but otherwise ineffective.
The clone damage part of the rainbow knife is almost impossible to treat for the average ship.
The armblade makes you give up an arm for what's ultimately a toolbox that can bleed, and pry open doors. Now you can use it to equip golems, or as cheap arnaments for the crew that don't completely suck.

## Changelog
:cl:
balance: xenoling get only 25 max chemicals, limiting ability use.
balance: xenolings generate chemicals half as fast
balance: xenolings only get 2 ability points
balance: xenolings can only store half as much DNA (this affects the strength of some abilities)
balance: changeling fake death cost raised 15 => 30
balance: ALL regenerative extracts now need time to be applied. This is increased when self applying!
balance: Stabilized light pink extract effect decreased by 80%
balance: Slime speed potion has a capped effect, you cannot make armor free of slowdown anymore.
balance: Slime armblade damage raised from 15 => 22.5
balance: Rainbow knife no longer deals clone damage.
balance: Rainbow knife damage increased from 15 => 18
balance: Chilling sepia extract duration crippled from 30 => 7 seconds.
balance: Regenerative extracts no longer Aheal you. Instead, they heal 35% of all damage. Still fully heals clone damage. Heals a little organ damage. Heals 10% of the average blood pool.
balance: Some regenerative extracts are better at healing specific damage types.
balance: Some extracts need less cores to be crossbred now.
/:cl:

