### PR TITLE
Syndicate Laboratory 4071 fixes and adjustments

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/lab4071.dmm
+++ b/_maps/RandomRuins/SpaceRuins/lab4071.dmm
@@ -176,10 +176,6 @@
 /area/ruin/space/has_grav/crazylab/crew)
 "dN" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid{
-	pixel_x = -6;
-	pixel_y = 13
-	},
 /obj/item/razor{
 	pixel_x = -9;
 	pixel_y = 1
@@ -190,6 +186,10 @@
 	},
 /obj/item/lipstick,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -5;
+	pixel_y = 8
+	},
 /turf/open/floor/material,
 /area/ruin/space/has_grav/crazylab/crew)
 "dO" = (
@@ -204,12 +204,11 @@
 	outfit = /datum/outfit/job/chemist/juniorchemist;
 	short_desc = "You are a chemist in an illegal laboratory."
 	},
-/obj/machinery/button{
-	dir = 4;
+/obj/machinery/button/door{
 	id = 64;
 	name = "Dorm Shutters";
-	pixel_x = 7;
-	pixel_y = 25
+	pixel_x = 5;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/crazylab/crew)
@@ -308,7 +307,7 @@
 	pixel_x = -5;
 	pixel_y = 7
 	},
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular{
 	pixel_x = 5
 	},
 /turf/open/floor/mineral/titanium,
@@ -964,6 +963,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = 98;
+	name = "Lab Shutters";
+	pixel_y = 24
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/crazylab/chem)
 "oJ" = (
@@ -1390,9 +1394,9 @@
 	opened = 1
 	},
 /obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/item/stack/sheet/mineral/uranium/fifty,
 /obj/item/stack/sheet/mineral/silver/fifty,
 /obj/machinery/light/broken,
+/obj/item/stack/sheet/mineral/uranium/twenty,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/space/has_grav/crazylab/chem)
 "vK" = (
@@ -1496,11 +1500,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/button{
+/obj/machinery/button/door{
 	dir = 8;
 	id = 32;
 	name = "Rec Room Shutters";
-	pixel_x = 25
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/crazylab/gamble)
@@ -1573,7 +1577,6 @@
 /obj/effect/turf_decal/trimline/orange/filled/warning{
 	dir = 5
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -1584,14 +1587,13 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "yl" = (
-/obj/machinery/button{
-	dir = 4;
-	id = 98;
-	name = "Lab Shutters";
-	pixel_x = 9
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = 18
 	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/space/has_grav/crazylab/chem)
+/turf/open/space/basic,
+/area/ruin/space/has_grav/crazylab/bar)
 "yu" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -1751,11 +1753,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "zX" = (
-/obj/structure/closet/crate/radiation,
 /obj/effect/turf_decal/trimline/orange/filled/warning{
 	dir = 5
 	},
 /obj/machinery/camera/all,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "Ad" = (
@@ -1942,6 +1944,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/stack/sheet/mineral/uranium/fifty,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "BS" = (
@@ -2091,23 +2094,21 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "DK" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "DN" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
@@ -2119,7 +2120,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "Ef" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
 /obj/effect/turf_decal/trimline/orange/filled/warning{
 	dir = 6
 	},
@@ -2243,31 +2246,27 @@
 /obj/effect/turf_decal/trimline/orange/filled/warning{
 	dir = 10
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/crazylab/engi)
-"Gc" = (
-/obj/machinery/power/smes,
-/obj/effect/turf_decal/trimline/orange/filled/warning,
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "Go" = (
 /obj/machinery/power/smes,
 /obj/effect/turf_decal/trimline/orange/filled/warning,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/engi)
 "Gu" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/effect/turf_decal/trimline/orange/filled/warning{
 	dir = 6
+	},
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -2509,6 +2508,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	id = 18;
+	name = "Botany Window Lockdown";
+	pixel_y = -25
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/crazylab/bar)
@@ -2899,9 +2904,10 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav/crazylab/outside)
 "Mk" = (
-/obj/item/reagent_containers/glass/bottle/romerol,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/research_notes/loot/genius{
+	origin_type = "experimental chemistry and explosives"
+	},
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav/crazylab/outside)
 "Mz" = (
@@ -2923,7 +2929,9 @@
 /turf/open/floor/plating/grass,
 /area/ruin/space/has_grav/crazylab/bar)
 "MV" = (
-/obj/structure/closet/secure_closet/security,
+/obj/structure/closet/secure_closet/security{
+	req_access = null
+	},
 /obj/item/clothing/suit/armor/vest,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/crazylab/armory)
@@ -2960,7 +2968,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/crazylab/armory)
 "NO" = (
-/obj/structure/closet/secure_closet/security,
+/obj/structure/closet/secure_closet/security{
+	req_access = null
+	},
 /obj/item/clothing/suit/armor/vest,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/armory)
@@ -3029,12 +3039,6 @@
 "OT" = (
 /obj/structure/flora/rock/pile,
 /obj/item/stack/sheet/mineral/uranium/fifty,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav/crazylab/outside)
-"OU" = (
-/mob/living/simple_animal/hostile/zombie,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav/crazylab/outside)
 "OX" = (
@@ -3254,9 +3258,10 @@
 /area/ruin/space/has_grav/crazylab/airlock)
 "Ry" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button{
-	bound_width = 128;
-	name = "EVA Shutters"
+/obj/machinery/button/door{
+	id = 128;
+	name = "EVA Shutters";
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/industrial/warning/dust{
 	dir = 6
@@ -3338,6 +3343,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = 132;
+	name = "Airlock Lockdown";
+	pixel_x = -23
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/airlock)
@@ -3479,10 +3490,16 @@
 /area/ruin/space/has_grav/crazylab/airlock)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor{
+	id = 132
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/crazylab/airlock)
 "We" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor{
+	id = 132
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Wf" = (
@@ -4108,7 +4125,7 @@ GV
 GV
 at
 at
-OU
+Me
 at
 at
 GV
@@ -4562,7 +4579,7 @@ CY
 Bg
 Hq
 Jj
-Br
+yl
 MB
 OX
 QB
@@ -4600,7 +4617,7 @@ Dd
 Bg
 Hc
 Jr
-Br
+yl
 MG
 Pd
 QB
@@ -4977,7 +4994,7 @@ yf
 zK
 BC
 DK
-Gc
+Go
 Ik
 Ks
 Lu
@@ -5083,7 +5100,7 @@ at
 ck
 ck
 ck
-mb
+hy
 oG
 sd
 vD
@@ -5125,7 +5142,7 @@ mc
 oJ
 sx
 vJ
-yl
+hy
 Ad
 hy
 hE
@@ -5611,7 +5628,7 @@ GV
 at
 at
 bw
-aT
+cB
 aT
 at
 GV
@@ -5725,9 +5742,9 @@ GV
 at
 aw
 bQ
-bA
+bQ
 fe
-aT
+bQ
 at
 GV
 GV
@@ -5761,7 +5778,7 @@ GV
 GV
 GV
 GV
-aT
+cB
 aw
 cB
 aw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a long list of issues with the space ruin lab4071.dmm.
- Fixes the SMES units having inverted input and output placements, which previously caused the facility to recieve no power whatsoever.
- Changes the type of button used for the window blast doors in order to make them function properly.
- Changes the type of medkit placed in the bathroom and surveillance ship to be a full version. This gives the players access to gauze to prevent them from bleeding out after a fight with spiders or carp. (Experienced thouroghly and agonizingly during testing).
- Removes the bottle of Literal Romerol from one of the outer asteroids. Replaces it with an equally valuable bunch of scientific papers about experimental chemistry and explosives. (Side note, no offense to the map creator but please do not put antagonist creating chemicals or items into ruins without proper precautions or balancing.)
- Adds blast doors to the botany window to prevent the spiders from locking onto a player and smashing the windows while they try to explore
- Adds blast doors to the airlock entrance to the facility. If players are truly desparate to steal everything from a ruin meant for ghostroles, then they can open up a wall with only slightly more effort.
- Fills one of the fuel crates in the generator room, deletes the other and replaces it with the nearby welding fuel tank.
- Removes a few carp from one of the outer asteroids. Eight carp stored in a 23 tile space is a dead person waiting to happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This ghettochem loving ghostrole will now be playable once more. The facility wont lose power unless the generators are not activated in a reasonable timeframe, and the windows will actually work alongside the prevention measures to keep greedy explorers away from your precious fuel and equipment. Also, items which create antagonists shouldnt be placed in ruins without proper concern for balancing and player idiocy (looking at the lavaland gluttony ruin and jungle alien ruin with violent intent).
Picture: 
![image](https://user-images.githubusercontent.com/95449138/176988574-726fae14-2185-4575-acd7-c0fddcf33a91.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: lab4071 ruin has received numerous tweaks and fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
