### PR TITLE
Adds protolathe boards to tech nodes & add new tech node

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -458,7 +458,7 @@
 	req_components = list()
 
 /obj/item/circuitboard/machine/protolathe
-	name = "Protolathe (Machine Board)"
+	name = "Universal Protolathe (Machine Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/rnd/production/protolathe
 	req_components = list(

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -258,10 +258,10 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/protolathe
-	name = "Machine Design (Protolathe Board)"
-	desc = "The circuit board for a protolathe."
-	id = "protolathe"
+/datum/design/board/uni_protolathe
+	name = "Machine Design (Universal Protolathe Board)"
+	desc = "The circuit board for a universal protolathe."
+	id = "uni_protolathe"
 	build_path = /obj/item/circuitboard/machine/protolathe
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -266,6 +266,54 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/protolathe/department/science
+	name = "Machine Design (Science Departmental Protolathe Board)"
+	desc = "The circuit board for a science departmental protolathe."
+	id = "sci_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/science
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/protolathe/department/security
+	name = "Machine Design (Security Departmental Protolathe Board)"
+	desc = "The circuit board for a security departmental protolathe."
+	id = "sec_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/security
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/protolathe/department/cargo
+	name = "Machine Design (Cargo Departmental Protolathe Board)"
+	desc = "The circuit board for a cargo departmental protolathe."
+	id = "car_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/cargo
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/protolathe/department/medical
+	name = "Machine Design (Medical Departmental Protolathe Board)"
+	desc = "The circuit board for a medical departmental protolathe."
+	id = "med_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/protolathe/department/engineering
+	name = "Machine Design (Engineering Departmental Protolathe Board)"
+	desc = "The circuit board for a engineering departmental protolathe."
+	id = "eng_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/engineering
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/protolathe/department/service
+	name = "Machine Design (Service Departmental Protolathe Board)"
+	desc = "The circuit board for a service departmental protolathe."
+	id = "ser_protolathe"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/service
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/circuit_imprinter
 	name = "Machine Design (Circuit Imprinter Board)"
 	desc = "The circuit board for a circuit imprinter."

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -1,5 +1,5 @@
 /obj/machinery/rnd/production/protolathe
-	name = "protolathe"
+	name = "universal protolathe"
 	desc = "Converts raw materials into useful objects."
 	icon_state = "protolathe"
 	circuit = /obj/item/circuitboard/machine/protolathe

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -242,7 +242,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "protolathe")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "uni_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -85,7 +85,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "detective_scanner", "defibrillator_compact")
+	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "detective_scanner", "defibrillator_compact", "med_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -144,7 +144,8 @@
 	prereq_ids = list("base")
 	design_ids = list(
 		"survey-handheld-advanced",
-		"design_disk_adv"
+		"design_disk_adv",
+		"sci_protolathe"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -168,7 +169,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded", "rpd_loaded", "sheetifier")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded", "rpd_loaded", "sheetifier", "eng_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -241,7 +242,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
@@ -563,7 +564,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "car_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 // WS Edit Start - Yeet The BSM
@@ -581,7 +582,7 @@
 	display_name = "Advanced Sanitation Technology"
 	description = "Clean things better, faster, stronger, and harder!"
 	prereq_ids = list("adv_engi")
-	design_ids = list("holobarrier_jani", "advmop", "buffer", "blutrash", "light_replacer", "spraybottle", "beartrap")
+	design_ids = list("holobarrier_jani", "advmop", "buffer", "blutrash", "light_replacer", "spraybottle", "beartrap", "ser_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -607,7 +608,7 @@
 	id = "sec_basic"
 	display_name = "Basic Security Equipment"
 	description = "Standard equipment used by security."
-	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag")
+	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag", "sec_protolathe")
 	prereq_ids = list("base")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -608,7 +608,7 @@
 	id = "exp_tools"
 	display_name = "Experimental Tools"
 	description = "Highly advanced tools."
-	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool"")
+	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -144,8 +144,7 @@
 	prereq_ids = list("base")
 	design_ids = list(
 		"survey-handheld-advanced",
-		"design_disk_adv",
-		"sci_protolathe"
+		"design_disk_adv"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -171,6 +170,15 @@
 	prereq_ids = list("engineering", "emp_basic")
 	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded", "rpd_loaded", "sheetifier", "eng_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+
+/datum/techweb_node/universal_lathe
+	id = "universal_lathe"
+	display_name = "Experimental Machines"
+	description = "Experimental machine designs, merging many functions of other machines into one with the same footprint."
+	prereq_ids = list("practical_bluespace", "adv_weaponry", "adv_biotech", "janitor", "adv_mining", "comptech")
+	design_ids = list("uni_protolathe")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 
 /datum/techweb_node/anomaly
@@ -242,7 +250,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "uni_protolathe")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
@@ -414,6 +422,7 @@
 		"seccamera",
 		"survey-handheld-elite",
 		"design_disk_super",
+		"sci_protolathe"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
@@ -599,7 +608,7 @@
 	id = "exp_tools"
 	display_name = "Experimental Tools"
 	description = "Highly advanced tools."
-	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool")
+	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool"")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -608,7 +617,7 @@
 	id = "sec_basic"
 	display_name = "Basic Security Equipment"
 	description = "Standard equipment used by security."
-	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag", "sec_protolathe")
+	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag")
 	prereq_ids = list("base")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
@@ -646,7 +655,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("pin_loyalty","gun_cell_upgraded", "gun_cell_large")
+	design_ids = list("pin_loyalty","gun_cell_upgraded", "gun_cell_large", "sec_protolathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

Adds All departmental protolathe boards to relevant tech nodes (Open to suggestions for alternative nodes)
adds a new machine design for each departmental protolathe board so they can be added to tech nodes
adds new tech node "Experimental Machines" which requires all other protolathe techs (except advanced engineering directly*) and unlocks the non-departmental lathe.
Renames non-departmental protolathe to Universal Protolathe
had to rename the protolathe machine design because, for some reason, it was causing crashes? renaming it completely solved the issue with no visible side effects

- Science - Computer Consoles
- Security - Advanced Weapon Development Technology
- Service - Advanced Sanitation Technology
- Cargo - Advanced Mining Technology
- Engineering - Advanced Engineering
- Medical - Advanced Biotechnology
- Universal - Experimental Machines

## Why It's Good For The Game

Until a better gameplay loop comes around, or major changes are done to remove the critical need for any type of protolathe, this measure would allow players to spend less time hunting protolathe boards from absurdly rare rock planet loot, and instead spend more time researching them, possibly allowing more time for inter-ship interaction, as there should be less downtime with landed ships if they lacked a board to start with.

the current intended rarity of protolathe boards is not a good design decision imo, and anyone who wants "gamer gear" will probably just wind up with it, and those who don't want or don't care about it will likely not wind up with it.

As a thought experiment, what happens if your sole protolathe on a ship that started with it is destroyed by anything? (meteor, bomb, careless crewmember, etc). You can't replace it without going to a rock planet and gambling with a 5% drop chance on a fairly rare destroyed machine. This can soak up an absolutely *monstrous* amount of time, leading to extended landings which I have seen been discussed as bad for gameplay.

Once something better than the current loop is done, this can be easily removed.

## Changelog
:cl:
tweak: Adds Science Protolathe board to Computer Consoles node
tweak: Adds Security Protolathe board to Advanced Weapon Development Technology node
tweak: Adds Service Protolathe board to Advanced Sanitation Technology node
tweak: Adds Cargo Protolathe board to Advanced Mining Technology node
tweak: Adds Engineering Protolathe board to Advanced Engineering node
tweak: Adds Medical Protolathe board to Advanced Biotechnology
tweak: renamed non-departmental Protolathe to Universal Protolathe
add: Adds new tech node "Experimental Machines", which requires every other tech a protolathe is found on, and costs 10,000 points.
add: Adds Universal Protolathe board to Experimental Machines node
/:cl:
