### PR TITLE
removes an empty to_chat proc from hydrotrays

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -347,7 +347,6 @@
 		to_chat(user, "<span class='warning'>It's filled with weeds!</span>")
 	if(pestlevel >= 5)
 		to_chat(user, "<span class='warning'>It's filled with tiny worms!</span>")
-	to_chat(user, "" )
 
 
 


### PR DESCRIPTION
## About The Pull Request

this removes an empty `to_chat` proc from hydroponics trays that i cannot discern the purpose of.

## Why It's Good For The Game

yes

## Changelog

no player-facing changes
