### PR TITLE
overmap star refactor

### DIFF
--- a/code/__DEFINES/overmap.dm
+++ b/code/__DEFINES/overmap.dm
@@ -1,24 +1,20 @@
 #define OVERMAP_GENERATOR_SOLAR "solar_system"
 #define OVERMAP_GENERATOR_RANDOM "random"
 
-//Add new star types here
-#define SMALLSTAR 1
-#define TWOSTAR 2
-#define MEDSTAR 3
-#define BIGSTAR 4
-
-//Star classes
-#define STARO 1 //Extremely bright blue main sequence star or (super)giant
-#define STARB 2 //Bright blue main sequence star or (super)giant
-#define STARA 3 //Light blue main sequence star
-#define STARF 4 //White main sequence star
-#define STARG 5 //Yellow main sequence star or supergiant
-#define STARK 6 //Orange dwarf, main sequence star, or hypergiant
-#define STARM 7 //Red dwarf or red (super)giant
-#define STARL 8 //Cool red dwarf
-#define START 9 //Methane dwarf
-#define STARY 10 //Sad lame brown dwarf
-#define STARD 11 //White dwarf
+// Star spectral types. A star's visible color is based on this.
+// Only loosely adherent to real spectral types, because real spectral types
+// are actually just a tool for classifying stellar emission spectra and
+// don't exactly correspond to different "types" of star.
+#define STAR_O 0 // Very hot/bright blue giant (IRL some of these are main-sequence)
+#define STAR_B 1 // Bright blue main sequence star / blue giant / white dwarf
+#define STAR_A 2 // Light blue main sequence star / cool blue giant/dwarf
+#define STAR_F 3 // White main sequence star
+#define STAR_G 4 // Yellow main sequence star / yellow giant
+#define STAR_K 5 // Orange main sequence star / hot red giant
+#define STAR_M 6 // Red dwarf or red giant
+#define STAR_L 7 // Cool red dwarf/giant OR very warm brown dwarf
+#define STAR_T 8 // Medium brown dwarf
+#define STAR_Y 9 // Very cool brown dwarf
 
 //Amount of times the overmap generator will attempt to place something before giving up
 #define MAX_OVERMAP_PLACEMENT_ATTEMPTS 5

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(overmap)
 
 	if (generator_type == OVERMAP_GENERATOR_SOLAR)
 		var/datum/overmap/star/center
-		var/startype = pick(/datum/overmap/star, /datum/overmap/star/medium, /datum/overmap/star/big, /datum/overmap/star/binary)
+		var/startype = pick(subtypesof(/datum/overmap/star))
 		center = new startype(list("x" = size / 2, "y" = size / 2))
 		radius_positions = list()
 		for(var/x in 1 to size)
@@ -63,6 +63,13 @@ SUBSYSTEM_DEF(overmap)
 	create_map()
 
 	return ..()
+
+/datum/controller/subsystem/overmap/proc/test_spawn_star(datum/overmap/star/star_type = null)
+	for(var/datum/overmap/star/old in overmap_objects)
+		QDEL_NULL(old)
+	if(!star_type)
+		star_type = pick(subtypesof(/datum/overmap/star))
+	new star_type(list("x" = size / 2, "y" = size / 2))
 
 /datum/controller/subsystem/overmap/fire()
 	if(events_enabled)

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -64,13 +64,6 @@ SUBSYSTEM_DEF(overmap)
 
 	return ..()
 
-/datum/controller/subsystem/overmap/proc/test_spawn_star(datum/overmap/star/star_type = null)
-	for(var/datum/overmap/star/old in overmap_objects)
-		QDEL_NULL(old)
-	if(!star_type)
-		star_type = pick(subtypesof(/datum/overmap/star))
-	new star_type(list("x" = size / 2, "y" = size / 2))
-
 /datum/controller/subsystem/overmap/fire()
 	if(events_enabled)
 		for(var/datum/overmap/event/E as anything in events)

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -8,7 +8,6 @@
 	Rename(gen_star_name())
 	token.desc = token_desc
 	alter_token_appearance()
-	token.SpinAnimation(rand(1 MINUTES, 4 MINUTES))
 
 /datum/overmap/star/proc/gen_star_name()
 	return "[pick(GLOB.star_names)] [pick(GLOB.greek_letters)]"

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -1,136 +1,169 @@
-/datum/overmap/star //TODO: refactor literally all of this this is painful
+/datum/overmap/star
 	name = "Star"
-	token_icon_state = "star1"
-	token_type = /obj/overmap/star
+	var/token_desc = "A star."
+	var/spectral_type = STAR_G
+	var/color_vary = 0
 
-/datum/overmap/star/Initialize(mapload)
-	. = ..()
-	Rename("[pick(GLOB.star_names)] [pick(GLOB.greek_letters)]")
+/datum/overmap/star/Initialize(position, ...)
+	Rename(gen_star_name())
+	token.desc = token_desc
+	alter_token_appearance()
+	token.SpinAnimation(rand(1 MINUTES, 4 MINUTES))
+
+/datum/overmap/star/proc/gen_star_name()
+	return "[pick(GLOB.star_names)] [pick(GLOB.greek_letters)]"
+
+/datum/overmap/star/proc/alter_token_appearance()
+	token.add_atom_colour(get_rand_spectral_color(spectral_type, color_vary), FIXED_COLOUR_PRIORITY)
+
+/datum/overmap/star/proc/get_rand_spectral_color(base_spec, vary_amt = 0)
+	var/adj_spec = base_spec + LERP(-vary_amt, vary_amt, rand())
+	var/result = gradient(
+		STAR_O, "#a6c4ff",
+		STAR_B, "#d9f9ff",
+		STAR_A, "#f0ffff",
+		STAR_F, "#ffffff",
+		STAR_G, "#ffff60",
+		STAR_K, "#ffb060",
+		STAR_M, "#f24f18",
+		STAR_L, "#e50b0b",
+		STAR_T, "#a60347",
+		STAR_Y, "#4a3059",
+		index = adj_spec
+	)
+	return result
+
+/*
+		Dwarf stars
+*/
+
+/datum/overmap/star/dwarf
+	token_icon_state = "star1"
+	token_desc = "A red dwarf. Smallest and most numerous of the main-sequence stars, some red dwarves boast trillion-year lifespans; none have yet died of old age."
+	spectral_type = STAR_M
+	color_vary = 0.5
+
+/datum/overmap/star/dwarf/orange
+	token_desc = "One of the main sequence stars, this orange dwarf star emits a steady glow, as it has for billions of years."
+	spectral_type = STAR_K
+	color_vary = 0.25
+
+/datum/overmap/star/dwarf/brown
+	token_desc = "Clocking in at only several dozen septillion tons, this body is much lighter than true stars. \
+Known as a \"brown dwarf\", it is unable to sustain hydrogen fusion, and is warmed by deuterium fusion instead."
+	spectral_type = STAR_T
+	color_vary = 1
+
+/datum/overmap/star/dwarf/white
+	token_desc = "The incredibly dense corpse of a former star. Still white-hot, it slowly radiates its remaining heat into space."
+	spectral_type = STAR_B
+	color_vary = 1
+
+/*
+		Mid-size stars
+*/
 
 /datum/overmap/star/medium
 	token_icon_state = "star2"
-	token_type = /obj/overmap/star/medium
+	token_desc = "A yellow main-sequence star. Deep beneath the surface, its core churns violently in fusion, so dense as to be utterly impenetrable to light or sound." // or Say It Ain't So
+	spectral_type = STAR_G
+	color_vary = 0.25
 
-/datum/overmap/star/big
+/datum/overmap/star/medium/alter_token_appearance()
+	token.icon = 'whitesands/icons/effects/overmap_large.dmi'
+	token.bound_height = 64
+	token.bound_width = 64
+	token.pixel_x = -16
+	token.pixel_y = -16
+	. = ..()
+
+/datum/overmap/star/medium/blue
+	token_desc = "A young, blue, massive main-sequence star. The reactions at its core are so intense as to whip the entire star into convection waves."
+	spectral_type = STAR_B
+
+/datum/overmap/star/medium/bluewhite
+	token_desc = "This main-sequence star is young and large; it burns hot and fast. Though not as blindingly bright as a giant, its glare is still harsh."
+	spectral_type = STAR_A
+
+/datum/overmap/star/medium/white
+	token_desc = "A bright white main-sequence star, with a surface temperature of 6,000 to 7,000 Kelvin. The core is much, much hotter."
+	spectral_type = STAR_F
+
+/datum/overmap/star/medium/orange
+	token_desc = "One of the main sequence stars, this orange dwarf star emits a steady glow, as it has for billions of years."
+	spectral_type = STAR_K
+
+/*
+		Giant stars
+*/
+
+/datum/overmap/star/giant
 	token_icon_state = "star3"
-	token_type = /obj/overmap/star/big
+	token_desc = "A blue giant star. Though massive and incredibly hot, it can only sustain its intense luminosity for so long."
+	spectral_type = STAR_B
+	color_vary = 1
+
+/datum/overmap/star/giant/alter_token_appearance()
+	token.icon = 'whitesands/icons/effects/overmap_larger.dmi'
+	token.bound_height = 96
+	token.bound_width = 96
+	token.pixel_x = -32
+	token.pixel_y = -32
+	. = ..()
+
+/datum/overmap/star/giant/yellow
+	token_desc = "Like many other yellow giants, this dying star \"pulsates\" as its brightness fluctuates rhythmically."
+	spectral_type = STAR_G
+	color_vary = 0.25
+
+/datum/overmap/star/giant/yellow/alter_token_appearance()
+	. = ..()
+	// adds a slight, slow flicker
+	// this took me far too long to get working right
+	var/half_duration = rand(7 SECONDS, 15 SECONDS)
+	animate(token, color = token.color, time = half_duration, loop = -1, easing = SINE_EASING, flags = ANIMATION_PARALLEL)
+	animate(color = get_rand_spectral_color(STAR_G - 0.5, 0.125), time = half_duration, easing = SINE_EASING)
+
+/datum/overmap/star/giant/red
+	token_desc = "Huge and imposing, this red giant has exhausted the hydrogen within its core, and has expanded and brightened as a result. It has begun to die."
+	spectral_type = STAR_M
+
+/*
+		Binary stars
+*/
 
 /datum/overmap/star/binary
 	token_icon_state = "binaryswoosh"
-	token_type = /obj/overmap/star/big/binary
+	token_desc = "Two stars, each locked the other's orbit. These systems form at stellar birth, and may persist long after one or both stars die."
+	color_vary = 0.75
 
-/obj/overmap/star
-	name = "Star"
-	desc = "A star."
-	icon = 'whitesands/icons/effects/overmap.dmi'
-	icon_state = "star1"
-	var/star_classes = list(\
-		STARK,
-		STARM,
-		STARL,
-		START,
-		STARY,
-		STARD
+/datum/overmap/star/binary/gen_star_name()
+	return (..() + " AB")
+
+/datum/overmap/star/binary/alter_token_appearance()
+	// we don't call the parent proc, since we do colors our own way
+	var/mutable_appearance/star_1
+	var/mutable_appearance/star_2
+	var/list/spectral_types = list(
+		STAR_B,
+		STAR_F,
+		STAR_G,
+		STAR_K,
+		STAR_M,
+		STAR_L,
+		STAR_T,
 	)
+	token.cut_overlays()
+	token.icon = 'whitesands/icons/effects/overmap_larger.dmi'
+	token.bound_height = 96
+	token.bound_width = 96
+	token.pixel_x = -32
+	token.pixel_y = -32
 
-/obj/overmap/star/Initialize(mapload, new_parent)
-	. = ..()
-	var/c = "#ffffff"
-	switch(pick(star_classes))
-		if(STARO)
-			c = "#75ffff"
-			desc = "A blue giant."
-		if(STARB)
-			c = "#c0ffff"
-		if(STARG)
-			c = "#ffff00"
-		if(STARK)
-			c = "#ff7f00"
-		if(STARM)
-			c = "#d50000"
-		if(STARL) //Take the L
-			c = "#a31300"
-		if(START)
-			c = "#a60347"
-			desc = "A brown dwarf"
-		if(STARY)
-			c = "#4a3059"
-			desc = "A brown dwarf."
-		if(STARD)
-			c = pick("#75ffff", "#c0ffff", "#ffffff")
-			desc = "A white dwarf."
-	add_atom_colour(c, FIXED_COLOUR_PRIORITY)
+	star_1 = mutable_appearance(icon_state = "binary1")
+	star_1.color = get_rand_spectral_color(pick(spectral_types), color_vary)
+	token.add_overlay(star_1)
 
-/obj/overmap/star/medium
-	icon = 'whitesands/icons/effects/overmap_large.dmi'
-	bound_height = 64
-	bound_width = 64
-	pixel_x = -16
-	pixel_y = -16
-	icon_state = "star2"
-	star_classes = list(\
-		STARB,
-		STARA,
-		STARF,
-		STARG,
-		STARK
-	)
-
-/obj/overmap/star/big
-	icon = 'whitesands/icons/effects/overmap_larger.dmi'
-	icon_state = "star3"
-	bound_height = 96
-	bound_width = 96
-	pixel_z = -32
-	pixel_w = -32
-	star_classes = list(\
-		STARO,
-		STARB,
-		STARG,
-		STARM
-	)
-
-/obj/overmap/star/big/binary
-	icon_state = "binaryswoosh"
-	var/class
-	star_classes = list(\
-		STARK,
-		STARM,
-		STARL,
-		START,
-		STARY,
-		STARD
-	)
-
-/obj/overmap/star/big/binary/Initialize(mapload)
-	. = ..()
-	name = "[pick(GLOB.greek_letters)] [pick(GLOB.star_names)] AB"
-	class = pick(star_classes)
-	color = "#ffffff"
-	add_star_overlay()
-
-/obj/overmap/star/big/binary/proc/add_star_overlay()
-	cut_overlays()
-	var/mutable_appearance/s1 = mutable_appearance(icon_state = "binary1")
-	var/mutable_appearance/s2 = mutable_appearance(icon_state = "binary2")
-	switch(class)
-		if(STARK)
-			s1.color = "#ff7f00"
-			s2.color = "#ffff00"
-		if(STARM)
-			s1.color = "#d50000"
-			s2.color = "#a31300"
-		if(STARL)
-			s1.color = "#a31300"
-			s2.color = "#ff7f00"
-		if(START)
-			s1.color = "#a60347"
-			s2.color = pick("#75ffff", "#c0ffff", "#ffffff")
-		if(STARY)
-			s1.color = "#4a3059"
-			s2.color = pick("#75ffff", "#c0ffff", "#ffffff")
-		if(STARD)
-			s1.color = pick("#75ffff", "#c0ffff", "#ffffff")
-			s2.color = pick("#4a3059", "#a60347", "#a31300")
-	add_overlay(s1)
-	add_overlay(s2)
+	star_2 = mutable_appearance(icon_state = "binary2")
+	star_2.color = get_rand_spectral_color(pick(spectral_types), color_vary)
+	token.add_overlay(star_2)

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -143,7 +143,7 @@ Known as a \"brown dwarf\", it is unable to sustain hydrogen fusion, and is warm
 	// we don't call the parent proc, since we do colors our own way
 	var/mutable_appearance/star_1
 	var/mutable_appearance/star_2
-	var/list/spectral_types = list(
+	var/static/list/spectral_types = list(
 		STAR_B,
 		STAR_F,
 		STAR_G,

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -48,8 +48,8 @@
 	color_vary = 0.25
 
 /datum/overmap/star/dwarf/brown
-	token_desc = "Clocking in at only several dozen septillion tons, this body is much lighter than true stars. \
-Known as a \"brown dwarf\", it is unable to sustain hydrogen fusion, and is warmed by deuterium fusion instead."
+	token_desc = "Clocking in at only several dozen septillion tons, this body is much lighter than true stars. " +\
+				"Known as a \"brown dwarf\", it is unable to sustain hydrogen fusion, and is warmed by deuterium fusion instead."
 	spectral_type = STAR_T
 	color_vary = 1
 


### PR DESCRIPTION
## About The Pull Request

Refactors the code for /datum/overmap/star, making each star type a distinct subtype of /datum/overmap/star instead of having one subtype for each star size. As a result, the system's star is now chosen by picking from subtypes of /datum/overmap/star. The colors are semi-randomized based on the base spectral class for that star type. The behavior for this has been moved into /datum/overmap/star, instead of using subtypes of /obj/overmap, because subtyping /obj/overmap is dumb.

Also, stars rotate automatically now by calling SpinAnimation on the token. I don't think this looks very good, but @triplezeta asked me to do it, and I did, because it was easy.

## Why It's Good For The Game

The old code was bad, using subtypes of overmap icons and doing a lot of picking from lists when it should've been using subtypes. The new code is easier to work with and more modular. Plus, the examine texts are nice.

## Changelog
:cl:
add: Overmap stars now spin automatically.
add: Overmap stars now always have examine text.
add: Yellow giant stars now flicker.
refactor: Refactored overmap star code; star probabilities and colors are altered as a result.
/:cl:
