### PR TITLE
Fixes a space tile I missed in jungle_surface_ninjashrine

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_surface_ninjashrine.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_surface_ninjashrine.dmm
@@ -51,9 +51,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/yew,
 /area/ruin/unpowered)
-"m" = (
-/turf/template_noop,
-/area/ruin/unpowered)
 "q" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plating/dirt/jungle/dark,
@@ -406,7 +403,7 @@ w
 R
 G
 A
-m
+R
 j
 R
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
replaces a turf passthrough with an actual turf
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Space tiles on a planet ruin are bad. Sorry for missing that one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A single dirt turf to jungle_surface_ninjashrine.dmm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
