### PR TITLE
Disables the Rube Goldberg

### DIFF
--- a/_maps/configs/engineeringmess.json
+++ b/_maps/configs/engineeringmess.json
@@ -33,6 +33,5 @@
 			"outfit": "/datum/outfit/job/miner",
 			"slots": 2
 		}
-	},
-	"cost": 750
+	}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On request from the original mapper, removes the Rube Goldberg from the purchase list until it gets remapped. Until then, it remains only as an admin spawn.

## Why It's Good For The Game

Mapper asked for it and the Rube is, frankly, a disaster in a bad way. It needs a lot of reworking to avoid a lot of the jank and occasional server-killing bugs it tends to bring into rounds

## Changelog

:cl:
del: Removed Rube Goldberg from the purchase list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
