### PR TITLE
Adds E-Cigars to loadout options

### DIFF
--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -22,6 +22,10 @@
 	display_name = "vape"
 	path = /obj/item/clothing/mask/vape
 
+/datum/gear/ecigar
+	display_name = "e-cigar"
+	path = /obj/item/clothing/mask/vape/cigar
+
 /datum/gear/bandana
 	display_name = "bandana, red"
 	path = /obj/item/clothing/mask/bandana/red


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes e-cigars available in loadouts as a general item. they're normally available by hacking a cigarette machine (just like the normal vape) so it's not like they're extra special or anything.

## Why It's Good For The Game

accessory loadout options are always nice

## Changelog

:cl:
add: e-cigars are now available in loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
