### PR TITLE
Stops ships being flooded with creature gibs when landing at a planet

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -34,7 +34,10 @@ All ShuttleMove procs go here
 				M.visible_message("<span class='warning'>[shuttle] slams into [M]!</span>")
 				SSblackbox.record_feedback("tally", "shuttle_gib", 1, M.type)
 				log_attack("[key_name(M)] was shuttle gibbed by [shuttle].")
-				M.gib()
+				if(iscarbon(M))
+					M.gib()
+				else
+					qdel(M)
 
 
 		else //non-living mobs shouldn't be affected by shuttles, which is why this is an else

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -34,10 +34,10 @@ All ShuttleMove procs go here
 				M.visible_message("<span class='warning'>[shuttle] slams into [M]!</span>")
 				SSblackbox.record_feedback("tally", "shuttle_gib", 1, M.type)
 				log_attack("[key_name(M)] was shuttle gibbed by [shuttle].")
-				if(iscarbon(M))
-					M.gib()
-				else
+				if(isanimal(M))
 					qdel(M)
+				else
+					M.gib()
 
 
 		else //non-living mobs shouldn't be affected by shuttles, which is why this is an else


### PR DESCRIPTION
## About The Pull Request

Shuttle landing now deletes simple mobs entirely instead of gibbing them, and only gibs carbons to prevent total RR.
May be a little hacky but I can't think of another solution

## Why It's Good For The Game

Ships squishing mobs is funny the first few times but can get tiring quickly.

## Changelog
:cl:
tweak: Shuttle landing now deletes simple mobs
/:cl: