### PR TITLE
Kepori and dwarf scooping but again

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -253,6 +253,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_ANTENNAE "antennae"
 /// The holder of this trait can be picked up and held by another mob that does NOT have this trait.
 #define TRAIT_HOLDABLE "holdable"
+/// the holder of this trait will be scooped instead of fireman carried
+#define TRAIT_SCOOPABLE "scoopable"
 
 //non-mob traits
 /// Used for limb-based paralysis, where replacing the limb will fix it.

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -146,7 +146,8 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_NOBREAK" = TRAIT_NOBREAK,			//WS edit - Whitesands
 		"TRAIT_ALLBREAK" = TRAIT_ALLBREAK,			//WS edit - Whitesands
 		"TRAIT_BADTOUCH" = TRAIT_BADTOUCH,
-		"TRAIT_HOLDABLE" = TRAIT_HOLDABLE
+		"TRAIT_HOLDABLE" = TRAIT_HOLDABLE,
+		"TRAIT_SCOOPABLE" = TRAIT_SCOOPABLE
 
 	),
 	/obj/item/bodypart = list(

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -262,7 +262,7 @@
 		defense_mod -= 2
 	if(HAS_TRAIT(target, TRAIT_GIANT))
 		defense_mod += 2
-	if(HAS_TRAIT(target, TRAIT_HOLDABLE))
+	if(HAS_TRAIT(target, TRAIT_SCOOPABLE))
 		defense_mod -= 1
 
 	if(ishuman(target))

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -93,7 +93,7 @@
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
-	ADD_TRAIT(owner, TRAIT_HOLDABLE, GENETIC_MUTATION)
+	ADD_TRAIT(owner, TRAIT_SCOOPABLE, GENETIC_MUTATION)
 	owner.transform = owner.transform.Scale(1, 0.8)
 	passtable_on(owner, GENETIC_MUTATION)
 	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
@@ -102,7 +102,7 @@
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
-	REMOVE_TRAIT(owner, TRAIT_HOLDABLE, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_SCOOPABLE, GENETIC_MUTATION)
 	owner.transform = owner.transform.Scale(1, 1.25)
 	passtable_off(owner, GENETIC_MUTATION)
 	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1053,13 +1053,16 @@
 
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if(pulling != target || grab_state != GRAB_AGGRESSIVE || stat != CONSCIOUS || a_intent != INTENT_GRAB)
+	if(pulling != target || stat != CONSCIOUS || a_intent != INTENT_GRAB)
 		return ..()
 
-	//If they can be picked up, and we can't (prevents recursion), try to pick the target mob up as an item.
-	if(HAS_TRAIT(target, TRAIT_HOLDABLE) && !HAS_TRAIT(src, TRAIT_HOLDABLE))
-		if(target.mob_try_pickup(user))
-			return
+	//If they can be scooped, try to scoop the target mob
+	if(HAS_TRAIT(target, TRAIT_SCOOPABLE))
+		if(ishuman(target))
+			if(scoop(target))
+				return
+	if(grab_state != GRAB_AGGRESSIVE)
+		return ..()
 	//If they dragged themselves and we're currently aggressively grabbing them try to piggyback
 	if(user == target)
 		if(can_piggyback(target))
@@ -1171,6 +1174,27 @@
 		visible_message("<span class='warning'>[src] fails to fireman carry [target]!</span>")
 	else
 		to_chat(src, "<span class='warning'>You can't fireman carry [target] while they're standing!</span>")
+
+/mob/living/carbon/human/proc/scoop(mob/living/carbon/target)
+	var/carrydelay = 20 //if you have latex you are faster at grabbing
+	var/skills_space = "" //cobby told me to do this
+	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
+		carrydelay = 10
+		skills_space = "expertly"
+	else if(HAS_TRAIT(src, TRAIT_QUICK_CARRY))
+		carrydelay = 15
+		skills_space = "quickly"
+	if(!incapacitated(FALSE, TRUE))
+		visible_message("<span class='notice'>[src] starts [skills_space] scooping [target] into their arms..</span>",
+		//Joe Medic starts quickly/expertly scooping Grey Tider into their arms..
+		"<span class='notice'>[carrydelay < 11 ? "Using your gloves' nanochips, you" : "You"] [skills_space] start to scoop [target] into your arms[carrydelay == 15 ? ", while assisted by the nanochips in your gloves.." : "..."]</span>")
+		//(Using your gloves' nanochips, you/You) ( /quickly/expertly) start to scoop Grey Tider into your arms(, while assisted by the nanochips in your gloves../...)
+		if(do_after(src, carrydelay, TRUE, target))
+			//Second check to make sure they're still valid to be carried
+			if(!incapacitated(FALSE, TRUE) && !target.buckled)
+				buckle_mob(target, TRUE, TRUE, 90, 1, 0)
+				return TRUE
+		visible_message("<span class='warning'>[src] fails to scoop [target]!</span>")
 
 /mob/living/carbon/human/proc/piggyback(mob/living/carbon/target)
 	if(can_piggyback(target))

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -3,7 +3,7 @@
 	id = SPECIES_KEPORI
 	default_color = "6060FF"
 	species_traits = list(MUTCOLORS, EYECOLOR, NO_UNDERWEAR)
-	inherent_traits = list(TRAIT_HOLDABLE)
+	inherent_traits = list(TRAIT_SCOOPABLE)
 	mutant_bodyparts = list("kepori_body_feathers", "kepori_tail_feathers", "kepori_feathers")
 	default_features = list("mcolor" = "0F0", "wings" = "None", "kepori_feathers" = "Plain", "kepori_body_feathers" = "Plain", "kepori_tail_feathers" = "Fan")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/chicken


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
copy of #1243 because i fucked up the cobblestone generator
This pull request removes the HOLDABLE trait from dwarves and keporit instead replacing it with the SCOOPABLE trait, which allows them to be fireman carried while standing, with a much shorter timer, and only requiring a passive grab
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Human mobs in mob holders were fairly scuffed codewise, allowing for a lot of unintended consequences such as kepori frying, and the inability to /me while being held, this entirely avoids those issues. It also makes very little sense for kepori(which are an average of 4'6", to be held in the same way that you hold much smaller animals) This PR was requested by @PiperDoots
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the SCOOPABLE trait
tweak: kepori and dwarves now use the SCOOPABLE trait instead of HOLDABLE
fix: fixed kepori frying
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
