### PR TITLE
Another Rube Goldpatch

### DIFF
--- a/_maps/shuttles/shiptest/engineeringmess.dmm
+++ b/_maps/shuttles/shiptest/engineeringmess.dmm
@@ -35,11 +35,11 @@
 /turf/open/floor/mineral/titanium,
 /area/ship/bridge)
 "aq" = (
-/obj/machinery/conveyor_switch{
-	id = "Con2"
-	},
-/obj/machinery/light{
+/obj/structure/window/reinforced/spawner{
 	dir = 8
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
@@ -289,6 +289,7 @@
 /turf/open/floor/plating/airless,
 /area/ship/hallway)
 "cL" = (
+/obj/effect/decal/cleanable/plasma,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen)
 "cM" = (
@@ -359,6 +360,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-6"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
@@ -540,6 +544,14 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
+"eU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1072,12 +1084,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/atmospherics)
 "jx" = (
@@ -1107,7 +1113,7 @@
 	icon_state = "steering_wheel";
 	pixel_y = 6
 	},
-/obj/structure/table/reinforced,
+/obj/structure/table/wood,
 /turf/open/floor/mineral/titanium,
 /area/ship/bridge)
 "jL" = (
@@ -1155,6 +1161,10 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/dorm)
 "kf" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/medical)
 "kj" = (
@@ -1218,6 +1228,8 @@
 /obj/item/circuitboard/machine/shuttle/smes,
 /obj/item/circuitboard/machine/shuttle/smes,
 /obj/item/circuitboard/machine/smes,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/circuitboard/machine/vendor,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "kG" = (
@@ -1277,6 +1289,7 @@
 /obj/effect/turf_decal/corner/brown/border{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "ll" = (
@@ -1494,24 +1507,6 @@
 "oK" = (
 /turf/closed/wall/mineral/wood,
 /area/ship/hallway)
-"oP" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
-/area/ship/engineering/atmospherics)
 "oY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1529,6 +1524,12 @@
 /obj/effect/turf_decal/corner/brown/border{
 	dir = 5
 	},
+/obj/item/mop,
+/obj/structure/mopbucket,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "pg" = (
@@ -1575,21 +1576,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/canteen)
 "pF" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
 	dir = 4
 	},
@@ -1893,21 +1885,6 @@
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen)
-"se" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/turf/open/floor/engine/airless,
-/area/ship/engineering/atmospherics)
 "sg" = (
 /obj/machinery/light{
 	dir = 8
@@ -1917,21 +1894,12 @@
 	pixel_x = 7;
 	secret_type = "/obj/item/clothing/shoes/drip"
 	},
+/obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "sk" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/ship/engineering/atmospherics)
 "sl" = (
@@ -2066,17 +2034,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "tm" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
 	dir = 10
 	},
@@ -2092,6 +2050,15 @@
 	},
 /obj/effect/turf_decal/spline/plain/yellow{
 	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
+"ts" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/dorm)
@@ -2363,15 +2330,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/ship/engineering/atmospherics)
-"vF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible/layer2,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
 "vJ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2380,18 +2338,8 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "vL" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /turf/open/floor/engine/airless,
 /area/ship/engineering/atmospherics)
 "vW" = (
@@ -2456,18 +2404,8 @@
 /turf/open/floor/plating/airless,
 /area/ship/hallway)
 "wH" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner,
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
 	dir = 4
 	},
@@ -2484,6 +2422,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"xa" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
 "xl" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -2811,6 +2753,12 @@
 /turf/closed/wall/mineral/titanium/survival,
 /area/ship/engineering/engine)
 "zK" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/canteen)
 "zL" = (
@@ -3231,6 +3179,12 @@
 	},
 /turf/open/floor/engine/airless,
 /area/ship/engineering/atmospherics)
+"Ee" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
 "Eg" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/airless,
@@ -3278,6 +3232,12 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
+"Fi" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering/atmospherics)
 "Fj" = (
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
@@ -3336,12 +3296,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/atmospherics)
 "FP" = (
@@ -3682,8 +3636,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Ij" = (
-/obj/effect/turf_decal/industrial/radiation{
-	dir = 4
+/obj/structure/window/reinforced/spawner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -3693,12 +3647,6 @@
 /area/ship/storage)
 "In" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/atmospherics)
 "Is" = (
@@ -3719,17 +3667,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "IG" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2,
 /turf/open/floor/engine,
 /area/ship/engineering/atmospherics)
@@ -3927,6 +3865,10 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "KQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
 "KT" = (
@@ -4006,16 +3948,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/holosign/barrier/atmos,
+/obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/medical)
 "LL" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -4137,10 +4074,6 @@
 /area/ship/hallway)
 "MR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
@@ -4161,18 +4094,13 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/canteen)
+"Ni" = (
+/obj/effect/turf_decal/trimline/bar,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
 "Nj" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
 	dir = 9
 	},
@@ -4432,6 +4360,13 @@
 /obj/structure/sign/departments/restroom,
 /turf/closed/wall/mineral/wood,
 /area/ship/crew/canteen)
+"Qp" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "Qw" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4746,6 +4681,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
+/obj/item/borg/upgrade/modkit/indoors,
 /turf/open/floor/plating/airless,
 /area/ship/hallway)
 "TC" = (
@@ -4797,16 +4733,6 @@
 "TU" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner,
 /turf/open/floor/engine/airless,
 /area/ship/engineering/atmospherics)
 "TV" = (
@@ -4942,6 +4868,9 @@
 /obj/effect/turf_decal/corner/brown/border{
 	dir = 6
 	},
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "UY" = (
@@ -5004,6 +4933,13 @@
 "VA" = (
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/ship/engineering/engine)
+"VJ" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "VK" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating/airless,
@@ -5018,6 +4954,7 @@
 /obj/effect/turf_decal/spline/plain/yellow{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/dorm)
 "VN" = (
@@ -5138,8 +5075,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/light{
+/obj/structure/window/reinforced/spawner{
 	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
@@ -5181,15 +5121,9 @@
 /turf/open/floor/plating/airless,
 /area/ship/hallway)
 "Xq" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
 	dir = 6
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -5961,7 +5895,7 @@ Zn
 OK
 gj
 MJ
-YS
+Ni
 oZ
 QQ
 Zg
@@ -6244,7 +6178,7 @@ jj
 ix
 bZ
 QQ
-Td
+ts
 OD
 QQ
 ke
@@ -6302,8 +6236,8 @@ hR
 eZ
 vj
 QQ
-OD
-OD
+Ee
+xa
 QQ
 aN
 Ji
@@ -6549,7 +6483,7 @@ Nj
 Wh
 tm
 IG
-vF
+LL
 bC
 dK
 Xo
@@ -6609,7 +6543,7 @@ VS
 RJ
 lX
 YB
-cF
+VJ
 bN
 vd
 BV
@@ -6650,7 +6584,7 @@ hR
 eZ
 Hi
 Xn
-CB
+Qp
 bT
 Hu
 kN
@@ -6776,7 +6710,7 @@ Uq
 yP
 Yt
 NO
-nG
+Fi
 JO
 AS
 sw
@@ -6816,7 +6750,7 @@ Zg
 Zg
 Xn
 kn
-Th
+eU
 PJ
 bT
 bT
@@ -6873,7 +6807,7 @@ Zg
 Zg
 Zg
 bT
-CB
+Ij
 yj
 FQ
 KT
@@ -6943,7 +6877,7 @@ Lc
 Ht
 br
 Cc
-Ij
+Lc
 Ht
 TS
 rk
@@ -6996,13 +6930,13 @@ wH
 Um
 vL
 bT
-oP
+wH
 Um
 vL
 bT
-oP
+wH
 Um
-se
+vL
 bT
 TU
 Um


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This patch does only a few things:
Removes the unfun excessive window paneling.
Removes the stray left over conveyor switch.
Adds some cleaning supplies to the thrusters room.
Adds a Kinetic Accelerator pressure modkit in a very inconvenient space.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
After playing the Rube Goldberg with a crew, I realized that some very minor issues made the rube a much bigger pain in the ass than intended.  The rifle is good but not effective against all mobs, and KA's are unreliable since most planets have atmos; so adding the pressure mod helps even that out (and in a funny place to incentivize the engineers to tear walls down). Having a very messy ship with no cleaning supplies is a huge pain in the ass, so a simple mop is a pretty good fix. And finally those excessive window paneling made expanding the ship interior a pain in the ass (they were under the fulltile window too which was even more of a pain).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Phoaly
tweak: Tweaks the Rube Goldberg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
