### PR TITLE
Li Tiegaui Update Plus Gear Reduction

### DIFF
--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -10,7 +10,6 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "aT" = (
-/obj/item/clothing/suit/space/hardsuit/combatmedic,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/effect/turf_decal/industrial/outline/red,
@@ -19,6 +18,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bl" = (
@@ -48,11 +48,11 @@
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bC" = (
-/obj/item/clothing/suit/space/hardsuit/combatmedic,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bX" = (
@@ -129,7 +129,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "dI" = (
-/obj/structure/frame/computer,
+/obj/machinery/computer/cargo/express,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "dR" = (
@@ -275,16 +275,25 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "gL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/aft)
 "gO" = (
-/obj/structure/fans/tiny,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "traumalobby";
 	name = "Lobby"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "traumashield"
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
@@ -300,6 +309,12 @@
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
 	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
@@ -383,10 +398,6 @@
 /area/ship/medical)
 "kC" = (
 /obj/machinery/door/window/brigdoor/southleft,
-/obj/item/defibrillator/compact/loaded,
-/obj/item/healthanalyzer/advanced,
-/obj/item/healthanalyzer/advanced,
-/obj/item/healthanalyzer/advanced,
 /obj/item/storage/belt/medical/surgery,
 /obj/item/storage/belt/medical/paramedic,
 /obj/item/clothing/gloves/color/latex/nitrile,
@@ -399,9 +410,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/clothing/glasses/hud/health/sunglasses,
-/obj/item/clothing/glasses/hud/health/sunglasses,
-/obj/item/clothing/glasses/hud/health/sunglasses,
 /obj/structure/closet/secure_closet/wall{
 	dir = 4;
 	icon_state = "sec_wall";
@@ -409,6 +417,12 @@
 	pixel_x = -28;
 	req_access_txt = "5"
 	},
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "kH" = (
@@ -420,6 +434,9 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
+"kO" = (
+/turf/open/floor/plasteel,
+/area/ship/storage)
 "kR" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
@@ -583,6 +600,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/cyan,
 /area/ship/crew)
+"nr" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
+/area/ship/storage)
 "nu" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -622,16 +648,25 @@
 	name = "Lobby Door Control";
 	normaldoorcontrol = 1;
 	pixel_x = -13;
-	pixel_y = 7
+	pixel_y = 7;
+	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "traumalobby";
 	name = "Lobby Shutter Control";
 	pixel_x = -13;
-	pixel_y = -1
+	pixel_y = -1;
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/industrial/hatch/red,
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	pixel_x = 13;
+	pixel_y = 7;
+	name = "Lobby Holoshield";
+	id = "traumashield"
+	},
 /turf/open/floor/plating,
 /area/ship/medical)
 "oS" = (
@@ -1083,6 +1118,12 @@
 /area/ship/medical)
 "zE" = (
 /obj/effect/turf_decal/trimline/opaque/red/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "zR" = (
@@ -1145,6 +1186,14 @@
 /obj/effect/turf_decal/corner/opaque/red/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"BH" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/ship/storage)
 "BK" = (
 /obj/effect/turf_decal/trimline/opaque/red/filled/line{
 	dir = 8
@@ -1167,7 +1216,12 @@
 	launch_status = 0;
 	port_direction = 2
 	},
-/obj/structure/fans/tiny,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "traumalobby";
 	name = "Lobby"
@@ -1528,6 +1582,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
+"Lq" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/advanced_airlock_controller{
+	pixel_x = 28
+	},
+/turf/open/floor/plating,
+/area/ship/storage)
 "Lt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1542,14 +1604,14 @@
 /area/ship/maintenance/starboard)
 "Lu" = (
 /obj/effect/turf_decal/trimline/opaque/red/arrow_ccw,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
@@ -1615,6 +1677,9 @@
 	},
 /obj/item/storage/backpack/satchel/med,
 /obj/item/gun/energy/e_gun/mini,
+/obj/item/defibrillator/compact/loaded,
+/obj/item/gun/syringe,
+/obj/item/reagent_containers/glass/bottle/sodium_thiopental,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
 "Ny" = (
@@ -1734,10 +1799,14 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "QQ" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/opaque/red/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/ship/storage)
 "QU" = (
 /obj/effect/landmark/start/paramedic,
@@ -1866,7 +1935,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/industrial/hatch/red,
-/obj/item/disk/design_disk/ammo_38_hunting,
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "Ti" = (
@@ -1910,6 +1978,20 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/carpet/cyan,
 /area/ship/crew)
+"TO" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "traumalobby";
+	name = "Lobby"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "traumashield"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/aft)
 "TR" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -1974,11 +2056,6 @@
 /obj/item/gun/ballistic/revolver/detective{
 	name = "\improper Colt Navy Special"
 	},
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
 "UO" = (
@@ -1993,13 +2070,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "UX" = (
-/obj/item/gun/ballistic/automatic/smg/vector{
-	spawnwithmagazine = 0
-	},
-/obj/item/ammo_box/magazine/smgm9mm/rubbershot,
-/obj/item/ammo_box/magazine/smgm9mm/rubbershot,
-/obj/item/gun/syringe,
-/obj/item/reagent_containers/glass/bottle/sodium_thiopental,
 /obj/item/ammo_box/magazine/co9mm{
 	ammo_type = /obj/item/ammo_casing/c9mm/rubbershot
 	},
@@ -2032,6 +2102,8 @@
 	pixel_x = -28;
 	req_access_txt = "5"
 	},
+/obj/item/gun/ballistic/automatic/pistol/commander/no_mag,
+/obj/item/ammo_box/magazine/co9mm,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Vq" = (
@@ -2218,11 +2290,14 @@
 /area/ship/crew)
 "Yb" = (
 /obj/effect/turf_decal/trimline/opaque/red/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/storage)
@@ -2304,12 +2379,12 @@ UG
 UG
 UG
 UG
-UG
-UG
-UG
-UG
-UG
-UG
+Uc
+zS
+zS
+OK
+OK
+Uc
 UG
 UG
 UG
@@ -2334,11 +2409,11 @@ UG
 UG
 Uc
 UI
-zS
+kO
 QQ
-Uc
-UG
-UG
+BH
+Lq
+nr
 UG
 UG
 UG
@@ -2366,8 +2441,8 @@ mG
 Ln
 hv
 OK
-Uc
-UG
+OK
+OK
 UG
 UG
 UG
@@ -2396,7 +2471,7 @@ Ln
 zE
 hq
 OK
-Qq
+UG
 UG
 UG
 UG
@@ -2613,7 +2688,7 @@ lH
 IG
 eS
 cn
-gO
+TO
 "}
 (12,1,1) = {"
 bX

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -143,9 +143,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "traumawindows";
-	name = "Window Blast Door"
+/obj/machinery/door/poddoor{
+	id = "traumaenginel"
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -160,9 +159,6 @@
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "el" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
@@ -171,6 +167,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/cryopod{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
@@ -351,13 +350,21 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+	dir = 4;
+	pixel_x = -26;
+	pixel_y = 6
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/industrial/warning,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = -6;
+	pixel_x = -25;
+	id = "traumaenginer";
+	name = "Engine Shutter Control"
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "iA" = (
@@ -581,10 +588,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/closet/emcloset/wall{
-	dir = 4;
-	pixel_x = -28
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -947,7 +950,8 @@
 "uE" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
-	pixel_y = -28
+	pixel_y = -38;
+	pixel_x = 7
 	},
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -1031,6 +1035,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -1338,13 +1345,21 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 6
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/industrial/warning,
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_y = -6;
+	pixel_x = 25;
+	id = "traumaenginel";
+	name = "Engine Shutter Control"
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "Go" = (
@@ -1405,6 +1420,9 @@
 /obj/machinery/door/window/northleft,
 /obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "Hr" = (
@@ -1433,10 +1451,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/closet/firecloset/wall{
-	dir = 8;
-	pixel_x = 28
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -1526,6 +1540,9 @@
 /obj/machinery/door/window/northright,
 /obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "KR" = (
@@ -1561,8 +1578,11 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/aft)
 "Lh" = (
-/obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/machinery/atmospherics/components/binary/pump/on/layer2,
+/obj/structure/closet/firecloset/wall{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "Ll" = (
@@ -1626,6 +1646,10 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty,
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "MP" = (
@@ -1634,6 +1658,10 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "MW" = (
@@ -1691,9 +1719,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "traumawindows";
-	name = "Window Blast Door"
+/obj/machinery/door/poddoor{
+	id = "traumaenginel"
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -1706,9 +1733,23 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "traumawindows";
-	name = "Window Blast Door"
+/obj/machinery/door/poddoor{
+	id = "traumaenginer"
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/starboard)
+"OB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -1740,8 +1781,11 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
 "Ps" = (
-/obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/machinery/atmospherics/components/binary/pump/on/layer2,
+/obj/structure/closet/emcloset/wall{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "PG" = (
@@ -2161,9 +2205,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "traumawindows";
-	name = "Window Blast Door"
+/obj/machinery/door/poddoor{
+	id = "traumaenginer"
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -2310,7 +2353,9 @@
 /area/ship/crew)
 "Yn" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/structure/curtain,
+/obj/structure/curtain/cloth{
+	color = "#ACD1E9"
+	},
 /turf/open/floor/plating,
 /area/ship/bridge)
 "Yv" = (
@@ -2800,7 +2845,7 @@ UG
 UG
 Ti
 UO
-Lt
+OB
 UO
 UG
 UG

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -414,9 +414,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/wall{
 	dir = 4;
 	icon_state = "sec_wall";
@@ -743,6 +740,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"rh" = (
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/aft)
 "ru" = (
 /obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 8
@@ -1191,6 +1195,9 @@
 /area/ship/hallway/aft)
 "Bl" = (
 /obj/effect/turf_decal/corner/opaque/red/full,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "BH" = (
@@ -1607,6 +1614,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/advanced_airlock_controller{
 	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ship/storage)
@@ -2136,9 +2146,6 @@
 	name = "Commander magazine (AP 9mm)"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/sign/poster/contraband/c20r{
-	pixel_y = 32
-	},
 /obj/structure/closet/secure_closet/wall{
 	dir = 4;
 	icon_state = "sec_wall";
@@ -2148,6 +2155,9 @@
 	},
 /obj/item/gun/ballistic/automatic/pistol/commander/no_mag,
 /obj/item/ammo_box/magazine/co9mm,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Vq" = (
@@ -2703,7 +2713,7 @@ ur
 go
 Bl
 Bl
-cn
+rh
 BN
 "}
 (11,1,1) = {"

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -1984,9 +1984,6 @@
 	},
 /turf/open/floor/engine,
 /area/ship/storage)
-"QS" = (
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
 "QU" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2686,7 +2683,7 @@ UG
 UG
 UG
 UG
-QS
+Uc
 OK
 MK
 AG

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -307,9 +307,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "hq" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plasteel/stairs/right{
 	dir = 8
 	},
@@ -1202,9 +1199,6 @@
 /obj/structure/cable{
 	icon_state = "4-10"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plasteel/stairs/medium{
 	dir = 8
 	},
@@ -1255,9 +1249,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
 "AG" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
 	},

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -1286,9 +1286,6 @@
 /obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/poddoor{
 	id = "traumaramp"
 	},

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -10,16 +10,22 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "aT" = (
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -25
+/obj/item/pickaxe/emergency{
+	name = "Medical Retrieval Tool";
+	desc = "For extracting yourself from rough landings, and getting to the even rougher ones"
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/medical,
-/turf/open/floor/plasteel,
+/obj/item/pickaxe/emergency{
+	name = "Medical Retrieval Tool";
+	desc = "For extracting yourself from rough landings, and getting to the even rougher ones"
+	},
+/obj/item/pickaxe/emergency{
+	name = "Medical Retrieval Tool";
+	desc = "For extracting yourself from rough landings, and getting to the even rougher ones"
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/item/circuitboard/machine/ore_redemption,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "bl" = (
 /obj/machinery/smartfridge/organ,
@@ -48,12 +54,16 @@
 /turf/open/floor/plasteel,
 /area/ship/storage)
 "bC" = (
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/medical,
-/turf/open/floor/plasteel,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "bX" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -83,26 +93,12 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "cs" = (
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/formaldehyde{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/glass/bottle/formaldehyde{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/syringe,
-/obj/structure/table/glass,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/effect/turf_decal/industrial/loading{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "cI" = (
@@ -149,21 +145,22 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "ed" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/airalarm/all_access{
-	pixel_y = 25
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/industrial/hatch/red,
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/rdserver,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/medical,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "el" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
 /obj/machinery/computer/cryopod{
-	pixel_y = -25
+	pixel_y = -34
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -240,28 +237,41 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "fn" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/industrial/outline/red,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -28
 	},
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs{
+	name = "organ freezer"
+	},
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/lungs,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/effect/turf_decal/industrial/hatch/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "fp" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/port)
 "fT" = (
-/obj/machinery/computer/operating,
-/obj/item/radio/intercom{
-	pixel_y = 25
+/obj/machinery/stasis,
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/industrial/hatch/red,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "go" = (
 /obj/effect/turf_decal/corner/opaque/red/full,
@@ -297,25 +307,21 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "hq" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/mineral/ore_redemption{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
+	},
 /area/ship/storage)
 "hv" = (
-/obj/effect/turf_decal/trimline/opaque/red/arrow_ccw,
-/obj/machinery/light/small,
-/obj/machinery/firealarm{
-	pixel_y = -28
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ship/storage)
 "hF" = (
 /obj/structure/table/reinforced,
@@ -326,12 +332,21 @@
 /obj/machinery/computer/helm,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"hQ" = (
+/obj/structure/table/optable,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/medical)
 "hT" = (
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/siding/white/end,
 /obj/structure/cable,
-/obj/effect/turf_decal/industrial/hatch/red,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/vault,
 /area/ship/storage)
 "ie" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -421,12 +436,12 @@
 	pixel_x = -28;
 	req_access_txt = "5"
 	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
+/obj/item/healthanalyzer/advanced,
+/obj/item/healthanalyzer/advanced,
+/obj/item/healthanalyzer/advanced,
+/obj/item/clothing/glasses/hud/health/sunglasses,
+/obj/item/clothing/glasses/hud/health/sunglasses,
+/obj/item/clothing/glasses/hud/health/sunglasses,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "kH" = (
@@ -436,11 +451,52 @@
 	},
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "kO" = (
-/turf/open/floor/plasteel,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "traumashield2"
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	id = "traumaramp"
+	},
+/turf/open/floor/engine,
 /area/ship/storage)
+"kP" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/medigel/sterilizine,
+/turf/open/floor/plasteel/tech,
+/area/ship/medical)
 "kR" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
@@ -533,11 +589,21 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "mG" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/machinery/firealarm{
+	pixel_y = 26;
+	pixel_x = -6
 	},
-/obj/effect/turf_decal/industrial/hatch/red,
-/turf/open/floor/plasteel,
+/obj/structure/sign/warning/gasmask{
+	pixel_x = -32
+	},
+/obj/item/stack/marker_beacon/thirty,
+/obj/item/stack/marker_beacon/thirty,
+/obj/item/stack/marker_beacon/thirty,
+/obj/item/stack/marker_beacon/thirty,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/rack,
+/obj/effect/turf_decal/industrial/outline/red,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "mO" = (
 /obj/machinery/computer/med_data,
@@ -582,7 +648,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -600,15 +665,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/cyan,
 /area/ship/crew)
-"nr" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel,
-/area/ship/storage)
 "nu" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -646,16 +702,15 @@
 /obj/machinery/button/door{
 	id = "lobbydoors";
 	name = "Lobby Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -13;
 	pixel_y = 7;
-	dir = 1
+	dir = 1;
+	normaldoorcontrol = 1
 	},
 /obj/machinery/button/door{
 	id = "traumalobby";
 	name = "Lobby Shutter Control";
 	pixel_x = -13;
-	pixel_y = -1;
+	pixel_y = -4;
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -666,6 +721,15 @@
 	pixel_y = 7;
 	name = "Lobby Holoshield";
 	id = "traumashield"
+	},
+/obj/machinery/button/door{
+	id = "lobbydoors";
+	name = "Lobby Door Bolts Control";
+	pixel_x = -13;
+	pixel_y = 7;
+	dir = 1;
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/plating,
 /area/ship/medical)
@@ -831,9 +895,6 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "sM" = (
-/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/cable{
@@ -844,6 +905,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
@@ -965,6 +1029,7 @@
 	},
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/industrial/hatch/red,
+/obj/item/circuitboard/machine/rdserver,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "uN" = (
@@ -1101,8 +1166,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "yi" = (
-/obj/item/pickaxe/mini,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -1123,19 +1186,28 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
 "zt" = (
-/obj/machinery/stasis,
 /obj/effect/turf_decal/industrial/outline/red,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "zE" = (
-/obj/effect/turf_decal/trimline/opaque/red/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/ship/storage)
 "zR" = (
 /obj/structure/table/reinforced,
@@ -1150,7 +1222,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 26
 	},
 /obj/item/paper_bin{
@@ -1160,14 +1232,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
-"zS" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/preopen{
-	id = "traumawindows";
-	name = "Window Blast Door"
-	},
-/turf/open/floor/plating,
-/area/ship/storage)
 "zT" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -1182,14 +1246,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+	pixel_x = -28;
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
+"AG" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ship/storage)
 "AJ" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/hallway/aft)
@@ -1201,12 +1273,26 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "BH" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "traumashield2";
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	id = "traumaramp"
+	},
+/turf/open/floor/engine,
 /area/ship/storage)
 "BK" = (
 /obj/effect/turf_decal/trimline/opaque/red/filled/line{
@@ -1242,6 +1328,17 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
+"Cr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/fore)
 "CX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -1303,17 +1400,18 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/gloves,
 /obj/item/storage/box/masks,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "DU" = (
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
 	},
-/obj/machinery/sleeper{
-	dir = 4
+/obj/machinery/computer/operating,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/turf_decal/industrial/outline/red,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "Ev" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1334,7 +1432,7 @@
 /area/ship/hallway/fore)
 "FE" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/industrial/outline/red,
@@ -1373,13 +1471,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "Gs" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	piping_layer = 2
-	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "GP" = (
@@ -1404,17 +1509,15 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "Hk" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/combatmedic,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/industrial/hatch/red,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/industrial/outline/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Hl" = (
 /obj/structure/sign/poster/contraband/random,
@@ -1521,15 +1624,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "Ko" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/outline/red,
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/medical,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Kv" = (
 /obj/effect/turf_decal/trimline/opaque/red/filled/line{
@@ -1604,21 +1713,16 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
 "Ln" = (
-/obj/effect/turf_decal/industrial/loading{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "6-8"
 	},
-/turf/open/floor/plasteel,
-/area/ship/storage)
-"Lq" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/ship/storage)
 "Lt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1633,23 +1737,25 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "Lu" = (
-/obj/effect/turf_decal/trimline/opaque/red/arrow_ccw,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/vault,
 /area/ship/storage)
-"LM" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/industrial/hatch/red,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ship/medical)
+"MK" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
 "MN" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -1701,7 +1807,6 @@
 /obj/item/clothing/under/suit/cmo,
 /obj/item/clothing/suit/toggle/labcoat/cmo,
 /obj/item/clothing/shoes/sneakers/white,
-/obj/item/clothing/glasses/hud/health/sunglasses,
 /obj/item/storage/belt/medical,
 /obj/item/clothing/neck/tie/light_blue,
 /obj/item/healthanalyzer/advanced,
@@ -1718,6 +1823,7 @@
 /obj/item/defibrillator/compact/loaded,
 /obj/item/gun/syringe,
 /obj/item/reagent_containers/glass/bottle/sodium_thiopental,
+/obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
 "Ny" = (
@@ -1791,7 +1897,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
 "Ps" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2,
 /obj/structure/closet/emcloset/wall{
 	dir = 4;
 	pixel_x = -28
@@ -1799,17 +1904,20 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "PG" = (
-/obj/effect/turf_decal/trimline/opaque/red/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/vault,
 /area/ship/storage)
 "PH" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -1840,6 +1948,21 @@
 "Qq" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/medical)
+"QE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/floor/vault,
+/area/ship/storage)
 "QP" = (
 /obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 4
@@ -1853,15 +1976,20 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "QQ" = (
-/obj/effect/turf_decal/trimline/opaque/red/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor{
+	id = "traumaramp"
+	},
+/turf/open/floor/engine,
 /area/ship/storage)
+"QS" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
 "QU" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1919,6 +2047,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"RB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/squid,
+/obj/item/reagent_containers/blood/universal,
+/turf/open/floor/plasteel/tech,
+/area/ship/medical)
 "RW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1936,34 +2075,47 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
-"Sy" = (
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/structure/closet/crate/freezer/surplus_limbs{
-	name = "organ freezer"
+"Sx" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -26;
+	pixel_x = -4;
+	name = "Emergency Ramp";
+	id = "traumaramp"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	pixel_y = -23;
+	pixel_x = 6;
+	name = "Emergency Ramp Shield";
+	id = "traumashield2"
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
+/area/ship/storage)
+"Sy" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/industrial/outline/red,
+/turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "SH" = (
-/obj/item/clothing/suit/space/hardsuit/combatmedic,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/suit_storage_unit/inherit,
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "SI" = (
 /obj/structure/bed,
@@ -1984,12 +2136,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "SR" = (
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/industrial/hatch/red,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 1
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/vault,
 /area/ship/storage)
 "Ti" = (
 /turf/closed/wall/mineral/titanium,
@@ -2087,10 +2241,6 @@
 "UG" = (
 /turf/template_noop,
 /area/template_noop)
-"UI" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/storage)
 "UJ" = (
 /obj/item/clothing/suit/armor/hos/trenchcoat,
 /obj/item/areaeditor/shuttle,
@@ -2188,21 +2338,26 @@
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/bridge)
 "Vu" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 10
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/surgical{
-	pixel_y = 6
-	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = 5
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "VM" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -2268,9 +2423,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Xb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -2282,6 +2434,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -2342,17 +2497,26 @@
 /turf/open/floor/carpet/cyan,
 /area/ship/crew)
 "Yb" = (
-/obj/effect/turf_decal/trimline/opaque/red/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/vault,
 /area/ship/storage)
 "Yk" = (
 /obj/structure/table,
@@ -2370,6 +2534,12 @@
 /area/ship/bridge)
 "Yv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -2434,12 +2604,12 @@ UG
 UG
 UG
 UG
-Uc
-zS
-zS
-OK
-OK
-Uc
+UG
+UG
+UG
+UG
+UG
+UG
 UG
 UG
 UG
@@ -2463,12 +2633,12 @@ UG
 UG
 UG
 Uc
-UI
+OK
 kO
 QQ
 BH
-Lq
-nr
+Uc
+UG
 UG
 UG
 UG
@@ -2491,13 +2661,13 @@ UG
 UG
 UG
 UG
-zS
+OK
 mG
 Ln
 hv
+Sx
 OK
-OK
-OK
+UG
 UG
 UG
 UG
@@ -2519,14 +2689,14 @@ UG
 UG
 UG
 UG
-Uc
+QS
 OK
-mG
-Ln
+MK
+AG
 zE
 hq
 OK
-UG
+Uc
 UG
 UG
 UG
@@ -2556,7 +2726,7 @@ Yb
 hT
 OK
 YM
-YM
+JA
 Qq
 UG
 UG
@@ -2585,7 +2755,7 @@ Lu
 bC
 OK
 fT
-LM
+ZN
 YM
 JA
 YM
@@ -2614,7 +2784,7 @@ PG
 aT
 OK
 Vu
-ZN
+Po
 DU
 lj
 fn
@@ -2639,12 +2809,12 @@ qd
 oX
 zo
 Ko
-PG
+QE
 SH
 bl
 Sy
 uo
-Po
+hQ
 HF
 cs
 YM
@@ -2671,9 +2841,9 @@ OK
 bu
 OK
 wC
-ZN
+RB
 Go
-ZN
+kP
 Yv
 zt
 YM
@@ -2698,7 +2868,7 @@ Pr
 BK
 Aj
 sM
-Ll
+Cr
 vn
 qQ
 Rs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates the Li Tieg to use proper airlock assemblies, have an outpost console, use a holoshield, and reduces its gear
The gear reduction is probably the important part. Two of the combat medic hardsuits have been swapped out for normal medical hardsuits, the CMO now has the syringe gun and compact defib, and the Vector has been swapped out for another pistol and ammo. The disk for .38 hunting ammo has been removed completely.
There are also more lights in the engine pods, as well as blast doors.
All the fire alarms have been fixed. They were all mapped backwards for some reason
The morgue airlock has been completely reworked under feedback 
The lobby airlock now has a bolting button, and a remote control. 
![2022 11 17-15 59 03](https://user-images.githubusercontent.com/94164348/202585387-8286da63-a361-42ee-be8c-4a55f44e74b1.png)

![2022 11 17-15 15 01](https://user-images.githubusercontent.com/94164348/202580136-70e2d3d7-6068-4d72-8767-098eca1fc808.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] The map loads this time I swear
## Why It's Good For The Game
The ship is kinda cool but also kinda overgeared. They have good medical gear, good combat gear, and a full research set up. Making it a bit less good at things gives other ships a chance to shine. Every ship should have the holoshields and outpost console
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: The Li Tieguai now uses holoshields.
tweak: The Li Tieguai's starting gear has been altered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
