### PR TITLE
Unpad a line in `code/datums/changelog.dm`

### DIFF
--- a/code/datums/changelog.dm
+++ b/code/datums/changelog.dm
@@ -24,7 +24,7 @@ GLOBAL_DATUM(changelog_tgui, /datum/changelog)
 		return ui.send_asset(changelog_item)
 
 /datum/changelog/ui_static_data()
-	var/list/data = list( "dates" = list() )
+	var/list/data = list("dates" = list())
 	var/regex/ymlRegex = regex(@"\.yml", "g")
 
 	for(var/archive_file in sortList(flist("html/changelogs/archive/")))


### PR DESCRIPTION
## About The Pull Request

Seems like #1211 was merged at same time as #1425, so there were two paddings that slipped in and is causing CI errors for every new PR since the last merge.

## Why It's Good For The Game

🦀🦀🦀 No more false errors 🦀🦀🦀 

## Changelog

:cl:
/:cl: