### PR TITLE
Removes an infinite materials exploit

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -8,7 +8,7 @@
 	item_state = "syringe_kit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	custom_materials = list(/datum/material/iron = 30000)
+	custom_materials = list(/datum/material/iron = 15000)
 	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes an infinite material exploit by reducing the material refund value for most ammo boxes. When handgun ammo was rebalanced, pistol ammo boxes were made printable on the autolathe, with a materials price equivalent to .38 speedloaders. However, the base ammo box's refund value was twice that, meaning you could just recycle ammo boxes indefinitely. This PR reduces the refund value to match their print cost at 15000 iron.

## Why It's Good For The Game

bug fix good

## Changelog
:cl:
fix: reduced refund value of ammo boxes to close materials exploit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
