### PR TITLE
Prevent duplicate names for vents and scrubbers

### DIFF
--- a/code/__HELPERS/sequential_id.dm
+++ b/code/__HELPERS/sequential_id.dm
@@ -1,0 +1,44 @@
+// Algorithm for allocating names for vents/scrubbers (you may use it for other purposes as long as it has same interface)
+//
+// By "name" here I mean sequential number of the scrubber/vent in the area
+// I keep track of all used names in the area with an array `names`
+// Array index means name, array value means id_tag
+// If value is null, the name is not used
+//
+// # So for example area has vents #1, #2 and #4, then array of names looks like
+// ["tag1", "tag2", null, "tag4"]
+//
+// When you allocate new name for id_tag, you scan array for free slot,
+// assign id_tag to that slot and return its index
+// if all slots occupied, you add value to the end of array
+//
+// When you deallocate name for id_tag, you find id_tag in the array
+// and set value of that element to null (or to some other meaningless value for id_tag)
+
+/**
+	Make new sequential number for this id_tag or reuse one of the free ones
+*/
+/proc/allocate_nameid(list/names, id_tag)
+	for (var/i in 1 to length(names))
+		if (names[i] == id_tag)
+			// this id_tag already has a name
+			return i
+		if (names[i] == null)
+			// found empty slot in the array
+			names[i] = id_tag
+			return i
+	// end of array, add new value to the end
+	names += id_tag
+	return length(names)
+
+/**
+	Free the previously used sequential number for vent/scrubber so it can be used again
+*/
+/proc/deallocate_nameid(list/names, id_tag)
+	var/i = names.Find(id_tag)
+	if (i == 0)
+		// name for this tag was never allocated
+		return FALSE
+	// erase id_tag value
+	names[i] = null
+	return TRUE

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -209,10 +209,15 @@
 //all air alarms in area are connected via magic
 /area
 	var/list/air_vent_names = list()
-	var/list/air_scrub_names = list()
+	var/list/air_vent_ids = list()
 	var/list/air_vent_info = list()
+
+	var/list/air_scrub_names = list()
+	var/list/air_scrub_ids = list()
 	var/list/air_scrub_info = list()
+
 	var/list/dp_air_vent_names = list()
+	var/list/dp_air_vent_ids = list()
 	var/list/dp_air_vent_info = list()
 
 /obj/machinery/airalarm/New(loc, ndir, nbuild)
@@ -323,7 +328,9 @@
 
 	if(!locked || user.has_unlimited_silicon_privilege)
 		data["vents"] = list()
-		for(var/id_tag in A.air_vent_names)
+		for(var/id_tag in A.air_vent_ids)
+			if (id_tag == null)
+				continue
 			var/long_name = A.air_vent_names[id_tag]
 			var/list/info = A.air_vent_info[id_tag]
 			if(!info || info["frequency"] != frequency || info["has_aac"])
@@ -342,7 +349,9 @@
 					"intdefault"= (info["internal"] == 0)
 				))
 		data["scrubbers"] = list()
-		for(var/id_tag in A.air_scrub_names)
+		for(var/id_tag in A.air_scrub_ids)
+			if (id_tag == null)
+				continue
 			var/long_name = A.air_scrub_names[id_tag]
 			var/list/info = A.air_scrub_info[id_tag]
 			if(!info || info["frequency"] != frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -51,6 +51,7 @@
 	if (A)
 		A.dp_air_vent_names -= id_tag
 		A.dp_air_vent_info -= id_tag
+		deallocate_nameid(A.dp_air_vent_ids, id_tag)
 	if(aac)
 		aac.vents -= src
 
@@ -152,7 +153,8 @@
 
 	var/area/A = get_area(src)
 	if(!A.dp_air_vent_names[id_tag])
-		name = "\improper [A.name] dual-port air vent #[A.dp_air_vent_names.len + 1]"
+		var/nameid = allocate_nameid(A.dp_air_vent_ids, id_tag)
+		name = "\improper [A.name] dual-port air vent #[nameid]"
 		A.dp_air_vent_names[id_tag] = name
 	A.dp_air_vent_info[id_tag] = signal.data
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -49,6 +49,7 @@
 	if (A)
 		A.air_vent_names -= id_tag
 		A.air_vent_info -= id_tag
+		deallocate_nameid(A.air_vent_ids, id_tag)
 	if(aac)
 		aac.vents -= src
 
@@ -163,7 +164,8 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_vent_names[id_tag])
-		name = "\improper [A.name] vent pump #[A.air_vent_names.len + 1]"
+		var/nameid = allocate_nameid(A.air_vent_ids, id_tag)
+		name = "\improper [A.name] vent pump #[nameid]"
 		A.air_vent_names[id_tag] = name
 	A.air_vent_info[id_tag] = signal.data
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -42,6 +42,7 @@
 	if (A)
 		A.air_scrub_names -= id_tag
 		A.air_scrub_info -= id_tag
+		deallocate_nameid(A.air_scrub_ids, id_tag)
 
 	SSradio.remove_object(src,frequency)
 	radio_connection = null
@@ -115,7 +116,8 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_scrub_names[id_tag])
-		name = "\improper [A.name] air scrubber #[A.air_scrub_names.len + 1]"
+		var/nameid = allocate_nameid(A.air_scrub_ids, id_tag)
+		name = "\improper [A.name] air scrubber #[nameid]"
 		A.air_scrub_names[id_tag] = name
 
 	A.air_scrub_info[id_tag] = signal.data

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -185,6 +185,7 @@
 #include "code\__HELPERS\records.dm"
 #include "code\__HELPERS\roundend.dm"
 #include "code\__HELPERS\sanitize_values.dm"
+#include "code\__HELPERS\sequential_id.dm"
 #include "code\__HELPERS\shell.dm"
 #include "code\__HELPERS\stat_helpers.dm"
 #include "code\__HELPERS\stat_tracking.dm"


### PR DESCRIPTION
Makes scrubbers and vents re-use sequential ids for their names. No longer you will have two vents #9 in the area.

## About The Pull Request

Currently game allocates names for new vents/scrubbers based on how many there are scrubbers in the area. New index for that name will be `names.len + 1`. Assume you have 9 scrubbers in the area. So if you remove, say scrubber #2 and then re-wrench it, it will be named scrubber #9 and have same name as your existing scrubber #9.
On /tg/ this issue was fixed 2 years ago by making scrubbers/vents have random alphanumeric name, which is pain to deal with (original idea was to re-use ids, but then it went south during the conversation in PR)
Here I'm using algorithm for allocating names that was originally proposed in https://github.com/tgstation/tgstation/pull/52398 by myself.

Benefit of this approach is that if you unwrench one vent/scrubber and wrench it back, it will have same name as before.

## Why It's Good For The Game

Makes construction of atmos systems less painful.

## Changelog
:cl:
fix: Prevent duplicate names for vents and scrubbers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
