### PR TITLE
nerfs manly dorf's healing powers

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -734,7 +734,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/carbon/human/badlands_chugs)
 	if(!istype(badlands_chugs))
 		return
-	if(!HAS_TRAIT(badlands_chugs, TRAIT_DWARF) && !HAS_TRAIT(badlands_chugs, TRAIT_ALCOHOL_TOLERANCE))
+	if(!HAS_TRAIT(badlands_chugs, TRAIT_DWARF))
 		return
 	to_chat(badlands_chugs, "<span class='notice'>Now THAT is MANLY!</span>")
 	dorf_mode = TRUE

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -731,24 +731,23 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A manly concoction made from Ale and Beer. Intended for true men only."
 	var/dorf_mode
 
-/datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/M)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(HAS_TRAIT(H, TRAIT_DWARF) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE))
-			// WS Edit Start - Dorfisms
-			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
-			dorf_mode = TRUE
-			if(H.dna && H.dna.check_mutation(DORFISM))
-				boozepwr = 120 //lifeblood of dwarves (boozepower = nutrition)
-				quality = DRINK_FANTASTIC //dorf drink for dorfs to drink
-			else
-				boozepwr = 5 //We've had worse in the mines
-			// WS Edit End - Dorfisms
+/datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/carbon/human/badlands_chugs)
+	if(!istype(badlands_chugs))
+		return
+	if(!HAS_TRAIT(badlands_chugs, TRAIT_DWARF) && !HAS_TRAIT(badlands_chugs, TRAIT_ALCOHOL_TOLERANCE))
+		return
+	to_chat(badlands_chugs, "<span class='notice'>Now THAT is MANLY!</span>")
+	dorf_mode = TRUE
+	if(badlands_chugs.dna?.check_mutation(DORFISM))
+		boozepwr = 120 //lifeblood of dwarves (boozepower = nutrition)
+		quality = DRINK_FANTASTIC //dorf drink for dorfs to drink
+	else
+		boozepwr = 5 //We've had worse in the mines
 
-/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/consumer)
 	if(dorf_mode)
-		M.adjustBruteLoss(-2)
-		M.adjustFireLoss(-2)
+		consumer.adjustBruteLoss(-0.5*REM)
+		consumer.adjustFireLoss(-0.5*REM)
 	return ..()
 
 /datum/reagent/consumable/ethanol/longislandicedtea


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
manly dorf no longer heals you if you have alcohol tolerance
manly dorf now heals 0.5 instead of 2

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
for a relatively simple drink, and a relatively innocent quirk, this really is a powerful heal (4 times stronger than kelotane which is an actual burn medicine, and it heals brute too) thats really secret
also dwarves are a roundstart race so

## Changelog

:cl:
balance: nerfs manly dorf's healing powers, it no longer works on people with alcohol tolerance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
