### PR TITLE
Fixes a minor mapping error I made

### DIFF
--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -25,8 +25,8 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/item/circuitboard/machine/ore_redemption,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "bl" = (

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -25,6 +25,8 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/item/circuitboard/machine/ore_redemption,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "bl" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Li Tieg now has a stack of metal and iron when loaded in. Like it used to. 
I seem to have removed them when I redid the bay, and forgotten to put them back in.
![StrongDMM_fonG8snaHk](https://user-images.githubusercontent.com/94164348/204670760-d980f6e0-e3d0-46f1-8521-179ea18325cc.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] It's a two line change but I did launch to make sure it didn't crash when loading in

## Why It's Good For The Game
Fixes a small problem I created
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: The Li Tieguai starts with materials again.


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
