### PR TITLE
fixes some vanity suit items not showing up

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -14,6 +14,7 @@
 	greyscale_colors = list(list(13, 16), list(10, 18), list(13, 21))
 	greyscale_icon_state = "coat"
 	supports_variations = VOX_VARIATION
+	mob_overlay_icon = 'icons/mob/clothing/suit.dmi'
 
 /obj/item/clothing/suit/worn_overlays(isinhands = FALSE)
 	. = list()


### PR DESCRIPTION
## About The Pull Request

missed this

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

sprites showing up is good

## Changelog

:cl:
fix: suit items show up again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
