### PR TITLE
Fixes up /me's formatting

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -61,7 +61,13 @@
 		return
 
 	user.log_message(msg, LOG_EMOTE)
-	var/space = should_have_space_before_emote(html_encode(msg)[1]) ? " " : ""
+
+	//Removing space if necessary, and adding punctuation to the end
+	var/space = should_have_space_before_emote(html_encode(msg)) ? " " : ""
+	var/end = copytext(msg, length(msg))
+	if(!(end in list("!", ".", "?", ":", "\"", "-")))
+		msg += "."
+
 	var/dchatmsg = "<b>[user]</b>[space][msg]"
 
 	var/tmp_sound = get_sound(user)
@@ -199,5 +205,6 @@
  * Returns TRUE if there should be a space, FALSE if there shouldn't.
  */
 /proc/should_have_space_before_emote(string)
-	var/static/regex/no_spacing_emote_characters = regex(@"(,|')")
+	var/static/regex/no_spacing_emote_characters = regex(@"^(,|&.*39)")
 	return no_spacing_emote_characters.Find(string) ? FALSE : TRUE
+// &#39;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Manual emotes now remove the separatory space if the /me starts with an apostrophe, and also automatically adds a period to the end of the emote if it doesn't have punctuation already. The code for the space removal was already there and works with commas, but because apostrophes are HELL FORMATTED it didn't work for them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Joe Tider's head explodes.
seriously HOW has this bug with apostrophes existed this long i hate html formatting i hate html formatting i hate html formatting
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Emotes now properly remove the separatory space when started with an apostrophe.
tweak: Emotes now auto-add a period at the end if no punctuation is given.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
