### PR TITLE
navigationally challenged is no longer auto-applied to new players

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -48,7 +48,3 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			badquirk = TRUE
 	if(badquirk)
 		cli.prefs.save_character()
-
-	// Assign wayfinding pinpointer granting quirk if they're new
-	if(cli.get_exp_living(TRUE) < EXP_ASSIGN_WAYFINDER && !user.has_quirk(/datum/quirk/needswayfinder))
-		user.add_quirk(/datum/quirk/needswayfinder, TRUE)


### PR DESCRIPTION
## About The Pull Request

i would remove the quirk outright since it's downright useless here sans a few ships but i'm making this PR to fix a different issue, namely the `to_chat` runtimes every time you spawn in on a ship in localhost

## Why It's Good For The Game

fixes a runtime by removing the thing that caused runtimes

## Changelog

:cl:
del: navigationally challenged is no longer automatically applied to newer players
/:cl: