### PR TITLE
Mutated seeds fix

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -409,8 +409,7 @@
 	if(length(myseed.mutatelist))
 		var/mutantseed = pick(myseed.mutatelist)
 		QDEL_NULL(myseed)
-		myseed = new mutantseed
-		myseed.loc = src
+		myseed = new mutantseed(src)
 	else
 		return
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -408,9 +408,9 @@
 	var/oldPlantName = myseed.plantname
 	if(length(myseed.mutatelist))
 		var/mutantseed = pick(myseed.mutatelist)
-		qdel(myseed)
-		myseed = null
+		QDEL_NULL(myseed)
 		myseed = new mutantseed
+		myseed.loc = src
 	else
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mutated seeds are now harvestable.
It looks like when seeds are mutated, it replaces the seeds in a hydroponics tray var, but doesnt actually move the new seeds to the tray, making it runtime on harvest.

## Why It's Good For The Game

Fixes #1248

## Changelog
:cl:
fix: mutated seeds are now harvestable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
