### PR TITLE
Changes the base mining mob and all basilisks environment_smash to ENVIRONMENT_SMASH_MINERALS

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -25,6 +25,7 @@
 	health = 175
 	harm_intent_damage = 5
 	obj_damage = 60
+	environment_smash = ENVIRONMENT_SMASH_MINERALS
 	melee_damage_lower = 7
 	melee_damage_upper = 15
 	attack_verb_continuous = "bites into"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -5,7 +5,7 @@
 	faction = list("mining")
 	weather_immunities = list("lava","ash")
 	obj_damage = 30
-	environment_smash = ENVIRONMENT_SMASH_WALLS
+	environment_smash = ENVIRONMENT_SMASH_MINERALS
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	response_harm_continuous = "strikes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Exactly as it says on the tin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mining mobs smashing walls and other infrastructure is a remnant of station-based gameplay and really isn't good for ships that are unfortunate enough to land next to a watcher tendril. This change should prevent watchers and most other mining mobs from smashing down the walls of a heavily armored ship just because they saw a tasty looking felinid static inside.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changes basilisk and base mining mob's environment smash tag to ENVIRONMENT_SMASH_MINERALS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
