### PR TITLE
adjusts reaction priorities to stop bugs

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -343,7 +343,7 @@
 			air.set_temperature((temperature*old_heat_capacity + energy_released)/new_heat_capacity)
 
 /datum/gas_reaction/genericfire
-	priority = -3 // very last reaction
+	priority = -4 // very last reaction
 	name = "Combustion"
 	id = "genericfire"
 
@@ -586,7 +586,7 @@
 		return REACTING
 
 /datum/gas_reaction/nitrylformation //The formation of nitryl. Endothermic. Requires N2O as a catalyst.
-	priority = 3
+	priority = 4
 	name = "Nitryl formation"
 	id = "nitrylformation"
 
@@ -631,7 +631,7 @@
 	return ..()
 
 /datum/gas_reaction/bzformation //Formation of BZ by combining plasma and tritium at low pressures. Exothermic.
-	priority = 4
+	priority = 5
 	name = "BZ Gas formation"
 	id = "bzformation"
 
@@ -676,7 +676,7 @@
 	return ..()
 
 /datum/gas_reaction/freonformation
-	priority = 5
+	priority = 6
 	name = "Freon formation"
 	id = "freonformation"
 
@@ -707,7 +707,7 @@
 		return REACTING
 
 /datum/gas_reaction/stimformation //Stimulum formation follows a strange pattern of how effective it will be at a given temperature, having some multiple peaks and some large dropoffs. Exo and endo thermic.
-	priority = 5
+	priority = 7
 	name = "Stimulum formation"
 	id = "stimformation"
 
@@ -755,7 +755,7 @@
 	return ..()
 
 /datum/gas_reaction/nobliumformation //Hyper-Noblium formation is extrememly endothermic, but requires high temperatures to start. Due to its high mass, hyper-nobelium uses large amounts of nitrogen and tritium. BZ can be used as a catalyst to make it less endothermic.
-	priority = 6
+	priority = 8
 	name = "Hyper-Noblium condensation"
 	id = "nobformation"
 
@@ -793,7 +793,7 @@
 	return ..()
 
 /datum/gas_reaction/stim_ball
-	priority = 7
+	priority = 9
 	name ="Stimulum Energy Ball"
 	id = "stimball"
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -30,7 +30,7 @@
 	var/list/min_requirements
 	var/list/max_requirements
 	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
-	var/priority = 100 //lower numbers are checked/react later than higher numbers. if two reactions have the same priority they may happen in either order
+	var/priority = 100 //lower numbers are checked/react later than higher numbers. Should be distinct per-reaction; auxmos breaks when two reactions have the same priority.
 	var/name = "reaction"
 	var/id = "r"
 


### PR DESCRIPTION
## About The Pull Request

lavaland planets have been mass-producing nitryl for a while. turns out auxmos breaks when you have two reactions with the same priority. they overwrite each other. this PR ensures there are no reaction priority collisions

## Why It's Good For The Game

makes reactions act how they should, stops lavaland planets from sometimes ending up all brown and ugly

## Changelog

:cl:
fix: Nitryl now only forms when it should.
/:cl:
