### PR TITLE
Ports a snippet of blind/deaf code from TG#59245

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -76,9 +76,9 @@
 			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE, separation = space)
+		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
 	else
-		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE, separation = space)
+		user.visible_message(msg, blind_message = "<span class='emote'>You hear how <b>[user]</b> [msg]</span>", visible_message_flags = EMOTE_MESSAGE)
 
 /// For handling emote cooldown, return true to allow the emote to happen
 /datum/emote/proc/check_cooldown(mob/user, intentional)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports a small bit of code from [#59245](https://github.com/tgstation/tgstation/pull/59245) which allows blind characters to "Hear" visible emotes, and deaf characters to "See" audible emotes.

## Why It's Good For The Game

Up until this point, blind characters have been locked out of perceiving the vast majority of emotes, as the default custom emote type is visible. Now every (custom) player emote is available to every player! This also means emotes will no longer be consumed by the void if your character is standing in a dark room.

![DeafEmotes](https://user-images.githubusercontent.com/86762641/177390176-3a76de4e-fa80-4211-baab-86f4fbfef48e.png)

![BlindEmotes](https://user-images.githubusercontent.com/86762641/177390189-91d0f2bd-59ce-47b2-a59d-9e8da778e9e4.png)

(As seen here, the wild Nyaru harassing the deaf and blind alike)

## Changelog
:cl:
tweak: blind people can now perceive visible emotes
tweak: deaf people can now perceive audible emotes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
