### PR TITLE
fixes newly created ship areas in expansion not being able to have outpost consoles in them

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -364,6 +364,7 @@
 	target_shuttle.shuttle_areas[newA] = TRUE
 
 	newA.connect_to_shuttle(target_shuttle, target_shuttle.get_docked())
+	newA.mobile_port = target_shuttle
 	for(var/atom/thing in newA)
 		thing.connect_to_shuttle(target_shuttle, target_shuttle.get_docked())
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -323,7 +323,7 @@
 	if(!area_choice)
 		to_chat(creator, "<span class='warning'>No choice selected. The area remains undefined.</span>")
 		return
-	var/area/newA
+	var/area/ship/newA
 	var/area/oldA = get_area(get_turf(creator))
 	if(!isarea(area_choice))
 		var/str = stripped_input(creator,"New area name:", "Blueprint Editing", "", MAX_NAME_LEN)


### PR DESCRIPTION
## About The Pull Request

fixes it by making sure that the shuttle area creator can Only create ship areas and passing along the `mobile_port` var to the new area

this likely fixes other things that are a bit off with ship expansion as well

## Why It's Good For The Game

yes

## Changelog

:cl:
fix: outpost consoles now work in new ship areas
/:cl: