### PR TITLE
Fixes Lingering PDA Message Overlay

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -590,8 +590,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 //EXTRA FUNCTIONS===================================
 
-	if(mode == 2 || mode == 21)//To clear message overlays.
-		cut_overlay(icon_alert)
+	cut_overlay(icon_alert) //To clear message overlays.
 
 	if((honkamt > 0) && (prob(60)))//For clown virus.
 		honkamt--

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -591,7 +591,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 //EXTRA FUNCTIONS===================================
 
 	if(mode == 2 || mode == 21)//To clear message overlays.
-		update_icon()
+		cut_overlay(icon_alert)
 
 	if((honkamt > 0) && (prob(60)))//For clown virus.
 		honkamt--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See changelog.
Fixes: #1474 

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
It's annoying you can't clear it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: The "new message" overlay on PDAs now actually goes away when you use your PDA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
