### PR TITLE
fixed the lawnmower and added it to the outpust

### DIFF
--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -41,6 +41,14 @@
 	crate_name = "janitorial cart crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/civilian/lawnmower
+	name = "Donk! Co. TM Deluxe Lawnmower 3003"
+	desc = "Removing plant from your backyard now made easy with the brand new Donk! Co. TM Deluxe Lawnmower 3003."
+	cost = 800
+	contains = list(/obj/vehicle/ridden/lawnmower)
+	crate_name = "Donk! Co. TM Deluxe Lawnmower 3003"
+	crate_type = /obj/structure/closet/crate/large
+    
 /*
 		Religious
 */

--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -42,7 +42,7 @@
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/civilian/lawnmower
-	name = "Donk! Co. TM Deluxe Lawnmower 3003"
+	name = "Lawnmower"
 	desc = "Removing plant from your backyard now made easy with the brand new Donk! Co. TM Deluxe Lawnmower 3003."
 	cost = 800
 	contains = list(/obj/vehicle/ridden/lawnmower)

--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -48,7 +48,7 @@
 	contains = list(/obj/vehicle/ridden/lawnmower)
 	crate_name = "Donk! Co. TM Deluxe Lawnmower 3003"
 	crate_type = /obj/structure/closet/crate/large
-    
+
 /*
 		Religious
 */

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -84,7 +84,7 @@
 
 /obj/vehicle/ridden/lawnmower
 	name = "Donk! Co. TM Deluxe Lawnmower 3003"
-	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is on"
+	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is <b>on</b>."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "lawnmower"
 	var/emagged = FALSE

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -83,8 +83,8 @@
 //For those who want to play farm simulator 503
 
 /obj/vehicle/ridden/lawnmower
-	name = "lawn mower"
-	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace."
+	name = "Donk! Co. TM Deluxe Lawnmower 3003"
+	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is on"
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "lawnmower"
 	var/emagged = FALSE
@@ -100,12 +100,14 @@
 
 /obj/vehicle/ridden/lawnmower/emagged
 	emagged = TRUE
+	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is off"
 
 /obj/vehicle/ridden/lawnmower/emag_act(mob/user)
 	if(emagged)
 		to_chat(user, "<span class='warning'>The safety mechanisms on \the [src] are already disabled!</span>")
 		return
 	to_chat(user, "<span class='warning'>You disable the safety mechanisms on \the [src].</span>")
+	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is off"
 	emagged = TRUE
 
 /obj/vehicle/ridden/lawnmower/Bump(atom/A)

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -107,7 +107,7 @@
 		to_chat(user, "<span class='warning'>The safety mechanisms on \the [src] are already disabled!</span>")
 		return
 	to_chat(user, "<span class='warning'>You disable the safety mechanisms on \the [src].</span>")
-	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is off"
+	desc = "Equipped with reliable safeties to prevent <i>accidents</i> in the workplace. The safety light is <b>off</b>."
 	emagged = TRUE
 
 /obj/vehicle/ridden/lawnmower/Bump(atom/A)

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -168,7 +168,7 @@
 		mowed = TRUE
 
 	var/obj/structure/flora/flora = locate(/obj/structure/flora) in loc
-	if(ayy_weeds)
+	if(flora)
 		if(!istype(flora, /obj/structure/flora/rock))
 			qdel(flora)
 			mowed = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR add a lawnmower to the outpust (not the emaged one altough it could be emaged) to make building more about building and less about clicking grass for 40 minutes.

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

Colony building is fun but removing the grass is unnecessarily painfull and long.
## Changelog

:cl:
add: The lawn mower is now buyable at the outpust for 800 credits.
fix: Fixed the lawnmower not destroying some flora because of  a typo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
