### PR TITLE
removes mob computer_id and lastKnownIP vars, adjusts borer/split personality code

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -42,7 +42,7 @@
 #define ROLE_SYNDICATE_CYBERSUN "Cybersun Space Syndicate" //Ghost role syndi from Forgottenship ruin
 #define ROLE_SYNDICATE_CYBERSUN_CAPTAIN "Cybersun Space Syndicate Captain" //Forgottenship captain syndie
 
-#define ROLE_BORER "borer" //WS Edit - Boreres
+#define ROLE_BORER "borer" //WS Edit - Borers
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -89,39 +89,16 @@
 
 	//Body to backseat
 
-	var/h2b_id = to_swap.computer_id
-	var/h2b_ip= to_swap.lastKnownIP
-	to_swap.computer_id = null
-	to_swap.lastKnownIP = null
-
-	free_backseat.ckey = to_swap.ckey
-
-	free_backseat.name = to_swap.name
 
 	if(to_swap.mind)
 		free_backseat.mind = to_swap.mind
-
-	if(!free_backseat.computer_id)
-		free_backseat.computer_id = h2b_id
-
-	if(!free_backseat.lastKnownIP)
-		free_backseat.lastKnownIP = h2b_ip
+	free_backseat.name = to_swap.name
+	free_backseat.ckey = to_swap.ckey
 
 	//Backseat to body
 
-	var/s2h_id = current_backseat.computer_id
-	var/s2h_ip= current_backseat.lastKnownIP
-	current_backseat.computer_id = null
-	current_backseat.lastKnownIP = null
-
-	to_swap.ckey = current_backseat.ckey
 	to_swap.mind = current_backseat.mind
-
-	if(!to_swap.computer_id)
-		to_swap.computer_id = s2h_id
-
-	if(!to_swap.lastKnownIP)
-		to_swap.lastKnownIP = s2h_ip
+	to_swap.ckey = current_backseat.ckey
 
 	current_controller = !current_controller
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,6 +91,7 @@
 	var/list/crew_objectives
 
 /datum/mind/New(_key)
+	SSticker.minds += src
 	key = _key
 	soulOwner = src
 	martial_art = default_martial_art
@@ -824,10 +825,9 @@
 /mob/proc/mind_initialize()
 	if(mind)
 		mind.key = key
-
 	else
 		mind = new /datum/mind(key)
-		SSticker.minds += mind
+
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -277,11 +277,13 @@
 			var/M_name = html_encode(M.name)
 			var/M_rname = html_encode(M.real_name)
 			var/M_key = html_encode(M.key)
+			var/M_last_ip = ""
 			var/previous_names = ""
-			if(M_key)
-				var/datum/player_details/P = GLOB.player_details[ckey(M_key)]
+			if(M.ckey)
+				var/datum/player_details/P = GLOB.player_details[M.ckey]
 				if(P)
 					previous_names = P.played_names.Join(",")
+					M_last_ip = P.last_known_ip
 			previous_names = html_encode(previous_names)
 
 			//output for each mob
@@ -300,7 +302,7 @@
 						<span hidden id="data[i]_rname">[M_rname]</span>
 						<span hidden id="data[i]_prevnames">[previous_names]</span>
 						<span hidden id="data[i]_key">[M_key]</span>
-						<span hidden id="data[i]_lastip">[M.lastKnownIP]</span>
+						<span hidden id="data[i]_lastip">[M_last_ip]</span>
 						<span hidden id="data[i]_isantag">[is_antagonist]</span>
 						<span hidden id="data[i]_ref">[REF(M)]</span>
 						</a>

--- a/code/modules/antagonists/borer/borer.dm
+++ b/code/modules/antagonists/borer/borer.dm
@@ -684,43 +684,19 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 3)
 		to_chat(victim, "<span class='userdanger'>You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours.</span>")
 
 		// host -> brain
-		var/h2b_id = victim.computer_id
-		var/h2b_ip= victim.lastKnownIP
-		victim.computer_id = null
-		victim.lastKnownIP = null
-
 		qdel(host_brain)
 		host_brain = new(src)
 
-		host_brain.ckey = victim.ckey
-
 		host_brain.name = victim.name
-
 		if(victim.mind)
 			host_brain.mind = victim.mind
-
-		if(!host_brain.computer_id)
-			host_brain.computer_id = h2b_id
-
-		if(!host_brain.lastKnownIP)
-			host_brain.lastKnownIP = h2b_ip
+		host_brain.ckey = victim.ckey
 
 		to_chat(host_brain, "You are trapped in your own mind. You feel that there must be a way to resist!")
 
 		// self -> host
-		var/s2h_id = src.computer_id
-		var/s2h_ip= src.lastKnownIP
-		src.computer_id = null
-		src.lastKnownIP = null
-
-		victim.ckey = src.ckey
 		victim.mind = src.mind
-
-		if(!victim.computer_id)
-			victim.computer_id = s2h_id
-
-		if(!victim.lastKnownIP)
-			victim.lastKnownIP = s2h_ip
+		victim.ckey = src.ckey
 
 		bonding = FALSE
 		controlling = TRUE
@@ -833,40 +809,13 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 3)
 
 	if(host_brain)
 
-		// these are here so bans and multikey warnings are not triggered on the wrong people when ckey is changed.
-		// computer_id and IP are not updated magically on their own in offline mobs -walter0o
-
 		// host -> self
-		var/h2s_id = victim.computer_id
-		var/h2s_ip= victim.lastKnownIP
-		victim.computer_id = null
-		victim.lastKnownIP = null
-
-		ckey = victim.ckey
 		mind = victim.mind
-
-
-		if(!computer_id)
-			computer_id = h2s_id
-
-		if(!host_brain.lastKnownIP)
-			lastKnownIP = h2s_ip
+		ckey = victim.ckey
 
 		// brain -> host
-		var/b2h_id = host_brain.computer_id
-		var/b2h_ip= host_brain.lastKnownIP
-		host_brain.computer_id = null
-		host_brain.lastKnownIP = null
-
-		victim.ckey = host_brain.ckey
-
 		victim.mind = host_brain.mind
-
-		if(!victim.computer_id)
-			victim.computer_id = b2h_id
-
-		if(!victim.lastKnownIP)
-			victim.lastKnownIP = b2h_ip
+		victim.ckey = host_brain.ckey
 
 	log_game("[src]/([src.ckey]) released control of [victim]/([victim.ckey]")
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -301,9 +301,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		reconnecting = TRUE
 		player_details = GLOB.player_details[ckey]
 		player_details.byond_version = full_version
+		player_details.last_known_ip = address
 	else
 		player_details = new(ckey)
 		player_details.byond_version = full_version
+		player_details.last_known_ip = address
 		GLOB.player_details[ckey] = player_details
 
 
@@ -505,7 +507,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				"Someone come hold me :(",\
 				"I need someone on me :(",\
 				"What happened? Where has everyone gone?",\
-				"Forever alone :("\
+				"Forever alone :(",\
+				"All Alone On A Late Night :^(",\
+				"Love me, feed me, don't leave me :("\
 			)
 
 			send2tgs("Server", "[cheesy_message] (No admins online)")

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -5,6 +5,8 @@
 	var/list/post_logout_callbacks = list()
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
+	/// The most recent address used by this player, loaded on client/New().
+	var/last_known_ip
 	var/datum/achievement_data/achievements
 
 /datum/player_details/New(key)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -296,7 +296,6 @@
 
 		character.update_parallax_teleport()
 
-	SSticker.minds += character.mind
 	character.client.init_verbs() // init verbs for the late join
 
 	if(ishuman(character))	//These procs all expect humans

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -3,8 +3,6 @@
   *
   * Things it does:
   * * Adds player to player_list
-  * * sets lastKnownIP
-  * * sets computer_id
   * * logs the login
   * * tells the world to update it's status (for player count)
   * * create mob huds for the mob if needed
@@ -26,8 +24,6 @@
 	if(!client)
 		return FALSE
 	add_to_player_list()
-	lastKnownIP	= client.address
-	computer_id	= client.computer_id
 	log_access("Mob Login: [key_name(src)] was assigned to a [type]")
 	world.update_status()
 	client.screen = list()				//remove hud items just in case

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -51,7 +51,6 @@
 	/// The zone this mob is currently targeting
 	var/zone_selected = BODY_ZONE_CHEST
 
-	var/computer_id = null
 	var/list/logging = list()
 
 	/// The machine the mob is interacting with (this is very bad old code btw)
@@ -109,9 +108,6 @@
 	var/list/possible_a_intents = null//Living
 	/// The movement intent of the mob (run/wal)
 	var/m_intent = MOVE_INTENT_RUN//Living
-
-	/// The last known IP of the client who was in this mob
-	var/lastKnownIP = null
 
 	/// movable atom we are buckled to
 	var/atom/movable/buckled = null//Living


### PR DESCRIPTION
## About The Pull Request

i noticed that borer and split personality code was bad. they were juggling mobs' computer_id and lastKnownIP vars, both of which weren't really used anywhere else (lastKnownIP was; i moved it to player_details). they were also swapping the mobs' minds AFTER their ckeys. this likely caused problems, as (i think) that creates duplicate minds that lack any of the skills or abilities of the originals, since editing keys automatically calls the Login() and Logout() procs, and Login() is what makes sure the mind vars are all correctly synchronized.

generally you shouldn't be reassigning minds directly ANYWAY, but this was a particularly bad way of doing so. i didn't update the code as much as i should've, but i wanted to get this squared away so i can write other code that relies on mind references working (more or less) correctly

also i made minds only add themselves to SSticker.minds in their New().
also also, i haven't actually tested this with borers or split personalities yet because i honestly, truly cannot be assed

## Why It's Good For The Game

borer and split personality code sucks. hopefully this makes it a tiny bit better

## Changelog
:cl:
refactor: Removed mob.computer_id; moved mob.lastKnownIP to player_details.last_known_ip
code: Borers and split personalities now move the mind reference before swapping player control. This may or may not alleviate some bugs.
/:cl:
