### PR TITLE
[SERVER ISSUE] Resolves recent perf issues

### DIFF
--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -157,9 +157,10 @@
 			token.icon_state = "strange_event"
 			token.color = null
 
-#ifdef FULL_INIT //Initialising planets roundstart isn't NECESSARY, but is very nice in production. Takes a long time to load, though.
-	load_level() //Load the level whenever it's randomised
-#endif
+// - SERVER ISSUE: LOADING ALL PLANETS AT ROUND START KILLS PERFORMANCE BEYOND WHAT IS REASONABLE. OPTIMIZE SSMOBS IF YOU WANT THIS BACK
+// #ifdef FULL_INIT //Initialising planets roundstart isn't NECESSARY, but is very nice in production. Takes a long time to load, though.
+// 	load_level() //Load the level whenever it's randomised
+// #endif
 
 	if(!preserve_level)
 		token.desc += "It may not still be here if you leave it."


### PR DESCRIPTION
Resolves server performance issues as of late by no longer loading every planet in the overmap at round start.
This caused all planets and their terrain to load in, which also meant all of their mobs, atmos, etc, would also load in; despite no players being there to interact.