### PR TITLE
Adds E-fuels, oh and a few other elzu changes relating to blood and APCs-unstale edition!

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -720,8 +720,15 @@
 	desc = "Unleash the ape!"
 	icon_state = "monkey_energy"
 	item_state = "monkey_energy"
-	list_reagents = list(/datum/reagent/consumable/monkey_energy = 50)
+	list_reagents = list(/datum/reagent/consumable/monkey_energy = 40, /datum/reagent/consumable/electrolytes = 10)
 	foodtype = SUGAR | JUNKFOOD
+
+/obj/item/reagent_containers/food/drinks/soda_cans/efuel
+	name = "E-Fuel"
+	desc = "Shocking for the Elzu!"
+	icon_state = "monkey_energy"
+	item_state = "monkey_energy"
+	list_reagents = list(,/datum/reagent/consumable/electrolytes = 50)
 
 /obj/item/reagent_containers/food/drinks/soda_cans/air
 	name = "canned air"

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -728,7 +728,7 @@
 	desc = "Shocking for the Elzu!"
 	icon_state = "monkey_energy"
 	item_state = "monkey_energy"
-	list_reagents = list(,/datum/reagent/consumable/electrolytes = 50)
+	list_reagents = list(/datum/reagent/consumable/electrolytes = 50)
 
 /obj/item/reagent_containers/food/drinks/soda_cans/air
 	name = "canned air"

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -12,6 +12,7 @@
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish
+	exotic_blood = /datum/reagent/consumable/liquidelectricity
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(DYNCOLORS, AGENDER, HAIR, FACEHAIR)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -823,7 +823,7 @@
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
 		if((H.a_intent == INTENT_HARM) && (E.drain_time < world.time))
-			if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
+			if(cell.charge <= (cell.maxcharge / 20)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
 				to_chat(H, "<span class='warning'>The APC's syphon safeties prevent you from draining power!</span>")
 				return
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -834,7 +834,7 @@
 			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
 			while(do_after(user, APC_DRAIN_TIME, target = src)) //WS edit
 				E.drain_time = world.time + APC_DRAIN_TIME //WS edit
-				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
+				if(cell.charge <= (cell.maxcharge / 20) || (stomach.crystal_charge > charge_limit))
 					return
 				if(istype(stomach))
 					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -720,7 +720,7 @@
 
 /datum/reagent/consumable/liquidelectricity
 	name = "Liquid Electricity"
-	description = "The blood of Elzuose, and the stuff that keeps them going. Great for them, horrid for anyone else."
+	description = "The blood of elzuosa, and the stuff that keeps them going. Great for them, horrid for anyone else."
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#97ee63"
 	taste_description = "pure electricity"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -733,7 +733,7 @@
 
 /datum/reagent/consumable/electrolytes
 	name = "Electrolytes"
-	description = "its what plants crave, and lightbulbs"
+	description = "It's what crystal-plant-dragons crave."
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#8effdd"
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -720,23 +720,29 @@
 
 /datum/reagent/consumable/liquidelectricity
 	name = "Liquid Electricity"
-	description = "The blood of Ethereals, and the stuff that keeps them going. Great for them, horrid for anyone else."
+	description = "The blood of Elzuose, and the stuff that keeps them going. Great for them, horrid for anyone else."
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#97ee63"
 	taste_description = "pure electricity"
-
-/datum/reagent/consumable/liquidelectricity/expose_mob(mob/living/M, method=TOUCH, reac_volume) //can't be on life because of the way blood works.
-	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))
-		var/mob/living/carbon/C = M
-		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
-		if(istype(stomach))
-			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)	  //WS Edit -- Ethereal Charge Scaling
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))
 		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
+
+/datum/reagent/consumable/electrolytes
+	name = "Electrolytes"
+	description = "its what plants crave, and lightbulbs"
+	nutriment_factor = 5 * REAGENTS_METABOLISM
+	color = "#8effdd"
+
+/datum/reagent/consumable/electrolytes/expose_mob(mob/living/M, method=TOUCH, reac_volume)
+	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))
+		var/mob/living/carbon/C = M
+		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
+		if(istype(stomach))
+			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)	  //WS Edit -- Ethereal Charge Scaling
 
 /datum/reagent/consumable/astrotame
 	name = "Astrotame"

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -14,8 +14,8 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry = 10,
-		/obj/item/reagent_containers/food/drinks/waterbottle = 10)
-		/obj/item/reagent_containers/food/drinks/soda_cans/efuel
+		/obj/item/reagent_containers/food/drinks/waterbottle = 10
+		/obj/item/reagent_containers/food/drinks/soda_cans/efuel = 5)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko = 6,
 		/obj/item/reagent_containers/food/drinks/soda_cans/shamblers = 6)

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -15,6 +15,7 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry = 10,
 		/obj/item/reagent_containers/food/drinks/waterbottle = 10)
+		/obj/item/reagent_containers/food/drinks/soda_cans/efuel
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko = 6,
 		/obj/item/reagent_containers/food/drinks/soda_cans/shamblers = 6)

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -14,7 +14,7 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry = 10,
-		/obj/item/reagent_containers/food/drinks/waterbottle = 10
+		/obj/item/reagent_containers/food/drinks/waterbottle = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/efuel = 5)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko = 6,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes some stuff for elzu, making it so that they can drain more power from apcs, and adds the NEW AND SHOCKING E-Fuel, which charges them!, also adds their blood back

## Why It's Good For The Game

![Discord_1sxh7XvtzU](https://user-images.githubusercontent.com/30062054/181794876-4580c9e0-2079-4756-9e76-c2f0f61c040e.png)

## Changelog

:cl:
add: E-Fuel
tweak: elzu now need their own blood now!!
tweak: elzu can now drain more power from APCs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
