### PR TITLE
Holofield Power Draw Increase + Subtype for mapping

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -607,7 +607,7 @@
 			qdel(src)
 			return
 
-		drain_power(250)
+		drain_power(500)
 
 /obj/machinery/shieldwall/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -600,6 +600,15 @@
 
 		drain_power(50)
 
+//Atmos shields suck more power
+/obj/machinery/shieldwall/atmos/process()
+	if(needs_power)
+		if(!gen_primary || !gen_primary.active || !gen_secondary || !gen_secondary.active)
+			qdel(src)
+			return
+
+		drain_power(250)
+
 /obj/machinery/shieldwall/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
 		if(BURN)
@@ -643,11 +652,3 @@
 /obj/machinery/shieldwall/atmos/Initialize()
 	. = ..()
 	air_update_turf(TRUE)
-
-/obj/machinery/shieldwall/atmos/process()
-	if(needs_power)
-		if(!gen_primary || !gen_primary.active || !gen_secondary || !gen_secondary.active)
-			qdel(src)
-			return
-
-		drain_power(250)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -492,6 +492,17 @@
 	anchored = TRUE
 	active = ACTIVE_SETUPFIELDS
 
+/obj/machinery/power/shieldwallgen/atmos/strong //these are for ruins and large hangars, try to not use them on ships
+	name = "high power holofield generator"
+	desc = "A holofield generator designed for use in starbase bays."
+	circuit = /obj/item/circuitboard/machine/shieldwallgen/atmos/strong
+	shield_range = 20
+	active_power_usage = 1000
+
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart
+	anchored = TRUE
+	active = ACTIVE_SETUPFIELDS
+
 /obj/machinery/power/shieldwallgen/atmos/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
@@ -632,3 +643,11 @@
 /obj/machinery/shieldwall/atmos/Initialize()
 	. = ..()
 	air_update_turf(TRUE)
+
+/obj/machinery/shieldwall/atmos/process()
+	if(needs_power)
+		if(!gen_primary || !gen_primary.active || !gen_secondary || !gen_secondary.active)
+			qdel(src)
+			return
+
+		drain_power(250)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -390,8 +390,19 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/shieldwallgen/atmos
-	name = "Atmospheric Holowall Generator (Machine Board)"
+	name = "Atmospheric Holofield Generator (Machine Board)"
 	build_path = /obj/machinery/power/shieldwallgen/atmos
+
+/obj/item/circuitboard/machine/shieldwallgen/atmos/strong
+	name = "High Power Atmospheric Holofield Generator (Machine Board)"
+	build_path = /obj/machinery/power/shieldwallgen/atmos/strong
+	req_components = list(/obj/item/stock_parts/manipulator/nano = 2,
+		/obj/item/stock_parts/micro_laser/high = 2,
+		/obj/item/stock_parts/capacitor/adv = 2,
+		/obj/item/stack/sheet/plasmaglass = 1,
+		/obj/item/stack/cable_coil = 5
+		)
+
 
 /obj/item/circuitboard/machine/pipedispenser
 	name = "Pipe dispenser (Machine Board)"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -396,12 +396,13 @@
 /obj/item/circuitboard/machine/shieldwallgen/atmos/strong
 	name = "High Power Atmospheric Holofield Generator (Machine Board)"
 	build_path = /obj/machinery/power/shieldwallgen/atmos/strong
-	req_components = list(/obj/item/stock_parts/manipulator/nano = 2,
+	req_components = list(
+		/obj/item/stock_parts/manipulator/nano = 2,
 		/obj/item/stock_parts/micro_laser/high = 2,
 		/obj/item/stock_parts/capacitor/adv = 2,
 		/obj/item/stack/sheet/plasmaglass = 1,
-		/obj/item/stack/cable_coil = 5
-		)
+		/obj/item/stack/cable_coil = 5,
+	)
 
 
 /obj/item/circuitboard/machine/pipedispenser


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Increases the power draw of the holofield generator by 10. Currently, holofields draw a pittance of power, 10 watts per tile plus 50 from each generator. For an example field of  4 tiles, that's 140 watts. That's not much, if you're running a single PACMAN at the lowest function you can sustain that. This leads to the fields just kinda staying on, and the ship staying open all the time. 
With a power draw of 500 per tile (plus 50 per generator) the holofields are a much more active draw. The example bay of 4 tiles now takes 2.1kw to run, which is still sustainable with a PACMAN, but not the absentminded turn the shield on and open the bay that it was. The max draw of the holofield is 4.1kw, for an 8 tile shield.

Holofields are maxed out at a length of 8, and the new atmos/strong variant maxes out at 20 (ideally I'd want 40 so it'd fit any ship), and draws a minimum of 2kw to stay running. This variant is intended for mapping ruins where a large airtight hangar is implied. At its max size, it will draw 12kw. 
<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I loaded and tested the things, and the balance implications seem fine to me.

## Why It's Good For The Game

More power management and another tool to use while mapping
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Strong Holofield subtype, for mapping large hangar bays
balance: the power draw of holofields has been increased tenfold, take care to not run them 24/7
spellcheck: the holofield circuits now have the same name as the machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
