### PR TITLE
removes deprecated map_generator variable on /area

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -48,7 +48,6 @@ SUBSYSTEM_DEF(mapping)
 	repopulate_sorted_areas()
 	process_teleport_locs()			//Sets up the wizard teleport locations
 	preloadTemplates()
-	run_map_generation()
 
 	// Add the transit levels
 	init_reserved_levels()
@@ -94,10 +93,6 @@ SUBSYSTEM_DEF(mapping)
 	z_list = SSmapping.z_list
 
 #define INIT_ANNOUNCE(X) to_chat(world, "<span class='boldannounce'>[X]</span>"); log_world(X)
-
-/datum/controller/subsystem/mapping/proc/run_map_generation()
-	for(var/area/A in world)
-		A.RunGeneration()
 
 /datum/controller/subsystem/mapping/proc/mapvote()
 	SSvote.initiate_vote("map", "automatic map rotation", TRUE) //WS Edit - Ghost Voting Rework

--- a/code/datums/mapgen/JungleGenerator.dm
+++ b/code/datums/mapgen/JungleGenerator.dm
@@ -83,13 +83,3 @@
 		selected_biome.generate_turf(gen_turf)
 		CHECK_TICK
 	report_completion(start_time, "Jungle Generator")
-/turf/open/genturf
-	name = "ungenerated turf"
-	desc = "If you see this, and you're not a ghost, yell at coders"
-	icon = 'icons/turf/debug.dmi'
-	icon_state = "genturf"
-
-/area/mine/planetgeneration
-	name = "planet generation area"
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
-	map_generator = /datum/map_generator/jungle_generator

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -76,9 +76,6 @@
 	var/lighting_brightness_bulb = 6
 	var/lighting_brightness_night = 6
 
-	///This datum, if set, allows terrain generation behavior to be ran on Initialize()
-	var/datum/map_generator/map_generator
-
 	///Used to decide what kind of reverb the area makes sound have
 	var/sound_environment = SOUND_ENVIRONMENT_NONE
 
@@ -187,22 +184,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/LateInitialize()
 	power_change()		// all machines set to current power level, also updates icon
 	update_beauty()
-
-/area/proc/RunGeneration()
-	if(map_generator)
-		map_generator = new map_generator()
-		var/list/turfs = list()
-		for(var/turf/T in contents)
-			turfs += T
-		map_generator.generate_terrain(turfs)
-
-/area/proc/test_gen()
-	if(map_generator)
-		var/list/turfs = list()
-		for(var/turf/T in contents)
-			turfs += T
-		map_generator.generate_terrain(turfs)
-
 
 /**
   * Register this area as belonging to a z level

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -136,7 +136,6 @@
 /area/lavaland/surface/outdoors/unexplored //monsters and ruins spawn here
 	icon_state = "unexplored"
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | CAVES_ALLOWED | FLORA_ALLOWED | MOB_SPAWN_ALLOWED
-	map_generator = /datum/map_generator/cave_generator/lavaland
 
 /area/lavaland/surface/outdoors/unexplored/danger //megafauna will also spawn here
 	icon_state = "danger"
@@ -184,7 +183,6 @@
 	icon_state = "unexplored"
 	poweralm = FALSE
 	area_flags = UNIQUE_AREA | FLORA_ALLOWED | MOB_SPAWN_ALLOWED | CAVES_ALLOWED
-	map_generator = /datum/map_generator/cave_generator/icemoon/surface
 
 /area/icemoon/surface/outdoors/unexplored/danger
 	icon_state = "unexplored"
@@ -209,7 +207,6 @@
 	ambientsounds = MINING
 	poweralm = FALSE
 	area_flags = UNIQUE_AREA | FLORA_ALLOWED
-	map_generator = /datum/map_generator/cave_generator/icemoon
 	min_ambience_cooldown = 70 SECONDS
 	max_ambience_cooldown = 220 SECONDS
 
@@ -276,7 +273,6 @@
 	ambientsounds = MINING
 	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | FLORA_ALLOWED
-	map_generator = /datum/map_generator/cave_generator/whitesands
 
 /area/whitesands/surface/outdoors // weather happens here
 	name = "Whitesands Dunes"
@@ -314,7 +310,6 @@
 	ambientsounds = MINING
 	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | FLORA_ALLOWED
-	map_generator = /datum/map_generator/jungle_generator
 
 /area/jungle/surface/outdoors // weather happens here
 	name = "Jungle Wastes"
@@ -352,7 +347,6 @@
 	ambientsounds = MINING
 	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | FLORA_ALLOWED
-	map_generator = /datum/map_generator/cave_generator/rockplanet
 
 /area/rock/surface/outdoors // weather happens here
 	name = "Industrial Wastes"


### PR DESCRIPTION
## About The Pull Request

areas had a map_generator variable, that ran a map_generator datum on them when SSmapping initialized. presumably, this was a holdover from lavaland-type map generation; we don't do things this way anymore, so this variable was useless and did nothing. i removed it, along with 2 other clearly-unused things in the jungle map generator file. i tested it by booting up a local server and generating the planets automatically; didn't run into any runtimes. have a hard time seeing how this would cause errors unless i am monumentally misunderstanding things

## Why It's Good For The Game

dumb, confusing, unused variables shouldn't be allowed to sit around.

## Changelog
:cl:
code: Removed deprecated map_generator variable on /area.
/:cl:
