### PR TITLE
Enigma-Class Ruin

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
@@ -1,22 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ac" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"bm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
 "br" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed,
@@ -71,16 +53,6 @@
 /obj/item/melee/greykingsword,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"bT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "bU" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating/snowed,
@@ -121,7 +93,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -137,8 +108,11 @@
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "dV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/ice/icemoon,
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "ed" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -196,15 +170,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/ice)
-"fz" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
 "fC" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/pod,
@@ -213,7 +178,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -345,6 +309,9 @@
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "kb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
@@ -444,33 +411,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"md" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/table/wood/reinforced,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 1
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "mg" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"mt" = (
-/obj/machinery/door/window/survival_pod{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
 /area/overmap_encounter/planetoid/ice)
 "mX" = (
 /obj/structure/cable,
@@ -515,9 +461,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
 	dir = 8
@@ -530,25 +473,7 @@
 "oM" = (
 /turf/template_noop,
 /area/template_noop)
-"oT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "pI" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -588,12 +513,6 @@
 /obj/effect/turf_decal/corner/bar/border,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"qM" = (
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 4
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
@@ -651,14 +570,6 @@
 /obj/item/electronics/airlock,
 /turf/open/floor/plating,
 /area/overmap_encounter/planetoid/ice)
-"tW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 4
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "uo" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -676,9 +587,6 @@
 "uJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "uQ" = (
@@ -714,16 +622,6 @@
 	},
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
-"uV" = (
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mob_spawn/human/corpse/cargo_tech,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "vD" = (
 /obj/effect/turf_decal/corner/bar/bordercee{
 	dir = 4
@@ -737,9 +635,6 @@
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "vI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
@@ -764,15 +659,6 @@
 "wN" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/corner/bar/border,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"xd" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 1
-	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "xi" = (
@@ -806,16 +692,7 @@
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"xO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "yd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c";
 	dir = 1
@@ -918,11 +795,6 @@
 	},
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
-"AQ" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "Bb" = (
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
@@ -931,9 +803,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
 	dir = 4;
 	color = "#57967f"
@@ -960,14 +829,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"CE" = (
-/obj/effect/turf_decal/spline/fancy/corner/brown{
-	color = "#997C4F";
-	dir = 8
-	},
-/obj/structure/bed,
-/turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "CG" = (
 /obj/structure/table/reinforced,
@@ -1011,21 +872,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/overmap_encounter/planetoid/ice)
-"Ej" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/beige/half{
-	color = "#ba774c"
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"Fh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "GG" = (
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
@@ -1035,22 +881,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"GJ" = (
-/obj/structure/table/wood/reinforced,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 1
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"GX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "GZ" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
@@ -1100,7 +930,6 @@
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "HH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
 	},
@@ -1133,9 +962,6 @@
 /area/overmap_encounter/planetoid/ice)
 "Ia" = (
 /obj/effect/turf_decal/spline/fancy/brown,
-/obj/machinery/atmospherics/pipe/simple/supply{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
@@ -1152,29 +978,6 @@
 	},
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"Ir" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/wall/white{
-	pixel_y = 32
-	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "IG" = (
 /obj/effect/turf_decal/spline/fancy/brown{
@@ -1195,9 +998,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "JB" = (
@@ -1244,28 +1044,12 @@
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
-"Lb" = (
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "Lr" = (
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c";
 	dir = 4
 	},
 /obj/item/wirecutters/old,
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"Lu" = (
-/obj/effect/decal/cleanable/food/plant_smudge,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 8
-	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "LU" = (
@@ -1324,18 +1108,8 @@
 /area/overmap_encounter/planetoid/ice)
 "Ne" = (
 /obj/structure/window/reinforced/survival_pod/spawner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"Nh" = (
-/obj/effect/turf_decal/corner/bar/border{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "NF" = (
 /obj/effect/turf_decal/corner/bar/border{
@@ -1384,18 +1158,6 @@
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"OM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "OW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 8
@@ -1437,9 +1199,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "QM" = (
@@ -1465,9 +1224,6 @@
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "Sa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -1561,9 +1317,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 4
 	},
@@ -1651,25 +1404,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/mob_spawn/human/corpse/cargo_tech,
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "Wj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
@@ -1779,12 +1518,6 @@
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
-"XY" = (
-/obj/effect/turf_decal/spline/fancy/brown{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
 "Yb" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1793,9 +1526,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "YI" = (
@@ -1859,7 +1589,7 @@ nk
 Eb
 oM
 nk
-nk
+wn
 Eb
 oM
 oM
@@ -1871,7 +1601,7 @@ oM
 oM
 oM
 oM
-nk
+wn
 lh
 nk
 nk
@@ -1895,7 +1625,7 @@ oM
 dP
 qb
 cE
-Nh
+Dz
 lI
 nk
 Df
@@ -1917,7 +1647,7 @@ dP
 WP
 Mh
 GG
-kb
+GG
 cJ
 Mh
 GG
@@ -1960,7 +1690,7 @@ Xe
 GG
 GG
 bE
-Fh
+GG
 oa
 zr
 jx
@@ -2001,7 +1731,7 @@ tf
 qb
 br
 kg
-Ej
+kg
 Tx
 hj
 HP
@@ -2041,7 +1771,7 @@ oM
 oM
 tf
 qb
-GX
+GG
 YI
 HH
 Tx
@@ -2106,7 +1836,7 @@ sC
 qb
 Bb
 GG
-kb
+GG
 Sa
 GG
 GG
@@ -2128,7 +1858,7 @@ UI
 vG
 oh
 fY
-VP
+Xp
 iO
 vG
 vG
@@ -2146,7 +1876,7 @@ oM
 oM
 nk
 nk
-nk
+wn
 nk
 HZ
 WE
@@ -2275,9 +2005,9 @@ oM
 oM
 wn
 NK
-bT
+kr
 Ne
-xO
+wn
 oM
 oM
 oM
@@ -2308,14 +2038,14 @@ oM
 oM
 "}
 (23,1,1) = {"
-nk
-WU
-nk
 oM
 oM
 oM
 oM
-nk
+oM
+oM
+oM
+wn
 zt
 hH
 JF
@@ -2329,16 +2059,16 @@ WU
 nk
 "}
 (24,1,1) = {"
-nk
-re
-nk
-WU
-WU
-nk
+oM
+oM
+oM
+oM
+oM
+oM
 oM
 nk
 CY
-bm
+AI
 ZG
 Eb
 oM
@@ -2350,12 +2080,12 @@ re
 nk
 "}
 (25,1,1) = {"
-nk
-kd
-nk
-re
-re
-nk
+oM
+oM
+oM
+oM
+oM
+oM
 oM
 nk
 qb
@@ -2371,16 +2101,16 @@ kd
 nk
 "}
 (26,1,1) = {"
-nk
-OW
-nk
-mt
-mt
-nk
+oM
+oM
+oM
+oM
+oM
+oM
 nk
 nk
 fe
-eF
+kb
 ZG
 nk
 nk
@@ -2392,12 +2122,12 @@ OW
 nk
 "}
 (27,1,1) = {"
-nk
-Ir
-CE
-uV
-Lb
-nk
+oM
+oM
+oM
+oM
+oM
+oM
 nk
 nk
 sk
@@ -2413,11 +2143,11 @@ ek
 nk
 "}
 (28,1,1) = {"
-nk
-xd
-tW
-os
-Xp
+oM
+oM
+oM
+oM
+oM
 IG
 JD
 nk
@@ -2434,9 +2164,9 @@ XV
 nk
 "}
 (29,1,1) = {"
-Eb
-fz
-OM
+oM
+oM
+oM
 pI
 Wg
 Wj
@@ -2455,36 +2185,36 @@ uJ
 Eb
 "}
 (30,1,1) = {"
-nk
-md
-ac
-dV
+oM
+oM
+oM
+oM
 GG
 Bb
 gw
 nk
 pM
-eF
+VP
 JB
 nk
 QP
 GG
 GG
 fC
-Lu
+PC
 Wy
 nk
 "}
 (31,1,1) = {"
-nk
-GJ
-GG
+oM
+oM
+oM
 PY
 LZ
 uq
 Ia
 nk
-qb
+dV
 RN
 JB
 nk
@@ -2497,10 +2227,10 @@ xi
 nk
 "}
 (32,1,1) = {"
-nk
-oT
-qM
-XY
+oM
+oM
+oM
+oM
 mg
 by
 QM
@@ -2515,12 +2245,12 @@ st
 pN
 Nd
 MA
-nk
+wn
 "}
 (33,1,1) = {"
-nk
-Eb
-AQ
+oM
+oM
+oM
 nk
 nk
 nk
@@ -2564,8 +2294,8 @@ oM
 oM
 oM
 oM
-nk
-nk
+wn
+wn
 Ze
 GG
 Mh

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
@@ -2,7 +2,7 @@
 "br" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "bt" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
@@ -10,14 +10,14 @@
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "by" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -25,7 +25,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "bS" = (
 /obj/item/clothing/glasses/cheapsuns,
 /obj/item/areaeditor/shuttle,
@@ -52,28 +52,28 @@
 /obj/item/disk/tech_disk/major,
 /obj/item/melee/greykingsword,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "bU" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "cE" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 8
 	},
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "cJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "cY" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/smartfridge/survival_pod/empty,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "dn" = (
 /obj/structure/window/reinforced/survival_pod/spawner/east,
 /obj/machinery/conveyor/auto{
@@ -83,12 +83,12 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "dr" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "dy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -98,7 +98,7 @@
 	},
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "dP" = (
 /obj/machinery/door/poddoor{
 	id = 7
@@ -106,14 +106,14 @@
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "dV" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
 	},
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ed" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -123,7 +123,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ey" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler,
@@ -131,7 +131,7 @@
 /obj/item/wallframe/firealarm,
 /obj/item/electronics/firealarm,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "eF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -143,7 +143,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "eV" = (
 /obj/machinery/conveyor/auto{
 	dir = 9
@@ -152,18 +152,18 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "fe" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "fC" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "fO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -183,7 +183,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "fY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -192,7 +192,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ga" = (
 /obj/effect/turf_decal/corner/bottlegreen/border{
 	dir = 5
@@ -205,7 +205,7 @@
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "gw" = (
 /obj/effect/turf_decal/spline/fancy/brown,
 /obj/machinery/atmospherics/pipe/simple/supply{
@@ -213,7 +213,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "gT" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /obj/machinery/door/firedoor/border_only{
@@ -221,7 +221,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "hj" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
@@ -234,7 +234,7 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "hw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -246,7 +246,7 @@
 /obj/effect/turf_decal/corner/bar/border,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "hH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -258,7 +258,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "hY" = (
 /obj/machinery/conveyor/auto{
 	dir = 5
@@ -267,7 +267,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ik" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 4
@@ -279,25 +279,25 @@
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "iH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop{
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "iO" = (
 /obj/effect/turf_decal/corner/bar/bordercorner,
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "jx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "kb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -306,13 +306,13 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "kg" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "kr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -321,7 +321,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "lh" = (
 /obj/machinery/mineral/mint{
 	name = "old coin press";
@@ -334,7 +334,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "lt" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light{
@@ -344,7 +344,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "lI" = (
 /obj/machinery/atmospherics/pipe/simple/supply{
 	dir = 5
@@ -359,7 +359,7 @@
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "lN" = (
 /obj/item/clothing/suit/toggle/lawyer/black,
 /obj/item/clothing/mask/spamton,
@@ -377,7 +377,7 @@
 	name = "Spamton Cosplay?"
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -394,47 +394,47 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "mg" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "mX" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "nk" = (
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "oa" = (
 /obj/item/weldingtool/old,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "oh" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ol" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "os" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "oD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -447,7 +447,7 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "oM" = (
 /turf/template_noop,
 /area/template_noop)
@@ -456,12 +456,12 @@
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "pL" = (
 /obj/effect/turf_decal/corner/bar/border,
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "pM" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -471,7 +471,7 @@
 	},
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "pN" = (
 /obj/machinery/light{
 	dir = 4
@@ -480,44 +480,44 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "qb" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "qc" = (
 /obj/effect/turf_decal/corner/bar/border,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "rR" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "sk" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "st" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 4
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "sz" = (
 /obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "sC" = (
 /obj/effect/spawner/structure/window/survival_pod,
 /obj/machinery/door/poddoor{
@@ -525,17 +525,17 @@
 	},
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "sY" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "tf" = (
 /obj/structure/fans/tiny,
 /obj/structure/poddoor_assembly,
 /obj/item/electronics/airlock,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "uo" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -545,16 +545,16 @@
 	dir = 6
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "uq" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "uJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "uQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -581,17 +581,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "vG" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "vK" = (
 /obj/machinery/light{
 	dir = 4
@@ -600,26 +600,26 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "wl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "wn" = (
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "wN" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/corner/bar/border,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "xi" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "xk" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /obj/machinery/door/firedoor/border_only{
@@ -627,7 +627,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "xx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -645,7 +645,7 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "yd" = (
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c";
@@ -653,7 +653,7 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "yx" = (
 /obj/machinery/door/airlock/survival_pod,
 /obj/structure/cable{
@@ -672,17 +672,17 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "yJ" = (
 /obj/effect/turf_decal/corner/bar/border,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "zr" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "zt" = (
 /obj/machinery/light{
 	dir = 8
@@ -691,7 +691,7 @@
 	dir = 9
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Af" = (
 /obj/item/hatchet,
 /obj/item/plant_analyzer,
@@ -714,7 +714,7 @@
 /obj/item/circuitboard/machine/hydroponics,
 /obj/item/circuitboard/machine/hydroponics,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ak" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -724,7 +724,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "AE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -733,7 +733,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "AI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -742,10 +742,10 @@
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Bb" = (
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "BA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -757,7 +757,7 @@
 	},
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Cq" = (
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c";
@@ -765,7 +765,7 @@
 	},
 /obj/item/crowbar/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Cs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -777,7 +777,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "CG" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband{
@@ -789,40 +789,40 @@
 	pixel_x = -11
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "CY" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Df" = (
 /obj/effect/turf_decal/corner/bar/bordercorner{
 	dir = 8
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Dz" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Eb" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "GG" = (
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "GH" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "GZ" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /obj/machinery/door/firedoor/border_only{
@@ -830,7 +830,7 @@
 	},
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Hj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -855,12 +855,12 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Hs" = (
 /obj/effect/spawner/structure/window/survival_pod,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "HG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -869,7 +869,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "HH" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
@@ -878,7 +878,7 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "HP" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
@@ -888,7 +888,7 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "HZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -900,12 +900,12 @@
 	name = "Heavy-duty mining gear storage"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ia" = (
 /obj/effect/turf_decal/spline/fancy/brown,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ip" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -919,39 +919,39 @@
 	},
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "IG" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Jj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
 /obj/item/multitool/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Jt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "JB" = (
 /obj/effect/turf_decal/corner/bar/border,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "JD" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 10
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "JF" = (
 /obj/machinery/light{
 	dir = 8
@@ -960,7 +960,7 @@
 	dir = 10
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Km" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 9
@@ -969,7 +969,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ku" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light{
@@ -979,12 +979,12 @@
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "KX" = (
 /obj/item/stack/ore/bluespace_crystal,
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Lr" = (
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c";
@@ -992,7 +992,7 @@
 	},
 /obj/item/wirecutters/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "LU" = (
 /obj/item/screwdriver/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1001,11 +1001,11 @@
 	name = "demonic-frost shipbreaker"
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "LZ" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Mg" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
@@ -1018,16 +1018,16 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Mh" = (
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "MA" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 6
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "MH" = (
 /obj/effect/turf_decal/corner/bottlegreen/border{
 	dir = 10
@@ -1039,14 +1039,14 @@
 	dir = 9
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Nd" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 4
 	},
 /turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "NF" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 6
@@ -1055,7 +1055,7 @@
 	name = "Heavy-duty mining gear storage"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "NK" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1064,7 +1064,7 @@
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "NN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1073,7 +1073,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Or" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1093,11 +1093,11 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "PC" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "PE" = (
 /obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
 	dir = 4;
@@ -1107,11 +1107,11 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "PY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "QC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1120,19 +1120,19 @@
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "QM" = (
 /obj/effect/turf_decal/spline/fancy/brown{
 	dir = 6
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "QP" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "RN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1142,14 +1142,14 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Sa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Sw" = (
 /obj/structure/table/reinforced,
 /obj/structure/fluff/paper/stack{
@@ -1159,7 +1159,7 @@
 	info = "Yo, this may be your last shipment before you have to turn in the ship and go into hiding. Their demands are getting pretty bad now and I'm telling you this for your own safety. Sincerely, B."
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "SZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1177,14 +1177,14 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Te" = (
 /obj/effect/turf_decal/corner/beige/bordercorner{
 	color = "#ba774c"
 	},
 /obj/item/wrench/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Tg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1197,19 +1197,19 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Tk" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ts" = (
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/effect/turf_decal/corner/bar/border,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Tx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1222,11 +1222,11 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ug" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ut" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1241,7 +1241,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -1250,7 +1250,7 @@
 	amount = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "UA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1261,14 +1261,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "UI" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 5
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "UR" = (
 /obj/effect/spawner/structure/window/survival_pod,
 /obj/machinery/door/firedoor/window,
@@ -1276,7 +1276,10 @@
 	id = 7
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
+"UU" = (
+/turf/template_noop,
+/area/ruin/unpowered)
 "UZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1291,7 +1294,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "VF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1300,7 +1303,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "VG" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen{
 	dir = 1
@@ -1310,7 +1313,7 @@
 	},
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "VP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1319,37 +1322,37 @@
 	dir = 8
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Wg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Wj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Wy" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Wz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "WD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "WE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1364,7 +1367,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "WP" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 1
@@ -1375,7 +1378,7 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Xe" = (
 /obj/machinery/light{
 	dir = 1
@@ -1389,7 +1392,7 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Xg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1402,13 +1405,13 @@
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Xp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "XJ" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
@@ -1416,11 +1419,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "XT" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Yb" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1430,7 +1433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "YI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -1439,7 +1442,7 @@
 	color = "#ba774c"
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "YR" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c";
@@ -1447,7 +1450,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "YZ" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 6
@@ -1468,15 +1471,15 @@
 /obj/item/stack/rods/twentyfive,
 /obj/item/circuitboard/machine/biogenerator,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "Ze" = (
 /obj/item/gps/computer,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 "ZG" = (
 /obj/effect/turf_decal/corner/bar/border,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 oM
@@ -1909,7 +1912,7 @@ oM
 wn
 NK
 kr
-oM
+UU
 oM
 oM
 oM

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
@@ -474,7 +474,6 @@
 /area/overmap_encounter/planetoid/ice)
 "mX" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "nk" = (
@@ -662,7 +661,6 @@
 /area/overmap_encounter/planetoid/ice)
 "uo" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/light{
 	dir = 4
 	},

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
@@ -124,16 +124,6 @@
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"ek" = (
-/obj/effect/turf_decal/spline/fancy/bottlegreen{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/food/tomato_smudge,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
 "ey" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler,
@@ -317,12 +307,6 @@
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"kd" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "kg" = (
 /obj/effect/turf_decal/corner/beige/half{
 	color = "#ba774c"
@@ -425,12 +409,6 @@
 "nk" = (
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/overmap_encounter/planetoid/ice)
-"nu" = (
-/obj/machinery/door/window/survival_pod{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "oa" = (
 /obj/item/weldingtool/old,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
@@ -515,18 +493,6 @@
 	dir = 1
 	},
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"qR" = (
-/obj/structure/window/reinforced/survival_pod/spawner,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"re" = (
-/obj/structure/window/reinforced/survival_pod/spawner/west,
-/turf/open/floor/plating,
 /area/overmap_encounter/planetoid/ice)
 "rR" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
@@ -615,18 +581,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
-"uR" = (
-/obj/effect/turf_decal/corner/bar/border{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
-"vD" = (
-/obj/effect/turf_decal/corner/bar/bordercee{
-	dir = 4
-	},
-/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "vG" = (
 /obj/effect/turf_decal/corner/bar/border{
@@ -761,12 +715,6 @@
 /obj/item/circuitboard/machine/hydroponics,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"Ai" = (
-/obj/structure/window/reinforced/survival_pod/spawner,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "Ak" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -847,13 +795,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
-"Dc" = (
-/obj/effect/turf_decal/corner/bar/border,
-/obj/effect/turf_decal/corner/bar/bordercorner{
-	dir = 1
-	},
-/turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
 "Df" = (
 /obj/effect/turf_decal/corner/bar/bordercorner{
@@ -1106,11 +1047,6 @@
 	},
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/ice)
-"Ne" = (
-/obj/structure/window/reinforced/survival_pod/spawner,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "NF" = (
 /obj/effect/turf_decal/corner/bar/border{
 	dir = 6
@@ -1158,17 +1094,6 @@
 	},
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"OW" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/door/window/survival_pod{
-	dir = 4
-	},
-/obj/item/wallframe/button,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/ice)
 "PC" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/pod,
@@ -1185,11 +1110,6 @@
 /area/overmap_encounter/planetoid/ice)
 "PY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed,
-/area/overmap_encounter/planetoid/ice)
-"Qx" = (
-/obj/structure/window/reinforced/survival_pod/spawner,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "QC" = (
@@ -1412,15 +1332,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/overmap_encounter/planetoid/ice)
-"Wl" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/bottlegreen{
-	dir = 8
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/ice)
 "Wy" = (
 /obj/effect/turf_decal/spline/fancy/bottlegreen,
 /turf/open/floor/pod,
@@ -1464,10 +1375,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"WU" = (
-/obj/structure/window/reinforced/survival_pod/spawner/east,
-/turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "Xe" = (
 /obj/machinery/light{
@@ -1513,10 +1420,6 @@
 "XT" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/pod,
-/area/overmap_encounter/planetoid/ice)
-"XV" = (
-/obj/effect/turf_decal/spline/fancy/bottlegreen,
-/turf/open/floor/plating/snowed,
 /area/overmap_encounter/planetoid/ice)
 "Yb" = (
 /obj/structure/cable{
@@ -1588,9 +1491,9 @@ nk
 nk
 Eb
 oM
-nk
-wn
-Eb
+oM
+oM
+oM
 oM
 oM
 oM
@@ -1609,9 +1512,9 @@ hY
 dn
 eV
 nk
-nk
-vD
-nk
+oM
+oM
+oM
 oM
 oM
 oM
@@ -1630,9 +1533,9 @@ lI
 nk
 Df
 Dz
-uR
-Dc
-UR
+oM
+oM
+oM
 oM
 oM
 oM
@@ -1922,7 +1825,7 @@ oM
 oM
 gT
 QC
-qR
+oM
 oM
 oM
 oM
@@ -1943,7 +1846,7 @@ oM
 oM
 GZ
 Cs
-Ai
+oM
 oM
 oM
 oM
@@ -1964,7 +1867,7 @@ oM
 oM
 GH
 AE
-Qx
+oM
 oM
 oM
 oM
@@ -1985,7 +1888,7 @@ oM
 oM
 xk
 Ak
-Qx
+oM
 oM
 oM
 oM
@@ -2006,8 +1909,8 @@ oM
 wn
 NK
 kr
-Ne
-wn
+oM
+oM
 oM
 oM
 oM
@@ -2054,9 +1957,9 @@ oM
 oM
 oM
 oM
-nk
-WU
-nk
+oM
+oM
+oM
 "}
 (24,1,1) = {"
 oM
@@ -2073,11 +1976,11 @@ ZG
 Eb
 oM
 nk
-WU
-WU
-nk
-re
-nk
+oM
+oM
+oM
+oM
+oM
 "}
 (25,1,1) = {"
 oM
@@ -2094,11 +1997,11 @@ pL
 nk
 oM
 nk
-re
-re
-nk
-kd
-nk
+oM
+oM
+oM
+oM
+oM
 "}
 (26,1,1) = {"
 oM
@@ -2115,11 +2018,11 @@ ZG
 nk
 nk
 nk
-nu
-nu
-nk
-OW
-nk
+oM
+oM
+oM
+oM
+oM
 "}
 (27,1,1) = {"
 oM
@@ -2138,9 +2041,9 @@ nk
 nk
 Km
 Xp
-Wl
-ek
-nk
+Mh
+oM
+oM
 "}
 (28,1,1) = {"
 oM
@@ -2160,8 +2063,8 @@ VG
 PE
 Xp
 PC
-XV
-nk
+oM
+oM
 "}
 (29,1,1) = {"
 oM
@@ -2182,7 +2085,7 @@ Ip
 Yb
 Jt
 uJ
-Eb
+oM
 "}
 (30,1,1) = {"
 oM

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm
@@ -1,0 +1,2626 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"bm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"br" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"bt" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"by" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"bE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"bS" = (
+/obj/item/clothing/glasses/cheapsuns,
+/obj/item/areaeditor/shuttle,
+/obj/item/clothing/neck/cloak/qm,
+/obj/item/clothing/head/beret/qm,
+/obj/item/clothing/under/suit/qm,
+/obj/item/clothing/under/rank/cargo/qm,
+/obj/item/clothing/under/rank/cargo/qm/skirt,
+/obj/item/clothing/under/suit/qm/skirt,
+/obj/structure/closet/wall/orange{
+	dir = 1;
+	pixel_y = -32;
+	name = "QM's Closet"
+	},
+/obj/item/stack/sheet/mineral/diamond/twenty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/stack/sheet/mineral/uranium/fifty,
+/obj/item/kinetic_crusher/old,
+/obj/item/gun/energy/kinetic_accelerator/old,
+/obj/item/disk/tech_disk/major,
+/obj/item/disk/tech_disk/major,
+/obj/item/melee/greykingsword,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"bT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"bU" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"cE" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"cJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"cY" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/smartfridge/survival_pod/empty,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"dn" = (
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"dr" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"dy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"dP" = (
+/obj/machinery/door/poddoor{
+	id = 7
+	},
+/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"dV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"ed" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"ek" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"ey" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler,
+/obj/item/wallframe/button,
+/obj/item/wallframe/firealarm,
+/obj/item/electronics/firealarm,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"eF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"eV" = (
+/obj/machinery/conveyor/auto{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"fe" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"fz" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"fC" = (
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"fO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
+	color = "#57967f";
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
+	color = "#57967f";
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"fY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/bordercorner{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"ga" = (
+/obj/effect/turf_decal/corner/bottlegreen/border{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/bottlegreen/border{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 5
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"gw" = (
+/obj/effect/turf_decal/spline/fancy/brown,
+/obj/machinery/atmospherics/pipe/simple/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"gT" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"hj" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 8
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"hw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/bar/border,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"hH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"hY" = (
+/obj/machinery/conveyor/auto{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"ik" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"iH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"iO" = (
+/obj/effect/turf_decal/corner/bar/bordercorner,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"jx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"kb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"kd" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"kg" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"kr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"lh" = (
+/obj/machinery/mineral/mint{
+	name = "old coin press";
+	desc = "Some kind of machine. Looks old from a long time of no use.";
+	input_dir = 2;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/corner/bar/bordercee{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"lt" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"lI" = (
+/obj/machinery/atmospherics/pipe/simple/supply{
+	dir = 5
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/bar/bordercorner{
+	dir = 1
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"lN" = (
+/obj/item/clothing/suit/toggle/lawyer/black,
+/obj/item/clothing/mask/spamton,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/shoes/sneakers/white,
+/obj/item/clothing/suit/armor/vest/blueshirt{
+	color = "#c14385"
+	},
+/obj/item/reagent_containers/glass/bottle/potion/flight,
+/obj/item/autosurgeon/syndicate/laser_arm,
+/obj/item/paper{
+	info = "Why did you want this? Now we're in serious debt to the Syndicate AND Them. Good going, dumbass."
+	},
+/obj/structure/closet/crate{
+	name = "Spamton Cosplay?"
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"lY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 4
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"md" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/table/wood/reinforced,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 1
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"mg" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"mt" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"mX" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"nk" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/overmap_encounter/planetoid/ice)
+"nu" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"oa" = (
+/obj/item/weldingtool/old,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"oh" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"ol" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"os" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"oD" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 8
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"oM" = (
+/turf/template_noop,
+/area/template_noop)
+"oT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"pI" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"pL" = (
+/obj/effect/turf_decal/corner/bar/border,
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"pM" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"pN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"qb" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"qc" = (
+/obj/effect/turf_decal/corner/bar/border,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"qM" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"qR" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"re" = (
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"rR" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"sk" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"st" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"sz" = (
+/obj/machinery/computer/monitor/secret{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"sC" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/obj/machinery/door/poddoor{
+	id = 7
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"sY" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"tf" = (
+/obj/structure/fans/tiny,
+/obj/structure/poddoor_assembly,
+/obj/item/electronics/airlock,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"tW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"uo" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 6
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"uq" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"uJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/spline/fancy/bottlegreen,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"uQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"uR" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"uV" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"vD" = (
+/obj/effect/turf_decal/corner/bar/bordercee{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"vG" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"vI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"vK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"wl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"wn" = (
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"wN" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/corner/bar/border,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"xd" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"xi" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen,
+/obj/effect/decal/cleanable/food/egg_smudge,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"xk" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"xx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"xO" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"yd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/beige/bordercorner{
+	color = "#ba774c";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"yx" = (
+/obj/machinery/door/airlock/survival_pod,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"yJ" = (
+/obj/effect/turf_decal/corner/bar/border,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"zr" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"zt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 9
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Af" = (
+/obj/item/hatchet,
+/obj/item/plant_analyzer,
+/obj/item/storage/bag/plants,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/obj/item/circuitboard/machine/plantgenes,
+/obj/item/circuitboard/machine/seed_extractor,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ai" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"Ak" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"AE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"AI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"AQ" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Bb" = (
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"BA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
+	dir = 4;
+	color = "#57967f"
+	},
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"Cq" = (
+/obj/effect/turf_decal/corner/beige/bordercorner{
+	color = "#ba774c";
+	dir = 8
+	},
+/obj/item/crowbar/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Cs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"CE" = (
+/obj/effect/turf_decal/spline/fancy/corner/brown{
+	color = "#997C4F";
+	dir = 8
+	},
+/obj/structure/bed,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"CG" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband{
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -11
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"CY" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Dc" = (
+/obj/effect/turf_decal/corner/bar/border,
+/obj/effect/turf_decal/corner/bar/bordercorner{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Df" = (
+/obj/effect/turf_decal/corner/bar/bordercorner{
+	dir = 8
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Dz" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Eb" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"Ej" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Fh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"GG" = (
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"GH" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"GJ" = (
+/obj/structure/table/wood/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"GX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"GZ" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Hj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/brown,
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Hs" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"HG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"HH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"HP" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 1
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"HZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 5
+	},
+/obj/machinery/suit_storage_unit/industrial{
+	name = "Heavy-duty mining gear storage"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ia" = (
+/obj/effect/turf_decal/spline/fancy/brown,
+/obj/machinery/atmospherics/pipe/simple/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ip" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"Ir" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/wall/white{
+	pixel_y = 32
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"IG" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Jj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/item/multitool/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Jt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"JB" = (
+/obj/effect/turf_decal/corner/bar/border,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"JD" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 10
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"JF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 10
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Km" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Ku" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"KX" = (
+/obj/item/stack/ore/bluespace_crystal,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Lb" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Lr" = (
+/obj/effect/turf_decal/corner/beige/bordercorner{
+	color = "#ba774c";
+	dir = 4
+	},
+/obj/item/wirecutters/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Lu" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"LU" = (
+/obj/item/screwdriver/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner{
+	desc = "An extremely well-geared shipbreaker, driven crazy or possessed by the demonic forces here, either way a terrifying enemy.";
+	name = "demonic-frost shipbreaker"
+	},
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"LZ" = (
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Mg" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Mh" = (
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"MA" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"MH" = (
+/obj/effect/turf_decal/corner/bottlegreen/border{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/bottlegreen/border{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 9
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Nd" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 4
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"Ne" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"Nh" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"NF" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 6
+	},
+/obj/machinery/suit_storage_unit/industrial{
+	name = "Heavy-duty mining gear storage"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"NK" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"NN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Or" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/brown{
+	color = "#997C4F";
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/corner/brown{
+	color = "#997C4F"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"OM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"OW" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/item/wallframe/button,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"PC" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"PE" = (
+/obj/effect/turf_decal/spline/fancy/corner/bottlegreen{
+	dir = 4;
+	color = "#57967f"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"PY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Qx" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"QC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"QM" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 6
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"QP" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"RN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Sa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Sw" = (
+/obj/structure/table/reinforced,
+/obj/structure/fluff/paper/stack{
+	dir = 5
+	},
+/obj/item/paper/crumpled/bloody{
+	info = "Yo, this may be your last shipment before you have to turn in the ship and go into hiding. Their demands are getting pretty bad now and I'm telling you this for your own safety. Sincerely, B."
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"SZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Te" = (
+/obj/effect/turf_decal/corner/beige/bordercorner{
+	color = "#ba774c"
+	},
+/obj/item/wrench/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Tg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 4
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Tk" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Ts" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/obj/effect/turf_decal/corner/bar/border,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Tx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ug" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ut" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Uu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/item/stack/cable_coil/cyan{
+	amount = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"UA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"UI" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 5
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"UR" = (
+/obj/effect/spawner/structure/window/survival_pod,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor{
+	id = 7
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"UZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"VF" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"VG" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/food/salt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"VP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Wg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Wj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Wl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/bottlegreen{
+	dir = 8
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/ice)
+"Wy" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Wz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"WD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"WE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/caution{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"WP" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"WU" = (
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Xe" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Xg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Xp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"XJ" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"XT" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"XV" = (
+/obj/effect/turf_decal/spline/fancy/bottlegreen,
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"XY" = (
+/obj/effect/turf_decal/spline/fancy/brown{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed,
+/area/overmap_encounter/planetoid/ice)
+"Yb" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"YI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c"
+	},
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"YR" = (
+/obj/effect/turf_decal/corner/beige/half{
+	color = "#ba774c";
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/ice)
+"YZ" = (
+/obj/effect/turf_decal/corner/bar/border{
+	dir = 6
+	},
+/obj/structure/closet/crate{
+	name = "construction materials"
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/storage/bag/construction,
+/obj/item/conveyor_switch_construct,
+/obj/item/stack/conveyor/thirty,
+/obj/item/stack/conveyor/thirty,
+/obj/item/conveyor_switch_construct,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/tile/bronze/thirty,
+/obj/item/stack/rods/twentyfive,
+/obj/item/circuitboard/machine/biogenerator,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"Ze" = (
+/obj/item/gps/computer,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+"ZG" = (
+/obj/effect/turf_decal/corner/bar/border,
+/turf/open/floor/pod,
+/area/overmap_encounter/planetoid/ice)
+
+(1,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+Eb
+nk
+oM
+nk
+nk
+Eb
+oM
+nk
+nk
+Eb
+oM
+oM
+oM
+oM
+"}
+(2,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+lh
+nk
+nk
+hY
+dn
+eV
+nk
+nk
+vD
+nk
+oM
+oM
+oM
+oM
+"}
+(3,1,1) = {"
+oM
+oM
+oM
+oM
+dP
+qb
+cE
+Nh
+lI
+nk
+Df
+Dz
+uR
+Dc
+UR
+oM
+oM
+oM
+oM
+"}
+(4,1,1) = {"
+oM
+oM
+oM
+oM
+dP
+WP
+Mh
+GG
+kb
+cJ
+Mh
+GG
+GG
+ZG
+UR
+oM
+oM
+oM
+oM
+"}
+(5,1,1) = {"
+oM
+oM
+oM
+oM
+dP
+WP
+GG
+Bb
+Wz
+wl
+GG
+Bb
+Xp
+ZG
+UR
+oM
+oM
+oM
+oM
+"}
+(6,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+Xe
+GG
+GG
+bE
+Fh
+oa
+zr
+jx
+wN
+nk
+oM
+oM
+oM
+oM
+"}
+(7,1,1) = {"
+oM
+oM
+oM
+oM
+tf
+qb
+LZ
+Te
+lY
+Tg
+YR
+Lr
+vI
+ZG
+tf
+oM
+oM
+oM
+oM
+"}
+(8,1,1) = {"
+oM
+oM
+oM
+oM
+tf
+qb
+br
+kg
+Ej
+Tx
+hj
+HP
+os
+ZG
+tf
+oM
+oM
+oM
+oM
+"}
+(9,1,1) = {"
+oM
+oM
+oM
+oM
+tf
+qb
+GG
+Tk
+Uu
+LU
+GG
+bt
+Xp
+ZG
+tf
+oM
+oM
+oM
+oM
+"}
+(10,1,1) = {"
+oM
+oM
+oM
+oM
+tf
+qb
+GX
+YI
+HH
+Tx
+Mg
+XJ
+ol
+yJ
+tf
+oM
+oM
+oM
+oM
+"}
+(11,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+Ku
+XT
+Cq
+ed
+oD
+UA
+yd
+NN
+Ts
+nk
+oM
+oM
+oM
+oM
+"}
+(12,1,1) = {"
+oM
+oM
+oM
+oM
+sC
+qb
+GG
+Ug
+Jj
+kr
+WD
+Ug
+Bb
+ZG
+sC
+oM
+oM
+oM
+oM
+"}
+(13,1,1) = {"
+oM
+oM
+oM
+oM
+sC
+qb
+Bb
+GG
+kb
+Sa
+GG
+GG
+Mh
+ZG
+sC
+oM
+oM
+oM
+oM
+"}
+(14,1,1) = {"
+oM
+oM
+oM
+oM
+sC
+UI
+vG
+oh
+fY
+VP
+iO
+vG
+vG
+YZ
+sC
+oM
+oM
+oM
+oM
+"}
+(15,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+nk
+nk
+nk
+HZ
+WE
+NF
+nk
+nk
+Eb
+nk
+oM
+oM
+oM
+oM
+"}
+(16,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+nk
+oM
+nk
+nk
+SZ
+nk
+nk
+oM
+Eb
+nk
+oM
+oM
+oM
+oM
+"}
+(17,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+gT
+QC
+qR
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(18,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+GZ
+Cs
+Ai
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(19,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+GH
+AE
+Qx
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(20,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+xk
+Ak
+Qx
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(21,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+wn
+NK
+bT
+Ne
+xO
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(22,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+nk
+nk
+xx
+nk
+nk
+oM
+oM
+oM
+oM
+oM
+oM
+oM
+"}
+(23,1,1) = {"
+nk
+WU
+nk
+oM
+oM
+oM
+oM
+nk
+zt
+hH
+JF
+nk
+oM
+oM
+oM
+oM
+nk
+WU
+nk
+"}
+(24,1,1) = {"
+nk
+re
+nk
+WU
+WU
+nk
+oM
+nk
+CY
+bm
+ZG
+Eb
+oM
+nk
+WU
+WU
+nk
+re
+nk
+"}
+(25,1,1) = {"
+nk
+kd
+nk
+re
+re
+nk
+oM
+nk
+qb
+eF
+pL
+nk
+oM
+nk
+re
+re
+nk
+kd
+nk
+"}
+(26,1,1) = {"
+nk
+OW
+nk
+mt
+mt
+nk
+nk
+nk
+fe
+eF
+ZG
+nk
+nk
+nk
+nu
+nu
+nk
+OW
+nk
+"}
+(27,1,1) = {"
+nk
+Ir
+CE
+uV
+Lb
+nk
+nk
+nk
+sk
+dy
+qc
+nk
+nk
+nk
+Km
+Xp
+Wl
+ek
+nk
+"}
+(28,1,1) = {"
+nk
+xd
+tW
+os
+Xp
+IG
+JD
+nk
+qb
+AI
+ZG
+nk
+MH
+VG
+PE
+Xp
+PC
+XV
+nk
+"}
+(29,1,1) = {"
+Eb
+fz
+OM
+pI
+Wg
+Wj
+Or
+Hj
+Xg
+UZ
+hw
+uQ
+fO
+BA
+Ip
+Yb
+Jt
+uJ
+Eb
+"}
+(30,1,1) = {"
+nk
+md
+ac
+dV
+GG
+Bb
+gw
+nk
+pM
+eF
+JB
+nk
+QP
+GG
+GG
+fC
+Lu
+Wy
+nk
+"}
+(31,1,1) = {"
+nk
+GJ
+GG
+PY
+LZ
+uq
+Ia
+nk
+qb
+RN
+JB
+nk
+ik
+Bb
+rR
+GG
+Bb
+xi
+nk
+"}
+(32,1,1) = {"
+nk
+oT
+qM
+XY
+mg
+by
+QM
+nk
+lt
+Ut
+uo
+nk
+ga
+Af
+st
+pN
+Nd
+MA
+nk
+"}
+(33,1,1) = {"
+nk
+Eb
+AQ
+nk
+nk
+nk
+nk
+nk
+nk
+yx
+nk
+nk
+nk
+nk
+nk
+nk
+nk
+nk
+nk
+"}
+(34,1,1) = {"
+oM
+oM
+oM
+nk
+nk
+nk
+ey
+bU
+dr
+VF
+mX
+Mh
+bS
+nk
+nk
+nk
+oM
+oM
+oM
+"}
+(35,1,1) = {"
+oM
+oM
+oM
+oM
+nk
+nk
+Ze
+GG
+Mh
+HG
+GG
+sY
+lN
+Eb
+nk
+oM
+oM
+oM
+oM
+"}
+(36,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+nk
+cY
+KX
+sz
+vK
+CG
+Sw
+iH
+nk
+oM
+oM
+oM
+oM
+oM
+"}
+(37,1,1) = {"
+oM
+oM
+oM
+oM
+oM
+nk
+nk
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+nk
+oM
+oM
+oM
+oM
+oM
+"}

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -19,6 +19,12 @@
 	description = "Slime ranchin with the bud."
 	suffix = "icemoon_surface_slimerancher.dmm"
 
+/datum/map_template/ruin/icemoon/enigmaruins
+	name = "Enigma Ruins"
+	id = "enigmaruins"
+	description = "Remains of an Enigma Shipworks ship, now inhabited by a posessed shipbreaker."
+	suffix = "icemoon_surface_enigmaruins.dmm"
+
 // above and below ground together
 
 

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -16,3 +16,4 @@
 #_maps/RandomRuins/IceRuins/icemoon_underground_brazillianlab.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_burnies_lair.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_wendigo_cave.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_enigmaruins.dmm


### PR DESCRIPTION
## About The Pull Request

Adds a ruin version of the Enigma-Class. Now it has good loot and finally has somewhere for the frost miner to spawn. This ruin can be found on ice planets.
![2022 06 17-10 12 09](https://user-images.githubusercontent.com/98407398/174315570-cfe87ded-82c5-42af-b67e-6bef576324cc.png)




## Why It's Good For The Game

The game needs more ruins, and this also gives a place for the Demonic Frost Miner to spawn.

## Changelog
:cl:
add: the Enigma-Class ruin, which has some pretty good(?) loot and a boss in the form of the demonic frost miner.
/:cl:

