### PR TITLE
Small Lab4071 fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/lab4071.dmm
+++ b/_maps/RandomRuins/SpaceRuins/lab4071.dmm
@@ -97,7 +97,7 @@
 /area/ruin/space/has_grav/crazylab/crew)
 "cn" = (
 /obj/structure/mirror,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "cq" = (
 /obj/structure/grille,
@@ -163,9 +163,8 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/crazylab/watchpost)
 "dI" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/ruin/space/has_grav/crazylab/outside)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/crazylab/crew)
 "dJ" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -329,7 +328,7 @@
 /turf/open/space,
 /area/ruin/space/has_grav/crazylab/gamble)
 "fY" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/gamble)
 "go" = (
 /obj/machinery/shower{
@@ -367,7 +366,7 @@
 /area/ruin/space/has_grav/crazylab/crew)
 "gK" = (
 /obj/structure/sign/poster/contraband/xenofauna_parasite,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "gP" = (
 /turf/open/floor/plasteel/grimy,
@@ -404,11 +403,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/crazylab/crew)
 "hy" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/chem)
 "hE" = (
 /obj/structure/sign/warning/nosmoking,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/chem)
 "hJ" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
@@ -478,7 +477,7 @@
 /area/ruin/space/has_grav/crazylab/gamble)
 "is" = (
 /obj/structure/sign/poster/contraband/masked_men,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/gamble)
 "iw" = (
 /obj/machinery/shower{
@@ -631,22 +630,22 @@
 /area/ruin/space/has_grav/crazylab/crew)
 "lb" = (
 /obj/effect/turf_decal/number/four,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "lc" = (
 /obj/effect/turf_decal/number/zero,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "ll" = (
 /turf/template_noop,
 /area/template_noop)
 "ln" = (
 /obj/effect/turf_decal/number/seven,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "lA" = (
 /obj/effect/turf_decal/number/one,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/crew)
 "lN" = (
 /obj/machinery/door/airlock/hatch,
@@ -663,7 +662,7 @@
 /area/ruin/space/has_grav/crazylab/crew)
 "mb" = (
 /obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/chem)
 "mc" = (
 /obj/structure/closet/secure_closet/chemical/heisenberg,
@@ -1369,7 +1368,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/crew)
 "vi" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/engi)
 "vk" = (
 /obj/machinery/door/airlock/hatch,
@@ -1386,7 +1385,7 @@
 /area/ruin/space/has_grav/crazylab/engi)
 "vD" = (
 /obj/structure/sign/warning/chemdiamond,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/chem)
 "vJ" = (
 /obj/structure/closet/crate/radiation{
@@ -1535,11 +1534,11 @@
 /area/ruin/space/has_grav/crazylab/bar)
 "xx" = (
 /obj/structure/sign/poster/contraband/space_cola,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "xH" = (
 /obj/structure/sign/warning/enginesafety,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/engi)
 "xO" = (
 /obj/effect/turf_decal/trimline/opaque/orange/filled/warning{
@@ -1583,7 +1582,7 @@
 /area/ruin/space/has_grav/crazylab/engi)
 "yk" = (
 /obj/structure/sign/poster/contraband/gec,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/engi)
 "yl" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -1631,7 +1630,7 @@
 /area/ruin/space/has_grav/crazylab/outside)
 "yI" = (
 /obj/structure/sign/poster/contraband/fun_police,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/gamble)
 "yR" = (
 /obj/machinery/airalarm/directional/south,
@@ -1761,7 +1760,7 @@
 /area/ruin/space/has_grav/crazylab/engi)
 "Ad" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/chem)
 "Ae" = (
 /obj/structure/table/reinforced,
@@ -1802,11 +1801,11 @@
 /area/ruin/space/has_grav/crazylab/gamble)
 "AG" = (
 /obj/structure/sign/poster/contraband/eat,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/gamble)
 "AL" = (
 /obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "AR" = (
 /obj/structure/table/wood/reinforced,
@@ -1998,7 +1997,7 @@
 /area/ruin/space/has_grav/crazylab/outside)
 "Ck" = (
 /obj/effect/turf_decal/number/four,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "Cn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2184,8 +2183,11 @@
 /area/ruin/space/has_grav/crazylab/chem)
 "Fo" = (
 /obj/effect/turf_decal/number/zero,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
+"Fr" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/crazylab/hydro)
 "Fu" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel/grimy,
@@ -2297,7 +2299,7 @@
 /area/ruin/space/has_grav/crazylab/outside)
 "GM" = (
 /obj/effect/turf_decal/number/seven,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "GO" = (
 /obj/structure/table/wood/reinforced,
@@ -2399,34 +2401,34 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/crazylab/bar)
 "HL" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "Ic" = (
 /obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "Ie" = (
 /obj/effect/turf_decal/number/four,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "Ik" = (
 /obj/effect/turf_decal/number/zero,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Im" = (
 /obj/effect/turf_decal/number/seven,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Ip" = (
 /obj/effect/turf_decal/number/one,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "It" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Iu" = (
 /obj/structure/sign/poster/retro/science,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Iv" = (
 /obj/machinery/door/airlock/hatch,
@@ -2445,7 +2447,7 @@
 /area/ruin/space/has_grav/crazylab/chem)
 "IC" = (
 /obj/effect/turf_decal/number/one,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "IF" = (
 /obj/structure/table/wood/reinforced,
@@ -2653,7 +2655,7 @@
 /area/ruin/space/has_grav/crazylab/airlock)
 "KM" = (
 /obj/structure/sign/poster/contraband/shamblers_juice,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bar)
 "KR" = (
 /obj/structure/table/wood/reinforced,
@@ -2999,6 +3001,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/crazylab/airlock)
+"Ok" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/crazylab/airlock)
 "Oq" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -3098,11 +3103,11 @@
 /area/ruin/space/has_grav/crazylab/armory)
 "Px" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "PD" = (
 /obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "PJ" = (
 /obj/machinery/suit_storage_unit/independent/mining/eva,
@@ -3300,7 +3305,7 @@
 /area/ruin/space/has_grav/crazylab/hydro)
 "St" = (
 /obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "Sz" = (
 /obj/structure/cable{
@@ -3355,17 +3360,17 @@
 /turf/open/space,
 /area/ruin/space/has_grav/crazylab/bomb)
 "TJ" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/space/has_grav/crazylab/bomb)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/crazylab/bar)
 "TK" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/bomb)
 "TM" = (
 /turf/closed/mineral/random/asteroid,
 /area/ruin/space/has_grav/crazylab/bomb)
 "TW" = (
 /obj/structure/sign/poster/contraband/rip_badger,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/hydro)
 "Ua" = (
 /obj/structure/spider/cocoon,
@@ -3459,7 +3464,7 @@
 /area/ruin/space/has_grav/crazylab/hydro)
 "Vx" = (
 /obj/structure/sign/poster/retro/we_watch,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/armory)
 "VE" = (
 /obj/structure/lattice,
@@ -3468,7 +3473,7 @@
 /area/ruin/space/has_grav/crazylab/airlock)
 "VM" = (
 /obj/structure/sign/warning,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/airlock)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -3604,19 +3609,19 @@
 /area/ruin/space/has_grav/crazylab/bomb)
 "Yl" = (
 /obj/effect/turf_decal/number/four,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/hydro)
 "Ym" = (
 /obj/effect/turf_decal/number/zero,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/hydro)
 "Yw" = (
 /obj/effect/turf_decal/number/seven,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/hydro)
 "Yy" = (
 /obj/effect/turf_decal/number/one,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/crazylab/hydro)
 "YA" = (
 /obj/structure/lattice,
@@ -4319,7 +4324,7 @@ GV
 GV
 GV
 GV
-dI
+ao
 ao
 fK
 fK
@@ -4333,7 +4338,7 @@ Ck
 Fo
 GM
 IC
-uo
+TJ
 ao
 ao
 GV
@@ -4372,7 +4377,7 @@ Fu
 GO
 IF
 KM
-uo
+TJ
 ao
 ad
 GV
@@ -4410,7 +4415,7 @@ Fw
 GS
 IK
 KR
-uo
+TJ
 at
 GV
 GV
@@ -4448,7 +4453,7 @@ FC
 GT
 IO
 KT
-uo
+TJ
 at
 at
 at
@@ -4485,9 +4490,9 @@ CO
 FE
 GU
 IR
-uo
-uo
-uo
+TJ
+TJ
+TJ
 at
 at
 at
@@ -4517,19 +4522,19 @@ nh
 pJ
 ug
 fY
-uo
+TJ
 AR
 CW
 Bg
 Hc
 IU
-uo
+TJ
 Mz
 uo
-uo
-Se
+TJ
+Fr
 TW
-Se
+Fr
 Se
 ao
 ao
@@ -4547,14 +4552,14 @@ GV
 GV
 at
 at
-ck
-ck
-ck
+dI
+dI
+dI
 fY
 nm
 pR
 fY
-uo
+TJ
 zg
 AT
 CY
@@ -4568,7 +4573,7 @@ QB
 Sm
 Ua
 Vr
-Se
+Fr
 Se
 ao
 ao
@@ -4584,14 +4589,14 @@ GV
 GV
 GV
 at
-ck
-ck
+dI
+dI
 go
 iw
-ck
+dI
 no
 pU
-uo
+TJ
 xe
 zh
 AW
@@ -4607,7 +4612,7 @@ Sn
 Uy
 Uy
 Vr
-Se
+Fr
 Se
 ao
 GV
@@ -4626,10 +4631,10 @@ cn
 dJ
 gp
 iE
-ck
+dI
 nq
 qi
-uo
+TJ
 xl
 zm
 Bg
@@ -4637,10 +4642,10 @@ Bg
 FK
 HG
 Jt
-uo
+TJ
 ML
 uo
-uo
+TJ
 Sp
 UH
 Vt
@@ -4660,7 +4665,7 @@ GV
 GV
 GV
 ao
-ck
+dI
 dN
 gr
 iZ
@@ -4675,9 +4680,9 @@ Dh
 FR
 HI
 Jy
-uo
-uo
-uo
+TJ
+TJ
+TJ
 HL
 St
 HL
@@ -4702,7 +4707,7 @@ cn
 dJ
 gt
 jb
-ck
+dI
 nC
 qt
 uu
@@ -4711,15 +4716,15 @@ zy
 Bo
 Bo
 FU
-uo
+TJ
 JA
-uo
+TJ
 MV
 Pe
 QF
 NO
 HL
-Se
+Fr
 Wx
 XO
 Yw
@@ -4737,19 +4742,19 @@ GV
 GV
 ao
 ck
-ck
-ck
+dI
+dI
 jl
 lb
 nI
 qv
 ck
 xx
-uo
+TJ
 Br
 Br
-uo
-uo
+TJ
+TJ
 JB
 KU
 Na
@@ -4775,19 +4780,19 @@ GV
 GV
 ao
 ao
-ck
+dI
 gv
 jo
 lc
 ob
 qy
 uC
-uo
+TJ
 zC
 Bt
 zF
 FV
-uo
+TJ
 JZ
 KY
 Nn
@@ -4795,10 +4800,10 @@ Pi
 QO
 SJ
 UN
-Se
+Fr
 WG
-Se
-Se
+Fr
+Fr
 at
 GV
 GV
@@ -4813,14 +4818,14 @@ GV
 GV
 ao
 ao
-ck
+dI
 gK
-ck
+dI
 ln
 od
 qL
 uQ
-uo
+TJ
 zF
 Bw
 Dn
@@ -4834,8 +4839,8 @@ QS
 SV
 UQ
 Vx
-Se
-Se
+Fr
+Fr
 at
 GV
 GV
@@ -4851,18 +4856,18 @@ GV
 GV
 ao
 ck
-ck
+dI
 dO
 jq
 lA
 od
 ra
 uT
-uo
-uo
-uo
-uo
-uo
+TJ
+TJ
+TJ
+TJ
+TJ
 Ic
 Ke
 Lc
@@ -4888,11 +4893,11 @@ GV
 GV
 GV
 ao
-ck
+dI
 ee
 gP
 jB
-ck
+dI
 oe
 rh
 ck
@@ -4981,7 +4986,7 @@ Ik
 Ks
 Lu
 NP
-It
+Ok
 at
 at
 at
@@ -5002,11 +5007,11 @@ ll
 GV
 GV
 ao
-ck
+dI
 eA
 hg
 jR
-ck
+dI
 oo
 rW
 vC
@@ -5019,7 +5024,7 @@ Im
 Kt
 Lw
 NU
-It
+Ok
 at
 at
 ao
@@ -5040,11 +5045,11 @@ ll
 GV
 GV
 ao
-ck
-ck
+dI
+dI
 hl
 jX
-ck
+dI
 or
 rY
 vi
@@ -5058,8 +5063,8 @@ Kz
 Lz
 It
 PD
-It
-It
+Ok
+Ok
 US
 VE
 US
@@ -5079,9 +5084,9 @@ GV
 GV
 ao
 at
-ck
-ck
-ck
+dI
+dI
+dI
 hy
 oG
 sd
@@ -5091,18 +5096,18 @@ zX
 BR
 Ef
 vi
-It
+Ok
 KB
 LB
-It
+Ok
 PJ
 Rg
-It
-It
+Ok
+Ok
 VM
-It
-It
-It
+Ok
+Ok
+Ok
 GV
 GV
 GV
@@ -5167,7 +5172,7 @@ Ae
 BS
 Ew
 mb
-It
+Ok
 KF
 LE
 Oc
@@ -5208,14 +5213,14 @@ Gv
 Iv
 KJ
 LM
-It
+Ok
 Qn
 Ry
-It
-It
+Ok
+Ok
 VM
-It
-It
+Ok
+Ok
 YJ
 GV
 GV
@@ -5246,7 +5251,7 @@ GJ
 IA
 KL
 LP
-It
+Ok
 Qr
 Qr
 It
@@ -5281,8 +5286,8 @@ me
 Cg
 EK
 mm
-It
-It
+Ok
+Ok
 LQ
 It
 ao
@@ -5319,8 +5324,8 @@ kg
 td
 Fh
 hy
-It
-It
+Ok
+Ok
 LQ
 ao
 ao
@@ -5933,7 +5938,7 @@ GV
 GV
 GV
 ao
-TJ
+TK
 TK
 TM
 TM


### PR DESCRIPTION
fixes walls

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
currently, Lab4071 (space chem ruin) has all their walls as the smoothing kind, leading to some pretty wonky looks. 
this pr changes most of the internal walls to non-diagonal, so it doesn't look as scuffed. 

![2023 01 13-17 29 44](https://user-images.githubusercontent.com/79304582/212370785-1fd3270d-3899-47e4-91ba-1439d4177b9d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
looks better!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed lab5071's walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
