### PR TITLE
Makes TEG not break when you sneeze on it (fix integrity_falure values)

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -9,7 +9,7 @@
 	icon = 'icons/obj/machines/thermoelectric.dmi'
 	icon_state = "circ-unassembled-0"
 	density = TRUE
-	integrity_failure = 75
+	integrity_failure = 0.375
 	move_resist = MOVE_RESIST_DEFAULT //can be pushed around like a regular machine
 
 	var/active = FALSE

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -5,7 +5,7 @@
 	icon_state = "teg-unassembled"
 	density = TRUE
 	use_power = NO_POWER_USE
-	integrity_failure = 75
+	integrity_failure = 0.375
 
 	var/obj/machinery/atmospherics/components/binary/circulator/cold_circ
 	var/obj/machinery/atmospherics/components/binary/circulator/hot_circ


### PR DESCRIPTION
## About The Pull Request

I was playing with TEG the other day and it broke when I accidentally hit it with multitool.
It turns out `integrity_failure` were set incorrectly (it should be a number between 0 and 1)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes are good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Makes TEG not break when you sneeze on it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
