### PR TITLE
rockplanet_cult is no longer coated in gibonite.

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_cult.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_cult.dmm
@@ -70,7 +70,7 @@
 /turf/open/floor/plasteel/dark,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "u" = (
-/turf/closed/mineral/gibtonite/rockplanet,
+/turf/closed/mineral/random/asteroid/rockplanet,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "v" = (
 /obj/structure/trap/cult,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changes out the gibonite spawn rock on rockplanet_cult for random mineral rock. It won't explode if you poke it now.
![2022 10 10-23 57 03](https://user-images.githubusercontent.com/94164348/195017740-9fdaaf44-2cc3-431d-bdb7-a999c39ec358.png)
It looks exactly the same
<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I dropped an admin bomb on the ruin and it only exploded once

## Why It's Good For The Game
Less incidents leading to things like #1545 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: rockplanet_cult is no longer coated in explosives. People who use plasmacutters and people who weren't expecting like 12 things of gibonite rejoice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
