### PR TITLE
(DNM) Adds real engines to shuttle ruins that lacked them.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -82,15 +82,11 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ar" = (
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 1
-	},
+/obj/machinery/power/shuttle/engine/electric,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "as" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 1
-	},
+/obj/machinery/power/shuttle/engine/fueled/plasma,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "at" = (
@@ -120,9 +116,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
+/obj/machinery/power/smes/shuttle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ay" = (
@@ -162,6 +156,9 @@
 "aE" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/firstaid/o2,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "aF" = (
@@ -1947,6 +1944,14 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
+"tN" = (
+/obj/structure/closet/crate/engineering,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/ruin/space/has_grav/derelictoutpost/dockedship)
 "uV" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2714,9 +2719,9 @@ ae
 ag
 ae
 am
-ar
+as
 ax
-aH
+tN
 aH
 aV
 bg
@@ -2750,7 +2755,7 @@ ae
 ag
 ae
 am
-as
+ar
 ay
 aI
 aI

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -16,8 +16,8 @@
 /area/template_noop)
 "ae" = (
 /obj/structure/fluff/broken_flooring{
-	icon_state = "plating";
-	dir = 4
+	dir = 4;
+	icon_state = "plating"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -93,8 +93,8 @@
 "an" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "plating";
-	dir = 4
+	dir = 4;
+	icon_state = "plating"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -105,8 +105,8 @@
 "ap" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "pile";
-	dir = 8
+	dir = 8;
+	icon_state = "pile"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -244,8 +244,8 @@
 /area/template_noop)
 "aE" = (
 /obj/structure/fluff/broken_flooring{
-	icon_state = "pile";
-	dir = 4
+	dir = 4;
+	icon_state = "pile"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -406,6 +406,12 @@
 /obj/item/shard,
 /turf/template_noop,
 /area/template_noop)
+"ds" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/caravan/freighter3)
 "dD" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered)
@@ -487,8 +493,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "gq" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 8
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
@@ -540,10 +546,7 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/shuttle/caravan/freighter3)
 "gP" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
+/turf/template_noop,
 /area/shuttle/caravan/freighter3)
 "gQ" = (
 /obj/structure/shuttle/engine/heater{
@@ -733,12 +736,6 @@
 	icon_state = "damaged2"
 	},
 /area/shuttle/caravan/freighter3)
-"hQ" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/caravan/freighter2)
 "hS" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
@@ -877,8 +874,8 @@
 	},
 /area/shuttle/caravan/freighter3)
 "io" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
@@ -1175,8 +1172,8 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
 "jV" = (
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 8
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
@@ -1276,15 +1273,17 @@
 /area/ruin/unpowered)
 "lD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
 "tH" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
 	},
-/turf/closed/wall/mineral/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
 /area/ruin/unpowered)
 "vE" = (
 /obj/machinery/door/airlock/external{
@@ -1305,6 +1304,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
+"Sp" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/caravan/freighter3)
+"Wr" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/caravan/freighter3)
 
 (1,1,1) = {"
 aa
@@ -3464,7 +3472,7 @@ aa
 aa
 aa
 hm
-hQ
+jV
 io
 io
 io
@@ -5179,8 +5187,8 @@ aa
 fZ
 gq
 gP
-gP
-gP
+Sp
+Wr
 bs
 ab
 aE
@@ -5231,7 +5239,7 @@ aa
 ga
 ga
 gQ
-gQ
+ds
 gQ
 iz
 bs

--- a/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
@@ -67,9 +67,9 @@
 	},
 /area/ruin/unpowered)
 "m" = (
-/obj/structure/shuttle/engine/propulsion/left{
+/obj/machinery/power/shuttle/engine/fueled/plasma{
 	color = "#FFFF00";
-	dir = 4
+	dir = 8
 	},
 /turf/template_noop,
 /area/ruin/unpowered)

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -36,8 +36,8 @@
 "ag" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Aft)
@@ -1131,6 +1131,9 @@
 /area/awaymission/BMPship/Aft)
 "dq" = (
 /obj/item/multitool,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Aft)
 "dr" = (
@@ -1143,8 +1146,8 @@
 /turf/open/floor/engine/airless,
 /area/awaymission/BMPship/Aft)
 "ds" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
 	},
 /turf/template_noop,
 /area/awaymission/BMPship/Aft)
@@ -1913,6 +1916,9 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 50
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Aft)
 "ft" = (
@@ -2186,8 +2192,8 @@
 "gl" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Fore)
@@ -2522,6 +2528,15 @@
 "hE" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/awaymission/BMPship/Fore)
+"uv" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/smes/shuttle{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/awaymission/BMPship/Aft)
 "vh" = (
 /turf/template_noop,
 /area/space/nearstation)
@@ -2541,6 +2556,12 @@
 "Mx" = (
 /turf/closed/mineral/random,
 /area/awaymission/BMPship/Midship)
+"Pe" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 8
+	},
+/turf/template_noop,
+/area/awaymission/BMPship/Aft)
 "QM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5541,14 +5562,14 @@ aa
 aa
 aa
 ht
-dr
+uv
 dr
 dr
 ht
 ht
 dr
 dr
-dr
+uv
 ht
 aa
 aa
@@ -5593,12 +5614,12 @@ aa
 aa
 ae
 ds
-ds
-ds
+Pe
+Pe
 ae
 ae
-ds
-ds
+Pe
+Pe
 ds
 ae
 aa

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -18,8 +18,8 @@
 	},
 /area/ruin/space/has_grav/powered/authorship)
 "e" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
 	},
 /turf/template_noop,
 /area/ruin/space/has_grav/powered/authorship)

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -12,6 +12,12 @@
 "d" = (
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/powered/mechtransport)
+"e" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/powered/mechtransport)
 "f" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/cobweb,
@@ -64,6 +70,12 @@
 	req_access_txt = "101"
 	},
 /turf/open/floor/mineral/titanium,
+/area/ruin/space/has_grav/powered/mechtransport)
+"q" = (
+/obj/machinery/power/smes/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 "r" = (
 /obj/effect/decal/cleanable/dirt,
@@ -175,6 +187,9 @@
 /area/ruin/space/has_grav/powered/mechtransport)
 "Q" = (
 /obj/structure/mecha_wreckage/gygax,
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
 /turf/open/floor/mineral/titanium/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 "R" = (
@@ -189,13 +204,35 @@
 "T" = (
 /turf/template_noop,
 /area/ruin/space/has_grav/powered/mechtransport)
+"U" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/template_noop,
+/area/ruin/space/has_grav/powered/mechtransport)
 "V" = (
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/ruin/space/has_grav/powered/mechtransport)
+"W" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/mineral/titanium/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
 "X" = (
-/obj/structure/shuttle/engine/propulsion,
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 1
+	},
 /turf/template_noop,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Z" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 
 (1,1,1) = {"
@@ -313,8 +350,8 @@ y
 w
 w
 Q
-d
-b
+H
+e
 X
 "}
 (8,1,1) = {"
@@ -329,10 +366,10 @@ w
 w
 B
 y
-s
-d
-d
-X
+W
+Z
+q
+U
 "}
 (9,1,1) = {"
 a
@@ -347,7 +384,7 @@ D
 D
 D
 d
+d
 b
 b
-X
 "}

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -942,8 +942,8 @@
 "cy" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
@@ -997,8 +997,8 @@
 /area/ruin/space/has_grav/onehalf/hallway)
 "cE" = (
 /obj/structure/frame/computer{
-	icon_state = "0";
-	dir = 8
+	dir = 8;
+	icon_state = "0"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
@@ -1008,8 +1008,8 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cG" = (
 /obj/structure/frame/computer{
-	icon_state = "0";
-	dir = 1
+	dir = 1;
+	icon_state = "0"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)


### PR DESCRIPTION

## About The Pull Request
This PR does what is says on the tin. Shuttle ruins now have plasma and ION engines instead of the prop "Propulsion Engines".
![image](https://user-images.githubusercontent.com/61367602/176887368-8ea0e515-d500-4891-ba0b-8683cc426f74.png)
![image](https://user-images.githubusercontent.com/61367602/176887460-7e5dc402-0071-4d3a-9c37-1e5af36785f7.png)
![image](https://user-images.githubusercontent.com/61367602/176887569-5bc377d3-bdff-4651-acab-6982ff0054e1.png)
![image](https://user-images.githubusercontent.com/61367602/176887629-41b8d979-6a54-4bf8-a410-7536a80ded12.png)
![image](https://user-images.githubusercontent.com/61367602/176887685-04095277-7f46-48f5-9991-022e2e84564f.png)
![image](https://user-images.githubusercontent.com/61367602/176887752-f6929cab-e0ff-4fed-8f9d-67464e92b400.png)

## Why It's Good For The Game
Brings older ruins up-to-date with newer ones- which already have real engines. 

## Changelog
:cl:
Tweak: Mechanical engines have replaced prop ones on space ruins
/:cl:
