### PR TITLE
Fixes the phantom map change that 1580 is causing 

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -5117,7 +5117,7 @@
 /obj/effect/decal/cleanable/oil{
 	icon_state = "streak3"
 	},
-/turf/open/floor/concrete/slab_3,
+/turf/open/floor/plasteel,
 /area/ruin/jungle/paradise/construction)
 "FY" = (
 /obj/structure/railing/corner{

--- a/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -5117,7 +5117,7 @@
 /obj/effect/decal/cleanable/oil{
 	icon_state = "streak3"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/concrete/slab_3,
 /area/ruin/jungle/paradise/construction)
 "FY" = (
 /obj/structure/railing/corner{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the map change that was sneaking its way into things after #1580 was merged
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] Game compiles and the ruin loads

## Why It's Good For The Game
Everyone can do their things without the Map Change label being applied to the pr when it shouldn't be.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: line endings on jungle_paradise. Not player facing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
