### PR TITLE
Caravan gets a holoshield + outpost console.

### DIFF
--- a/_maps/shuttles/shiptest/IndiCaravanTypeA.dmm
+++ b/_maps/shuttles/shiptest/IndiCaravanTypeA.dmm
@@ -2088,6 +2088,10 @@
 /area/ship/cargo)
 "Ks" = (
 /obj/structure/table/reinforced,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = -31
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
 "KL" = (

--- a/_maps/shuttles/shiptest/IndiCaravanTypeA.dmm
+++ b/_maps/shuttles/shiptest/IndiCaravanTypeA.dmm
@@ -1,4 +1,23 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "cargoblastdoors";
+	name = "Cargo Bay Blast Door"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "caravanbay";
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
 "ah" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -120,7 +139,7 @@
 	},
 /obj/machinery/computer/atmos_control/incinerator{
 	dir = 4;
-	sensors = list("nemo_incinerator_sensor" = "Incinerator Chamber")
+	sensors = list("nemo_incinerator_sensor"="Incinerator Chamber")
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -148,6 +167,14 @@
 	dir = 4;
 	input_dir = 8;
 	output_dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_y = 23;
+	pixel_x = 6;
+	id = "caravanbay"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -824,6 +851,12 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"oz" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew)
 "oA" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -1024,6 +1057,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"sZ" = (
+/obj/structure/girder,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/external)
 "tk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1186,7 +1226,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 8;
-	sensors = list("nemo_air_sensor" = "Air Mix Tank")
+	sensors = list("nemo_air_sensor"="Air Mix Tank")
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -1278,11 +1318,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor/orange,
-/obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor{
 	id = "cargoblastdoors";
 	name = "Cargo Bay Blast Door"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "caravanbay";
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
@@ -1320,7 +1366,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1;
-	sensors = list("nemo_n2_sensor" = "Nitrogen Tank")
+	sensors = list("nemo_n2_sensor"="Nitrogen Tank")
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -1350,6 +1396,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "ys" = (
@@ -1378,6 +1427,12 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/bridge)
+"yI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "zi" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/oil,
@@ -1408,7 +1463,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("nemo_tox_sensor" = "Plasma Tank")
+	sensors = list("nemo_tox_sensor"="Plasma Tank")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer4{
 	dir = 8
@@ -1788,6 +1843,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "GS" = (
@@ -2134,6 +2192,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Ng" = (
@@ -2200,6 +2261,9 @@
 "OO" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
@@ -2469,7 +2533,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/machinery/modular_computer/console/preset/command{
+/obj/machinery/computer/cargo/express{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -2875,6 +2939,18 @@
 	},
 /turf/open/floor/engine/air,
 /area/ship/engineering/atmospherics)
+"Zs" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "cargoblastdoors";
+	name = "Cargo Bay Blast Door"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
 "Zu" = (
 /obj/structure/curtain/cloth/fancy,
 /obj/structure/bed,
@@ -2910,6 +2986,12 @@
 	name = "Blast Door Control";
 	pixel_x = 25;
 	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
@@ -3188,7 +3270,7 @@ bZ
 (14,1,1) = {"
 bZ
 bZ
-xo
+Zs
 OO
 eI
 Bv
@@ -3208,7 +3290,7 @@ bZ
 (15,1,1) = {"
 bZ
 bZ
-xo
+ad
 ZV
 Jn
 Hf
@@ -3230,7 +3312,7 @@ bZ
 bZ
 Ba
 cp
-Vq
+yI
 MP
 yo
 Ah
@@ -3332,7 +3414,7 @@ NB
 WK
 WK
 WK
-NB
+sZ
 WK
 WK
 tk
@@ -3352,7 +3434,7 @@ re
 re
 re
 re
-LR
+oz
 WK
 ls
 Ur


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I've resolved to patch ships that don't have an outpost console or holofans whenever I see them. This converts the Caravan's bay to use holoshields, gives it a button for them, adds another newscaster to the bridge, and replaces the bridge's modular console with a Outpost Communications Console
![2022 10 11-15 09 37](https://user-images.githubusercontent.com/94164348/195207426-375f333b-38df-42de-b13f-088ef09f4212.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
More newscasters + outpost console + we stan holoshields
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: The caravan-class now comes stock with an outpost communications console. And holoshields. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
