### PR TITLE
Adds mining hardsuits to the cargo catalogue

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -28,6 +28,15 @@
 					/obj/item/clothing/head/helmet/space/pilot/random)
 	crate_name = "pilot space suit crate"
 
+/datum/supply_pack/spacesuit_armor/mining_hardsuits_indie
+	name = "Mining Hardsuit Crate"
+	desc = "Two independent branded mining hardsuits for when explorer suits just dont cut it."
+	cost = 4000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/mining/independent,
+					/obj/item/clothing/suit/space/hardsuit/mining/independent)
+	crate_name = "mining hardsuit crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
 /datum/supply_pack/spacesuit_armor/med_hardsuit
 	name = "Medical Hardsuit Crate"
 	desc = "Two medical hardsuits, resistant to diseases and useful for retrieving patients in space."
@@ -36,6 +45,24 @@
 					/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"
 	crate_type = /obj/structure/closet/crate/medical
+
+/datum/supply_pack/spacesuit_armor/mining_hardsuit_heavy
+	name = "Heavy Mining Hardsuit Crate"
+	desc = "One deluxe heavy mining hardsuit for dangerous frontier operations. Comes with a pair of EXOCOM jet boots."
+	cost = 6000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/mining/heavy,
+					/obj/item/clothing/shoes/bhop)
+	crate_name = "heavy mining hardsuit crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/spacesuit_armor/sec_hardsuit_bundle
+	name = "Security Hardsuit Crate"
+	desc = "Contains two security hardsuits for light combat duty."
+	cost = 7500
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security/independent,
+					/obj/item/clothing/suit/space/hardsuit/security/independent)
+	crate_name = "security hardsuit crate"
+	crate_type = /obj/structure/closet/crate/secure/gear
 
 /datum/supply_pack/spacesuit_armor/sci_hardsuit
 	name = "Science Hardsuit Crate"
@@ -67,15 +94,6 @@
 					/obj/item/clothing/suit/space/hardsuit/engine/atmos)
 	crate_name = "atmospherics hardsuit crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
-
-/datum/supply_pack/spacesuit_armor/sec_hardsuit_bundle
-	name = "Security Hardsuit Crate"
-	desc = "Contains two security hardsuits for light combat duty."
-	cost = 7500
-	contains = list(/obj/item/clothing/suit/space/hardsuit/security/independent,
-					/obj/item/clothing/suit/space/hardsuit/security/independent)
-	crate_name = "security hardsuit crate"
-	crate_type = /obj/structure/closet/crate/secure/gear
 
 /datum/supply_pack/spacesuit_armor/swat
 	name = "SWAT Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a pack for two indie mining hardsuits and a separate, more expensive pack for one heavy mining hardsuit and a pair of jump boots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
Mining hardsuits really should be orderable from outposts, seeing as its the main thing to do on planets and asteroids. Also the heavy mining hardsuit looks really cool and I wanted it to be obtainable from cargo again. Drip.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: adds the heavy mining hardsuit and independent mining hardsuits to the cargo catalogue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
