### PR TITLE
Duct Tapes an Outpost Console to the Delta Class

### DIFF
--- a/_maps/shuttles/shiptest/whiteship_delta.dmm
+++ b/_maps/shuttles/shiptest/whiteship_delta.dmm
@@ -2343,7 +2343,7 @@
 /obj/effect/turf_decal/corner/opaque/blue{
 	dir = 8
 	},
-/obj/structure/frame/computer{
+/obj/machinery/computer/cargo/express{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts a Outpost Communication Console on the Bridge of the Delta Class Frigate

## Why It's Good For The Game

I keep hearing things about how outposts are core content and how every ship should start with the console. This brings the Delta up to speed on it. 
## Changelog

:cl:
add: An Outpost Communication Console on the Delta's bridge
del: A computer frame on the Delta's bridge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
