### PR TITLE
Adds a new Ice Planet ruin, the Hydroponics Lab

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -1466,12 +1466,16 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "Dj" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/green{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez{
+	pixel_x = 4;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -2128,15 +2132,16 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "Vd" = (
-/obj/machinery/plantgenes/seedvault{
-	pixel_y = 8
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/purple{
 	dir = 1
+	},
+/obj/item/reagent_containers/glass/bottle/diethylamine{
+	pixel_x = -4;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -21,6 +21,24 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
+"ai" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	color = "#99BB76"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 8;
+	color = "#99BB76"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "am" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -34,20 +52,20 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "aJ" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = -1
-	},
-/obj/machinery/light/dim,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/caseless{
-	pixel_x = 6;
-	pixel_y = 6;
-	dir = 5
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "bd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65,6 +83,8 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/green,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "bq" = (
@@ -74,6 +94,12 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "bv" = (
@@ -82,6 +108,22 @@
 	pixel_y = -9;
 	pixel_x = -9;
 	dir = 5
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -98,7 +140,8 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "bV" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -108,6 +151,12 @@
 /obj/structure/table,
 /obj/item/seeds/replicapod{
 	pixel_y = -1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -122,15 +171,11 @@
 	pixel_y = 12
 	},
 /obj/item/toy/figure/botanist,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "dw" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/item/ammo_casing/caseless{
-	pixel_y = 12;
-	pixel_x = -7
-	},
-/turf/open/floor/plasteel/tech,
+/obj/item/toy/katana,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "dB" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
@@ -138,6 +183,14 @@
 /area/ruin/powered/hydroponicslab)
 "dD" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/spline/fancy/grey,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ed" = (
@@ -149,15 +202,9 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "eD" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/caseless{
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/tech,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "eX" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -179,6 +226,12 @@
 /obj/item/reagent_containers/blood/OMinus{
 	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in blue letters: "DAEDALUS""
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "gb" = (
@@ -188,6 +241,38 @@
 	pixel_x = -3
 	},
 /turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"gf" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_y = -9;
+	pixel_x = 11;
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 4;
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "gA" = (
 /turf/open/floor/plating/snowed/temperatre{
@@ -203,9 +288,33 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "gM" = (
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
-/turf/closed/mineral/snowmountain/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = 4;
+	dir = 8
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	dir = 8;
+	color = "#C3630C"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	dir = 4;
+	color = "#C3630C"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "gO" = (
 /obj/structure/table,
 /obj/item/shovel/spade{
@@ -217,7 +326,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "gU" = (
 /obj/structure/curtain,
@@ -227,21 +347,51 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/hydroponicslab)
 "hd" = (
-/obj/machinery/light/dim{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/multitool{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "hg" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /obj/machinery/door/window/brigdoor,
 /turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"hs" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"hw" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ammo_casing/caseless{
+	pixel_x = -8;
+	pixel_y = 6;
+	dir = 9
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	color = "#C3630C"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"hz" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/lime,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "hF" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -261,6 +411,12 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"ic" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/orange,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ij" = (
 /obj/effect/decal/cleanable/dirt,
@@ -293,6 +449,12 @@
 	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iB" = (
@@ -312,19 +474,22 @@
 /obj/item/ammo_box/magazine/m45{
 	pixel_y = 0
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iJ" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/item/trash/chips{
+	pixel_x = -1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/caseless{
-	pixel_y = -9;
-	pixel_x = 11;
-	dir = 10
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "iQ" = (
 /obj/structure/table,
@@ -336,10 +501,28 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"iY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/lime,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "jl" = (
 /obj/effect/decal/cleanable/food/salt,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "jr" = (
@@ -347,6 +530,21 @@
 /obj/item/circuitboard/machine/hydroponics{
 	pixel_x = -4;
 	pixel_y = 2
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"jC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -358,26 +556,46 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "kw" = (
-/obj/structure/table,
-/obj/item/seeds/cannabis{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/item/paper/fluff/ruins/hydroponicslab/botanist{
-	pixel_x = -2;
-	pixel_y = 2
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"kS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
 	},
-/obj/item/pen{
-	pixel_x = -9
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"kU" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 1;
+	color = "#AE8CA8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "lj" = (
-/obj/item/trash/chips{
-	pixel_x = -1
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
@@ -388,6 +606,12 @@
 	pixel_y = 4
 	},
 /obj/item/cultivator,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "lF" = (
@@ -402,9 +626,52 @@
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
+"lO" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 4;
+	color = "#B7D993"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 1;
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"mb" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 8;
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"md" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
 "me" = (
-/obj/item/toy/katana,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "mQ" = (
 /obj/structure/frame/computer{
@@ -416,6 +683,12 @@
 	},
 /obj/item/shard{
 	pixel_x = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -434,14 +707,29 @@
 /area/ruin/powered/hydroponicslab)
 "mW" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -3;
-	pixel_y = 2
+	pixel_y = 12;
+	pixel_x = 11
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/caseless{
-	pixel_x = -8;
-	pixel_y = 6;
-	dir = 9
+	pixel_y = 4;
+	dir = 5;
+	pixel_x = 2
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	color = "#AE8CA8"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 8;
+	color = "#AE8CA8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -450,11 +738,30 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
+"ni" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 1;
+	color = "#99BB76"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "nj" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/hydroponics{
 	pixel_y = 2;
 	pixel_x = -3
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -465,10 +772,26 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "nt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "nD" = (
@@ -480,6 +803,26 @@
 /obj/item/wallframe/camera{
 	pixel_x = -8;
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nI" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	dir = 4;
+	color = "#C3630C"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -495,6 +838,12 @@
 /obj/item/screwdriver{
 	pixel_x = 2
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "nP" = (
@@ -505,6 +854,47 @@
 /area/ruin/powered/hydroponicslab)
 "nS" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"oo" = (
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/ammo_casing/caseless{
+	pixel_x = -5;
+	pixel_y = 9;
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"oK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"oO" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 1;
+	color = "#99BB76"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "oT" = (
@@ -545,6 +935,12 @@
 /obj/item/reagent_containers/glass/bottle{
 	pixel_x = -6
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "pG" = (
@@ -559,8 +955,26 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/hydroponicslab)
 "pR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet,
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"qc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "qh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -573,6 +987,12 @@
 	pixel_x = -1;
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "qt" = (
@@ -582,6 +1002,12 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ri" = (
@@ -595,12 +1021,31 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
+"sr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "ss" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "sx" = (
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"sM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "tk" = (
@@ -614,10 +1059,19 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "to" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = -1
 	},
-/turf/open/floor/carpet,
+/obj/machinery/light/dim,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 6;
+	pixel_y = 6;
+	dir = 5
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/orange,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "tE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -625,16 +1079,35 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "tQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "tS" = (
-/obj/item/pen/blue{
-	pixel_y = -2;
-	pixel_x = -6
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"uo" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"uR" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
 	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 1;
+	color = "#AE8CA8"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	color = "#AE8CA8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -644,11 +1117,25 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "uZ" = (
 /obj/machinery/door/airlock/grunge,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/grey,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "vg" = (
@@ -678,31 +1165,59 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating/rust,
+/area/ruin/powered/hydroponicslab)
+"xq" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "xx" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"xE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"xJ" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/item/ammo_casing/caseless{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "yi" = (
-/obj/item/trash/sosjerky{
-	pixel_x = 4;
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/boritos{
+	pixel_x = -2;
 	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "ys" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "yV" = (
-/obj/structure/chair/plastic{
-	dir = 1
-	},
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "zw" = (
 /obj/structure/table/wood,
@@ -712,16 +1227,52 @@
 	},
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
-"zN" = (
+"zy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_box/magazine/m45{
-	pixel_y = 0
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/purple,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"zH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"zN" = (
+/obj/item/pen/blue{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"zO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "zV" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Ac" = (
@@ -730,15 +1281,35 @@
 	pixel_x = 15
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/tech,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "AL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/plastic,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "AT" = (
 /turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"Bc" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/item/ammo_casing/caseless{
+	pixel_y = -1;
+	dir = 5;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Bx" = (
 /turf/open/floor/plasteel/rockvault,
@@ -754,15 +1325,47 @@
 /area/ruin/powered/hydroponicslab)
 "Cr" = (
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"CD" = (
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/icemoon/surface/outdoors)
+"CG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "Dj" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "DH" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"DK" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "DO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -771,6 +1374,24 @@
 "DV" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"Eb" = (
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Eo" = (
+/obj/item/trash/sosjerky{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
 "Ey" = (
 /turf/template_noop,
 /area/template_noop)
@@ -785,12 +1406,24 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Fy" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/hydroponics{
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -801,6 +1434,26 @@
 	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/shreds,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/red{
+	dir = 4;
+	color = "#B4696A"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/red{
+	dir = 1;
+	color = "#B4696A"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Gr" = (
@@ -818,9 +1471,28 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"GE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating/rust,
+/area/ruin/powered/hydroponicslab)
 "GK" = (
-/turf/closed/mineral/snowmountain/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "GN" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plasteel/stairs,
@@ -831,7 +1503,8 @@
 	pixel_x = 1;
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "He" = (
 /obj/structure/table,
@@ -850,22 +1523,35 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
+"HK" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
 "Ik" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
-"IR" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/light/small/broken{
+"IQ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/item/ammo_casing/caseless{
-	pixel_y = -1;
-	dir = 5;
-	pixel_x = 3
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"IR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "Jn" = (
 /obj/structure/table,
@@ -874,6 +1560,26 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"JD" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"JS" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/orange,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "JZ" = (
@@ -882,6 +1588,10 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Kj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "Kr" = (
 /obj/structure/chair/office,
@@ -915,11 +1625,23 @@
 "Mx" = (
 /mob/living/simple_animal/hostile/killertomato,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 10
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Mz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "MN" = (
@@ -935,6 +1657,26 @@
 /area/ruin/powered/hydroponicslab)
 "MZ" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 8;
+	color = "#99BB76"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 4;
+	color = "#99BB76"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Nf" = (
@@ -949,14 +1691,20 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Nv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/boritos{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
@@ -976,6 +1724,26 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"NT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Oz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Pa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -988,6 +1756,12 @@
 /obj/item/reagent_containers/glass/bottle{
 	pixel_x = -6;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1009,22 +1783,33 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
+"PE" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/purple,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "PQ" = (
-/obj/structure/chair/plastic{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "PR" = (
-/obj/structure/showcase/machinery/tv,
-/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"PY" = (
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "Qm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can{
-	pixel_x = 5;
-	pixel_y = -6
+/obj/structure/showcase/machinery/tv,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
@@ -1037,17 +1822,58 @@
 /obj/structure/table,
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
+"Qu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
 "QA" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 12;
-	pixel_x = 11
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/item/ammo_casing/caseless{
-	pixel_y = 4;
-	dir = 5;
-	pixel_x = 2
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"QT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"Ri" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/green,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Rn" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"RV" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/green,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "RX" = (
@@ -1060,15 +1886,29 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/green{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "So" = (
+/obj/effect/turf_decal/techfloor,
 /obj/effect/decal/cleanable/greenglow,
+/obj/effect/turf_decal/spline/fancy/purple,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Sq" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "SW" = (
@@ -1077,14 +1917,46 @@
 	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Ti" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"TJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "TR" = (
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"UF" = (
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = -6
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/red,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "UK" = (
 /obj/structure/toilet{
@@ -1104,18 +1976,18 @@
 	pixel_y = 8
 	},
 /obj/structure/table,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Vo" = (
-/obj/structure/table,
-/obj/item/pen{
-	pixel_x = -6
-	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "Vy" = (
 /obj/structure/table,
@@ -1129,29 +2001,41 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
-"VN" = (
-/obj/item/ammo_casing/caseless{
-	pixel_x = 8;
-	pixel_y = 4;
-	dir = 8
+"VH" = (
+/obj/structure/table,
+/obj/item/seeds/cannabis{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/paper/fluff/ruins/hydroponicslab/botanist{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -9
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"VN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "We" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/powered/hydroponicslab)
 "Wi" = (
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
-	pixel_x = 2;
-	pixel_y = -3
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
-/obj/item/ammo_casing/caseless{
-	pixel_x = -5;
-	pixel_y = 9;
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
+/area/icemoon/surface/outdoors)
 "WK" = (
 /obj/item/stack/cable_coil/yellow{
 	pixel_x = 4;
@@ -1161,6 +2045,12 @@
 /obj/item/wallframe/camera{
 	pixel_x = -7;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1176,23 +2066,52 @@
 	},
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
+"XC" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	dir = 1;
+	color = "#C3630C"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/orange{
+	color = "#C3630C"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "YO" = (
 /obj/machinery/computer/security{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/red,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Zd" = (
-/obj/structure/marker_beacon,
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/surface/outdoors)
+"ZI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
+/area/ruin/powered/hydroponicslab)
 "ZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grown/mushroom/amanita{
 	pixel_y = 5
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1209,18 +2128,18 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey
@@ -1242,21 +2161,21 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey
@@ -1274,25 +2193,25 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 DV
 Ey
 Ey
@@ -1306,28 +2225,28 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 DV
 DV
 Ey
@@ -1340,28 +2259,28 @@ Ey
 (5,1,1) = {"
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 We
 hJ
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 DV
 DV
 DV
@@ -1374,34 +2293,34 @@ Ey
 "}
 (6,1,1) = {"
 Ey
-GK
-GK
-GK
-GK
-gM
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+CD
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 UK
 gU
 hJ
-GK
-GK
+Zd
+Zd
 DV
 DV
 DV
 DV
-GK
-GK
+Zd
+Zd
 Ey
 Ey
 Ey
@@ -1409,18 +2328,18 @@ Ey
 "}
 (7,1,1) = {"
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 We
 We
@@ -1429,33 +2348,33 @@ hJ
 pL
 MN
 hJ
-GK
-GK
+Zd
+Zd
 DV
 DV
 DV
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 "}
 (8,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 We
 hJ
 We
 hJ
 We
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 am
 Qt
@@ -1464,136 +2383,136 @@ We
 si
 hJ
 hJ
-GK
+Zd
 DV
 DV
 DV
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 "}
 (9,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 We
-kw
+VH
 WK
 jl
-sx
+jC
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 We
 bD
-pR
-tQ
+CG
+me
 Va
 TR
 DO
 We
-GK
+Zd
 DV
 DV
 DV
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 "}
 (10,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 Cr
-sx
+ZI
 GP
-fd
+zy
 We
 hJ
 We
 hJ
 hJ
-hd
-tQ
-tQ
-Qm
-PQ
-yi
+pR
+IR
+lj
+zH
+Nv
+Eo
 We
-GK
+Zd
 DV
 DV
 DV
 DV
 DV
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 "}
 (11,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 Nl
 bV
 He
 So
 hJ
-iJ
+gf
 SW
 mQ
 hJ
 Pj
-lj
-PR
-AL
-Nv
-yV
+iJ
+Qm
+PQ
+yi
+HK
 hJ
-GK
-GK
+Zd
+Zd
 DV
 DV
 DV
 DV
 DV
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 Ey
 "}
 (12,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 We
 Vd
 dB
 xb
-sx
+PE
 hJ
-IR
+Bc
 pG
 YO
 We
@@ -1604,64 +2523,64 @@ We
 hJ
 hJ
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 DV
 DV
 DV
 DV
 DV
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 "}
 (13,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 nS
-sx
+kU
 Vy
-QA
+mW
 zV
 FO
-dw
-Vo
+xJ
+UF
 hJ
 si
 hJ
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 DV
 DV
 DV
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 "}
 (14,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 hJ
-fd
-sx
-fd
+qc
+uR
+TJ
 We
 bv
 Mz
@@ -1671,28 +2590,28 @@ TR
 DO
 We
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 DV
 DV
 DV
 DV
-GK
-GK
-GK
+Zd
+Zd
+Zd
 "}
 (15,1,1) = {"
 Ey
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 We
 hJ
 dD
@@ -1702,78 +2621,78 @@ We
 Ik
 We
 hJ
-ys
-tQ
+QT
+me
 DO
 hJ
 hJ
 We
 hJ
 hJ
-GK
-GK
-GK
 Zd
+Zd
+Zd
+Wi
 gA
 DV
 DV
 DV
-GK
-GK
-GK
+Zd
+Zd
+Zd
 "}
 (16,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 hJ
-sx
-VN
-eD
+JD
+gM
+GK
 nD
 hJ
 TR
 TR
 zw
-tQ
-Ti
+IR
+xx
 TR
 hJ
 mU
 ag
 oT
 hJ
-GK
 Zd
+Wi
 gA
 gA
 gA
 gA
 gA
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 "}
 (17,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 ZN
-dB
+nI
 gC
 KD
-sx
+JS
 hJ
 Pa
 Kr
 Xt
-Ti
-Ti
+aJ
+xx
 TR
 ed
 AT
@@ -1785,193 +2704,193 @@ gA
 gA
 gA
 gA
+Wi
 Zd
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 "}
 (18,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
-cu
-fd
+IQ
+Kj
 pn
 Nf
-aJ
+to
 hJ
 TR
 DO
 JZ
-tQ
-tQ
+IR
+PY
 DO
 We
 AT
 Pz
 ab
 hJ
-GK
-gA
 Zd
 gA
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Wi
+gA
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 "}
 (19,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 We
 uX
 sx
 pj
 da
-MZ
+ic
 We
 vH
 vH
 vH
-Ti
-Ti
+aJ
+xx
 jY
 We
 hJ
 hJ
 We
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 "}
 (20,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 iz
 fd
 dB
-mW
-fd
+hw
+kS
 GN
-tQ
+AL
+hd
+kw
 Ti
-tQ
-tQ
-Ti
+QA
 hZ
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 "}
 (21,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 nn
-sx
-MZ
-fd
+sM
+XC
+kS
 hJ
 hJ
 hJ
 tQ
-to
-Ti
+Qu
+QA
 TR
 hJ
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 "}
 (22,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 We
 hJ
 uZ
 We
 hJ
-me
+dw
 We
 hJ
 hJ
 We
 hJ
 We
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 hJ
 We
 hJ
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
 "}
 (23,1,1) = {"
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 lw
 EV
@@ -1980,33 +2899,33 @@ Mx
 hJ
 hJ
 hJ
-fd
+nq
 kr
-fd
+Oz
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 hJ
 We
-nt
-Gr
+tS
+gP
 hJ
 hJ
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 "}
 (24,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 pE
 Ac
@@ -2015,9 +2934,9 @@ Sq
 Ph
 hJ
 fN
-bV
+gz
 cu
-bV
+iY
 We
 hJ
 hJ
@@ -2028,31 +2947,31 @@ hJ
 hJ
 gb
 nh
-Gr
-nt
+uo
+Vo
 ac
 We
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (25,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 We
 Dj
 Gy
 vm
 MV
-cu
+Ri
 hJ
 jr
-Wi
-zN
-sx
+oo
+ZI
+mb
 Fy
 nL
 nj
@@ -2063,34 +2982,34 @@ bd
 We
 lF
 iw
-Gr
-ij
 nt
+ij
+ys
 We
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (26,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 We
 gO
 tk
 NA
-fd
+Kj
 bg
 We
-fd
+NT
 iB
-tS
+zN
 sx
 sx
-fd
-sx
+GE
+hz
 ss
 AT
 eh
@@ -2099,33 +3018,33 @@ ss
 Bx
 hg
 Gr
-nt
+VN
 Hg
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (27,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 RX
-MV
+oO
 cu
-MV
-sx
-uZ
-sx
+xq
+ai
+Rn
+lO
 bP
-sx
-sx
-bV
-fd
-fd
+ZI
+Eb
+bA
+xE
+sr
 hJ
 tE
 ri
@@ -2134,30 +3053,30 @@ hJ
 Ks
 vg
 hF
-xx
-nt
+eD
+VN
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (28,1,1) = {"
 Ey
-GK
-GK
-GK
+Zd
+Zd
+Zd
 hJ
 hJ
 qh
-sx
+ni
 dB
-Mx
+RV
 hJ
-sx
+DK
 eX
-fd
-sx
+oK
+hs
 hJ
 hJ
 We
@@ -2168,21 +3087,21 @@ We
 hJ
 Cg
 nh
-hF
-nt
+zO
+PR
 ac
 We
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (29,1,1) = {"
 Ey
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 We
 Jn
@@ -2194,31 +3113,31 @@ aC
 bq
 We
 hJ
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 We
 We
-nt
-Gr
+yV
+md
 hJ
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 "}
 (30,1,1) = {"
 Ey
 Ey
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
 hJ
 hJ
 We
@@ -2228,57 +3147,57 @@ hJ
 hJ
 We
 We
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 hJ
 hJ
 hJ
 hJ
-GK
-GK
-GK
+Zd
+Zd
+Zd
 Ey
 Ey
 "}
 (31,1,1) = {"
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 "}
@@ -2286,33 +3205,33 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey
@@ -2323,30 +3242,30 @@ Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey
 Ey
 Ey
-GK
-GK
-GK
-GK
-GK
+Zd
+Zd
+Zd
+Zd
+Zd
 Ey
 Ey
 Ey

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -21,23 +21,10 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
-"ai" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/spline/fancy/corner/green{
-	color = "#99BB76"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/green{
-	dir = 8;
-	color = "#99BB76"
-	},
-/turf/open/floor/plasteel/tech,
+"aj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "am" = (
 /obj/machinery/microwave,
@@ -221,10 +208,10 @@
 "fN" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/BMinus{
-	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in bright blue letters: "ICARUS""
+	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in bright blue letters: ICARUS"
 	},
 /obj/item/reagent_containers/blood/OMinus{
-	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in blue letters: "DAEDALUS""
+	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in blue letters: DAEDALUS"
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 9
@@ -386,11 +373,6 @@
 /obj/effect/turf_decal/spline/fancy/corner/orange{
 	color = "#C3630C"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
-"hz" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/spline/fancy/lime,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "hF" = (
@@ -580,19 +562,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
-"kU" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
-	dir = 1;
-	color = "#AE8CA8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "lj" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -626,27 +595,9 @@
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
-"lO" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/lime{
-	dir = 4;
-	color = "#B7D993"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/lime{
-	dir = 1;
-	color = "#B7D993"
-	},
+"lS" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/lime,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "mb" = (
@@ -745,9 +696,9 @@
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/corner/green{
+/obj/effect/turf_decal/spline/fancy/corner/purple{
 	dir = 1;
-	color = "#99BB76"
+	color = "#AE8CA8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1017,19 +968,27 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
+"sd" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 1;
+	color = "#AE8CA8"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	color = "#AE8CA8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "si" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/wood/walnut,
-/area/ruin/powered/hydroponicslab)
-"sr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/lime{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ss" = (
 /obj/machinery/door/airlock/highsecurity,
@@ -1093,24 +1052,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
-"uR" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
-	dir = 1;
-	color = "#AE8CA8"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
-	color = "#AE8CA8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "uX" = (
 /obj/structure/table,
 /obj/item/seeds/plump/walkingmushroom,
@@ -1133,9 +1074,11 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal,
 /obj/effect/turf_decal/spline/fancy/grey{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/spline/fancy/grey,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "vg" = (
@@ -1150,6 +1093,10 @@
 "vH" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"wb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "xb" = (
 /obj/structure/table,
@@ -1167,12 +1114,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
-"xq" = (
-/mob/living/simple_animal/hostile/killertomato,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating,
-/area/ruin/powered/hydroponicslab)
 "xx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
@@ -1187,6 +1128,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"xH" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "xJ" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -1344,6 +1291,11 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
+"Df" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
+/area/ruin/powered/hydroponicslab)
 "Dj" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/effect/turf_decal/techfloor{
@@ -1414,6 +1366,29 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"Fi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/lime{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Fo" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/grey,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Fy" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/hydroponics{
@@ -1459,6 +1434,11 @@
 "Gr" = (
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
+"Gt" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/purple,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Gy" = (
 /mob/living/simple_animal/hostile/killertomato,
 /obj/effect/decal/cleanable/food/tomato_smudge,
@@ -1470,11 +1450,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
-"GE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "GK" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -1588,10 +1563,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/walnut,
-/area/ruin/powered/hydroponicslab)
-"Kj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "Kr" = (
 /obj/structure/chair/office,
@@ -1708,6 +1679,24 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
+"Nx" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	color = "#99BB76"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 8;
+	color = "#99BB76"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "NA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1783,9 +1772,14 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
-"PE" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/spline/fancy/purple,
+"PI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "PQ" = (
@@ -1854,21 +1848,6 @@
 /obj/effect/turf_decal/spline/fancy/green,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
-"Rn" = (
-/obj/machinery/door/airlock/grunge,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
-/obj/effect/turf_decal/spline/fancy/grey{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/grey{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "RV" = (
 /mob/living/simple_animal/hostile/killertomato,
 /obj/effect/decal/cleanable/dirt,
@@ -1932,13 +1911,26 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
-"TJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
+"Ts" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/purple{
-	dir = 6
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 4;
+	color = "#B7D993"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 1;
+	color = "#B7D993"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1981,6 +1973,19 @@
 	},
 /obj/effect/turf_decal/spline/fancy/purple{
 	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Vk" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 1;
+	color = "#99BB76"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -2096,11 +2101,6 @@
 "Zd" = (
 /turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/surface/outdoors)
-"ZI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating,
-/area/ruin/powered/hydroponicslab)
 "ZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2438,7 +2438,7 @@ Zd
 Zd
 hJ
 Cr
-ZI
+Df
 GP
 zy
 We
@@ -2510,7 +2510,7 @@ We
 Vd
 dB
 xb
-PE
+Gt
 hJ
 Bc
 pG
@@ -2543,7 +2543,7 @@ Zd
 Zd
 hJ
 nS
-kU
+ni
 Vy
 mW
 zV
@@ -2579,8 +2579,8 @@ Zd
 hJ
 hJ
 qc
-uR
-TJ
+sd
+PI
 We
 bv
 Mz
@@ -2718,7 +2718,7 @@ Zd
 Zd
 hJ
 IQ
-Kj
+wb
 pn
 Nf
 to
@@ -2859,7 +2859,7 @@ Zd
 hJ
 We
 hJ
-uZ
+Fo
 We
 hJ
 dw
@@ -2970,7 +2970,7 @@ Ri
 hJ
 jr
 oo
-ZI
+Df
 mb
 Fy
 nL
@@ -3000,7 +3000,7 @@ We
 gO
 tk
 NA
-Kj
+wb
 bg
 We
 NT
@@ -3008,8 +3008,8 @@ iB
 zN
 sx
 sx
-GE
-hz
+aj
+lS
 ss
 AT
 eh
@@ -3035,16 +3035,16 @@ hJ
 RX
 oO
 cu
-xq
-ai
-Rn
-lO
+xH
+Nx
+uZ
+Ts
 bP
-ZI
+Df
 Eb
 bA
 xE
-sr
+Fi
 hJ
 tE
 ri
@@ -3069,7 +3069,7 @@ Zd
 hJ
 hJ
 qh
-ni
+Vk
 dB
 RV
 hJ

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -1,0 +1,2354 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"ac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"ag" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 3;
+	pixel_y = -2;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"am" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"aC" = (
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_y = 0
+	},
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"aJ" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_y = 0
+	},
+/obj/item/clothing/shoes/winterboots{
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"bg" = (
+/obj/machinery/light/dim,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bq" = (
+/obj/structure/table,
+/obj/item/seeds/replicapod{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bv" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/item/ammo_casing/caseless{
+	pixel_y = -9;
+	pixel_x = -9;
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/energybar{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/structure/table,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"bP" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"bV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"ct" = (
+/obj/structure/table,
+/obj/item/seeds/replicapod{
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"cu" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"da" = (
+/obj/structure/table,
+/obj/item/seeds/watermelon{
+	pixel_x = -13;
+	pixel_y = 12
+	},
+/obj/item/toy/figure/botanist,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"dw" = (
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = 4;
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"dB" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"dD" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"ed" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"eh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"eX" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"fd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"fM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"fN" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/BMinus{
+	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in bright blue letters: "ICARUS""
+	},
+/obj/item/reagent_containers/blood/OMinus{
+	desc = "Contains blood used for transfusion. Must be attached to an IV drip. Something is scribbled on the back in blue letters: "DAEDALUS""
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gb" = (
+/obj/structure/table,
+/obj/item/seeds/kudzu{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"gA" = (
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/surface/outdoors)
+"gC" = (
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gM" = (
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/icemoon/surface/outdoors)
+"gO" = (
+/obj/structure/table,
+/obj/item/shovel/spade{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gU" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hydroponicslab)
+"hd" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_y = -9;
+	pixel_x = 11;
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"hg" = (
+/mob/living/simple_animal/hostile/venus_human_trap,
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"hF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"hJ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/hydroponicslab)
+"hZ" = (
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 1;
+	pixel_y = -2;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"ij" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"iw" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/rods{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/shard{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/shard{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"iz" = (
+/obj/structure/table,
+/obj/item/seeds/starthistle/corpse_flower{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"iB" = (
+/obj/effect/mob_spawn/human/scientist,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"iH" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ammo_casing/caseless{
+	pixel_x = -8;
+	pixel_y = 6;
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"iJ" = (
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = -6
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"iQ" = (
+/obj/structure/table,
+/obj/item/seeds/tomato/killer{
+	pixel_y = -9;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato/blue{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"jl" = (
+/obj/effect/decal/cleanable/food/salt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"jr" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/hydroponics{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"jY" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"kr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"kw" = (
+/obj/item/pen/blue{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"lj" = (
+/obj/item/trash/chips{
+	pixel_x = -1
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"lw" = (
+/obj/structure/table,
+/obj/item/plant_analyzer{
+	pixel_x = 13;
+	pixel_y = 4
+	},
+/obj/item/cultivator,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"lF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/seeds/nettle/death{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"me" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 12;
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/ammo_casing/caseless{
+	pixel_y = 4;
+	dir = 5;
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"mQ" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/item/shard{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/shard{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"mU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/clothing/shoes/winterboots{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/clothing/shoes/winterboots{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"mW" = (
+/obj/structure/table,
+/obj/item/seeds/cannabis{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/paper/fluff/ruins/hydroponicslab/botanist{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"nj" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/hydroponics{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"nD" = (
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 7;
+	pixel_y = -4;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/wrench{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"nP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"nS" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"oT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/clothing/suit/hooded/wintercoat{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hooded/wintercoat{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"pj" = (
+/obj/structure/table,
+/obj/item/seeds/apple{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"pn" = (
+/obj/structure/table,
+/obj/item/seeds/glowshroom{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"pE" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/diethylamine{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"pG" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"pL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hydroponicslab)
+"pR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"qh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 2;
+	pixel_y = -4;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"qt" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"ri" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/biohazard{
+	pixel_x = 32
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"si" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"ss" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"sx" = (
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"tk" = (
+/obj/effect/mob_spawn/human/botanist,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/hatchet{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"to" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"tE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"tQ" = (
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"tS" = (
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"uX" = (
+/obj/structure/table,
+/obj/item/seeds/plump/walkingmushroom,
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"uZ" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"vg" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"vm" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"vH" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"xb" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/ammonia{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/diethylamine{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/bottle/ethanol{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"xx" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/item/ammo_casing/caseless{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"yi" = (
+/obj/item/trash/sosjerky{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"ys" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"yV" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"zw" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_y = 5;
+	pixel_x = -1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"zN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"zV" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Ac" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4;
+	pixel_x = 15
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"AL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/plastic,
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"AT" = (
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"Bx" = (
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"Cg" = (
+/obj/item/seeds/kudzu{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"Cr" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Dj" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"DH" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"DO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"DV" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"Ey" = (
+/turf/template_noop,
+/area/template_noop)
+"EV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Fy" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/hydroponics{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"FO" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/clothing/under/rank/security/officer{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Gr" = (
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"Gy" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4;
+	pixel_x = 15
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"GK" = (
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hydroponicslab)
+"GN" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plasteel/stairs,
+/area/ruin/powered/hydroponicslab)
+"GP" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"He" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/sodium{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Hg" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"Ik" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"IR" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/surface/outdoors)
+"Jn" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"JZ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Kr" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Ks" = (
+/obj/structure/table,
+/obj/item/flamethrower/full/tank{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
+"KD" = (
+/obj/structure/table,
+/obj/item/seeds/cherry{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/seeds/carrot{
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Mx" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Mz" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"MN" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hydroponicslab)
+"MV" = (
+/mob/living/simple_animal/hostile/killertomato,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"MZ" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Nf" = (
+/obj/item/paper/guides/jobs/hydroponics{
+	pixel_y = 5
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Nl" = (
+/obj/machinery/seed_extractor,
+/obj/machinery/light/dim{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Nv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/boritos{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"NA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato/blue{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Pa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Ph" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Pj" = (
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 1;
+	pixel_y = 4;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Pz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"PQ" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"PR" = (
+/obj/structure/showcase/machinery/tv,
+/obj/structure/table,
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"Qm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"Qt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/chips{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"QA" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"RX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"So" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Sq" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"SW" = (
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Ti" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"TR" = (
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"UK" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = -1
+	},
+/obj/machinery/light/dim,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 6;
+	pixel_y = 6;
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Va" = (
+/obj/item/trash/cheesie{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Vd" = (
+/obj/machinery/plantgenes/seedvault{
+	pixel_y = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Vo" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/item/ammo_casing/caseless{
+	pixel_y = -1;
+	dir = 5;
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Vy" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"VN" = (
+/obj/item/toy/katana,
+/turf/open/floor/plating,
+/area/ruin/powered/hydroponicslab)
+"We" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/powered/hydroponicslab)
+"Wi" = (
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/ammo_casing/caseless{
+	pixel_x = -5;
+	pixel_y = 9;
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"WK" = (
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 4;
+	pixel_y = -2;
+	amount = 2
+	},
+/obj/item/wallframe/camera{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Xt" = (
+/obj/structure/table/wood,
+/obj/item/folder{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"YO" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"Zd" = (
+/turf/closed/mineral/snowmountain/icemoon,
+/area/icemoon/surface/outdoors)
+"ZN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+
+(1,1,1) = {"
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+"}
+(2,1,1) = {"
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+"}
+(3,1,1) = {"
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+DV
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+"}
+(4,1,1) = {"
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+DV
+DV
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+"}
+(5,1,1) = {"
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+We
+hJ
+hJ
+Zd
+Zd
+Zd
+DV
+DV
+DV
+DV
+Ey
+Ey
+Ey
+Ey
+Ey
+"}
+(6,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+Zd
+gM
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+GK
+gU
+hJ
+Zd
+Zd
+DV
+DV
+DV
+DV
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+"}
+(7,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+We
+We
+hJ
+hJ
+pL
+MN
+hJ
+Zd
+Zd
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+"}
+(8,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+We
+hJ
+We
+hJ
+We
+hJ
+Zd
+Zd
+Zd
+hJ
+am
+Qt
+DH
+We
+si
+hJ
+hJ
+Zd
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+"}
+(9,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+We
+mW
+WK
+jl
+sx
+hJ
+Zd
+Zd
+Zd
+We
+bD
+pR
+tQ
+Va
+TR
+DO
+We
+Zd
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+"}
+(10,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+Cr
+sx
+GP
+fd
+We
+hJ
+We
+hJ
+hJ
+tS
+tQ
+tQ
+Qm
+PQ
+yi
+We
+Zd
+DV
+DV
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+"}
+(11,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+Nl
+bV
+He
+So
+hJ
+hd
+SW
+mQ
+hJ
+Pj
+lj
+PR
+AL
+Nv
+yV
+hJ
+Zd
+Zd
+DV
+DV
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+Ey
+"}
+(12,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+We
+Vd
+dB
+xb
+sx
+hJ
+Vo
+pG
+YO
+We
+TR
+fM
+hJ
+We
+hJ
+hJ
+hJ
+Zd
+Zd
+Zd
+DV
+DV
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+"}
+(13,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+nS
+sx
+Vy
+me
+zV
+FO
+xx
+iJ
+hJ
+si
+hJ
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+DV
+DV
+DV
+Zd
+Zd
+Zd
+Zd
+"}
+(14,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+hJ
+fd
+sx
+fd
+We
+bv
+Mz
+aJ
+hJ
+TR
+DO
+We
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+DV
+DV
+DV
+DV
+Zd
+Zd
+Zd
+"}
+(15,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+Zd
+We
+hJ
+dD
+hJ
+We
+We
+Ik
+We
+hJ
+ys
+tQ
+DO
+hJ
+hJ
+We
+hJ
+hJ
+Zd
+Zd
+Zd
+IR
+gA
+DV
+DV
+DV
+Zd
+Zd
+Zd
+"}
+(16,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+hJ
+sx
+dw
+QA
+nD
+hJ
+TR
+TR
+zw
+tQ
+Ti
+TR
+hJ
+mU
+ag
+oT
+hJ
+Zd
+IR
+gA
+gA
+gA
+gA
+gA
+Zd
+Zd
+Zd
+Zd
+"}
+(17,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+ZN
+dB
+gC
+KD
+sx
+hJ
+Pa
+Kr
+Xt
+Ti
+Ti
+TR
+ed
+AT
+AT
+bd
+ed
+gA
+gA
+gA
+gA
+gA
+IR
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(18,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+cu
+fd
+pn
+Nf
+UK
+hJ
+TR
+DO
+JZ
+tQ
+tQ
+DO
+We
+AT
+Pz
+ab
+hJ
+Zd
+gA
+IR
+gA
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(19,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+We
+uX
+sx
+pj
+da
+MZ
+We
+vH
+vH
+vH
+Ti
+Ti
+jY
+We
+hJ
+hJ
+We
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(20,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+iz
+fd
+dB
+iH
+fd
+GN
+tQ
+Ti
+tQ
+tQ
+Ti
+hZ
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(21,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+nn
+sx
+MZ
+fd
+hJ
+hJ
+hJ
+tQ
+to
+Ti
+TR
+hJ
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(22,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+We
+hJ
+uZ
+We
+hJ
+VN
+We
+hJ
+hJ
+We
+hJ
+We
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+hJ
+We
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+"}
+(23,1,1) = {"
+Zd
+Zd
+Zd
+Zd
+hJ
+lw
+EV
+MZ
+Mx
+hJ
+hJ
+hJ
+fd
+kr
+fd
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+hJ
+We
+nt
+Gr
+hJ
+hJ
+Zd
+Zd
+Zd
+Zd
+"}
+(24,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+pE
+Ac
+sx
+Sq
+Ph
+hJ
+fN
+bV
+cu
+bV
+We
+hJ
+hJ
+hJ
+We
+We
+hJ
+hJ
+gb
+nh
+Gr
+nt
+ac
+We
+Zd
+Zd
+Zd
+Ey
+"}
+(25,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+We
+Dj
+Gy
+vm
+MV
+cu
+hJ
+jr
+Wi
+zN
+sx
+Fy
+nL
+nj
+We
+bd
+nP
+bd
+We
+lF
+iw
+Gr
+ij
+nt
+We
+Zd
+Zd
+Zd
+Ey
+"}
+(26,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+We
+gO
+tk
+NA
+fd
+bg
+We
+fd
+iB
+kw
+sx
+sx
+fd
+sx
+ss
+AT
+eh
+AT
+ss
+Bx
+hg
+Gr
+nt
+Hg
+hJ
+Zd
+Zd
+Zd
+Ey
+"}
+(27,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+RX
+MV
+cu
+MV
+sx
+uZ
+sx
+bP
+sx
+sx
+bV
+fd
+fd
+hJ
+tE
+ri
+ab
+hJ
+Ks
+vg
+hF
+Gr
+nt
+hJ
+Zd
+Zd
+Zd
+Ey
+"}
+(28,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+hJ
+hJ
+qh
+sx
+dB
+Mx
+hJ
+sx
+eX
+fd
+sx
+hJ
+hJ
+We
+hJ
+hJ
+hJ
+We
+hJ
+Cg
+nh
+hF
+nt
+ac
+We
+Zd
+Zd
+Zd
+Ey
+"}
+(29,1,1) = {"
+Ey
+Zd
+Zd
+Zd
+Zd
+hJ
+We
+Jn
+iQ
+qt
+We
+ct
+aC
+bq
+We
+hJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+We
+We
+nt
+Gr
+hJ
+hJ
+Zd
+Zd
+Zd
+Ey
+"}
+(30,1,1) = {"
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+hJ
+hJ
+We
+hJ
+hJ
+hJ
+hJ
+We
+We
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+hJ
+hJ
+hJ
+hJ
+Zd
+Zd
+Zd
+Ey
+Ey
+"}
+(31,1,1) = {"
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+"}
+(32,1,1) = {"
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+"}
+(33,1,1) = {"
+Ey
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+Ey
+Zd
+Zd
+Zd
+Zd
+Zd
+Ey
+Ey
+Ey
+Ey
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -37,21 +37,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "aJ" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_y = 0
-	},
-/obj/item/clothing/shoes/winterboots{
-	pixel_y = 0
-	},
-/obj/item/ammo_box/magazine/m45{
-	pixel_y = 0
-	},
-/obj/item/ammo_box/magazine/m45{
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/tech,
+/obj/item/toy/katana,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "bd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -129,10 +116,15 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "dw" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 12;
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/caseless{
-	pixel_x = 8;
 	pixel_y = 4;
-	dir = 8
+	dir = 5;
+	pixel_x = 2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -151,6 +143,17 @@
 "eh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"eD" = (
+/obj/item/pen/blue{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "eX" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -196,8 +199,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "gM" = (
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
-/turf/closed/mineral/snowmountain/icemoon,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/icemoon/surface/outdoors)
 "gO" = (
 /obj/structure/table,
@@ -220,14 +225,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/hydroponicslab)
 "hd" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/caseless{
-	pixel_y = -9;
-	pixel_x = 11;
-	dir = 10
+	pixel_x = 8;
+	pixel_y = 4;
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -307,15 +308,16 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iJ" = (
+/obj/machinery/light/dim{
+	dir = 1
+	},
 /obj/structure/table,
-/obj/item/pen{
-	pixel_x = -6
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/tech,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "iQ" = (
 /obj/structure/table,
@@ -352,13 +354,17 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "kw" = (
-/obj/item/pen/blue{
-	pixel_y = -2;
-	pixel_x = -6
+/obj/structure/table,
+/obj/item/seeds/cannabis{
+	pixel_x = 5;
+	pixel_y = 4
 	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
-	pixel_x = 3;
+/obj/item/paper/fluff/ruins/hydroponicslab/botanist{
+	pixel_x = -2;
 	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -390,15 +396,13 @@
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "me" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 12;
-	pixel_x = 11
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = -6
 	},
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/item/ammo_casing/caseless{
-	pixel_y = 4;
-	dir = 5;
-	pixel_x = 2
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
+	pixel_x = 3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -429,17 +433,14 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "mW" = (
-/obj/structure/table,
-/obj/item/seeds/cannabis{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
+	pixel_x = 2;
+	pixel_y = -3
 	},
-/obj/item/paper/fluff/ruins/hydroponicslab/botanist{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/pen{
-	pixel_x = -9
+/obj/item/ammo_casing/caseless{
+	pixel_x = -5;
+	pixel_y = 9;
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -626,16 +627,16 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "tS" = (
-/obj/machinery/light/dim{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/multitool{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_y = -9;
+	pixel_x = 11;
+	dir = 10
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "uX" = (
 /obj/structure/table,
@@ -680,10 +681,19 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "xx" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/item/ammo_casing/caseless{
-	pixel_y = 12;
-	pixel_x = -7
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_y = 0
+	},
+/obj/item/clothing/shoes/winterboots{
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -822,12 +832,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "GK" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/plasteel/freezer,
-/area/ruin/powered/hydroponicslab)
+/turf/closed/mineral/snowmountain/icemoon,
+/area/icemoon/surface/outdoors)
 "GN" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plasteel/stairs,
@@ -863,11 +869,16 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "IR" = (
-/obj/structure/marker_beacon,
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 10
 	},
-/area/icemoon/surface/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Jn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grown/tomato{
@@ -1039,13 +1050,10 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "QA" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/item/ammo_casing/caseless{
-	pixel_x = 8;
-	pixel_y = -5
+	pixel_y = 12;
+	pixel_x = -7
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1086,17 +1094,10 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "UK" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = -1
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/machinery/light/dim,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/caseless{
-	pixel_x = 6;
-	pixel_y = 6;
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/freezer,
 /area/ruin/powered/hydroponicslab)
 "Va" = (
 /obj/item/trash/cheesie{
@@ -1137,23 +1138,20 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "VN" = (
-/obj/item/toy/katana,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = -1
+	},
+/obj/machinery/light/dim,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 6;
+	pixel_y = 6;
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "We" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/powered/hydroponicslab)
-"Wi" = (
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/ammo_casing/caseless{
-	pixel_x = -5;
-	pixel_y = 9;
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "WK" = (
 /obj/item/stack/cable_coil/yellow{
@@ -1186,6 +1184,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Zd" = (
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
 /turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/surface/outdoors)
 "ZN" = (
@@ -1209,18 +1208,18 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey
@@ -1242,21 +1241,21 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey
@@ -1274,25 +1273,25 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 DV
 Ey
 Ey
@@ -1306,28 +1305,28 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 DV
 DV
 Ey
@@ -1340,28 +1339,28 @@ Ey
 (5,1,1) = {"
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 We
 hJ
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 DV
 DV
 DV
@@ -1374,34 +1373,34 @@ Ey
 "}
 (6,1,1) = {"
 Ey
-Zd
-Zd
-Zd
-Zd
-gM
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-hJ
 GK
+GK
+GK
+GK
+Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+hJ
+UK
 gU
 hJ
-Zd
-Zd
+GK
+GK
 DV
 DV
 DV
 DV
-Zd
-Zd
+GK
+GK
 Ey
 Ey
 Ey
@@ -1409,18 +1408,18 @@ Ey
 "}
 (7,1,1) = {"
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 We
 We
@@ -1429,33 +1428,33 @@ hJ
 pL
 MN
 hJ
-Zd
-Zd
+GK
+GK
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 "}
 (8,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 We
 hJ
 We
 hJ
 We
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 am
 Qt
@@ -1464,33 +1463,33 @@ We
 si
 hJ
 hJ
-Zd
+GK
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 "}
 (9,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 We
-mW
+kw
 WK
 jl
 sx
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 We
 bD
 pR
@@ -1499,24 +1498,24 @@ Va
 TR
 DO
 We
-Zd
+GK
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 "}
 (10,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 Cr
 sx
@@ -1527,38 +1526,38 @@ hJ
 We
 hJ
 hJ
-tS
+iJ
 tQ
 tQ
 Qm
 PQ
 yi
 We
-Zd
+GK
 DV
 DV
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
 Ey
 "}
 (11,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 Nl
 bV
 He
 So
 hJ
-hd
+tS
 SW
 mQ
 hJ
@@ -1569,24 +1568,24 @@ AL
 Nv
 yV
 hJ
-Zd
-Zd
+GK
+GK
 DV
 DV
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 Ey
 "}
 (12,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 We
 Vd
 dB
@@ -1604,59 +1603,59 @@ We
 hJ
 hJ
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 DV
 DV
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 "}
 (13,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 nS
 sx
 Vy
-me
+dw
 zV
 FO
-xx
-iJ
+QA
+me
 hJ
 si
 hJ
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 DV
 DV
 DV
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 "}
 (14,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 hJ
 fd
@@ -1665,34 +1664,34 @@ fd
 We
 bv
 Mz
-aJ
+xx
 hJ
 TR
 DO
 We
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 DV
 DV
 DV
 DV
-Zd
-Zd
-Zd
+GK
+GK
+GK
 "}
 (15,1,1) = {"
 Ey
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 We
 hJ
 dD
@@ -1710,28 +1709,28 @@ hJ
 We
 hJ
 hJ
-Zd
-Zd
-Zd
-IR
+GK
+GK
+GK
+gM
 gA
 DV
 DV
 DV
-Zd
-Zd
-Zd
+GK
+GK
+GK
 "}
 (16,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 hJ
 sx
-dw
-QA
+hd
+IR
 nD
 hJ
 TR
@@ -1745,23 +1744,23 @@ mU
 ag
 oT
 hJ
-Zd
-IR
+GK
+gM
 gA
 gA
 gA
 gA
 gA
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 "}
 (17,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 ZN
 dB
@@ -1785,24 +1784,24 @@ gA
 gA
 gA
 gA
-IR
-Zd
-Zd
-Zd
-Zd
-Zd
+gM
+GK
+GK
+GK
+GK
+GK
 "}
 (18,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 cu
 fd
 pn
 Nf
-UK
+VN
 hJ
 TR
 DO
@@ -1815,23 +1814,23 @@ AT
 Pz
 ab
 hJ
-Zd
+GK
 gA
-IR
+gM
 gA
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 "}
 (19,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 We
 uX
 sx
@@ -1850,23 +1849,23 @@ hJ
 hJ
 We
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 "}
 (20,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 iz
 fd
@@ -1881,27 +1880,27 @@ tQ
 Ti
 hZ
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 "}
 (21,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 nn
 sx
@@ -1916,62 +1915,62 @@ Ti
 TR
 hJ
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 "}
 (22,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 We
 hJ
 uZ
 We
 hJ
-VN
+aJ
 We
 hJ
 hJ
 We
 hJ
 We
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 hJ
 We
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
 "}
 (23,1,1) = {"
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 lw
 EV
@@ -1984,12 +1983,12 @@ fd
 kr
 fd
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 hJ
 We
@@ -1997,16 +1996,16 @@ nt
 Gr
 hJ
 hJ
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 "}
 (24,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 pE
 Ac
@@ -2032,16 +2031,16 @@ Gr
 nt
 ac
 We
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (25,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 We
 Dj
 Gy
@@ -2050,7 +2049,7 @@ MV
 cu
 hJ
 jr
-Wi
+mW
 zN
 sx
 Fy
@@ -2067,16 +2066,16 @@ Gr
 ij
 nt
 We
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (26,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 We
 gO
 tk
@@ -2086,7 +2085,7 @@ bg
 We
 fd
 iB
-kw
+eD
 sx
 sx
 fd
@@ -2102,16 +2101,16 @@ Gr
 nt
 Hg
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (27,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 RX
 MV
@@ -2137,16 +2136,16 @@ hF
 Gr
 nt
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (28,1,1) = {"
 Ey
-Zd
-Zd
-Zd
+GK
+GK
+GK
 hJ
 hJ
 qh
@@ -2172,17 +2171,17 @@ hF
 nt
 ac
 We
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (29,1,1) = {"
 Ey
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 We
 Jn
@@ -2194,12 +2193,12 @@ aC
 bq
 We
 hJ
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 We
 We
@@ -2207,18 +2206,18 @@ nt
 Gr
 hJ
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 "}
 (30,1,1) = {"
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
 hJ
 hJ
 We
@@ -2228,57 +2227,57 @@ hJ
 hJ
 We
 We
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 hJ
 hJ
 hJ
 hJ
-Zd
-Zd
-Zd
+GK
+GK
+GK
 Ey
 Ey
 "}
 (31,1,1) = {"
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 "}
@@ -2286,33 +2285,33 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey
@@ -2323,30 +2322,30 @@ Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey
 Ey
 Ey
-Zd
-Zd
-Zd
-Zd
-Zd
+GK
+GK
+GK
+GK
+GK
 Ey
 Ey
 Ey

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -37,8 +37,17 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "aJ" = (
-/obj/item/toy/katana,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = -1
+	},
+/obj/machinery/light/dim,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 6;
+	pixel_y = 6;
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "bd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -116,15 +125,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "dw" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 12;
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/item/ammo_casing/caseless{
-	pixel_y = 4;
-	dir = 5;
-	pixel_x = 2
+	pixel_y = 12;
+	pixel_x = -7
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -145,13 +149,13 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "eD" = (
-/obj/item/pen/blue{
-	pixel_y = -2;
-	pixel_x = -6
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 10
 	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_x = 8;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -199,10 +203,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "gM" = (
-/obj/structure/marker_beacon,
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
+/turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/surface/outdoors)
 "gO" = (
 /obj/structure/table,
@@ -225,12 +227,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/hydroponicslab)
 "hd" = (
-/obj/item/ammo_casing/caseless{
-	pixel_x = 8;
-	pixel_y = 4;
-	dir = 8
+/obj/machinery/light/dim{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "hg" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -295,29 +301,30 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iH" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/ammo_casing/caseless{
-	pixel_x = -8;
-	pixel_y = 6;
-	dir = 9
+/obj/item/clothing/shoes/winterboots{
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45{
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iJ" = (
-/obj/machinery/light/dim{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/multitool{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/caseless{
+	pixel_y = -9;
+	pixel_x = 11;
+	dir = 10
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "iQ" = (
 /obj/structure/table,
@@ -396,15 +403,8 @@
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "me" = (
-/obj/structure/table,
-/obj/item/pen{
-	pixel_x = -6
-	},
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/tech,
+/obj/item/toy/katana,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "mQ" = (
 /obj/structure/frame/computer{
@@ -433,14 +433,15 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "mW" = (
-/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
-	pixel_x = 2;
-	pixel_y = -3
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -3;
+	pixel_y = 2
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ammo_casing/caseless{
-	pixel_x = -5;
-	pixel_y = 9;
-	dir = 4
+	pixel_x = -8;
+	pixel_y = 6;
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -627,14 +628,13 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "tS" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/item/pen/blue{
+	pixel_y = -2;
+	pixel_x = -6
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/caseless{
-	pixel_y = -9;
-	pixel_x = 11;
-	dir = 10
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -681,21 +681,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "xx" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_y = 0
-	},
-/obj/item/clothing/shoes/winterboots{
-	pixel_y = 0
-	},
-/obj/item/ammo_box/magazine/m45{
-	pixel_y = 0
-	},
-/obj/item/ammo_box/magazine/m45{
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/tech,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "yi" = (
 /obj/item/trash/sosjerky{
@@ -869,13 +856,14 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "IR" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 10
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/caseless{
-	pixel_x = 8;
-	pixel_y = -5
+	pixel_y = -1;
+	dir = 5;
+	pixel_x = 3
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1050,10 +1038,15 @@
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "QA" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/item/ammo_casing/caseless{
+/obj/effect/decal/cleanable/blood/drip{
 	pixel_y = 12;
-	pixel_x = -7
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/ammo_casing/caseless{
+	pixel_y = 4;
+	dir = 5;
+	pixel_x = 2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1114,14 +1107,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Vo" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = -6
 	},
-/obj/item/ammo_casing/caseless{
-	pixel_y = -1;
-	dir = 5;
-	pixel_x = 3
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer{
+	pixel_x = 3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1138,20 +1130,27 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "VN" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_y = -1
-	},
-/obj/machinery/light/dim,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/caseless{
-	pixel_x = 6;
-	pixel_y = 6;
-	dir = 5
+	pixel_x = 8;
+	pixel_y = 4;
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "We" = (
 /turf/closed/wall/r_wall/rust,
+/area/ruin/powered/hydroponicslab)
+"Wi" = (
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/ammo_casing/caseless{
+	pixel_x = -5;
+	pixel_y = 9;
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "WK" = (
 /obj/item/stack/cable_coil/yellow{
@@ -1184,8 +1183,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Zd" = (
-/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab,
-/turf/closed/mineral/snowmountain/icemoon,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/icemoon/surface/outdoors)
 "ZN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1377,7 +1378,7 @@ GK
 GK
 GK
 GK
-Zd
+gM
 GK
 GK
 GK
@@ -1526,7 +1527,7 @@ hJ
 We
 hJ
 hJ
-iJ
+hd
 tQ
 tQ
 Qm
@@ -1557,7 +1558,7 @@ bV
 He
 So
 hJ
-tS
+iJ
 SW
 mQ
 hJ
@@ -1592,7 +1593,7 @@ dB
 xb
 sx
 hJ
-Vo
+IR
 pG
 YO
 We
@@ -1625,11 +1626,11 @@ hJ
 nS
 sx
 Vy
-dw
+QA
 zV
 FO
-QA
-me
+dw
+Vo
 hJ
 si
 hJ
@@ -1664,7 +1665,7 @@ fd
 We
 bv
 Mz
-xx
+iH
 hJ
 TR
 DO
@@ -1712,7 +1713,7 @@ hJ
 GK
 GK
 GK
-gM
+Zd
 gA
 DV
 DV
@@ -1729,8 +1730,8 @@ GK
 hJ
 hJ
 sx
-hd
-IR
+VN
+eD
 nD
 hJ
 TR
@@ -1745,7 +1746,7 @@ ag
 oT
 hJ
 GK
-gM
+Zd
 gA
 gA
 gA
@@ -1784,7 +1785,7 @@ gA
 gA
 gA
 gA
-gM
+Zd
 GK
 GK
 GK
@@ -1801,7 +1802,7 @@ cu
 fd
 pn
 Nf
-VN
+aJ
 hJ
 TR
 DO
@@ -1816,7 +1817,7 @@ ab
 hJ
 GK
 gA
-gM
+Zd
 gA
 GK
 GK
@@ -1870,7 +1871,7 @@ hJ
 iz
 fd
 dB
-iH
+mW
 fd
 GN
 tQ
@@ -1942,7 +1943,7 @@ hJ
 uZ
 We
 hJ
-aJ
+me
 We
 hJ
 hJ
@@ -2049,7 +2050,7 @@ MV
 cu
 hJ
 jr
-mW
+Wi
 zN
 sx
 Fy
@@ -2085,7 +2086,7 @@ bg
 We
 fd
 iB
-eD
+tS
 sx
 sx
 fd
@@ -2133,7 +2134,7 @@ hJ
 Ks
 vg
 hF
-Gr
+xx
 nt
 hJ
 GK

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -21,11 +21,6 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
-"aj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating/rust,
-/area/ruin/powered/hydroponicslab)
 "am" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -221,6 +216,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"fO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating/rust,
+/area/ruin/powered/hydroponicslab)
 "gb" = (
 /obj/structure/table,
 /obj/item/seeds/kudzu{
@@ -332,6 +332,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hydroponicslab)
+"gV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "hd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -557,7 +561,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/obj/effect/turf_decal/spline/fancy/orange{
+/obj/effect/turf_decal/spline/fancy/lime{
 	dir = 6
 	},
 /turf/open/floor/plasteel/tech,
@@ -567,6 +571,19 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"lk" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 1;
+	color = "#AE8CA8"
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "lw" = (
 /obj/structure/table,
@@ -594,11 +611,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/rockvault,
-/area/ruin/powered/hydroponicslab)
-"lS" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/spline/fancy/lime,
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "mb" = (
 /obj/effect/turf_decal/corner_techfloor_grid{
@@ -696,9 +708,9 @@
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
+/obj/effect/turf_decal/spline/fancy/corner/green{
 	dir = 1;
-	color = "#AE8CA8"
+	color = "#99BB76"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -861,6 +873,16 @@
 	},
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
+"oY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/purple{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "pj" = (
 /obj/structure/table,
 /obj/item/seeds/apple{
@@ -961,30 +983,18 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"qB" = (
+/mob/living/simple_animal/hostile/killertomato,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
+/area/ruin/powered/hydroponicslab)
 "ri" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
 /turf/open/floor/vault,
-/area/ruin/powered/hydroponicslab)
-"sd" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
-	dir = 1;
-	color = "#AE8CA8"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/purple{
-	color = "#AE8CA8"
-	},
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "si" = (
 /obj/machinery/door/airlock/maintenance,
@@ -997,6 +1007,11 @@
 /area/ruin/powered/hydroponicslab)
 "sx" = (
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"sK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel/tech,
+/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "sM" = (
 /obj/effect/turf_decal/techfloor{
@@ -1052,6 +1067,24 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
+"uz" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	color = "#99BB76"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/green{
+	dir = 8;
+	color = "#99BB76"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "uX" = (
 /obj/structure/table,
 /obj/item/seeds/plump/walkingmushroom,
@@ -1074,11 +1107,9 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal,
 /obj/effect/turf_decal/spline/fancy/grey{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/grey{
-	dir = 4
-	},
+/obj/effect/turf_decal/spline/fancy/grey,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "vg" = (
@@ -1093,10 +1124,6 @@
 "vH" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/walnut,
-/area/ruin/powered/hydroponicslab)
-"wb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "xb" = (
 /obj/structure/table,
@@ -1128,12 +1155,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
-"xH" = (
-/mob/living/simple_animal/hostile/killertomato,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "xJ" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -1207,6 +1228,21 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
+"zT" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/grey{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "zV" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -1261,6 +1297,16 @@
 "Bx" = (
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
+"BC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/orange{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Cg" = (
 /obj/item/seeds/kudzu{
 	pixel_y = 3;
@@ -1290,11 +1336,6 @@
 	dir = 9
 	},
 /turf/open/floor/carpet,
-/area/ruin/powered/hydroponicslab)
-"Df" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
-/turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
 "Dj" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
@@ -1366,29 +1407,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
-"Fi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/lime{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
-"Fo" = (
-/obj/machinery/door/airlock/grunge,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/corner_techfloor_grid/diagonal{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_techfloor_grid/diagonal,
-/obj/effect/turf_decal/spline/fancy/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/grey,
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "Fy" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/hydroponics{
@@ -1433,11 +1451,6 @@
 /area/ruin/powered/hydroponicslab)
 "Gr" = (
 /turf/open/floor/grass,
-/area/ruin/powered/hydroponicslab)
-"Gt" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/spline/fancy/purple,
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Gy" = (
 /mob/living/simple_animal/hostile/killertomato,
@@ -1497,6 +1510,11 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
 /turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"HF" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/purple,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "HK" = (
 /obj/structure/chair/plastic{
@@ -1593,6 +1611,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"LM" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 4;
+	color = "#B7D993"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/lime{
+	dir = 1;
+	color = "#B7D993"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "Mx" = (
 /mob/living/simple_animal/hostile/killertomato,
 /obj/effect/decal/cleanable/dirt,
@@ -1679,24 +1720,6 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
-"Nx" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/spline/fancy/corner/green{
-	color = "#99BB76"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/green{
-	dir = 8;
-	color = "#99BB76"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "NA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1771,16 +1794,6 @@
 	dir = 4
 	},
 /turf/open/floor/vault,
-/area/ruin/powered/hydroponicslab)
-"PI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/purple{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "PQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1911,31 +1924,13 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
-"Ts" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/lime{
-	dir = 4;
-	color = "#B7D993"
-	},
-/obj/effect/turf_decal/spline/fancy/corner/lime{
-	dir = 1;
-	color = "#B7D993"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
 "TR" = (
 /turf/open/floor/wood/walnut,
+/area/ruin/powered/hydroponicslab)
+"Uh" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/lime,
+/turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "UF" = (
 /obj/structure/table,
@@ -1973,19 +1968,6 @@
 	},
 /obj/effect/turf_decal/spline/fancy/purple{
 	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/powered/hydroponicslab)
-"Vk" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/corner/green{
-	dir = 1;
-	color = "#99BB76"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -2101,6 +2083,24 @@
 "Zd" = (
 /turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/surface/outdoors)
+"Zm" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	dir = 1;
+	color = "#AE8CA8"
+	},
+/obj/effect/turf_decal/spline/fancy/corner/purple{
+	color = "#AE8CA8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
 "ZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2438,7 +2438,7 @@ Zd
 Zd
 hJ
 Cr
-Df
+sK
 GP
 zy
 We
@@ -2510,7 +2510,7 @@ We
 Vd
 dB
 xb
-Gt
+HF
 hJ
 Bc
 pG
@@ -2543,7 +2543,7 @@ Zd
 Zd
 hJ
 nS
-ni
+lk
 Vy
 mW
 zV
@@ -2579,8 +2579,8 @@ Zd
 hJ
 hJ
 qc
-sd
-PI
+Zm
+oY
 We
 bv
 Mz
@@ -2718,7 +2718,7 @@ Zd
 Zd
 hJ
 IQ
-wb
+gV
 pn
 Nf
 to
@@ -2791,7 +2791,7 @@ iz
 fd
 dB
 hw
-kS
+BC
 GN
 AL
 hd
@@ -2825,7 +2825,7 @@ hJ
 nn
 sM
 XC
-kS
+BC
 hJ
 hJ
 hJ
@@ -2859,7 +2859,7 @@ Zd
 hJ
 We
 hJ
-Fo
+uZ
 We
 hJ
 dw
@@ -2970,7 +2970,7 @@ Ri
 hJ
 jr
 oo
-Df
+sK
 mb
 Fy
 nL
@@ -3000,7 +3000,7 @@ We
 gO
 tk
 NA
-wb
+gV
 bg
 We
 NT
@@ -3008,8 +3008,8 @@ iB
 zN
 sx
 sx
-aj
-lS
+fO
+Uh
 ss
 AT
 eh
@@ -3035,16 +3035,16 @@ hJ
 RX
 oO
 cu
-xH
-Nx
-uZ
-Ts
+qB
+uz
+zT
+LM
 bP
-Df
+sK
 Eb
 bA
 xE
-Fi
+kS
 hJ
 tE
 ri
@@ -3069,7 +3069,7 @@ Zd
 hJ
 hJ
 qh
-Vk
+ni
 dB
 RV
 hJ

--- a/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_hydroponics_lab.dmm
@@ -6,6 +6,7 @@
 "ac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "ag" = (
@@ -131,14 +132,15 @@
 /area/ruin/powered/hydroponicslab)
 "ct" = (
 /obj/structure/table,
-/obj/item/seeds/replicapod{
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
 /obj/effect/turf_decal/spline/fancy/lime{
 	dir = 5
+	},
+/obj/item/seeds/cabbage{
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -164,7 +166,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "dD" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal{
 	dir = 4
 	},
@@ -173,10 +174,11 @@
 /obj/effect/turf_decal/spline/fancy/grey{
 	dir = 1
 	},
+/obj/machinery/door/airlock/research,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ed" = (
-/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/airlock/hatch,
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "eh" = (
@@ -184,9 +186,16 @@
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "eD" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "eX" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -217,15 +226,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "fO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel/tech,
 /turf/open/floor/plating/rust,
 /area/ruin/powered/hydroponicslab)
 "gb" = (
-/obj/structure/table,
-/obj/item/seeds/kudzu{
-	pixel_y = 2;
-	pixel_x = -3
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 9
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
@@ -246,6 +254,17 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"gl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "gz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -268,9 +287,8 @@
 /area/icemoon/surface/outdoors)
 "gC" = (
 /obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder{
-	pixel_x = 3;
-	pixel_y = 0
+/obj/item/seeds/berry{
+	pixel_x = 3
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -324,6 +342,7 @@
 "gP" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fernybush,
+/mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "gU" = (
@@ -348,8 +367,13 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "hg" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
-/obj/machinery/door/window/brigdoor,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/corner/bar{
+	dir = 1;
+	color = "#791500"
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "hs" = (
@@ -380,8 +404,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "hF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/grass,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "hJ" = (
 /turf/closed/wall/r_wall,
@@ -405,22 +429,21 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "ij" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "iw" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/stack/rods{
-	pixel_x = -6;
-	pixel_y = -2
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
 	},
-/obj/item/shard{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/shard{
-	pixel_x = 4
+/obj/effect/turf_decal/spline/fancy/corner/bar{
+	dir = 8;
+	color = "#791500"
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
@@ -479,13 +502,13 @@
 /area/ruin/powered/hydroponicslab)
 "iQ" = (
 /obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/tomato/blood{
+	pixel_x = 7;
+	pixel_y = 7
+	},
 /obj/item/seeds/tomato/killer{
 	pixel_y = -9;
 	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/snacks/grown/tomato/blue{
-	pixel_x = 4;
-	pixel_y = 10
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -500,6 +523,14 @@
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/lime,
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"jh" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "jl" = (
 /obj/effect/decal/cleanable/food/salt,
@@ -564,6 +595,7 @@
 /obj/effect/turf_decal/spline/fancy/lime{
 	dir = 6
 	},
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "lj" = (
@@ -602,12 +634,13 @@
 /area/ruin/powered/hydroponicslab)
 "lF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/seeds/nettle/death{
-	pixel_x = 3;
-	pixel_y = 4
-	},
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
 	dir = 1
 	},
 /turf/open/floor/plasteel/rockvault,
@@ -635,6 +668,17 @@
 	dir = 10
 	},
 /turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"mu" = (
+/mob/living/simple_animal/hostile/venus_human_trap,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "mQ" = (
 /obj/structure/frame/computer{
@@ -698,7 +742,13 @@
 /area/ruin/powered/hydroponicslab)
 "nh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/northright,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 5
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "ni" = (
@@ -716,12 +766,16 @@
 /area/ruin/powered/hydroponicslab)
 "nj" = (
 /obj/structure/table,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/item/circuitboard/machine/hydroponics{
 	pixel_y = 2;
 	pixel_x = -3
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 10
 	},
 /obj/effect/turf_decal/spline/fancy/lime{
 	dir = 10
@@ -989,11 +1043,16 @@
 /obj/item/stack/tile/plasteel/tech,
 /turf/open/floor/plating,
 /area/ruin/powered/hydroponicslab)
+"qN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/hydroponicslab)
 "ri" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "si" = (
@@ -1004,6 +1063,15 @@
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
+"sv" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 5
+	},
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "sx" = (
 /turf/open/floor/plasteel/tech,
@@ -1052,6 +1120,17 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
+"tP" = (
+/obj/structure/table,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 10
+	},
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
 "tQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -1065,7 +1144,24 @@
 /area/ruin/powered/hydroponicslab)
 "uo" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
+/area/ruin/powered/hydroponicslab)
+"up" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 9
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "uz" = (
 /obj/effect/turf_decal/corner_techfloor_grid{
@@ -1100,7 +1196,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "uZ" = (
-/obj/machinery/door/airlock/grunge,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal{
 	dir = 4
@@ -1110,10 +1205,32 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/grey,
+/obj/machinery/door/airlock,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"vc" = (
+/obj/structure/table,
+/obj/structure/sign/poster/contraband/kudzu{
+	pixel_x = -32
+	},
+/obj/item/seeds/kudzu{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/ruin/powered/hydroponicslab)
 "vg" = (
-/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "vm" = (
@@ -1147,14 +1264,8 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "xE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/lime{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
+/obj/machinery/door/airlock,
+/turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "xJ" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -1178,14 +1289,26 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "ys" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/c,
-/turf/open/floor/grass,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "yV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "zw" = (
 /obj/structure/table/wood,
@@ -1226,6 +1349,9 @@
 "zO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "zT" = (
@@ -1244,7 +1370,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "zV" = (
-/obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal,
 /obj/effect/turf_decal/corner_techfloor_grid/diagonal{
@@ -1256,6 +1381,7 @@
 /obj/effect/turf_decal/spline/fancy/grey{
 	dir = 8
 	},
+/obj/machinery/door/airlock/security,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Ac" = (
@@ -1295,6 +1421,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Bx" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "BC" = (
@@ -1308,13 +1435,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Cg" = (
-/obj/item/seeds/kudzu{
-	pixel_y = 3;
-	pixel_x = 3
-	},
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/rockvault,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar,
+/obj/structure/sign/warning/fire{
+	pixel_y = 32
+	},
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "Cr" = (
 /obj/machinery/biogenerator,
@@ -1346,6 +1474,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/powered/hydroponicslab)
+"DA" = (
+/obj/effect/turf_decal/spline/plain/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "DH" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -1408,17 +1544,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Fy" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/hydroponics{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/lime{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/spline/fancy/bar,
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "FO" = (
 /obj/effect/decal/cleanable/blood,
@@ -1450,6 +1578,12 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Gr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "Gy" = (
@@ -1482,7 +1616,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "GN" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/engineering,
 /turf/open/floor/plasteel/stairs,
 /area/ruin/powered/hydroponicslab)
 "GP" = (
@@ -1508,7 +1642,7 @@
 /area/ruin/powered/hydroponicslab)
 "Hg" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "HF" = (
@@ -1526,17 +1660,21 @@
 /turf/open/floor/carpet,
 /area/ruin/powered/hydroponicslab)
 "Ik" = (
-/obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/security,
 /turf/open/floor/wood/walnut,
 /area/ruin/powered/hydroponicslab)
 "IQ" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/orange{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder{
+	pixel_x = 3;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
@@ -1545,6 +1683,23 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
+/area/ruin/powered/hydroponicslab)
+"Je" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/rods{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/shard{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/shard{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/spline/fancy/bar,
+/turf/open/floor/plasteel/rockvault,
 /area/ruin/powered/hydroponicslab)
 "Jn" = (
 /obj/structure/table,
@@ -1590,14 +1745,16 @@
 "Ks" = (
 /obj/structure/table,
 /obj/item/flamethrower/full/tank{
-	pixel_x = 4;
+	pixel_x = 11;
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/rockvault,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/spline/plain/bar,
+/turf/open/floor/vault,
 /area/ruin/powered/hydroponicslab)
 "KD" = (
 /obj/structure/table,
@@ -1691,6 +1848,17 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
+"Nd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/bar{
+	dir = 10
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/powered/hydroponicslab)
 "Nf" = (
 /obj/item/paper/guides/jobs/hydroponics{
 	pixel_y = 5
@@ -1727,9 +1895,9 @@
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/snacks/grown/tomato/blue{
+/obj/item/reagent_containers/food/snacks/grown/tomato/blood{
 	pixel_x = -5;
-	pixel_y = 10
+	pixel_y = 7
 	},
 /obj/item/reagent_containers/glass/bottle/nutrient/rh{
 	pixel_y = 1
@@ -1744,6 +1912,7 @@
 /obj/effect/turf_decal/spline/fancy/lime{
 	dir = 1
 	},
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel/tech,
 /area/ruin/powered/hydroponicslab)
 "Oz" = (
@@ -1974,6 +2143,9 @@
 "Vo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "Vy" = (
@@ -2012,6 +2184,7 @@
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light,
 /turf/open/floor/grass,
 /area/ruin/powered/hydroponicslab)
 "We" = (
@@ -2380,7 +2553,7 @@ am
 Qt
 DH
 We
-si
+xE
 hJ
 hJ
 Zd
@@ -2874,12 +3047,12 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
 hJ
 hJ
 We
 hJ
+We
+Zd
 Zd
 Zd
 Zd
@@ -2907,15 +3080,15 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
 hJ
 hJ
 We
-tS
-gP
+up
+vc
+tP
 hJ
-hJ
+Zd
+Zd
 Zd
 Zd
 Zd
@@ -2940,16 +3113,16 @@ iY
 We
 hJ
 hJ
-hJ
 We
 We
-hJ
 hJ
 gb
-nh
-uo
-Vo
-ac
+Nd
+gl
+DA
+eD
+hJ
+We
 We
 Zd
 Zd
@@ -2972,20 +3145,20 @@ jr
 oo
 sK
 mb
-Fy
 nL
 nj
 We
 bd
 nP
-bd
 We
 lF
 iw
-nt
 ij
-ys
-We
+mu
+jh
+uo
+tS
+hJ
 Zd
 Zd
 Zd
@@ -3007,18 +3180,18 @@ NT
 iB
 zN
 sx
-sx
 fO
 Uh
 ss
 AT
 eh
-AT
 ss
-Bx
+sv
 hg
-Gr
-VN
+Bx
+Fy
+Vo
+nt
 Hg
 hJ
 Zd
@@ -3040,20 +3213,20 @@ uz
 zT
 LM
 bP
-sK
+qN
 Eb
 bA
-xE
 kS
 hJ
 tE
 ri
-ab
 hJ
 Ks
 vg
 hF
-eD
+Je
+nt
+gP
 VN
 hJ
 Zd
@@ -3078,15 +3251,15 @@ eX
 oK
 hs
 hJ
-hJ
 We
 hJ
 hJ
 hJ
-We
 hJ
 Cg
 nh
+ys
+yV
 zO
 PR
 ac
@@ -3117,12 +3290,12 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
 hJ
 We
 We
-yV
+hJ
+We
+Gr
 md
 hJ
 hJ
@@ -3156,7 +3329,7 @@ Zd
 Zd
 Zd
 Zd
-hJ
+We
 hJ
 hJ
 hJ

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -19,6 +19,12 @@
 	description = "Slime ranchin with the bud."
 	suffix = "icemoon_surface_slimerancher.dmm"
 
+/datum/map_template/ruin/icemoon/hydroponicslab //Shiptest edit
+	name = "Hydroponics Lab"
+	id = "hydroponicslab"
+	description = "An abandoned hydroponics research facility containing hostile plant fauna."
+	suffix = "icemoon_hydroponics_lab.dmm"
+
 // above and below ground together
 
 

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -86,3 +86,7 @@
 	icon_state = "dk_yellow"
 	mood_bonus = -10
 	mood_message = "<span class='boldwarning'>I want to leave this place.</span>\n"
+
+/area/ruin/powered/hydroponicslab
+	name = "Hydroponics Lab"
+	icon_state = "dk_yellow"

--- a/code/modules/ruins/icemoonruin_code/hydroponicslab.dm
+++ b/code/modules/ruins/icemoonruin_code/hydroponicslab.dm
@@ -1,0 +1,13 @@
+///////////	hydroponicslab items
+
+/obj/item/paper/fluff/ruins/hydroponicslab/botanist
+	info = "FRIDAY<BR><BR>The doc's taught me well, but the crushing weight of this mountain is really starting to make me question why I even agreed to be their assistant in the first place. The doc used to be a little more light-hearted, but they've gotten more and more manic over the past couple of months. They've locked himself deeper in the facility more and more often, to the point where I sometimes go days without seeing them. Perhaps this cannabis can help lighten them up..."
+	name = "botanist's diary"
+
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/officer
+	info = "MONDAY<BR><BR>I owe the doc more than a couple of beers by now. Saved my ass more times than I can count. But something's not... right. I've never seen them this way before. I mean, I've seen them cram late nights before and they got a little nutty... but this is a new kind of nutty.<BR><BR>THURSDAY<BR><BR>Some sketchy looking guys came in. We haven't had visitors in forever. They started to shout at me but they were just listing off drinks. I thought it was perhaps just some random hermits, but when I reached for my gun, they were quicker on the draw. Just as I thought they were about to blast me to bits the doc came bursting through the door. They seemed like they were pleading about something but they were uttering the same gibberish. I tried asking the doc about what that was all about, but they seemed to dodge the question. I can only hope that will be the last visit we get"
+	name = "officer's diary"
+
+/obj/item/paper/crumpled/bloody/fluff/ruins/hydroponicslab/researcher
+	info = "SATURDAY<BR><BR>It looks like karma has finally caught up. I was a fool to ever think I could repay my debts. I was a villain for creating such abhorities. And I was a coward. I could have saved us both. But I just stood there, listening to the screams. If I had just taken the flamethrower last night...<BR><BR><BR><BR>I can only hope our benefactors find our blood and give us a second chance. Perhaps I'll be able to make things right again."
+	name = "bloody note"

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3074,6 +3074,7 @@
 #include "code\modules\ruins\lavaland_ruin_code.dm"
 #include "code\modules\ruins\rockplanet_ruin_code.dm"
 #include "code\modules\ruins\icemoonruin_code\hotsprings.dm"
+#include "code\modules\ruins\icemoonruin_code\hydroponicslab.dm"
 #include "code\modules\ruins\icemoonruin_code\library.dm"
 #include "code\modules\ruins\icemoonruin_code\wrath.dm"
 #include "code\modules\ruins\lavalandruin_code\biodome_clown_planet.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new Ice Planet ruin, the Hydroponics Lab. Located deep within a mountain, this old and rusted laboratory focuses on growing experimental and deadly plants.

![2022 07 12-16 45 36](https://user-images.githubusercontent.com/65363339/178592061-cb3ed0eb-fa1c-47a3-9711-cd2388a50ac2.png)

The main loot is as follows:

- Two M1911 handguns + one magazine in total
- One flamethrower
- Security winter coat
- Security jumpsuit
- Jackboots
- A variety of botany tools including a botany locker
- Tools + multitool
- Biogenerator, seed extractor
- Hydroponic trays
- Bottles of ammonia, diethylamine, ez-nutrient, unstable mutagen, left-4-zed, robust harvest, sodium and ethanol
- Replica pod seed
- Killer tomato seed
- Kudzu seed
- A variety of other plants and seeds
- Biosuit

The katana located in the walls is a replica. I hope some poor sap looks at this PR, sees the katana, and goes "OMG REAL KATANA!!!" and wastes their time trying to tear down the walls.

## Why It's Good For The Game

Ice ruins are lacking and we don't have any hydroponics themed ruins on the ice just yet.

More ruins = good

## Changelog
:cl:
add: Added a new ruin on Ice Planets, the Hydroponics Lab.
/:cl:
