### PR TITLE
Fixes epicenters doing double damage

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -335,6 +335,8 @@ SUBSYSTEM_DEF(explosions)
 				var/atom/A = I
 				if (length(A.contents) && !(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.GetAllContents()
+				if(istype(A, /mob/living))
+					items -= A				// Because GetAllContents returns the mob too, resulting in double damage
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))


### PR DESCRIPTION

## About The Pull Request

This makes explosion epicenters not do twice as much damage to mobs, helping to reduce instant death from heavy explosions as well as significantly reducing the damage of explosive projectiles that did way more damage than they should have. This is a port of https://github.com/yogstation13/Yogstation/pull/13983

- [X] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

Allows balancing/use of explosive projectiles and stuff without the issue of them doing a bonus 30-60 damage, depending on bomb armor. TG absolutely grilled me for all the things it affects at https://github.com/tgstation/tgstation/pull/68860

## Changelog

:cl:

tweak: Epicenters no longer explode mobs a second time 4 no raisin

/:cl:


