### PR TITLE
Removes golem mutation toxin, readds the IPC mutation toxin recipe

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -631,14 +631,6 @@
 		return TRUE
 	return ..()
 
-/datum/reagent/mutationtoxin/golem
-	name = "Golem Mutation Toxin"
-	description = "A crystal toxin."
-	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/golem/random
-	process_flags = ORGANIC | SYNTHETIC //WS Edit - IPCs
-	taste_description = "rocks"
-
 /datum/reagent/mutationtoxin/abductor
 	name = "Abductor Mutation Toxin"
 	description = "An alien toxin."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -627,10 +627,6 @@
 	results = list(/datum/reagent/mutationtoxin/pod = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/plantnutriment/eznutriment = 10)
 
-/datum/chemical_reaction/mutationtoxin/golem
-	results = list(/datum/reagent/mutationtoxin/golem = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/liquidadamantine = 20)
-
 /datum/chemical_reaction/mutationtoxin/abductor
 	results = list(/datum/reagent/mutationtoxin/abductor = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/medicine/morphine = 10, /datum/reagent/toxin/mutetoxin = 10)
@@ -642,6 +638,10 @@
 /datum/chemical_reaction/mutationtoxin/squid
 	results = list(/datum/reagent/mutationtoxin/squid = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/consumable/sodiumchloride = 10, /datum/reagent/water = 20)
+
+/datum/chemical_reaction/mutationtoxin/ipc
+	results = list(/datum/reagent/mutationtoxin/ipc = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/teslium = 20)
 
 //////////////Mutatuion toxins made out of advanced toxin/////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes golem mutation toxin, which shouldn't exist
Re-adds the IPC mutation toxin recipe, which should exist but got removed in the betterlimbs port for an unspecified reason which was not explicitly stated in the PR or its original port.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The reason I was given for why IPC mutation toxin didn't exist was because IPCs could not process mutation toxins and thus could not be turned back if they had been mutated into an IPC in the first place. This was tested and proven wrong.  IPC mutation toxin would reasonably be the only way to create an IPC in-game without admin intervention, and should exist for that reason.

On the other hand, despite the above reasoning, golem mutation toxin still existed and is the actual mutation that you cannot reverse, as golems cannot process mutation toxins. This removes that and prevents such a situation from ever happening.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: IPC mutation toxin recipe
del: Golem mutation toxin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

