### PR TITLE
Default Ship Limit & Example Config Update

### DIFF
--- a/_maps/example_ship_config.json
+++ b/_maps/example_ship_config.json
@@ -5,6 +5,8 @@
 	"prefix": "STSV",
 	"namelists": ["GENERAL", "SPACE", "FANTASY", "WEAPONS"],
 	"map_path": "_maps/shuttles/shiptest/null.dmm",
+	"map_id": "null",
+	"limit": 2,
 	"job_slots": {
 		"The First Slot will always be the 'captain' that the purchaser becomes.": {
 			"outfit": "/datum/outfit/job/captain",

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,7 +11,7 @@
 	var/port_x_offset
 	var/port_y_offset
 
-	var/limit
+	var/limit = 2
 	var/cost
 	var/short_name
 	var/list/job_slots = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sets a standard ship limit of 2 to a class and updates the example ship config json to include the limit line. This means that ships without a different limit set in their config will be capped to 2 per round by default. I chose 2 simply because it's a pretty commonsense limit- round population isn't really high enough to demand a higher cap than that, and we have so many classes available that something should always be available. Also helps discourage people from just spawning a new example of a ship class that's already in game but understaffed.

## Why It's Good For The Game

imposes a commonsense limit preventing overpopulation of older ships that haven't been updated yet, and actually makes the example config accurate for mappers, good all around

## Changelog

:cl:
config: Ships are now limited to 2 per class by default
config: Updated example ship config with limit variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
