### PR TITLE
Kepori tackle is now innate action

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -30,6 +30,7 @@
 	no_equip = list(ITEM_SLOT_BACK)
 	mutanttongue = /obj/item/organ/tongue/kepori
 	species_language_holder = /datum/language_holder/kepori
+	var/datum/action/innate/keptackle/keptackle
 	/// # Inherit tackling variables #
 	/// See: [/datum/component/tackler/var/stamina_cost]
 	var/tackle_stam_cost = 10
@@ -69,9 +70,32 @@
 
 /datum/species/kepori/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	..()
-	C.AddComponent(/datum/component/tackler, stamina_cost= tackle_stam_cost, base_knockdown= base_knockdown, range= tackle_range, speed= tackle_speed, skill_mod= skill_mod, min_distance= min_distance)
-
+	if(ishuman(C))
+		keptackle = new
+		keptackle.Grant(C)
 
 /datum/species/kepori/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
-	. = ..()
+	if(keptackle)
+		keptackle.Remove(C)
 	qdel(C.GetComponent(/datum/component/tackler))
+	..()
+
+
+/datum/action/innate/keptackle
+	name = "Pounce"
+	desc = "Ready yourself to pounce."
+	check_flags = AB_CHECK_CONSCIOUS
+	button_icon_state = "tackle"
+	icon_icon = 'icons/obj/clothing/gloves.dmi'
+	background_icon_state = "bg_alien"
+
+/datum/action/innate/keptackle/Activate()
+	var/mob/living/carbon/human/H = owner
+	var/datum/species/kepori/kep = H.dna.species
+	if(H.GetComponent(/datum/component/tackler))
+		qdel(H.GetComponent(/datum/component/tackler))
+		to_chat(H, "<span class='notice'>You relax, no longer ready to pounce.</span>")
+		return
+	H.AddComponent(/datum/component/tackler, stamina_cost= kep.tackle_stam_cost, base_knockdown= kep.base_knockdown, range= kep.tackle_range, speed= kep.tackle_speed, skill_mod= kep.skill_mod, min_distance= kep.min_distance)
+	H.visible_message("<span class='notice'>[H] gets ready to pounce!</span>", \
+		"<span class='notice'>You ready yourself to pounce!</span>", null, COMBAT_MESSAGE_RANGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
changes the kepori tackle ability from a constantly active trait to a species action, while the issues with using tackler gloves at the same time still exist, this alleviates them by making it not permanently remove your innate tackle when you take gloves off, since you can just turn it back on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves the feel of a somewhat shoddily coded feature.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: kepori pounces are now a species action toggle!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
