### PR TITLE
The Hindenburg(Balloon Alerts)

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -133,6 +133,9 @@
 
 #define RUNECHAT_PLANE 20
 
+/// Plane for balloon text (text that fades up)
+#define BALLOON_CHAT_PLANE 21
+
 //HUD layer defines
 
 #define FULLSCREEN_PLANE 31

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -331,6 +331,10 @@ block( \
 	O.screen_loc = screen_loc
 	return O
 
+/// Removes an image from a client's `.images`. Useful as a callback.
+/proc/remove_image_from_client(image/image, client/remove_from)
+	remove_from?.images -= image
+
 /proc/remove_images_from_clients(image/I, list/show_to)
 	for(var/client/C in show_to)
 		C.images -= I

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -153,7 +153,7 @@
 /proc/tkMaxRangeCheck(mob/user, atom/target)
 	var/d = get_dist(user, target)
 	if(d > TK_MAXRANGE)
-		to_chat(user, "<span class='warning'>Your mind won't reach that far.</span>")
+		user.balloon_alert(user, "can't reach that far!")
 		return
 	return TRUE
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -21,6 +21,7 @@
 /// Macro from Lummox used to get height from a MeasureText proc
 #define WXH_TO_HEIGHT(x)			text2num(copytext(x, findtextEx(x, "x") + 1))
 
+#define MAPTEXT(text) {"<span class='maptext'>[##text]</span>"}//tg's maptext define.
 /**
  * # Chat Message Overlay
  *

--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -52,10 +52,11 @@
 
 		deploy_location = get_step(user, user.dir) //Gets spawn location for thing_to_be_deployed if there is a user
 		if(deploy_location.is_blocked_turf(TRUE))
-			to_chat(user, "<span class='warning'>There's insufficient room to deploy here!</span>")
+			source.balloon_alert(user, "there's no room to deploy here.")
 			return
 		new_direction = user.dir //Gets the direction for thing_to_be_deployed if there is a user
-		to_chat(user, "<span class='notice'>You start deploying the [parent]...</span>")
+		to_chat(user, "<span class='notice'>You start deploying the [parent].</span>")
+		source.balloon_alert(user, "deploying...")
 		playsound(source, 'sound/items/ratchet.ogg', 50, TRUE)
 		if(!do_after(user, deploy_time))
 			return

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -72,11 +72,10 @@
 		if(last_act + (40 * I.toolspeed) > world.time)//prevents message spam
 			return
 		last_act = world.time
-		to_chat(user, "<span class='notice'>You start picking...</span>")
+		balloon_alert(user, "digging...")
 
 		if(I.use_tool(src, user, 40, volume=50))
 			if(ismineralturf(src))
-				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
 				gets_drilled(user, TRUE)
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 	else
@@ -109,7 +108,7 @@
 	..()
 
 /turf/closed/mineral/attack_alien(mob/living/carbon/alien/M)
-	to_chat(M, "<span class='notice'>You start digging into the rock...</span>")
+	balloon_alert(user, "digging...")
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE)
 	if(do_after(M, 40, target = src))
 		to_chat(M, "<span class='notice'>You tunnel into the rock.</span>")

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -108,7 +108,7 @@
 	..()
 
 /turf/closed/mineral/attack_alien(mob/living/carbon/alien/M)
-	balloon_alert(user, "digging...")
+	balloon_alert(M, "digging...")
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE)
 	if(do_after(M, 40, target = src))
 		to_chat(M, "<span class='notice'>You tunnel into the rock.</span>")

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -73,7 +73,7 @@
 			if(!isturf(user.loc))
 				return
 
-			baloon_alert(user, "you start digging...")
+			balloon_alert(user, "you start digging...")
 
 			if(W.use_tool(src, user, 40, volume=50))
 				if(!can_dig(user))

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -73,12 +73,11 @@
 			if(!isturf(user.loc))
 				return
 
-			to_chat(user, "<span class='notice'>You start digging...</span>")
+			baloon_alert(user, "you start digging...")
 
 			if(W.use_tool(src, user, 40, volume=50))
 				if(!can_dig(user))
 					return TRUE
-				to_chat(user, "<span class='notice'>You dig a hole.</span>")
 				getDug()
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, W.type)
 				return TRUE

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -1,0 +1,90 @@
+#define BALLOON_TEXT_WIDTH 200
+#define BALLOON_TEXT_SPAWN_TIME (0.2 SECONDS)
+#define BALLOON_TEXT_FADE_TIME (0.1 SECONDS)
+#define BALLOON_TEXT_FULLY_VISIBLE_TIME (0.7 SECONDS)
+#define BALLOON_TEXT_TOTAL_LIFETIME(mult) (BALLOON_TEXT_SPAWN_TIME + BALLOON_TEXT_FULLY_VISIBLE_TIME*mult + BALLOON_TEXT_FADE_TIME)
+/// The increase in duration per character in seconds
+#define BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT (0.05)
+/// The amount of characters needed before this increase takes into effect
+#define BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN 10
+
+/// Creates text that will float from the atom upwards to the viewer.
+/atom/proc/balloon_alert(mob/viewer, text)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	INVOKE_ASYNC(src, .proc/balloon_alert_perform, viewer, text)
+
+/// Create balloon alerts (text that floats up) to everything within range.
+/// Will only display to people who can see.
+/atom/proc/balloon_alert_to_viewers(message, self_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	var/list/hearers = get_hearers_in_view(vision_distance, src)
+	hearers -= ignored_mobs
+
+	for (var/mob/hearer in hearers)
+		if (hearer.is_blind())
+			continue
+
+		balloon_alert(hearer, (hearer == src && self_message) || message)
+
+// Do not use.
+// MeasureText blocks. I have no idea for how long.
+// I would've made the maptext_height update on its own, but I don't know
+// if this would look bad on laggy clients.
+/atom/proc/balloon_alert_perform(mob/viewer, text)
+	var/client/viewer_client = viewer.client
+	if (isnull(viewer_client))
+		return
+
+	var/bound_width = world.icon_size
+	if (ismovable(src))
+		var/atom/movable/movable_source = src
+		bound_width = movable_source.bound_width
+
+	var/image/balloon_alert = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
+	balloon_alert.plane = BALLOON_CHAT_PLANE
+	balloon_alert.alpha = 0
+	balloon_alert.appearance_flags = RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM
+	balloon_alert.maptext = MAPTEXT("<span style='text-align: center; -dm-text-outline: 1px #0005'>[text]</span>")
+	balloon_alert.maptext_x = (BALLOON_TEXT_WIDTH - bound_width) * -0.5
+	balloon_alert.maptext_height = WXH_TO_HEIGHT(viewer_client?.MeasureText(text, null, BALLOON_TEXT_WIDTH))
+	balloon_alert.maptext_width = BALLOON_TEXT_WIDTH
+
+	viewer_client?.images += balloon_alert
+
+	var/duration_mult = 1
+	var/duration_length = length(text) - BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
+
+	if(duration_length > 0)
+		duration_mult += duration_length*BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT
+
+	animate(
+		balloon_alert,
+		pixel_y = world.icon_size * 1.2,
+		time = BALLOON_TEXT_TOTAL_LIFETIME(1),
+		easing = SINE_EASING | EASE_OUT,
+	)
+
+	animate(
+		alpha = 255,
+		time = BALLOON_TEXT_SPAWN_TIME,
+		easing = CUBIC_EASING | EASE_OUT,
+		flags = ANIMATION_PARALLEL,
+	)
+
+	animate(
+		alpha = 0,
+		time = BALLOON_TEXT_FULLY_VISIBLE_TIME*duration_mult,
+		easing = CUBIC_EASING | EASE_IN,
+	)
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_image_from_client, balloon_alert, viewer_client), BALLOON_TEXT_TOTAL_LIFETIME(duration_mult))
+
+#undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
+#undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT
+#undef BALLOON_TEXT_FADE_TIME
+#undef BALLOON_TEXT_FULLY_VISIBLE_TIME
+#undef BALLOON_TEXT_SPAWN_TIME
+#undef BALLOON_TEXT_TOTAL_LIFETIME
+#undef BALLOON_TEXT_WIDTH

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -161,18 +161,23 @@
 		playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 		if(message)
 			if(pointblank)
-				user.visible_message("<span class='danger'>[user] fires [src] point blank at [pbtarget]!</span>", \
-								"<span class='danger'>You fire [src] point blank at [pbtarget]!</span>", \
-								"<span class='hear'>You hear a gunshot!</span>", COMBAT_MESSAGE_RANGE, pbtarget)
+				user.visible_message(
+						span_danger("[user] fires [src] point blank at [pbtarget]!"),
+						span_danger("You fire [src] point blank at [pbtarget]!"),
+						span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+				)
 				to_chat(pbtarget, "<span class='userdanger'>[user] fires [src] point blank at you!</span>")
 				if(pb_knockback > 0 && ismob(pbtarget))
 					var/mob/PBT = pbtarget
 					var/atom/throw_target = get_edge_target_turf(PBT, user.dir)
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else
-				user.visible_message("<span class='danger'>[user] fires [src]!</span>", \
-								"<span class='danger'>You fire [src]!</span>", \
-								"<span class='hear'>You hear a gunshot!</span>", COMBAT_MESSAGE_RANGE)
+				user.visible_message(
+						span_danger("[user] fires [src]!"),
+						blind_message = span_hear("You hear a gunshot!"),
+						vision_distance = COMBAT_MESSAGE_RANGE,
+						ignored_mobs = user
+				)
 
 /obj/item/gun/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -29,6 +29,10 @@
 
 	var/recharge_timerid
 
+/obj/item/gun/energy/recharge/kinetic_accelerator/shoot_with_empty_chamber(mob/living/user)
+	playsound(src, dry_fire_sound, 30, TRUE) //click sound but no to_chat message to cut on spam
+	return
+
 /obj/item/gun/energy/kinetic_accelerator/examine(mob/user)
 	. = ..()
 	if(max_mod_capacity)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -61,18 +61,19 @@
 		spillable = TRUE
 
 	update_icon()
-	. += "<span class='notice'>Currently transferring [amount_per_transfer_from_this]u with each pour.</span>"
-/obj/item/reagent_containers/examine(mob/user)
-	if(!can_have_cap)
-		return ..()
 
+/obj/item/reagent_containers/examine(mob/user)
 	. = ..()
-	if(cap_lost)
-		. += "<span class='notice'>The cap seems to be missing.</span>"
-	else if(cap_on)
-		. += "<span class='notice'>The cap is firmly on to prevent spilling. Alt-click to remove the cap.</span>"
+	. += "<span class='notice'>Currently transferring [amount_per_transfer_from_this]u with each pour.</span>"
+	if(!can_have_cap)
+		return
 	else
-		. += "<span class='notice'>The cap has been taken off. Alt-click to put a cap on.</span>"
+		if(cap_lost)
+			. += "<span class='notice'>The cap seems to be missing.</span>"
+		else if(cap_on)
+			. += "<span class='notice'>The cap is firmly on to prevent spilling. Alt-click to remove the cap.</span>"
+		else
+			. += "<span class='notice'>The cap has been taken off. Alt-click to put a cap on.</span>"
 
 /obj/item/reagent_containers/is_injectable(mob/user, allowmobs = TRUE)
 	if(can_have_cap && cap_on)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -61,7 +61,7 @@
 		spillable = TRUE
 
 	update_icon()
-
+	. += "<span class='notice'>Currently transferring [amount_per_transfer_from_this]u with each pour.</span>"
 /obj/item/reagent_containers/examine(mob/user)
 	if(!can_have_cap)
 		return ..()
@@ -104,7 +104,7 @@
 					amount_per_transfer_from_this = possible_transfer_amounts[i+1]
 				else
 					amount_per_transfer_from_this = possible_transfer_amounts[1]
-				to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
+				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u")
 				return
 
 /obj/item/reagent_containers/attack(mob/M, mob/user, def_zone)

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -1759,6 +1759,7 @@
 #include "code\modules\awaymissions\mission_code\stationCollision.dm"
 #include "code\modules\awaymissions\mission_code\undergroundoutpost45.dm"
 #include "code\modules\awaymissions\mission_code\wildwest.dm"
+#include "code\modules\balloon_alert\balloon_alert.dm"
 #include "code\modules\buildmode\bm_mode.dm"
 #include "code\modules\buildmode\buildmode.dm"
 #include "code\modules\buildmode\buttons.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the useful by nature and much beloathed by implementation [balloon alert system ](https://github.com/tgstation/tgstation/pull/59130) from /TG/, as well as [visible balloon alerts](https://github.com/tgstation/tgstation/pull/59256).
Also ports elements of the [balloon alert mining implementation](https://github.com/tgstation/tgstation/pull/67816) as a test-drive of using these alerts to help sculpt down chat bloat. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides us a very robust tool for a specific situation:
-Lots of messages in a short time
-No complex information conveyed
If we don't go completely crazy with it like /tg/ this should help cut down on chat spam.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Balloon Alerts, which appear visually over a character's head and convey a short string of text before disappearing.
add: Area Balloon alerts, the above but visible to anyone nearby.
tweak: Digging into terrain now displays a balloon alert and does not chat log, to prevent spam.
tweak: Guns now do not trigger their "x fires y!" message for the user unless shot at point-blank.
tweak: The Kinetic Accelerator now no longer logs a *click* in chat when fired while on cooldown.
tweak: Reagent containers now balloon alert instead of chat logging when their reagent transfer amount is changed. Their transfer amount can now also be found in their description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
