### PR TITLE
Adds crafting recipes for glass shards and plasma glass shards

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -11,7 +11,8 @@
 GLOBAL_LIST_INIT(glass_recipes, list ( \
 	new/datum/stack_recipe("directional window", /obj/structure/window/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile window", /obj/structure/window/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe("glass floor tile", /obj/item/stack/tile/glass, 1, 4, 20) \
+	new/datum/stack_recipe("glass floor tile", /obj/item/stack/tile/glass, 1, 4, 20), \
+	new/datum/stack_recipe("glass shard", /obj/item/shard, 1) \
 ))
 
 /obj/item/stack/sheet/glass
@@ -86,7 +87,8 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 
 GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	new/datum/stack_recipe("directional window", /obj/structure/window/plasma/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe("fulltile window", /obj/structure/window/plasma/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
+	new/datum/stack_recipe("fulltile window", /obj/structure/window/plasma/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	new/datum/stack_recipe("plasma glass shard", /obj/item/shard/plasma, 1) \
 ))
 
 /obj/item/stack/sheet/plasmaglass
@@ -139,7 +141,8 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("directional reinforced window", /obj/structure/window/reinforced/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile reinforced window", /obj/structure/window/reinforced/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe(" reinforced glass tile", /obj/item/stack/tile/glass/reinforced, 1, 4, 20) \
+	new/datum/stack_recipe(" reinforced glass tile", /obj/item/stack/tile/glass/reinforced, 1, 4, 20), \
+	new/datum/stack_recipe("glass shard", /obj/item/shard, 1) \
 ))
 
 
@@ -185,7 +188,8 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 
 GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	new/datum/stack_recipe("directional reinforced window", /obj/structure/window/plasma/reinforced/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe("fulltile reinforced window", /obj/structure/window/plasma/reinforced/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
+	new/datum/stack_recipe("fulltile reinforced window", /obj/structure/window/plasma/reinforced/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	new/datum/stack_recipe("plasma glass shard", /obj/item/shard/plasma, 1) \
 ))
 
 /obj/item/stack/sheet/plasmarglass


### PR DESCRIPTION
## About The Pull Request

Reinforced glass, glass, plasma glass and reinforced plasma glass can now be turned into SHARDS.

## Why It's Good For The Game

Reduces the TWO STEP process of creating glass shards to a SINGLE BUTTON. No more smashing windows for SHARDS.

## Changelog

:cl:
add: Hand crafting recipes for glass shards
add: Hand crafting recipes for plasma glass shards
/:cl:

- [x] I affirm that nothing broke when I tested this