### PR TITLE
Allows people to be buckled to operating tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -575,7 +575,7 @@
 	canSmoothWith = null
 	can_buckle = 1
 	buckle_lying = NO_BUCKLE_LYING
-	buckle_requires_restraints = TRUE
+	buckle_requires_restraints = FALSE
 	can_flip = FALSE
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I really do not like how scuffed it is to get yourself onto an op table for a doctor.
now it encourages doctors to use surgery tables over (stasis) beds due to the fact it speeds up simple surgeries like tend wounds, making their job a little quicker.
Alongside the fact it's a /TG/ parity that many people would like.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A light amount of parity with /TG/ is always a good thing; we shouldn't mirror the entire system but something as simple as this will clear up a few gripes about our current medical system.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: you can now buckle others (or yourself) to operating tables, making them much more space-OSHA approved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
