### PR TITLE
DIsables the Boyardee-B

### DIFF
--- a/_maps/configs/diner_b.json
+++ b/_maps/configs/diner_b.json
@@ -17,6 +17,5 @@
 			"outfit": "/datum/outfit/job/assistant/waiter/syndicate",
 			"slots": 2
 		}
-	},
-	"enabled": true
+	}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR disables (but doesn't delete) the Boyardee-B variant

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [X] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The ship is a near identical copy of the Boyardee however, worse in most ways as its niche is "boyardee but hydroponics is significantly worse, making the kitchen significantly worse", with the kitchen being like, the main part of the boyardee

It also has a massive ration pack stock pile which, is the antithesis of the boyardee niche. Along with this, it has many errors with perspective, and its niche of boyardee but worse + guns being less than optimal, I feel as if it is better to disable this.

## Changelog

:cl:
del: Disables the Boyardee-B
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
