### PR TITLE
Move Rejuvenate admin proc to it's own file and adds it to the right click verb menu for mobs 

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -94,6 +94,7 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 GLOBAL_PROTECT(admin_verbs_sounds)
 GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/cmd_select_equipment,
+	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/cmd_admin_gib_self,
 	/client/proc/cmd_change_command_name,
 	/client/proc/cmd_admin_create_centcom_report,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -355,26 +355,6 @@
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Custom AI Law") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_rejuvenate(mob/living/M in GLOB.mob_list)
-	set category = "Debug"
-	set name = "Rejuvenate"
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	if(!mob)
-		return
-	if(!istype(M))
-		alert("Cannot revive a ghost")
-		return
-	M.revive(full_heal = TRUE, admin_revive = TRUE)
-
-	log_admin("[key_name(usr)] healed / revived [key_name(M)]")
-	var/msg = "<span class='danger'>Admin [key_name_admin(usr)] healed / revived [ADMIN_LOOKUPFLW(M)]!</span>"
-	message_admins(msg)
-	admin_ticket_log(M, msg)
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Rejuvinate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /client/proc/cmd_admin_create_centcom_report()
 	set category = "Admin.Events"
 	set name = "Create Command Report"

--- a/code/modules/admin/verbs/rejuvenate.dm
+++ b/code/modules/admin/verbs/rejuvenate.dm
@@ -1,0 +1,20 @@
+/client/proc/cmd_admin_rejuvenate(mob/living/M in GLOB.mob_list)
+	set category = "Admin.Game"
+	set name = "Rejuvenate"
+
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!mob)
+		return
+	if(!istype(M))
+		alert("Cannot revive a ghost")
+		return
+	M.revive(full_heal = 1, admin_revive = 1)
+
+	log_admin("[key_name(usr)] healed / revived [key_name(M)]")
+	var/msg = "Admin [key_name(usr)] healed / revived [key_name(M)]!" // yogs - Yog Tickets
+	message_admins(msg)
+	admin_ticket_log(M, msg)
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Rejuvinate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -357,7 +357,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	for(var/path in mutant_organs)
 		var/obj/item/organ/I = new path()
-		I.Insert(C, drop_if_replaced = FALSE)
+		var/obj/item/organ/old = C.getorgan(I)
+		if(old)
+			QDEL_NULL(old)
+		I.Insert(C)
 
 /datum/species/proc/replace_body(mob/living/carbon/C, var/datum/species/new_species)
 	new_species ||= C.dna.species //If no new species is provided, assume its src.

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	for(var/path in mutant_organs)
 		var/obj/item/organ/I = new path()
-		I.Insert(C)
+		I.Insert(C, drop_if_replaced = FALSE)
 
 /datum/species/proc/replace_body(mob/living/carbon/C, var/datum/species/new_species)
 	new_species ||= C.dna.species //If no new species is provided, assume its src.

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -1461,6 +1461,7 @@
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
 #include "code\modules\admin\verbs\reestablish_db_connection.dm"
+#include "code\modules\admin\verbs\rejuvenate.dm"
 #include "code\modules\admin\verbs\secrets.dm"
 #include "code\modules\admin\verbs\selectequipment.dm"
 #include "code\modules\admin\verbs\shuttlepanel.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
this is mostly just a pet peeve of mine that when I'm testing stuff in a private server i was struggling to operate the aheal quickly, so i just took how Yogs does it that i'm used to and made it a right click quick action.

In addition the aheal method of organ replacement no longer replaces and drops mutant body parts every time you do it. i noticed i kept dropping moth wings or lizard tails every time i did it, so now the old one just gets deleted like it's being fixed, rather than a new limb growing in and shedding the old one


https://user-images.githubusercontent.com/46236974/177071007-71980935-c732-41dc-a933-924b3b702923.mp4



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

slightly easier as an admin to aheal mobs through the right click menu instead of the debug options

## Changelog
:cl:
tweak: admin aheal proc moved to the right click options on mobs
code: the insert mutant organs part of regenerate organs no longer drops your previous version on the ground if you had one. if you have a tail or wings, it will get replaced by your default and delete the old. if you're missing the organ entirely, you just get a new one
admin: admins who are trying to aheal just right click a mob/player/carbon/pet and select rejuvenate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
