### PR TITLE
Quick Scav Patch

### DIFF
--- a/_maps/shuttles/shiptest/scav.dmm
+++ b/_maps/shuttles/shiptest/scav.dmm
@@ -187,9 +187,6 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ship/external)
 "gr" = (
@@ -1240,7 +1237,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/computer/cargo/express{
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
 /turf/open/floor/carpet/nanoweave/blue,
@@ -1278,7 +1275,7 @@
 /turf/template_noop,
 /area/template_noop)
 "Rx" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/cargo/express,
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "Rz" = (

--- a/_maps/shuttles/shiptest/scav.dmm
+++ b/_maps/shuttles/shiptest/scav.dmm
@@ -436,13 +436,6 @@
 "nw" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
-"nG" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
 "nN" = (
 /obj/machinery/holopad/emergency,
 /obj/structure/cable{
@@ -1794,7 +1787,7 @@ Rc
 "}
 (17,1,1) = {"
 Rc
-nG
+Rc
 fp
 OM
 YY

--- a/_maps/shuttles/shiptest/scav.dmm
+++ b/_maps/shuttles/shiptest/scav.dmm
@@ -129,10 +129,12 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "scav_door";
 	name = "Dusty Blast Door"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "scavbay"
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
@@ -488,7 +490,6 @@
 "oV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "scav_door";
 	name = "Dusty Blast Door"
@@ -583,12 +584,12 @@
 "rb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/space/syndicate/orange{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = "degrading orange space suit";
 	w_class = 4
 	},
 /obj/item/clothing/head/helmet/space/syndicate/black/orange{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = "degrading black space helmet";
 	w_class = 4
 	},
@@ -710,7 +711,7 @@
 	},
 /mob/living/simple_animal/pet/cat/original{
 	butcher_difficulty = 100;
-	damage_coeff = list("brute" = 1, "fire" = 1.5, "toxin" = 1, "clone" = 1, "stamina" = 0, "oxygen" = 0);
+	damage_coeff = list("brute"=1,"fire"=1.5,"toxin"=1,"clone"=1,"stamina"=0,"oxygen"=0);
 	desc = "The product of alien DNA and bored geneticists. This one looks awefully sturdy.";
 	health = 200;
 	name = "Scav";
@@ -1012,6 +1013,12 @@
 	pixel_x = 7;
 	pixel_y = 26
 	},
+/obj/machinery/button/shieldwallgen{
+	name = "Bay Air Shield";
+	pixel_y = 36;
+	pixel_x = -8;
+	id = "scavbay"
+	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "Fq" = (
@@ -1224,14 +1231,14 @@
 /area/ship/cargo)
 "Pu" = (
 /obj/structure/window/reinforced,
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -28
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/computer/cargo/express{
+	dir = 4
+	},
 /turf/open/floor/carpet/nanoweave/blue,
 /area/ship/bridge)
 "Qd" = (
@@ -1277,7 +1284,7 @@
 "Sd" = (
 /obj/item/clothing/suit/space/hardsuit/combatmedic{
 	allowed = list(/obj/item/gun,/obj/item/circular_saw,/obj/item/tank/internals,/obj/item/storage/box/pillbottles,/obj/item/storage/firstaid,/obj/item/stack/medical/gauze,/obj/item/stack/medical/suture,/obj/item/stack/medical/mesh,/obj/item/storage/bag/chemistry);
-	armor = list("melee" = 25, "bullet" = 10, "laser" = 20, "energy" = 15, "bomb" = 5, "bio" = 80, "rad" = 50, "fire" = 65, "acid" = 75);
+	armor = list("melee"=25,"bullet"=10,"laser"=20,"energy"=15,"bomb"=5,"bio"=80,"rad"=50,"fire"=65,"acid"=75);
 	desc = "What was once the standard issue hardsuit of infectious disease officers, before the NT ERT squads. this one looks like it has been degrading for quite a long time.";
 	name = "degrading biological hardsuit"
 	},
@@ -1330,7 +1337,6 @@
 /area/ship/bridge)
 "Un" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "scav_door";
 	name = "Dusty Blast Door"
@@ -1358,10 +1364,13 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "scav_door";
 	name = "Dusty Blast Door"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "scavbay";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
@@ -1469,12 +1478,12 @@
 /area/ship/cargo)
 "Zv" = (
 /obj/item/clothing/suit/space/syndicate/black{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = "degrading black space suit";
 	w_class = 4
 	},
 /obj/item/clothing/head/helmet/space/syndicate/black{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = "degrading black space helmet";
 	w_class = 4
 	},
@@ -1488,12 +1497,12 @@
 /area/ship/cargo)
 "Zy" = (
 /obj/item/clothing/suit/space/syndicate/blue{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = "degrading blue space suit";
 	w_class = 4
 	},
 /obj/item/clothing/head/helmet/space/syndicate/black/blue{
-	armor = list("melee" = 5, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 85);
+	armor = list("melee"=5,"bullet"=10,"laser"=10,"energy"=10,"bomb"=30,"bio"=30,"rad"=30,"fire"=30,"acid"=85);
 	name = " degrading black space helmet";
 	w_class = 4
 	},

--- a/_maps/shuttles/shiptest/scav.dmm
+++ b/_maps/shuttles/shiptest/scav.dmm
@@ -436,6 +436,13 @@
 "nw" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
+"nG" = (
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
 "nN" = (
 /obj/machinery/holopad/emergency,
 /obj/structure/cable{
@@ -1787,7 +1794,7 @@ Rc
 "}
 (17,1,1) = {"
 Rc
-Rc
+nG
 fp
 OM
 YY

--- a/_maps/shuttles/shiptest/scav.dmm
+++ b/_maps/shuttles/shiptest/scav.dmm
@@ -902,6 +902,10 @@
 "BE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/industrial/outline/blue,
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "BG" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![2022 10 12-21 02 13](https://user-images.githubusercontent.com/94164348/195496498-607f7383-e5f5-4181-aef8-41b025fa6e19.png)



Patches the Scav-class Drifter to have holoshields in the front, and an outpost communications console. The outpost console is replacing a security camera console, the singular camera has been removed from the ship. I also added a newscaster to the main bay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
We're moving to holoshields last I checked, and every ship should have an outpost comms console. Newscasters are just cool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: The Scav Class now has holoshields and an outpost communication console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
