### PR TITLE
Fixes hotspots and makes igniters actually work properly

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -40,7 +40,7 @@
 	if (src.on && !(machine_stat & NOPOWER))
 		var/turf/location = src.loc
 		if (isturf(location))
-			location.hotspot_expose(1000,500,1)
+			location.hotspot_expose(1000,2500,1)
 	return 1
 
 /obj/machinery/igniter/Initialize()

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -83,7 +83,7 @@
 
 	location.active_hotspot = src
 
-	bypassing = volume > CELL_VOLUME*0.95 || location.air.return_temperature() > FUSION_TEMPERATURE_THRESHOLD
+	bypassing = volume > CELL_VOLUME*0.95 || location.air.return_temperature() >= FUSION_TEMPERATURE_THRESHOLD
 
 	if(bypassing)
 		if(temperature > location.air.return_temperature())
@@ -93,7 +93,8 @@
 	else
 		var/datum/gas_mixture/affected = location.air.remove_ratio(volume/location.air.return_volume())
 		if(affected) //in case volume is 0
-			affected.set_temperature(temperature)
+			if(temperature > affected.return_temperature())
+				affected.set_temperature(temperature) //don't set the temperature lower than what it was
 			affected.react(src)
 			temperature = affected.return_temperature()
 			volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -86,6 +86,8 @@
 	bypassing = volume > CELL_VOLUME*0.95 || location.air.return_temperature() > FUSION_TEMPERATURE_THRESHOLD
 
 	if(bypassing)
+		if(temperature > location.air.return_temperature())
+			location.air.set_temperature(temperature) //now actually starts fires like intended
 		volume = location.air.reaction_results["fire"]*FIRE_GROWTH_RATE
 		temperature = location.air.return_temperature()
 	else


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

1) Increased exposed volume of igniters to make them start fires like intended

2) Fixes hotspots not starting fires as intended when the exposed volume is over 2375 liters

3) Fixes hotspots making the air colder when the exposed volume is 2375 liters or less and the exposed temperature is less than the temperature of the air

4) Prevents hotspots from causing fusion to happen twice in one reaction tick at exactly 10,000 kelvin

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to ignite the burn for a thermoelectric generator without having to throw in a bunch of lit welders would be nice.

## Changelog

:cl:
tweak: increased hotspot exposed volume of igniters to 2500
fix: fixes hotspots not starting fires when the exposed volume is over 2375 liters
fix: fixes hotspots making the air colder when the exposed volume is 2375 liters or less
fix: prevents hotspots from causing fusion to happen twice in a single tick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
