### PR TITLE
Removes Masinyane from Purchase

### DIFF
--- a/_maps/configs/masinyane.json
+++ b/_maps/configs/masinyane.json
@@ -5,7 +5,6 @@
 	"namelists": ["MYTHOLOGICAL", "NATURAL"],
 	"map_path": "_maps/shuttles/shiptest/masinyane.dmm",
 	"map_id": "masinyane",
-	"roundstart": true,
 	"job_slots": {
 		"Private Ship Owner": {
 			"outfit": "/datum/outfit/job/captain/independent/owner",
@@ -20,6 +19,5 @@
 			"outfit": "/datum/outfit/job/assistant/independent/crewmatefancy",
 			"slots": 1
 		}
-	},
-	"cost": 7000
+	}
 }


### PR DESCRIPTION
removes masinyane from roundstart (why was it even a roundstart spawn?) and purchase

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the Masinyane from both purchase and roundstart spawning, making it an admin-only ship.

## Why It's Good For The Game
![masinpill](https://user-images.githubusercontent.com/60533805/179327190-d5f58fc5-2a2b-4729-a0e7-90e77b97044f.png)
Pill syndrome at its finest.

## Changelog
:cl:
del: Removed Masinyane from roundstart spawning and purchase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
