### PR TITLE
undoes a fuckup on a ruin

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_colony.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_colony.dmm
@@ -1,144 +1,140 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ag" = (
 /obj/effect/overlay/palmtree_l,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "aW" = (
 /obj/item/instrument/guitar,
-/turf/open/floor/carpet/blue,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/blue{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "bt" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "bO" = (
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "cr" = (
 /obj/item/reagent_containers/food/snacks/kebab/rat/double,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "cC" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "cS" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "dE" = (
 /obj/item/seeds/cocoapod,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "dH" = (
 /obj/structure/fence{
 	icon_state = "corner"
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "fd" = (
 /obj/item/cultivator/rake,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "fj" = (
 /obj/item/storage/cans/sixbeer,
-/turf/open/floor/carpet/orange,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/orange{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "fC" = (
 /obj/structure/flora/tree/palm,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "gn" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "gv" = (
 /obj/structure/fluff/beach_umbrella/cap,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "hh" = (
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "hQ" = (
 /obj/structure/fence{
 	dir = 5;
 	icon_state = "corner"
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "iJ" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/item/melee/roastingstick,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "kd" = (
 /obj/effect/mob_spawn/human/corpse/pirate,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "kV" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "carp"
 	},
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "lr" = (
 /obj/item/toy/beach_ball,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "lD" = (
 /obj/structure/fence,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "mt" = (
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "mI" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -149,29 +145,27 @@
 	pixel_x = 15
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "nl" = (
 /obj/item/shovel/spade,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "ns" = (
 /obj/structure/fence{
 	icon_state = "door_closed"
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "nB" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "on" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses/garb{
@@ -181,75 +175,70 @@
 	pixel_y = 9
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "pp" = (
 /obj/structure/chair/plastic{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "pv" = (
 /turf/open/floor/plating/beach/sand{
-	icon_state = "sand_dug"
+	icon_state = "sand_dug";
+	light_range = 2
 	},
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "pN" = (
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "pU" = (
 /obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "pY" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "qq" = (
 /obj/effect/overlay/coconut,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "qG" = (
 /obj/item/clothing/suit/space/hardsuit/carp/old,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "qP" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/item/storage/firstaid/o2,
-/turf/open/floor/wood,
-/area/ruin/unpowered{
+/turf/open/floor/wood{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "rD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "ta" = (
-/turf/open/floor/carpet/blue,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/blue{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "ug" = (
 /obj/structure/closet/crate/freezer{
 	name = "Cooler"
@@ -272,22 +261,22 @@
 /obj/item/reagent_containers/food/drinks/beer/light,
 /obj/item/reagent_containers/food/drinks/beer/light,
 /obj/item/reagent_containers/food/drinks/beer/light,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "uw" = (
 /obj/structure/flora/rock/beach,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "vG" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
-/turf/open/floor/carpet/purple,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/purple{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "wb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -297,42 +286,40 @@
 	},
 /obj/structure/table/wood,
 /obj/item/megaphone,
-/turf/open/floor/wood,
-/area/ruin/unpowered{
+/turf/open/floor/wood{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "wf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/curtain,
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "xK" = (
 /obj/structure/chair/plastic,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "xT" = (
 /obj/item/stack/sheet/sandblock,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Ap" = (
 /obj/structure/fluff/beach_umbrella/security,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "AV" = (
 /obj/item/storage/crayons,
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "CR" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -345,16 +332,16 @@
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/under/shorts/red,
 /obj/item/clothing/glasses/sunglasses,
-/turf/open/floor/wood,
-/area/ruin/unpowered{
+/turf/open/floor/wood{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Dl" = (
 /obj/structure/mineral_door/sandstone,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Dx" = (
 /obj/item/toy/crayon/spraycan{
 	pixel_x = -5;
@@ -364,10 +351,10 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "EB" = (
 /obj/structure/fence{
 	dir = 4
@@ -375,115 +362,111 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "EC" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Fm" = (
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "FV" = (
 /obj/effect/overlay/palmtree_r,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "FW" = (
 /mob/living/simple_animal/hostile/carp,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Gh" = (
 /obj/structure/fence{
 	dir = 9;
 	icon_state = "corner"
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Hg" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "IV" = (
 /obj/item/stack/ore/glass/beach,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Ja" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Jb" = (
 /obj/item/seeds/cocoapod/vanillapod,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "JX" = (
 /obj/structure/mineral_door/sandstone,
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "KA" = (
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "KM" = (
 /turf/template_noop,
 /area/template_noop)
 "Ld" = (
 /obj/structure/fluff/beach_umbrella/science,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Li" = (
 /turf/open/water/beach/deep,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "Lz" = (
 /obj/structure/fluff/beach_umbrella/engine,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "ML" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Nl" = (
 /obj/item/toy/seashell,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Nz" = (
-/turf/open/floor/plasteel/stairs/old,
-/area/ruin/unpowered{
+/turf/open/floor/plasteel/stairs/old{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "NG" = (
 /obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
 	pixel_x = 13
@@ -493,9 +476,7 @@
 	name = "glock-ness monster plushie"
 	},
 /turf/open/water/beach/deep,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "NL" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/backpack/duffelbag,
@@ -508,77 +489,73 @@
 /obj/item/clothing/under/color/red,
 /obj/item/clothing/under/color/white,
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "Oa" = (
 /obj/item/melee/skateboard/pro,
 /turf/open/floor/wood,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "Om" = (
 /obj/structure/fence{
 	dir = 10;
 	icon_state = "corner"
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Pd" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Px" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Qf" = (
-/turf/open/floor/concrete/slab_1,
-/area/ruin/unpowered{
+/turf/open/floor/concrete/slab_1{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "RK" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /obj/item/melee/skateboard/hoverboard,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "RM" = (
 /obj/structure/sink/puddle,
-/turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered{
+/turf/open/floor/plating/dirt/jungle{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "RV" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "SS" = (
-/turf/open/floor/carpet/red,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/red{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Te" = (
 /obj/structure/railing,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Tr" = (
 /obj/item/reagent_containers/food/drinks/colocup{
 	pixel_x = -7;
@@ -592,33 +569,31 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/turf/open/floor/carpet/red,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/red{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "TW" = (
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "TZ" = (
-/turf/open/floor/carpet/purple,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/purple{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "US" = (
 /turf/open/water/beach,
-/area/ruin/unpowered{
-	light_range = 2
-	})
+/area/ruin/unpowered)
 "Vn" = (
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Vx" = (
 /obj/structure/table/rolling,
 /obj/item/reagent_containers/food/snacks/kebab/fiesta,
@@ -628,103 +603,103 @@
 /obj/item/reagent_containers/food/snacks/kebab/fiesta{
 	pixel_y = 13
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "VG" = (
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "VX" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Ww" = (
 /obj/item/melee/roastingstick,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xd" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xe" = (
 /obj/item/storage/cans/sixbeer,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xh" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xo" = (
 /obj/structure/statue/sandstone/assistant,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Xz" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ruin/unpowered{
+/turf/open/floor/wood{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Yi" = (
 /obj/item/toy/plush/lizardplushie{
 	name = "Soaks-The-Rays"
 	},
-/turf/open/floor/carpet/orange,
-/area/ruin/unpowered{
+/turf/open/floor/carpet/orange{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Yq" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "#"
 	},
-/turf/open/floor/concrete,
-/area/ruin/unpowered{
+/turf/open/floor/concrete{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "Zz" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "ZA" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered{
+/turf/open/floor/plating/grass/beach{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 "ZI" = (
-/turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered{
+/turf/open/floor/plating/beach/sand{
 	light_range = 2
-	})
+	},
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 KM

--- a/_maps/RandomRuins/BeachRuins/beach_colony.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_colony.dmm
@@ -2,99 +2,143 @@
 "ag" = (
 /obj/effect/overlay/palmtree_l,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "aW" = (
 /obj/item/instrument/guitar,
 /turf/open/floor/carpet/blue,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "bt" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "bO" = (
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "cr" = (
 /obj/item/reagent_containers/food/snacks/kebab/rat/double,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "cC" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "cS" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "dE" = (
 /obj/item/seeds/cocoapod,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "dH" = (
 /obj/structure/fence{
 	icon_state = "corner"
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "fd" = (
 /obj/item/cultivator/rake,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "fj" = (
 /obj/item/storage/cans/sixbeer,
 /turf/open/floor/carpet/orange,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "fC" = (
 /obj/structure/flora/tree/palm,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "gn" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "gv" = (
 /obj/structure/fluff/beach_umbrella/cap,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "hh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "hQ" = (
 /obj/structure/fence{
 	dir = 5;
 	icon_state = "corner"
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "iJ" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/item/melee/roastingstick,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "kd" = (
 /obj/effect/mob_spawn/human/corpse/pirate,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "kV" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "carp"
 	},
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "lr" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "lD" = (
 /obj/structure/fence,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "mt" = (
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "mI" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -105,21 +149,29 @@
 	pixel_x = 15
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "nl" = (
 /obj/item/shovel/spade,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ns" = (
 /obj/structure/fence{
 	icon_state = "door_closed"
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "nB" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "on" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses/garb{
@@ -129,37 +181,53 @@
 	pixel_y = 9
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "pp" = (
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "pv" = (
 /turf/open/floor/plating/beach/sand{
 	icon_state = "sand_dug"
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "pN" = (
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "pU" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "pY" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "qq" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "qG" = (
 /obj/item/clothing/suit/space/hardsuit/carp/old,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "qP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -167,15 +235,21 @@
 /obj/structure/window/reinforced,
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "rD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ta" = (
 /turf/open/floor/carpet/blue,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ug" = (
 /obj/structure/closet/crate/freezer{
 	name = "Cooler"
@@ -199,15 +273,21 @@
 /obj/item/reagent_containers/food/drinks/beer/light,
 /obj/item/reagent_containers/food/drinks/beer/light,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "uw" = (
 /obj/structure/flora/rock/beach,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "vG" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
 /turf/open/floor/carpet/purple,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "wb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -218,29 +298,41 @@
 /obj/structure/table/wood,
 /obj/item/megaphone,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "wf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/curtain,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "xK" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "xT" = (
 /obj/item/stack/sheet/sandblock,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Ap" = (
 /obj/structure/fluff/beach_umbrella/security,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "AV" = (
 /obj/item/storage/crayons,
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "CR" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -254,11 +346,15 @@
 /obj/item/clothing/under/shorts/red,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Dl" = (
 /obj/structure/mineral_door/sandstone,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Dx" = (
 /obj/item/toy/crayon/spraycan{
 	pixel_x = -5;
@@ -269,7 +365,9 @@
 	pixel_y = 3
 	},
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "EB" = (
 /obj/structure/fence{
 	dir = 4
@@ -278,78 +376,114 @@
 	dir = 4
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "EC" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Fm" = (
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "FV" = (
 /obj/effect/overlay/palmtree_r,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "FW" = (
 /mob/living/simple_animal/hostile/carp,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Gh" = (
 /obj/structure/fence{
 	dir = 9;
 	icon_state = "corner"
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Hg" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "IV" = (
 /obj/item/stack/ore/glass/beach,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Ja" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Jb" = (
 /obj/item/seeds/cocoapod/vanillapod,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "JX" = (
 /obj/structure/mineral_door/sandstone,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "KA" = (
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "KM" = (
 /turf/template_noop,
 /area/template_noop)
 "Ld" = (
 /obj/structure/fluff/beach_umbrella/science,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Li" = (
 /turf/open/water/beach/deep,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Lz" = (
 /obj/structure/fluff/beach_umbrella/engine,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ML" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Nl" = (
 /obj/item/toy/seashell,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Nz" = (
 /turf/open/floor/plasteel/stairs/old,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "NG" = (
 /obj/item/gun/ballistic/automatic/pistol/m1911/no_mag{
 	pixel_x = 13
@@ -359,7 +493,9 @@
 	name = "glock-ness monster plushie"
 	},
 /turf/open/water/beach/deep,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "NL" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/backpack/duffelbag,
@@ -372,55 +508,77 @@
 /obj/item/clothing/under/color/red,
 /obj/item/clothing/under/color/white,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Oa" = (
 /obj/item/melee/skateboard/pro,
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Om" = (
 /obj/structure/fence{
 	dir = 10;
 	icon_state = "corner"
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Pd" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Px" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Qf" = (
 /turf/open/floor/concrete/slab_1,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "RK" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /obj/item/melee/skateboard/hoverboard,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "RM" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/plating/dirt/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "RV" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "SS" = (
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Te" = (
 /obj/structure/railing,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Tr" = (
 /obj/item/reagent_containers/food/drinks/colocup{
 	pixel_x = -7;
@@ -435,22 +593,32 @@
 	pixel_y = -3
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "TW" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "TZ" = (
 /turf/open/floor/carpet/purple,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "US" = (
 /turf/open/water/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Vn" = (
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Vx" = (
 /obj/structure/table/rolling,
 /obj/item/reagent_containers/food/snacks/kebab/fiesta,
@@ -461,72 +629,102 @@
 	pixel_y = 13
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "VG" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "VX" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Ww" = (
 /obj/item/melee/roastingstick,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xd" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xe" = (
 /obj/item/storage/cans/sixbeer,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xh" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xo" = (
 /obj/structure/statue/sandstone/assistant,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Xz" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Yi" = (
 /obj/item/toy/plush/lizardplushie{
 	name = "Soaks-The-Rays"
 	},
 /turf/open/floor/carpet/orange,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Yq" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "#"
 	},
 /turf/open/floor/concrete,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "Zz" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ZA" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/grass/beach,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 "ZI" = (
 /turf/open/floor/plating/beach/sand,
-/area/ruin/unpowered)
+/area/ruin/unpowered{
+	light_range = 2
+	})
 
 (1,1,1) = {"
 KM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
sets light range to 2 on the ruin turfs of beach_colony.dmm
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [X] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
the ruin is no longer pitch fucking dark in the middle of a daylit planet (hopefully)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: changes light range to 2 on the turfs of beach_colony
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
