### PR TITLE
Ports SSmetrics from bee, which was ported from Para

### DIFF
--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -38,7 +38,7 @@ standards:
 
     - exactly:
           [
-              291,
+              292,
               "non-bitwise << uses",
               '(?<!\d)(?<!\d\s)(?<!<)<<(?!=|\s\d|\d|<|\/)',
           ]

--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -80,6 +80,7 @@
 /datum/controller/subsystem/##X/New(){ \
 	NEW_SS_GLOBAL(SS##X); \
 	PreInit(); \
+	ss_id=#X;\
 } \
 /datum/controller/subsystem/##X
 
@@ -87,6 +88,7 @@
 /datum/controller/subsystem/timer/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
 	PreInit();\
+	ss_id="timer_[#X]";\
 }\
 /datum/controller/subsystem/timer/##X
 
@@ -94,5 +96,6 @@
 /datum/controller/subsystem/processing/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
 	PreInit();\
+	ss_id="processing_[#X]";\
 }\
 /datum/controller/subsystem/processing/##X

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -93,3 +93,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 
 /proc/daysSince(realtimev)
 	return round((world.realtime - realtimev) / (24 HOURS))
+
+/// Returns the time in an ISO-8601 friendly format. Used when dumping data into external services such as ElasticSearch
+/proc/iso_timestamp(timevar)
+	return time2text(timevar || world.timeofday, "YYYY-MM-DDThh:mm:ss")

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -557,3 +557,10 @@
 			// even a high pressure zone will be less than 1.5x one atmos
 			return key_value > 0 && key_value < 1.5
 	return FALSE
+
+// Elasticsearch stuffs
+/datum/config_entry/flag/elasticsearch_metrics_enabled
+
+/datum/config_entry/string/elasticsearch_metrics_endpoint
+
+/datum/config_entry/string/elasticsearch_metrics_apikey

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -13,6 +13,9 @@
 	/// Name of the subsystem - you must change this
 	name = "fire coderbus"
 
+	/// The unique ID of the subsystem - you must change this
+	var/ss_id = "fire_coderbus_again"
+
 	/// Order of initialization. Higher numbers are initialized first, lower numbers later. Use or create defines such as [INIT_ORDER_DEFAULT] so we can see the order in one file.
 	var/init_order = INIT_ORDER_DEFAULT
 
@@ -263,3 +266,18 @@
 		if (NAMEOF(src, queued_priority)) //editing this breaks things.
 			return FALSE
 	. = ..()
+
+/**
+	* Returns the metrics for the subsystem.
+	*
+	* This can be overriden on subtypes for variables that could affect tick usage
+	* Example: ATs on SSair
+**/
+/datum/controller/subsystem/proc/get_metrics()
+	SHOULD_CALL_PARENT(TRUE)
+	// Please dont ever modify this. Youll break existing metrics and that will upset me.
+	var/list/out = list()
+	out["cost"] = cost
+	out["tick_usage"] = tick_usage
+	out["custom"] = list() // Override as needed on child
+	return out

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -11,6 +11,11 @@ SUBSYSTEM_DEF(acid)
 	msg = "P:[length(processing)]"
 	return ..()
 
+/datum/controller/subsystem/acid/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
 
 /datum/controller/subsystem/acid/fire(resumed = 0)
 	if (!resumed)

--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -11,6 +11,11 @@ SUBSYSTEM_DEF(fire_burning)
 	msg = "P:[length(processing)]"
 	return ..()
 
+/datum/controller/subsystem/fire_burning/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
 
 /datum/controller/subsystem/fire_burning/fire(resumed = 0)
 	if (!resumed)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -56,6 +56,19 @@ SUBSYSTEM_DEF(garbage)
 	#endif
 	#endif
 
+/datum/controller/subsystem/garbage/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	// You can calculate TGCR in kibana
+	cust["total_harddels"] = totaldels
+	cust["total_softdels"] = totalgcs
+	var/i = 0
+	for(var/list/L in queues)
+		i++
+		cust["queue_[i]"] = length(L)
+
+	.["custom"] = cust
+
 
 /datum/controller/subsystem/garbage/PreInit()
 	InitQueues()
@@ -169,6 +182,7 @@ SUBSYSTEM_DEF(garbage)
 		if(GCd_at_time > cut_off_time)
 			break // Everything else is newer, skip them
 		count++
+
 		var/refID = L[2]
 		var/datum/D
 		D = locate(refID)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -69,7 +69,6 @@ SUBSYSTEM_DEF(garbage)
 
 	.["custom"] = cust
 
-
 /datum/controller/subsystem/garbage/PreInit()
 	InitQueues()
 

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -10,6 +10,13 @@ SUBSYSTEM_DEF(lighting)
 	msg = "L:[length(sources_queue)]|C:[length(corners_queue)]|O:[length(objects_queue)]"
 	return ..()
 
+/datum/controller/subsystem/lighting/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["sources_queue"] = length(GLOB.lighting_update_lights)
+	cust["corners_queue"] = length(GLOB.lighting_update_corners)
+	cust["objects_queue"] = length(GLOB.lighting_update_objects)
+	.["custom"] = cust
 
 /datum/controller/subsystem/lighting/Initialize(timeofday)
 	if(!initialized)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -13,9 +13,9 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/get_metrics()
 	. = ..()
 	var/list/cust = list()
-	cust["sources_queue"] = length(GLOB.lighting_update_lights)
-	cust["corners_queue"] = length(GLOB.lighting_update_corners)
-	cust["objects_queue"] = length(GLOB.lighting_update_objects)
+	cust["sources_queue"] = length(sources_queue)
+	cust["corners_queue"] = length(corners_queue)
+	cust["objects_queue"] = length(objects_queue)
 	.["custom"] = cust
 
 /datum/controller/subsystem/lighting/Initialize(timeofday)

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -11,6 +11,13 @@ SUBSYSTEM_DEF(machines)
 	fire()
 	return ..()
 
+
+/datum/controller/subsystem/machines/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
+
 /datum/controller/subsystem/machines/proc/makepowernets()
 	for(var/datum/powernet/PN in powernets)
 		qdel(PN)

--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -1,0 +1,63 @@
+/*
+
+	Ok listen up
+
+	This thing ingests data to ElasticSearch in a VERY SPECIFIC FORMAT
+	Not only is changing this a very bad idea due to elasticsearch being very finnicky with data formatting,
+	but if you edit this subsystem and its fields, you invalidate a lot of existing data
+
+	Dont touch this shit without speaking to crossed or AA07 first
+
+*/
+SUBSYSTEM_DEF(metrics)
+	name = "Metrics"
+	wait = 30 SECONDS
+	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME // ALL THE LEVELS
+	flags = SS_KEEP_TIMING // This needs to ingest every 30 IRL seconds, not ingame seconds.
+	/// The real time of day the server started. Used to calculate time drift
+	var/world_init_time = 0 // Not set in here. Set in world/New()
+
+/datum/controller/subsystem/metrics/Initialize(start_timeofday)
+	if(!CONFIG_GET(flag/elasticsearch_metrics_enabled))
+		flags |= SS_NO_FIRE // Disable firing to save CPU
+	return ..()
+
+
+/datum/controller/subsystem/metrics/fire(resumed)
+	var/datum/http_request/request = new()
+	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/elasticsearch_metrics_endpoint), get_metrics_json(), list(
+		"Authorization" = "ApiKey [CONFIG_GET(string/elasticsearch_metrics_apikey)]",
+		"Content-Type" = "application/json"
+	))
+	request.begin_async() // Fire and forget who gives a shit
+
+/datum/controller/subsystem/metrics/proc/get_metrics_json()
+	var/list/out = list()
+	out["@timestamp"] = iso_timestamp() // This is required by ElasticSearch, complete with this name. DO NOT REMOVE THIS.
+	out["cpu"] = world.cpu
+	out["maptick"] = world.map_cpu
+	out["elapsed_processed"] = world.time
+	out["elapsed_real"] = (REALTIMEOFDAY - world_init_time)
+	out["client_count"] = length(GLOB.clients)
+	out["round_id"] = text2num(GLOB.round_id) // This is so we can filter the metrics by a single round ID
+
+	var/server_name = CONFIG_GET(string/serversqlname)
+	if(server_name)
+		out["server_name"] = server_name
+
+	// Funnel in all SS metrics
+	var/list/ss_data = list()
+	for(var/datum/controller/subsystem/SS in Master.subsystems)
+		ss_data[SS.ss_id] = SS.get_metrics()
+
+	out["subsystems"] = ss_data
+	// And send it all
+	return json_encode(out)
+
+/*
+
+// Uncomment this if you add new metrics to verify how the JSON formats
+
+/client/verb/debug_metrics()
+	usr << browse(SSmetrics.get_metrics_json(), "window=aadebug")
+*/

--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -39,6 +39,11 @@ SUBSYSTEM_DEF(metrics)
 	out["elapsed_processed"] = world.time
 	out["elapsed_real"] = (REALTIMEOFDAY - world_init_time)
 	out["client_count"] = length(GLOB.clients)
+	out["time_dilation_current"] = SStime_track.time_dilation_current
+	out["time_dilation_1m"] = SStime_track.time_dilation_avg
+	out["time_dilation_5m"] = SStime_track.time_dilation_avg_slow
+	out["time_dilation_15m"] = SStime_track.time_dilation_avg_fast
+	out["harddel_count"] = length(GLOB.world_qdel_log)
 	out["round_id"] = text2num(GLOB.round_id) // This is so we can filter the metrics by a single round ID
 
 	var/server_name = CONFIG_GET(string/serversqlname)

--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -12,16 +12,17 @@
 SUBSYSTEM_DEF(metrics)
 	name = "Metrics"
 	wait = 30 SECONDS
-	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME // ALL THE LEVELS
+	runlevels = ALL
 	flags = SS_KEEP_TIMING // This needs to ingest every 30 IRL seconds, not ingame seconds.
 	/// The real time of day the server started. Used to calculate time drift
 	var/world_init_time = 0 // Not set in here. Set in world/New()
+
+GENERAL_DATUM_PROTECT(/datum/controller/subsystem/metrics)
 
 /datum/controller/subsystem/metrics/Initialize(start_timeofday)
 	if(!CONFIG_GET(flag/elasticsearch_metrics_enabled))
 		flags |= SS_NO_FIRE // Disable firing to save CPU
 	return ..()
-
 
 /datum/controller/subsystem/metrics/fire(resumed)
 	var/datum/http_request/request = new()

--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -17,7 +17,6 @@ SUBSYSTEM_DEF(metrics)
 	/// The real time of day the server started. Used to calculate time drift
 	var/world_init_time = 0 // Not set in here. Set in world/New()
 
-GENERAL_DATUM_PROTECT(/datum/controller/subsystem/metrics)
 
 /datum/controller/subsystem/metrics/Initialize(start_timeofday)
 	if(!CONFIG_GET(flag/elasticsearch_metrics_enabled))

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -14,6 +14,12 @@ SUBSYSTEM_DEF(mobs)
 	msg = "P:[length(GLOB.mob_living_list)]"
 	return ..()
 
+/datum/controller/subsystem/mobs/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(GLOB.mob_living_list)
+	.["custom"] = cust
+
 /datum/controller/subsystem/mobs/proc/MaxZChanged()
 	if (!islist(clients_by_zlevel))
 		clients_by_zlevel = new /list(world.maxz,0)

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -29,10 +29,11 @@ SUBSYSTEM_DEF(overmap)
 	var/list/list/overmap_container
 
 /datum/controller/subsystem/overmap/get_metrics()
-	var/list/metrics = ..()
-	metrics["overmap_objects"] = length(overmap_objects)
-	metrics["controlled_ships"] = length(controlled_ships)
-	return metrics
+	. = ..()
+	var/list/cust = list()
+	cust["overmap_objects"] = length(overmap_objects)
+	cust["controlled_ships"] = length(controlled_ships)
+	.["cust"] = cust
 
 /**
  * Creates an overmap object for shuttles, triggers initialization procs for ships

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -28,6 +28,12 @@ SUBSYSTEM_DEF(overmap)
 	///The two-dimensional list that contains every single tile in the overmap as a sublist.
 	var/list/list/overmap_container
 
+/datum/controller/subsystem/overmap/get_metrics()
+	var/list/metrics = ..()
+	metrics["overmap_objects"] = length(overmap_objects)
+	metrics["controlled_ships"] = length(controlled_ships)
+	return metrics
+
 /**
  * Creates an overmap object for shuttles, triggers initialization procs for ships
  */

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(overmap)
 	var/list/cust = list()
 	cust["overmap_objects"] = length(overmap_objects)
 	cust["controlled_ships"] = length(controlled_ships)
-	.["cust"] = cust
+	.["custom"] = cust
 
 /**
  * Creates an overmap object for shuttles, triggers initialization procs for ships

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -14,6 +14,12 @@ SUBSYSTEM_DEF(processing)
 	msg = "[stat_tag]:[length(processing)]"
 	return ..()
 
+/datum/controller/subsystem/processing/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
+
 /datum/controller/subsystem/processing/fire(resumed = 0)
 	if (!resumed)
 		currentrun = processing.Copy()

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -12,6 +12,11 @@ SUBSYSTEM_DEF(spacedrift)
 	msg = "P:[length(processing)]"
 	return ..()
 
+/datum/controller/subsystem/spacedrift/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
 
 /datum/controller/subsystem/spacedrift/fire(resumed = 0)
 	if (!resumed)

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -40,6 +40,12 @@ SUBSYSTEM_DEF(tgui)
 	msg = "P:[length(open_uis)]"
 	return ..()
 
+/datum/controller/subsystem/tgui/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(open_uis)
+	.["custom"] = cust
+
 /datum/controller/subsystem/tgui/fire(resumed = FALSE)
 	if(!resumed)
 		src.current_run = open_uis.Copy()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -15,6 +15,11 @@ SUBSYSTEM_DEF(throwing)
 	msg = "P:[length(processing)]"
 	return ..()
 
+/datum/controller/subsystem/throwing/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust
 
 /datum/controller/subsystem/throwing/fire(resumed = 0)
 	if (!resumed)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -52,6 +52,12 @@ SUBSYSTEM_DEF(timer)
 	/// How many times bucket was reset
 	var/bucket_reset_count = 0
 
+/datum/controller/subsystem/timer/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["bucket_count"] = bucket_count
+	.["custom"] = cust
+
 /datum/controller/subsystem/timer/PreInit()
 	bucket_list.len = BUCKET_LEN
 	head_offset = world.time

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -25,3 +25,9 @@ SUBSYSTEM_DEF(weather)
 			for(var/b in iterated_controller.current_weathers)
 				returned_weathers += iterated_controller.current_weathers[b]
 	return returned_weathers
+
+/datum/controller/subsystem/weather/get_metrics()
+	. = ..()
+	var/list/cust = list()
+	cust["processing"] = length(processing)
+	.["custom"] = cust

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -13,14 +13,12 @@ SUBSYSTEM_DEF(weather)
 
 /datum/controller/subsystem/weather/fire()
 	// process active weather controllers
-	for(var/i in weather_controllers)
-		var/datum/weather_controller/iterated_controller = i
+	for(var/datum/weather_controller/iterated_controller as anything in weather_controllers)
 		iterated_controller.process()
 
 /datum/controller/subsystem/weather/proc/get_all_current_weather()
 	var/list/returned_weathers = list()
-	for(var/i in weather_controllers)
-		var/datum/weather_controller/iterated_controller = i
+	for(var/datum/weather_controller/iterated_controller as anything in weather_controllers)
 		if(iterated_controller.current_weathers)
 			for(var/b in iterated_controller.current_weathers)
 				returned_weathers += iterated_controller.current_weathers[b]
@@ -29,5 +27,7 @@ SUBSYSTEM_DEF(weather)
 /datum/controller/subsystem/weather/get_metrics()
 	. = ..()
 	var/list/cust = list()
-	cust["processing"] = length(processing)
+	cust["processing"] = 0
+	for(var/datum/weather_controller/iterated_controller as anything in weather_controllers)
+		cust["processing"] += length(iterated_controller.current_weathers)
 	.["custom"] = cust

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -35,6 +35,7 @@ GLOBAL_VAR(restart_counter)
 	enable_debugger()
 
 	log_world("World loaded at [time_stamp()]!")
+	SSmetrics.world_init_time = REALTIMEOFDAY // Important
 
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -51,6 +51,7 @@
 #include "subsystem_init.dm"
 #include "supply_pack.dm"
 #include "teleporters.dm"
+#include "subsystem_metric_sanity.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
 

--- a/code/modules/unit_tests/subsystem_metric_sanity.dm
+++ b/code/modules/unit_tests/subsystem_metric_sanity.dm
@@ -1,0 +1,22 @@
+// Unit test to ensure SS metrics are valid
+/datum/unit_test/subsystem_metric_sanity/Run()
+	for(var/datum/controller/subsystem/SS in Master.subsystems)
+		if(SS.ss_id == initial(SS.ss_id)) // initial() works here because ss_id is set at runtime during /New()
+			Fail("[SS.type] has no SS ID, somehow!")
+			continue
+		var/list/data = SS.get_metrics()
+		if(length(data) != 3)
+			Fail("SS[SS.ss_id] has invalid metrics data!")
+			continue
+		if(isnull(data["cost"]))
+			Fail("SS[SS.ss_id] has invalid metrics data! No 'cost' found in [json_encode(data)]")
+			continue
+		if(isnull(data["tick_usage"]))
+			Fail("SS[SS.ss_id] has invalid metrics data! No 'tick_usage' found in [json_encode(data)]")
+			continue
+		if(isnull(data["custom"]))
+			Fail("SS[SS.ss_id] has invalid metrics data! No 'custom' found in [json_encode(data)]")
+			continue
+		if(!islist(data["custom"]))
+			Fail("SS[SS.ss_id] has invalid metrics data! 'custom' is not a list in [json_encode(data)]")
+			continue

--- a/config/config.txt
+++ b/config/config.txt
@@ -573,3 +573,13 @@ RESPAWN_TIMER 600
 ## Custom shuttle spam prevention. Changine these numbers allows you to change the maxsize and amount of custom shuttles.
 MAX_SHUTTLE_COUNT 20
 MAX_SHUTTLE_SIZE 300
+
+### ALL SETTINGS FOR SSmetrics ###
+## Uncomment the line below to enable SSmetrics sending data to ElasticSearch. You will need to fill in the other lines if you do
+#ELASTICSEARCH_METRICS_ENABLED
+
+## POST URL of your elasticsearch metrics. Include the IP, protocol, and datastream/index
+ELASTICSEARCH_METRICS_ENDPOINT http://10.0.0.40:9201/ss13-metrics-stream/_doc
+
+## ElasticSearch API key. This is formatted into the headers. Look at the ElasticSearch doc for how to make this
+ELASTICSEARCH_METRICS_APIKEY thisIsSomethingThatsBased64Encoded==

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -323,6 +323,7 @@
 #include "code\controllers\subsystem\machines.dm"
 #include "code\controllers\subsystem\mapping.dm"
 #include "code\controllers\subsystem\materials.dm"
+#include "code\controllers\subsystem\metrics.dm"
 #include "code\controllers\subsystem\minor_mapping.dm"
 #include "code\controllers\subsystem\mobs.dm"
 #include "code\controllers\subsystem\moods.dm"


### PR DESCRIPTION
## About The Pull Request
Ports: beestation/beestation-hornet#5152 which was a port of ParadiseSS13/Paradise#16549, as well as ports BeeStation/BeeStation-Hornet#8007.

Adds a subsystem that optionally shoots server metrics to an elasticsearch server. I think you can guess why I decided to port this.

## Why It's Good For The Game
Good for monitoring the server's status, most importantly the specific subsystems so that we can tell if something is going awry.

## Changelog

:cl: AffectedArc07, Crossedfall
add: Added a subsystem which can send server metrics straight into ElasticSearch.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
