### PR TITLE
balloon alert pr bugfixes

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -29,7 +29,7 @@
 
 	var/recharge_timerid
 
-/obj/item/gun/energy/recharge/kinetic_accelerator/shoot_with_empty_chamber(mob/living/user)
+/obj/item/gun/energy/kinetic_accelerator/shoot_with_empty_chamber(mob/living/user)
 	playsound(src, dry_fire_sound, 30, TRUE) //click sound but no to_chat message to cut on spam
 	return
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -64,7 +64,12 @@
 
 /obj/item/reagent_containers/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>Currently transferring [amount_per_transfer_from_this]u with each pour.</span>"
+	if(istype(src, /obj/item/reagent_containers/glass))
+		. += "<span class='notice'>Currently transferring [amount_per_transfer_from_this]u with each pour.</span>"
+	if(istype(src, /obj/item/reagent_containers/dropper))
+		. += "<span class='notice'>Currently squeezing out [amount_per_transfer_from_this]u drops.</span>"
+	if(istype(src, /obj/item/reagent_containers/syringe))
+		. += "<span class='notice'>Currently injecting [amount_per_transfer_from_this]u at a time.</span>"
 	if(!can_have_cap)
 		return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I am a stinky dumb coder

-Fixes a really dumb mistake with KA *click* suppression, it should work now
-The pour amount alert no longer appears on _every reagent container's_ examine. No more apples that are "currently pouring 5 units at a time".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [X] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: KA *click* message suppression fixed. Bugged subvariant removed.
fix: The reagent pour amount information in examine now shows up on beakers, droppers, and syringes, instead of every single reagent item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
