### PR TITLE
Adds a crafting recipe for meson sunglasses

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -121,6 +121,26 @@
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses = 1)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/sunmeson
+	name = "Meson Scanner Sunglasses"
+	result = /obj/item/clothing/glasses/meson/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(
+		/obj/item/clothing/glasses/meson = 1,
+		/obj/item/clothing/glasses/sunglasses = 1,
+		/obj/item/stack/cable_coil = 5
+	)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/sunmesonremoval
+	name = "Meson Scanner Removal"
+	result = /obj/item/clothing/glasses/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/meson/sunglasses = 1)
+	category = CAT_CLOTHING
+
 /datum/crafting_recipe/sciencesunglasses
 	name = "Science Sunglasses"
 	result = /obj/item/clothing/glasses/sunglasses/chemical

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -158,9 +158,9 @@
 	vision_correction = 1
 
 /obj/item/clothing/glasses/meson/sunglasses
-	name = "optical meson scannerglasses"
+	name = "optical meson scanner sunglasses"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting conditions. This pair is built into a pair of sunglasses."
-	icon_state = "sunnmeson"
+	icon_state = "sunmeson"
 	flash_protect = FLASH_PROTECTION_FLASH
 
 #undef MODE_NONE


### PR DESCRIPTION
## About The Pull Request

Adds a crafting recipe for meson sunglasses. Also fixes them not having a sprite because of a typo.

## Why It's Good For The Game

Every other sunglasses HUD can be crafted, so why not meson sunglasses?

## Changelog
:cl:
add: adds crafting recipe for meson sunglasses
fix: fixes meson sunglasses not having a sprite because of a typo
/:cl: