### PR TITLE
Sun-light traits for z-levels

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -49,6 +49,16 @@ require only minor tweaks.
 #define ZTRAIT_ACIDRAIN "Weather_Acidrain"
 #define ZTRAIT_TEMPERATURE_GRADIENT "Weather_Gradient" //WS edit - Whitesands
 
+// enum - how SSsun should calculate sun exposure on this level
+#define ZTRAIT_SUN_TYPE "Sun Cycle Type"
+	// if left null, the value below will be assumed
+	// default & original SSsun behaviour - orbit the 'station' horizontially
+	#define AZIMUTH null
+	// static - exposed everywhere by default
+	#define STATIC_EXPOSED "Static Exposed"
+	// static - obstructed everywhere
+	#define STATIC_OBSTRUCTED "Static Obstructed"
+
 // number - bombcap is multiplied by this before being applied to bombs
 #define ZTRAIT_BOMBCAP_MULTIPLIER "Bombcap Multiplier"
 

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -57,7 +57,7 @@ require only minor tweaks.
 	// static - exposed everywhere by default
 	#define STATIC_EXPOSED "Static Exposed"
 	// static - obstructed everywhere
-	#define STATIC_OBSTRUCTED "Static Obstructed"
+	#define STATIC_OBSCURED "Static Obscured"
 
 // number - bombcap is multiplied by this before being applied to bombs
 #define ZTRAIT_BOMBCAP_MULTIPLIER "Bombcap Multiplier"

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -137,7 +137,17 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/transit_name = "Transit Map Zone"
 	var/datum/map_zone/mapzone = SSmapping.create_map_zone(transit_name)
-	var/datum/virtual_level/vlevel = SSmapping.create_virtual_level(transit_name, list(ZTRAIT_RESERVED = TRUE), mapzone, transit_width, transit_height, ALLOCATION_FREE)
+	var/datum/virtual_level/vlevel = SSmapping.create_virtual_level(
+		transit_name,
+		list(
+			ZTRAIT_RESERVED = TRUE,
+			ZTRAIT_SUN_TYPE = STATIC_EXPOSED
+		),
+		mapzone,
+		transit_width,
+		transit_height,
+		ALLOCATION_FREE
+	)
 
 	vlevel.reserve_margin(TRANSIT_SIZE_BORDER)
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -139,7 +139,7 @@
 	obscured = TRUE
 
 	var/sun_type = virtual_level_trait(ZTRAIT_SUN_TYPE)
-	if(sun_type == STATIC_OBSTRUCTED)
+	if(sun_type == STATIC_OBSCURED)
 		return
 		// go straight to jail
 	if(sun_type == STATIC_EXPOSED)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -143,14 +143,15 @@
 		return
 		// go straight to jail
 	if(sun_type == STATIC_EXPOSED)
-		var/turf/T = loc
-		T = T && T.above()
-		if (!T)
+		var/turf/loc_turf = loc
+		loc_turf = loc_turf && loc_turf.above()
+		if (!loc_turf)
 			var/count = 0
-			for(var/turf/Tt in orange(1, src))
-				count += !isgroundlessturf(Tt)
-			if (count >= 9) return
-		else if(!isopenturf(T))
+			for(var/turf/other_turf in orange(1, src))
+				count += !isgroundlessturf(other_turf)
+			if (count >= 9)
+				return
+		else if(!isopenturf(loc_turf))
 			return
 		obscured = FALSE
 		return

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -138,6 +138,24 @@
 /obj/machinery/power/solar/proc/occlusion_setup()
 	obscured = TRUE
 
+	var/sun_type = virtual_level_trait(ZTRAIT_SUN_TYPE)
+	if(sun_type == STATIC_OBSTRUCTED)
+		return
+		// go straight to jail
+	if(sun_type == STATIC_EXPOSED)
+		var/turf/T = loc
+		T = T && T.above()
+		if (!T)
+			var/count = 0
+			for(var/turf/Tt in orange(1, src))
+				count += !isgroundlessturf(Tt)
+			if (count >= 9) return
+		else if(!isopenturf(T))
+			return
+		obscured = FALSE
+		return
+		// do not continue
+
 	var/distance = OCCLUSION_DISTANCE
 	var/target_x = round(sin(SSsun.azimuth), 0.01)
 	var/target_y = round(cos(SSsun.azimuth), 0.01)
@@ -161,6 +179,11 @@
 	sunfrac = 0
 	if(obscured)
 		return 0
+
+	var/sun_type = virtual_level_trait(ZTRAIT_SUN_TYPE)
+	if (sun_type == STATIC_EXPOSED)
+		sunfrac = 1
+		return 1
 
 	var/sun_azimuth = SSsun.azimuth
 	if(azimuth_current == sun_azimuth) //just a quick optimization for the most frequent case


### PR DESCRIPTION
## About The Pull Request

This is a "minimal-effort" PR for now. It adds three traits available for z-levels. Amongst them being the one that enables the original asimuth code as default. With two others that favors more a static method: 
- `STATIC_EXPOSED`, exposed by default and does not check for azimuth, but neighbors in its `orange(1, src)` vicinity. 
- `STATIC_OBSCURED` that blocks out the sunlight entirely.

It was intended to fix #1421 for the ships in hard space, but not touching the planets case since the day/night controller seems to be absent from this codebase. A more invasive solution would be needed here.

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

Makes the solars more useful, and their power is maximized to their highest efficiency possible by default.

## Changelog

:cl:
tweak: Adjusted solar power to make use of sunlight traits for z-levels.
/:cl:
