### PR TITLE
Minor(?) rewrites to lighting code

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -13,12 +13,6 @@ SUBSYSTEM_DEF(lighting)
 
 /datum/controller/subsystem/lighting/Initialize(timeofday)
 	if(!initialized)
-		if (CONFIG_GET(flag/starlight))
-			for(var/I in GLOB.sortedAreas)
-				var/area/A = I
-				if (A.dynamic_lighting == DYNAMIC_LIGHTING_IFSTARLIGHT)
-					A.luminosity = 0
-
 		create_all_lighting_objects()
 		initialized = TRUE
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -152,20 +152,19 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/Initialize()
 	icon_state = ""
 
-	if(requires_power)
-		luminosity = 0
-	else
+	if(dynamic_lighting == DYNAMIC_LIGHTING_IFSTARLIGHT)
+		dynamic_lighting = CONFIG_GET(flag/starlight) ? DYNAMIC_LIGHTING_ENABLED : DYNAMIC_LIGHTING_DISABLED
+
+	if(!requires_power)
 		power_light = TRUE
 		power_equip = TRUE
 		power_environ = TRUE
 
 		if(dynamic_lighting == DYNAMIC_LIGHTING_FORCED)
 			dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
-			luminosity = 0
-		else if(dynamic_lighting != DYNAMIC_LIGHTING_IFSTARLIGHT)
+		else
 			dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
-	if(dynamic_lighting == DYNAMIC_LIGHTING_IFSTARLIGHT)
-		dynamic_lighting = CONFIG_GET(flag/starlight) ? DYNAMIC_LIGHTING_ENABLED : DYNAMIC_LIGHTING_DISABLED
+			luminosity = TRUE
 
 	. = ..()
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -171,7 +171,6 @@
 
 /area/shuttle/escape/meteor
 	name = "\proper a meteor with engines strapped to it"
-	luminosity = NONE
 
 /area/shuttle/transport
 	name = "Transport Shuttle"

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -1,5 +1,5 @@
 /area
-	luminosity           = TRUE
+	luminosity           = FALSE // This used to be TRUE; it was changed to FALSE, as most areas had it reset to FALSE anyway.
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 
 /area/proc/set_dynamic_lighting(var/new_dynamic_lighting = DYNAMIC_LIGHTING_ENABLED)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -28,9 +28,6 @@
 	myturf.lighting_object = src
 	myturf.luminosity = 0
 
-	for(var/turf/open/space/S in RANGE_TURFS(1, src)) //RANGE_TURFS is in code\__HELPERS\game.dm
-		S.update_starlight()
-
 	needs_update = TRUE
 	SSlighting.objects_queue += src
 

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -1,6 +1,7 @@
 /proc/create_all_lighting_objects()
 	for(var/turf/T in world)
-		if(IS_DYNAMIC_LIGHTING(T) && IS_DYNAMIC_LIGHTING(T.loc))
+		var/area/A = T.loc
+		if(IS_DYNAMIC_LIGHTING(T) && IS_DYNAMIC_LIGHTING(A))
 			new/atom/movable/lighting_object(T)
 
 		// Initial starlight updates used to be done in lighting_object initialize,

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -9,5 +9,9 @@
 				continue
 
 			new/atom/movable/lighting_object(T)
+			// Initial starlight updates used to be done in lighting_object initialize,
+			// but doing them here means ChangeTurf doesn't occasionally recalculate starlight twice.
+			for(var/turf/open/space/S in RANGE_TURFS(1, T))
+				S.update_starlight()
 			CHECK_TICK
 		CHECK_TICK

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -1,17 +1,11 @@
 /proc/create_all_lighting_objects()
-	for(var/area/A in world)
-		if(!IS_DYNAMIC_LIGHTING(A))
-			continue
-
-		for(var/turf/T in A)
-
-			if(!IS_DYNAMIC_LIGHTING(T))
-				continue
-
+	for(var/turf/T in world)
+		if(IS_DYNAMIC_LIGHTING(T) && IS_DYNAMIC_LIGHTING(T.loc))
 			new/atom/movable/lighting_object(T)
-			// Initial starlight updates used to be done in lighting_object initialize,
-			// but doing them here means ChangeTurf doesn't occasionally recalculate starlight twice.
-			for(var/turf/open/space/S in RANGE_TURFS(1, T))
-				S.update_starlight()
-			CHECK_TICK
+
+		// Initial starlight updates used to be done in lighting_object initialize,
+		// but doing them here means ChangeTurf doesn't occasionally recalculate starlight twice.
+		if(isspaceturf(T))
+			var/turf/open/space/S = T
+			S.update_starlight()
 		CHECK_TICK

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -99,7 +99,7 @@
 /turf/proc/change_area(area/old_area, area/new_area)
 	if(SSlighting.initialized)
 		if (new_area.dynamic_lighting != old_area.dynamic_lighting)
-			if (new_area.dynamic_lighting)
+			if (IS_DYNAMIC_LIGHTING(src))
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()


### PR DESCRIPTION
## About The Pull Request

This PR does three things.

First, it makes the code that determines area luminosity and lighting mode a little bit more comprehensible. I don't think I changed any behavior (especially since we don't use any areas with DYNAMIC_LIGHTING_IFSTARLIGHT anymore, though if we DID, it'd fix a minor bug), I just wanted to make it easier to read.

Second, it stops /turf/change_area() from adding dynamic lighting overlays when the turf isn't supposed to be dynamically lit. I'm not sure if this caused any noticeable problems, but it contributed to some performance inefficiency when generating planets.

Third, it moves one of the code's two starlight updates into /create_all_lighting_objects() (run by SSlighting) and out of /atom/movable/lighting_object/Initialize(). This means there may be slightly more light_source datums created in certain situations and makes init times 1-3 seconds slower locally (depending on whether the starlight config flag is set), but it should also speed up planet generation slightly as ChangeTurf() now calculates starlight only once instead of twice when transitioning from a space turf to a non-space turf. I wouldn't expect a huge change, though; I can do some timing locally if requested.

## Why It's Good For The Game

Hopefully speeds up planet generation and improves code quality somewhat. Fingers crossed.

## Changelog
:cl:
refactor: Minor changes to some area luminosity and starlight code to improve code quality and performance.
/:cl:
