### PR TITLE
Fixes display of suit icons on mobs

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -14,6 +14,7 @@
 	greyscale_colors = list(list(13, 16), list(10, 18), list(13, 21))
 	greyscale_icon_state = "coat"
 	supports_variations = VOX_VARIATION
+	mob_overlay_icon = 'icons/mob/clothing/suit.dmi'
 
 /obj/item/clothing/suit/worn_overlays(isinhands = FALSE)
 	. = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I've noticed that children of /obj/item/clothing/suit don't have any mob_overlay_icon and that caused them to not be displayed on mobs. How/why did that happen I do not know. I don't know how long it has been broken either, but that seems to fix it (tested on a randomgen human with jackets that were not previously displayed, also tested with random other items with mob overlay icons from other files as a sanity check and they are displayed too)

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->
It's nice to see what you're wearing when you're wearing something.

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Suits are now displayed on mobs(humanoids etc) when worn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
