### PR TITLE
fixes spaced tile on rockplanet_harmfactory

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_harmfactory.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_harmfactory.dmm
@@ -184,7 +184,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/ruin/powered)
 "ei" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{

--- a/_maps/RandomRuins/RockRuins/rockplanet_harmfactory.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_harmfactory.dmm
@@ -97,7 +97,7 @@
 	pixel_x = -7;
 	pixel_y = 4
 	},
-/obj/item/circuitboard/computer/research,
+/obj/item/circuitboard/computer/rdconsole,
 /turf/open/floor/plasteel/patterned,
 /area/ruin/powered)
 "ck" = (


### PR DESCRIPTION
spaced tile under the super quirky smes

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes a spaced tile in rockplanet_harmfactory, under the magical smes
also changes the research monitor into a research console (requested change)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
there shouldn't be any space tiles on planets
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed spaced tile on rockplanet_harmfactory
fix: fixed wrong research board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
