### PR TITLE
Autolathe revamp: Material eject button (+bugfixes)

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -34,7 +34,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "silver"
 	id = "silver"
 	desc = "Silver"
-	color = list(255/255, 284/255, 302/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
+	color = "#ffffff"
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/silver
 	ore_type = /obj/item/stack/ore/silver
@@ -46,7 +46,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "gold"
 	id = "gold"
 	desc = "Gold"
-	color = list(340/255, 240/255, 50/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //gold is shiny, but not as bright as bananium
+	color = "#fff032" //gold is shiny, but not as bright as bananium
 	strength_modifier = 1.2
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/gold
@@ -60,7 +60,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "diamond"
 	id = "diamond"
 	desc = "Highly pressurized carbon"
-	color = list(48/255, 272/255, 301/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
+	color = "#30ffff"
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 	ore_type = /obj/item/stack/ore/diamond
@@ -74,7 +74,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "uranium"
 	id = "uranium"
 	desc = "Uranium"
-	color = rgb(48, 237, 26)
+	color = "#30ed1a"
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	ore_type = /obj/item/stack/ore/uranium
@@ -95,7 +95,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "plasma"
 	id = "plasma"
 	desc = "Isn't plasma a state of matter? Oh whatever."
-	color = list(298/255, 46/255, 352/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
+	color = "#ff2eff"
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/plasma
 	ore_type = /obj/item/stack/ore/plasma
@@ -119,7 +119,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "bluespace crystal"
 	id = "bluespace_crystal"
 	desc = "Crystals with bluespace properties"
-	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
+	color = "#4086e2"
 	alpha = 200
 	categories = list(MAT_CATEGORY_ORE = TRUE)
 	beauty_modifier = 0.5
@@ -132,7 +132,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "bananium"
 	id = "bananium"
 	desc = "Material with hilarious properties"
-	color = list(460/255, 464/255, 0, 0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //obnoxiously bright yellow
+	color = "#ffff00" //obnoxiously bright yellow
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/bananium
 	ore_type = /obj/item/stack/ore/bananium

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -49,7 +49,7 @@
 							)
 
 /obj/machinery/autolathe/Initialize()
-	AddComponent(/datum/component/material_container,list(/datum/material/iron, /datum/material/glass, /datum/material/silver, /datum/material/gold, /datum/material/plasma, /datum/material/uranium, /datum/material/titanium), 0, TRUE, null, null, CALLBACK(src, .proc/AfterMaterialInsert))
+	AddComponent(/datum/component/material_container,list(/datum/material/iron, /datum/material/glass, /datum/material/plastic, /datum/material/silver, /datum/material/gold, /datum/material/plasma, /datum/material/uranium, /datum/material/titanium), 0, TRUE, null, null, CALLBACK(src, .proc/AfterMaterialInsert))
 	. = ..()
 
 	wires = new /datum/wires/autolathe(src)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -87,9 +87,11 @@
 	for(var/mat_id in materials.materials)
 		var/datum/material/M = mat_id
 		var/mineral_count = materials.materials[mat_id]
+		var/sheets_count = CEILING(mineral_count / MINERAL_MATERIAL_AMOUNT, 0.1)
 		var/list/material_data = list(
 			name = M.name,
 			mineral_amount = mineral_count,
+			sheets_amount = sheets_count,
 			matcolour = M.color,
 		)
 		data["materials"] += list(material_data)
@@ -184,6 +186,21 @@
 		. = TRUE
 	if(action == "diskEject")
 		eject(usr)
+
+	if(action == "materialEject")
+		var/material_name = params["materialName"]
+		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+		var/amount = text2num(params["amount"])
+		if(amount <= 0 || amount > 50)
+			return
+
+		for(var/mat in materials.materials)
+			var/datum/material/M = mat
+			if("[M]" == material_name)
+				stack_trace("Found [M] for [material_name], attempting to eject [amount]")
+				materials.retrieve_sheets(amount, M, get_turf(src))
+				. = TRUE
+				break
 
 	if(action == "make")
 		if (!busy)

--- a/tgui/packages/tgui/interfaces/Autolathe.js
+++ b/tgui/packages/tgui/interfaces/Autolathe.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { Button, LabeledList, Section, ProgressBar, Flex, Box, Table, Collapsible, Input, Dimmer, Icon } from '../components';
+import { Button, LabeledList, Section, ProgressBar, Flex, Box, Table, Collapsible, Input, NumberInput, Dimmer, Icon } from '../components';
 import { Window } from '../layouts';
 import { capitalize } from "common/string";
 
@@ -57,21 +57,15 @@ export const Autolathe = (props, context) => {
               {filteredmaterials.length > 0 && (
                 <Collapsible title="Materials">
                   <LabeledList>
-                    {filteredmaterials.map(filteredmaterial => (
-                      <LabeledList.Item
-                        key={filteredmaterial.id}
-                        label={capitalize(filteredmaterial.name)}>
-                        <ProgressBar
-                          style={{
-                            transform: 'scaleX(-1) scaleY(1)',
-                          }}
-                          value={materialsmax - filteredmaterial.mineral_amount}
-                          maxValue={materialsmax}
-                          color="black"
-                          backgroundColor={filteredmaterial.matcolour}>
-                          <div style={{ transform: 'scaleX(-1)' }}>{filteredmaterial.mineral_amount + ' cm³'}</div>
-                        </ProgressBar>
-                      </LabeledList.Item>
+                    {filteredmaterials.map(material => (
+                      <MaterialRow
+                        key={material.id}
+                        material={material}
+                        materialsmax={materialsmax}
+                        onRelease={amount => act('materialEject', {
+                          materialName: material.name,
+                          amount: amount,
+                        })} />
                     ))}
                   </LabeledList>
                 </Collapsible>)}
@@ -210,5 +204,80 @@ export const Autolathe = (props, context) => {
         )}
       </Window.Content>
     </Window>
+  );
+};
+
+
+const MaterialRow = (props, context) => {
+  const { material, materialsmax, onRelease } = props;
+
+  const [
+    amount,
+    setAmount,
+  ] = useLocalState(context, "amount" + material.name, 1);
+
+  const amountAvailable = Math.floor(material.amount);
+  return (
+    <LabeledList.Item
+      key={material.id}>
+      <Table width="100%">
+        <Table.Row>
+          <Table.Cell>
+            {capitalize(material.name)}
+          </Table.Cell>
+          <Table.Cell textAlign="right">
+            <Box mr={2} color="label" inline>
+              {material.sheets_amount} sheets
+            </Box>
+          </Table.Cell>
+          <Table.Cell collapsing textAlign="right">
+              <Button
+              disabled={material.sheets_amount< 1}
+              content="x1"
+              onClick={() => onRelease(1)} />
+              <Button
+              disabled={material.sheets_amount< 5}
+              content="x5"
+              onClick={() => onRelease(5)} />
+            <Button
+              disabled={material.sheets_amount< 10}
+              content="x10"
+              onClick={() => onRelease(10)} />
+            <Button
+              disabled={material.sheets_amount< 25}
+              content="x25"
+              onClick={() => onRelease(25)} />
+          </Table.Cell>
+          <Table.Cell collapsing textAlign="right">
+            <NumberInput
+              width="32px"
+              step={1}
+              stepPixelSize={5}
+              minValue={1}
+              maxValue={material.sheets_amount}
+              value={amount}
+              onChange={(e, value) => setAmount(value)} />
+            <Button
+              disabled={material.sheets_amount< 1}
+              content="Release"
+              onClick={() => onRelease(amount)} />
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell colspan="4">
+            <ProgressBar
+              style={{
+                transform: 'scaleX(-1) scaleY(1)',
+              }}
+              value={materialsmax - material.mineral_amount}
+              maxValue={materialsmax}
+              color="black"
+              backgroundColor={material.matcolour}>
+              <div style={{ transform: 'scaleX(-1)' }}>{material.mineral_amount + ' cm³'}</div>
+            </ProgressBar>
+          </Table.Cell>
+        </Table.Row>
+      </Table>
+    </LabeledList.Item>
   );
 };

--- a/tgui/packages/tgui/interfaces/Autolathe.js
+++ b/tgui/packages/tgui/interfaces/Autolathe.js
@@ -231,11 +231,11 @@ const MaterialRow = (props, context) => {
             </Box>
           </Table.Cell>
           <Table.Cell collapsing textAlign="right">
-              <Button
+            <Button
               disabled={material.sheets_amount< 1}
               content="x1"
               onClick={() => onRelease(1)} />
-              <Button
+            <Button
               disabled={material.sheets_amount< 5}
               content="x5"
               onClick={() => onRelease(5)} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was missing ways to get non-glass/iron materials out of the autolathe, this should fix it!


- [x] Adds material eject buttons in TGUI
- [x] Makes Autolathe accept Plastic again
- [x] Fix material colors not showing under materials

![](https://media.discordapp.net/attachments/837744059291533395/989210383464136814/unknown.png)


## Why It's Good For The Game

deconstruction an autolathe to get your precious titanium back shouldn't be a thing

## Changelog
:cl:
add: TGUI for ejecting materials from the Autolathe
fix: Autolathe not accepting plastic
fix: Autolathe material display not showing colors correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
