### PR TITLE
Advanced Airlock Controller fix: Actually considers airlocks at edge of map as external

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -581,8 +581,9 @@
 					if(assume_roles)
 						for(var/adir in GLOB.cardinals)					// Checking all the turfs around the airlock
 							var/turf/check_turf = get_step(T2, adir)
-							if(!check_turf) //You can step out of the map bondaries
-								continue
+							if(!check_turf) // No turf to be found? It's likely an external one in that case, if not, cry about it. (Mainly for ships)
+								airlocks[A] = EXTERIOR_AIRLOCK
+								break
 							if(check_turf.initial_gas_mix != OPENTURF_DEFAULT_ATMOS)
 								airlocks[A] = EXTERIOR_AIRLOCK
 								break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An issue with many maps is that if the airlock is at the edge of the map and turf checks happen to check if an airlock is external or not, the logic for it returns that it's just an internal one. And leaved the AAC broken, which sucks.

So, to fix this there is this small PR to fix this. I have tested this on my own PR ship (Flanger), Shetland and ScrapperB and some others that I don't recall that had broken AACs

## Why It's Good For The Game

Fixes the advanced airlock controller on many ships, such as but not limited to Shetland, ScrapperB, ...

## Changelog
:cl:
fix: Advanced Airlock Controllers now considers airlocks at edge of map as external
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
