### PR TITLE
Gives a well deserved nerf to Icemoon mining fauna.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
@@ -65,12 +65,6 @@
 	SLEEP_CHECK_DEATH(8)
 	return ..()
 
-/mob/living/simple_animal/hostile/asteroid/ice_demon/Life()
-	. = ..()
-	if(!. || target)
-		return
-	adjustHealth(-maxHealth*0.025)
-
 /mob/living/simple_animal/hostile/asteroid/ice_demon/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT
 	move_resist = MOVE_RESIST_DEFAULT
@@ -154,12 +148,6 @@
 	do_teleport(src, end, 0,  channel=TELEPORT_CHANNEL_BLUESPACE, forced = TRUE)
 	SLEEP_CHECK_DEATH(8)
 	return ..()
-
-/mob/living/simple_animal/hostile/asteroid/ice_demon/Life()
-	. = ..()
-	if(!. || target)
-		return
-	adjustHealth(-maxHealth*0.025)
 
 /mob/living/simple_animal/hostile/asteroid/old_demon/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice whelp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice whelp.dm
@@ -18,14 +18,13 @@
 	health = 300
 	obj_damage = 15
 	environment_smash = ENVIRONMENT_SMASH_MINERALS
-	armour_penetration = 20
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attack_verb_continuous = "chomps"
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/magic/demon_attack1.ogg'
-	vision_range = 7
-	aggro_vision_range = 7
+	vision_range = 5
+	aggro_vision_range = 5
 	move_resist = MOVE_FORCE_VERY_STRONG
 	butcher_results = list(/obj/item/stack/ore/diamond = 3, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/bone = 10, /obj/item/stack/sheet/animalhide/ashdrake = 1)
 	loot = list()
@@ -42,12 +41,6 @@
 	var/turf/T = get_ranged_target_turf_direct(src, target, fire_range)
 	var/list/burn_turfs = getline(src, T) - get_turf(src)
 	dragon_fire_line(src, burn_turfs)
-
-/mob/living/simple_animal/hostile/asteroid/ice_whelp/Life()
-	. = ..()
-	if(!. || target)
-		return
-	adjustHealth(-maxHealth*0.025)
 
 /mob/living/simple_animal/hostile/asteroid/ice_whelp/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -46,13 +46,6 @@
 	speed = 7
 	move_to_delay = 7
 
-/mob/living/simple_animal/hostile/asteroid/polarbear/Life()
-	. = ..()
-	if(target)
-		return
-	adjustHealth(-maxHealth*0.025)
-	aggressive_message_said = FALSE
-
 /mob/living/simple_animal/hostile/asteroid/polarbear/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT
 	move_resist = MOVE_RESIST_DEFAULT

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -113,13 +113,6 @@
 		visible_message("<span class='warning'>You notice a damaged ear that might be salvagable.</span>")
 	..()
 
-/mob/living/simple_animal/hostile/asteroid/wolf/Life()
-	. = ..()
-	if(!. || target)
-		return
-	adjustHealth(-maxHealth*0.025)
-	retreat_message_said = FALSE
-
 /obj/item/crusher_trophy/wolf_ear
 	name = "wolf ear"
 	desc = "The battered remains of a wolf's ear. You could attach it to a crusher, or use the fur to craft a trophy."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the stupidly powerful health regeneration from Ice whelps, ice demons and polar bears. This was also removed on main TG for similar reasons, go figure.
Removes the armor peircing abilities of the ice whelp, due to it being buggy and applying to the fire breath for some reason. This means if you ever got hit directly by the fire breath attack and took a larger amount of damage than you should have, this is the code to blame.
Decreases the aggro distance of ice whelps, making it so that situations where they break onto your ship and massacre your crew happen even less often.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ice fauna has been way too powerful for too long with this regen. When a planet becomes known for fauna that murders entire ships due to an unlucky spawn, its time for a nerf. Ice whelps will still be plenty powerful with their combination of burn and brute damage, so don't get too cocky and try to take one on without a proper weapon. 

Example of why this change was necessary: 
![image](https://user-images.githubusercontent.com/95449138/173946684-d28556c9-1158-4c62-aaf7-3410442b42ac.png)
A single ice whelp murders an entire ship. Every time a crewmember tried to fight it, they would get it to almost no hp, die, and then watch in horror as it regenerated back to full health in under two minutes. They also husk bodies when they hit them with fire breath. Isn't that swell?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removed health regeneration from ice mining mobs
balance: removed armor peircing from the ice whelp
balance: lowered the ice whelp's aggro range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
