### PR TITLE
Hyena Tweaks

### DIFF
--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -3258,7 +3258,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Zb" = (
-/turf/open/floor/plating/catwalk_floor,
+/obj/structure/catwalk/over,
+/turf/open/floor/plating/airless,
 /area/ship/external)
 "Zg" = (
 /obj/effect/turf_decal/industrial/warning{

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -391,7 +391,7 @@
 /obj/item/ammo_box/a357/match,
 /obj/item/codespeak_manual/unlimited,
 /obj/item/pen/edagger,
-/obj/item/radio/headset/syndicate/alt/leader,
+/obj/item/radio/headset/syndicate/captain,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "hy" = (

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -36,6 +36,9 @@
 	codes_txt = "patrol;next_patrol=crew";
 	location = "cargo"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "bJ" = (
@@ -47,8 +50,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/storage/belt/military/assault,
-/obj/item/storage/belt/military/assault,
 /obj/item/clothing/suit/armor/vest/syndie,
 /obj/item/clothing/suit/armor/vest/syndie,
 /obj/item/clothing/head/helmet/operator,
@@ -272,8 +273,6 @@
 	icon_state = "syndicate";
 	name = "ammunition locker"
 	},
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -287,6 +286,8 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/industrial/outline,
+/obj/item/storage/box/lethalshot,
+/obj/item/ammo_box/c10mm,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security/armory)
 "fA" = (
@@ -407,13 +408,6 @@
 /obj/item/paper_bin/carbon,
 /obj/item/folder/syndicate,
 /obj/item/pen/fourcolor,
-/obj/machinery/button/door{
-	dir = 1;
-	id = "wreckercargobay";
-	name = "cargo bay doors";
-	pixel_x = 10;
-	pixel_y = -25
-	},
 /obj/item/gps/mining{
 	pixel_x = 9;
 	pixel_y = -6
@@ -425,13 +419,20 @@
 /obj/item/stamp/qm{
 	name = "foreman's rubber stamp"
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = -5;
-	pixel_y = -22
-	},
-/obj/item/circuitboard/machine/protolathe/department/cargo,
 /obj/item/circuitboard/machine/rdserver,
+/obj/item/circuitboard/machine/techfab/department/cargo,
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	id = "hyena_cargo";
+	pixel_x = -10;
+	pixel_y = -24
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	id = "wreckercargobay";
+	name = "cargo bay doors";
+	pixel_y = -25
+	},
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
 "ir" = (
@@ -573,6 +574,9 @@
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "jI" = (
@@ -595,8 +599,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_x = 5;
+	pixel_y = -22
 	},
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
@@ -1033,14 +1039,28 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
-"sx" = (
-/obj/structure/fans/tiny,
+"so" = (
 /obj/machinery/door/poddoor{
 	id = "wreckercargobay";
 	name = "Cargo Bay Exterior Blast Door"
 	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "hyena_cargo";
+	locked = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"sx" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/poddoor{
+	id = "wreckercargobay";
+	name = "Cargo Bay Exterior Blast Door"
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sA" = (
@@ -1179,6 +1199,9 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "uf" = (
@@ -1190,9 +1213,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 8
+/obj/structure/frame/machine{
+	anchored = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/office)
@@ -1242,14 +1264,7 @@
 	id = "wreckerwindows";
 	name = "Window Shutters";
 	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	dir = 8;
-	id = "wreckercargobay";
-	name = "cargo bay doors";
-	pixel_x = -5;
-	pixel_y = -5
+	pixel_y = 3
 	},
 /obj/item/gps{
 	pixel_x = 7
@@ -1418,6 +1433,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "yD" = (
@@ -1460,6 +1478,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/steeldecal/steel_decals_central4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "zq" = (
@@ -1728,7 +1749,6 @@
 "Dq" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/circuitboard/computer/rdconsole,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "DE" = (
@@ -1927,6 +1947,15 @@
 	pixel_y = -25
 	},
 /obj/machinery/light/floor,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	id = "hyena_cargo";
+	pixel_x = -10;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "GV" = (
@@ -2078,12 +2107,11 @@
 /turf/open/floor/plating,
 /area/ship/storage)
 "JS" = (
-/obj/structure/fans/tiny,
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/poddoor{
 	id = "wreckercargobay";
 	name = "Cargo Bay Exterior Blast Door"
 	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Kb" = (
@@ -2273,9 +2301,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"LC" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/maintenance/fore)
 "LU" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
@@ -2363,6 +2388,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "MR" = (
@@ -2391,12 +2419,19 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/cargo)
 "NN" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 1;
+	id = "hyena_cargo";
+	locked = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /obj/machinery/door/poddoor{
 	id = "wreckercargobay";
 	name = "Cargo Bay Exterior Blast Door"
 	},
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Ok" = (
@@ -2480,14 +2515,6 @@
 	icon_state = "syndicate";
 	name = "firearms locker"
 	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_y = 2
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
 /obj/structure/sign/poster/contraband/syndicate_pistol{
 	pixel_x = 32
 	},
@@ -2498,6 +2525,7 @@
 	pixel_y = -25
 	},
 /obj/effect/turf_decal/industrial/outline,
+/obj/item/gun/ballistic/shotgun/lethal,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security/armory)
 "Pn" = (
@@ -2594,6 +2622,9 @@
 	},
 /obj/effect/turf_decal/arrows{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
@@ -2697,6 +2728,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/analyzer,
 /obj/effect/turf_decal/steeldecal/steel_decals_central4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "SP" = (
@@ -2749,6 +2783,12 @@
 	},
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "Tu" = (
@@ -2781,12 +2821,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
-"TY" = (
-/obj/structure/sign/number/four{
-	dir = 1
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/bridge)
 "Ua" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4
@@ -3143,13 +3177,13 @@
 /obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "XZ" = (
 /obj/structure/sign/number/nine,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/fore)
-"Yf" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/fore)
 "Yv" = (
@@ -3580,7 +3614,7 @@ XG
 Bg
 jY
 yn
-LC
+oO
 Zb
 "}
 (17,1,1) = {"
@@ -3600,7 +3634,7 @@ fL
 Ib
 ik
 yn
-Yf
+mL
 oO
 "}
 (18,1,1) = {"
@@ -3621,7 +3655,7 @@ Xj
 uf
 yn
 mL
-Yf
+mL
 "}
 (19,1,1) = {"
 cs
@@ -3644,7 +3678,7 @@ DF
 mL
 "}
 (20,1,1) = {"
-TY
+xZ
 Ap
 Ap
 TR
@@ -3734,8 +3768,8 @@ NF
 NF
 NF
 NF
-NN
-NN
+so
+JS
 JS
 sx
 NN
@@ -3759,7 +3793,7 @@ nn
 nn
 nn
 nn
-LC
+oO
 mL
 mL
 "}
@@ -3820,6 +3854,6 @@ nn
 nn
 nn
 nn
-LC
+oO
 uP
 "}

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -332,6 +332,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
+"gg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline,
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "gh" = (
 /obj/structure/closet/secure_closet/freezer{
 	anchored = 1;
@@ -606,6 +613,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
+"kg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline,
+/obj/structure/closet/crate/medical,
+/obj/item/bodybag,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "kr" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
@@ -670,6 +685,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "lt" = (
@@ -1834,22 +1850,18 @@
 /area/ship/crew/dorm)
 "Ff" = (
 /obj/structure/table/reinforced,
-/obj/structure/closet/wall/white/med{
-	dir = 1;
-	name = "medicine locker";
-	pixel_y = -28
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/medical{
-	pixel_x = -5;
-	pixel_y = -4
-	},
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
 	dir = 4;
 	pixel_x = -25
 	},
+/obj/structure/closet/wall/white/med{
+	dir = 1;
+	name = "medicine locker";
+	pixel_y = -28
+	},
+/obj/item/storage/pill_bottle/lsd,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/dorm)
 "Fr" = (
@@ -2004,6 +2016,13 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/port)
+"Ii" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/outline,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "Ik" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/industrial/outline,
@@ -3277,7 +3296,6 @@
 /area/ship/cargo)
 "ZM" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/industrial/outline,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
@@ -3706,7 +3724,7 @@ rd
 Ap
 lg
 ZM
-Mp
+Ii
 Zi
 bl
 si
@@ -3744,8 +3762,8 @@ mf
 aF
 le
 Ap
-ZM
-Mp
+kg
+gg
 Mp
 iC
 Tg

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -408,7 +408,6 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
-/obj/machinery/computer/cargo/express,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "ik" = (

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -408,6 +408,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
+/obj/machinery/computer/cargo/express,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "ik" = (
@@ -915,9 +916,6 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/bridge)
 "pI" = (
-/obj/structure/frame/computer{
-	dir = 1
-	},
 /obj/item/radio/intercom/wideband{
 	dir = 8;
 	pixel_x = 22
@@ -926,6 +924,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/cargo/express{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "pP" = (

--- a/_maps/shuttles/shiptest/gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/gorlex_hyena.dmm
@@ -678,9 +678,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/turf_decal/industrial/outline,
-/obj/structure/closet/crate/freezer{
-	opened = 1
-	},
+/obj/structure/closet/crate/freezer,
 /obj/machinery/airalarm/all_access{
 	dir = 4;
 	pixel_x = -25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

More balance adjustments to the Hyena.

- Replaced Stechkins in armory with 1x pump shotgun
- Removed assault belts from armory
- Removed RnD console board
- Replaced cargo protolathe board with cargo techfab board
- Replaced tinyfans with atmos shield generator
- Added outpost communication console to bridge
- Moved medical supplies to disused corner of cargo bay
- Added rollerbed, bodybag, 1x random blood bag to medical area

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [X] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

balance changes as always

## Changelog

:cl:
tweak: Modified Hyena RnD and medical equipment
tweak: Replaced Hyena tinyfans with shield wall generators
balance: Replaced Hyena stechkins with pump shotgun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
