### PR TITLE
fixes lighting on the jungle_interceptor

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
@@ -24,11 +24,11 @@
 /obj/structure/lattice{
 	icon_state = "lattice-14"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ak" = (
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ao" = (
 /obj/structure/grille/broken,
@@ -46,7 +46,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "au" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ax" = (
 /obj/structure/spacevine,
@@ -83,7 +83,7 @@
 /area/ruin/jungle/interceptor/starlauncherone)
 "aU" = (
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "aX" = (
 /obj/structure/cable,
@@ -120,7 +120,7 @@
 "bc" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bd" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -153,12 +153,12 @@
 /area/ruin/jungle/interceptor/crashsite)
 "bh" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "bl" = (
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bo" = (
 /obj/item/stack/cable_coil/cut/orange,
@@ -185,7 +185,7 @@
 /area/ruin/jungle/interceptor/crewquarters)
 "by" = (
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "bA" = (
 /obj/structure/spacevine,
@@ -193,7 +193,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "bC" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bD" = (
 /obj/machinery/mass_driver{
@@ -207,16 +207,16 @@
 /area/ruin/jungle/interceptor/starlauncherone)
 "bI" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bK" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bL" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "bN" = (
 /obj/structure/lattice{
@@ -304,7 +304,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "cg" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "cj" = (
 /obj/structure/grille/broken,
@@ -400,7 +400,7 @@
 /turf/open/floor/plating,
 /area/ruin/jungle/interceptor/starhall)
 "cL" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "cN" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -413,7 +413,7 @@
 "cP" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "cT" = (
 /obj/effect/decal/cleanable/plastic,
@@ -424,7 +424,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/robot_debris/gib,
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "cX" = (
 /obj/structure/chair/stool/bar{
@@ -445,21 +445,21 @@
 "dc" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "df" = (
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "dj" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ds" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "dv" = (
 /obj/structure/closet/wall/blue{
@@ -482,7 +482,7 @@
 /area/ruin/jungle/interceptor/crewquarters)
 "dy" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "dA" = (
 /obj/structure/cable/green{
@@ -563,7 +563,7 @@
 	icon_state = "lattice-13"
 	},
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "en" = (
 /obj/item/stack/ore/salvage/scraptitanium,
@@ -576,7 +576,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "eC" = (
 /obj/item/shard,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "eD" = (
 /obj/structure/cable/yellow{
@@ -591,7 +591,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "eE" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "eG" = (
 /obj/item/restraints/handcuffs/cable,
@@ -613,7 +613,7 @@
 "eQ" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "eR" = (
 /obj/structure/girder,
@@ -676,7 +676,7 @@
 "fk" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "fl" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -706,7 +706,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "fu" = (
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "fw" = (
 /obj/effect/turf_decal/corner/opaque/blue/half{
@@ -719,7 +719,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-127"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "fI" = (
 /obj/effect/turf_decal/corner/opaque/blue{
@@ -819,11 +819,11 @@
 	},
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ge" = (
 /obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "gf" = (
 /obj/structure/chair,
@@ -929,7 +929,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "gR" = (
 /obj/effect/decal/remains/robot,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "gU" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -940,7 +940,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-143"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "hi" = (
 /obj/structure/grille/broken,
@@ -960,7 +960,7 @@
 "hw" = (
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "hx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -976,7 +976,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "hy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "hC" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -1052,7 +1052,7 @@
 /area/ruin/jungle/interceptor/security)
 "hS" = (
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "hV" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/border{
@@ -1176,11 +1176,11 @@
 /area/ruin/jungle/interceptor/starhall)
 "iC" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "iO" = (
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1373,7 +1373,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "kE" = (
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "kL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1427,18 +1427,21 @@
 /obj/structure/lattice{
 	icon_state = "lattice-127"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/starlaunchertwo)
 "ll" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
+/area/ruin/jungle/interceptor/crashsite)
+"lm" = (
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "lp" = (
 /obj/structure/lattice{
 	icon_state = "lattice-139"
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1500,7 +1503,7 @@
 	icon_state = "1-9"
 	},
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ma" = (
 /obj/structure/grille,
@@ -1534,19 +1537,19 @@
 "my" = (
 /obj/structure/frame/machine,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "mz" = (
 /obj/structure/lattice{
 	icon_state = "lattice-143"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "mA" = (
 /obj/structure/lattice{
 	icon_state = "lattice-21"
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "mH" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -1556,6 +1559,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/jungle/interceptor/starhall)
+"mM" = (
+/turf/open/floor/plating/dirt/jungle/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "mU" = (
 /obj/structure/closet/wall/blue{
 	dir = 4;
@@ -1586,7 +1592,7 @@
 	icon_state = "lattice-139"
 	},
 /obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ne" = (
 /turf/open/floor/plating/dirt/jungle/dark,
@@ -1641,7 +1647,7 @@
 	icon_state = "lattice-127"
 	},
 /obj/item/shard,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/bridge)
 "nD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1671,11 +1677,11 @@
 /obj/structure/flora/tree/jungle{
 	icon_state = "tree2"
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "nO" = (
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "nW" = (
 /obj/effect/turf_decal/corner/opaque/blue/bordercorner{
@@ -1768,7 +1774,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "oJ" = (
 /obj/structure/lattice,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "oM" = (
 /obj/machinery/power/port_gen/pacman,
@@ -1821,7 +1827,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-3"
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "pq" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -1856,7 +1862,7 @@
 /obj/effect/decal/cleanable/molten_object,
 /obj/structure/grille/broken,
 /obj/item/shard,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "px" = (
 /obj/structure/catwalk/over,
@@ -1898,7 +1904,7 @@
 "pG" = (
 /obj/structure/spacevine,
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "pJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1906,7 +1912,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "pM" = (
 /obj/item/stack/cable_coil/cut/yellow,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle,
 /area/ruin/jungle/interceptor/crashsite)
 "pO" = (
 /obj/effect/turf_decal/corner/opaque/yellow/full,
@@ -1921,7 +1927,7 @@
 "pW" = (
 /obj/item/shard,
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "pX" = (
 /turf/open/floor/plating/rust,
@@ -1930,7 +1936,7 @@
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/structure/girder,
 /obj/structure/girder,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "qa" = (
 /obj/machinery/door/airlock/public/glass,
@@ -2031,7 +2037,7 @@
 /area/ruin/jungle/interceptor/starlauncherone)
 "qw" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "qx" = (
 /obj/machinery/deepfryer,
@@ -2099,6 +2105,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/interceptor/bridge)
+"ri" = (
+/obj/item/stack/cable_coil/cut/yellow,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "rp" = (
 /obj/effect/turf_decal/corner/opaque/purple/three_quarters{
 	icon_state = "borderfloor_white";
@@ -2110,14 +2120,14 @@
 /area/ruin/jungle/interceptor/porthall)
 "rq" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "rs" = (
 /obj/structure/lattice{
 	icon_state = "lattice-127"
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "rx" = (
 /obj/structure/cable/orange{
@@ -2154,9 +2164,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/jungle/interceptor/starhall)
+"rO" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "rQ" = (
 /obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "rU" = (
 /obj/structure/closet/emcloset/wall{
@@ -2179,16 +2193,16 @@
 "rX" = (
 /obj/structure/spacevine/dense,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "sa" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "sc" = (
 /obj/structure/frame/machine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "sd" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -2208,7 +2222,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-13"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "sl" = (
 /obj/structure/sink/kitchen{
@@ -2266,11 +2280,15 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/bridge)
+"sV" = (
+/obj/item/shard,
+/turf/open/floor/plating/dirt/jungle/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "sX" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "tf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2349,7 +2367,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-127"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/forehall)
 "tH" = (
 /obj/structure/catwalk/over,
@@ -2381,7 +2399,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-127"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "tX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -2395,18 +2413,18 @@
 "ud" = (
 /obj/item/stack/ore/salvage/scraptitanium,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "uf" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/starhall)
 "uk" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2486,7 +2504,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "uN" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "uR" = (
 /obj/structure/table/wood/bar,
@@ -2543,11 +2561,11 @@
 "vj" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "vl" = (
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "vs" = (
 /obj/structure/girder,
@@ -2623,7 +2641,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-23"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "wg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2665,11 +2683,11 @@
 "wv" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "wz" = (
 /obj/item/stack/cable_coil/cut/green,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "wD" = (
 /obj/effect/turf_decal/corner/opaque/orange/border{
@@ -2776,7 +2794,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "wW" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "xa" = (
 /obj/structure/table/wood/bar,
@@ -2810,6 +2828,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/jungle/interceptor/porthall)
+"xn" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "xr" = (
 /obj/effect/turf_decal/corner/opaque/blue/half{
 	dir = 4
@@ -2822,7 +2844,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-139"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "xA" = (
 /obj/structure/chair/stool/bar{
@@ -2866,7 +2888,7 @@
 	icon_state = "lattice-141"
 	},
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle,
 /area/ruin/jungle/interceptor/crashsite)
 "yc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -2902,7 +2924,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-3"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ym" = (
 /obj/machinery/mineral/ore_redemption{
@@ -2916,11 +2938,11 @@
 /area/ruin/jungle/interceptor/afthall)
 "yn" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "yp" = (
 /obj/item/stack/cable_coil/cut/green,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ys" = (
 /obj/structure/cable/orange{
@@ -2983,7 +3005,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "yH" = (
 /obj/item/shard,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "yZ" = (
 /obj/effect/turf_decal/corner_steel_grid/full,
@@ -3026,7 +3048,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "zm" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "zq" = (
 /obj/machinery/mass_driver{
@@ -3088,7 +3110,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-159"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle,
 /area/ruin/jungle/interceptor/crashsite)
 "Ac" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -3127,7 +3149,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-21"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ar" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -3144,7 +3166,7 @@
 "Ax" = (
 /obj/structure/spacevine,
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ay" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3175,7 +3197,7 @@
 "AM" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "AP" = (
 /turf/closed/wall/mineral/titanium,
@@ -3200,6 +3222,12 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/interceptor/forehall)
+"Bb" = (
+/obj/structure/lattice{
+	icon_state = "lattice-4"
+	},
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle/interceptor/crashsite)
 "Bc" = (
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/industrial/warning{
@@ -3288,7 +3316,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "BH" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "BM" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/border{
@@ -3333,7 +3361,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "Cg" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ch" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3350,7 +3378,7 @@
 "Ci" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Cj" = (
 /obj/machinery/mass_driver{
@@ -3432,7 +3460,7 @@
 "CO" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "CR" = (
 /obj/structure/spacevine,
@@ -3477,7 +3505,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "Dg" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Dn" = (
 /obj/structure/cable/green{
@@ -3503,7 +3531,7 @@
 /area/ruin/jungle/interceptor/security)
 "Dw" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Dx" = (
 /obj/machinery/disposal/bin,
@@ -3520,7 +3548,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "DC" = (
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "DD" = (
 /obj/effect/turf_decal/corner/opaque/purple/three_quarters{
@@ -3537,7 +3565,7 @@
 "DE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "DG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3579,11 +3607,11 @@
 /area/ruin/jungle/interceptor/starhall)
 "DX" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Eb" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ef" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -3600,20 +3628,20 @@
 /area/ruin/jungle/interceptor/porthall)
 "Ez" = (
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "EJ" = (
 /obj/structure/lattice{
 	icon_state = "lattice-3"
 	},
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "EK" = (
 /obj/structure/lattice{
 	icon_state = "lattice-8"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "EL" = (
 /obj/structure/cable/orange{
@@ -3624,7 +3652,7 @@
 	},
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle,
 /area/ruin/jungle/interceptor/security)
 "EO" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -3654,7 +3682,7 @@
 	icon_state = "lattice-127"
 	},
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "Ff" = (
 /obj/structure/cable/green{
@@ -3767,7 +3795,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "Gi" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Gj" = (
 /obj/structure/grille/broken,
@@ -3923,15 +3951,15 @@
 /obj/structure/lattice{
 	icon_state = "lattice-39"
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "HB" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "HD" = (
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "HE" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -4030,7 +4058,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-223"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/afthall)
 "Iw" = (
 /obj/machinery/door/airlock/public,
@@ -4065,7 +4093,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-3"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "IN" = (
 /obj/machinery/processor,
@@ -4093,7 +4121,7 @@
 "Ja" = (
 /obj/item/stack/cable_coil/cut/red,
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Je" = (
 /obj/structure/table/wood/bar,
@@ -4147,7 +4175,7 @@
 "Jx" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "JA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4328,7 +4356,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "KY" = (
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "KZ" = (
 /obj/structure/cable/green{
@@ -4371,7 +4399,7 @@
 /area/ruin/jungle/interceptor/starlauncherone)
 "Lh" = (
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ln" = (
 /obj/effect/turf_decal/corner/opaque/blue/border,
@@ -4497,7 +4525,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "Mn" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ms" = (
 /obj/structure/grille/broken,
@@ -4519,7 +4547,7 @@
 /area/ruin/jungle/interceptor/starhall)
 "Mw" = (
 /obj/structure/girder,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "MA" = (
 /obj/item/clothing/under/rank/prisoner,
@@ -4574,7 +4602,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "MO" = (
 /obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4610,7 +4638,7 @@
 "MT" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ni" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -4679,7 +4707,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-23"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "NV" = (
 /obj/structure/window/reinforced/spawner,
@@ -4704,7 +4732,7 @@
 /area/ruin/jungle/interceptor/afthall)
 "NZ" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Oc" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -4721,7 +4749,7 @@
 	icon_state = "lattice-47"
 	},
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ok" = (
 /obj/structure/chair,
@@ -4846,7 +4874,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "OK" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "OL" = (
 /obj/machinery/power/terminal,
@@ -4862,7 +4890,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "OM" = (
 /obj/item/stack/cable_coil/cut/yellow,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "OO" = (
 /obj/item/shard,
@@ -4889,7 +4917,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "OU" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "OW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4986,12 +5014,12 @@
 /area/ruin/jungle/interceptor/starhall)
 "Qo" = (
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Qp" = (
 /obj/structure/grille/broken,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Qq" = (
 /obj/item/stack/ore/salvage/scraptitanium,
@@ -5040,7 +5068,7 @@
 	icon_state = "lattice-12"
 	},
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "QE" = (
 /obj/effect/decal/cleanable/plastic,
@@ -5169,7 +5197,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-1"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "RT" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -5262,7 +5290,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "St" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Sy" = (
 /obj/structure/catwalk/over,
@@ -5366,7 +5394,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "SU" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "SW" = (
 /obj/structure/grille,
@@ -5395,7 +5423,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "Tq" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Tw" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -5413,7 +5441,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "TG" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "TI" = (
 /turf/open/floor/plasteel/stairs/right,
@@ -5485,7 +5513,7 @@
 	icon_state = "lattice-23"
 	},
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Uf" = (
 /obj/machinery/door/airlock/public/glass,
@@ -5524,7 +5552,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "Ut" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Uu" = (
 /obj/structure/spacevine,
@@ -5535,7 +5563,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "UB" = (
 /obj/machinery/door/window/eastright{
@@ -5618,7 +5646,7 @@
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "UW" = (
 /obj/structure/cable/green{
@@ -5632,7 +5660,7 @@
 	dir = 8
 	},
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "UY" = (
 /obj/structure/table/reinforced,
@@ -5717,7 +5745,7 @@
 /area/ruin/jungle/interceptor/crashsite)
 "Vy" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "VC" = (
 /obj/structure/bed,
@@ -5735,7 +5763,7 @@
 /area/ruin/jungle/interceptor/crewquarters)
 "VD" = (
 /obj/item/stack/cable_coil/cut/orange,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "VE" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/border{
@@ -5750,7 +5778,7 @@
 "VI" = (
 /obj/item/stack/ore/salvage/scraptitanium,
 /obj/structure/girder/displaced,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "VK" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -5806,7 +5834,7 @@
 "VY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "We" = (
 /obj/structure/cable/orange{
@@ -5861,7 +5889,7 @@
 "Wq" = (
 /obj/item/stack/cable_coil/cut/orange,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/porthall)
 "Wt" = (
 /turf/closed/wall/mineral/titanium,
@@ -5892,7 +5920,7 @@
 "WB" = (
 /obj/structure/spacevine/dense,
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "WC" = (
 /obj/structure/table,
@@ -5911,7 +5939,7 @@
 /obj/structure/frame/machine,
 /obj/structure/spacevine,
 /obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "WW" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/bordercorner{
@@ -5946,7 +5974,7 @@
 /obj/structure/lattice{
 	icon_state = "lattice-137"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Xj" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -5997,7 +6025,7 @@
 /area/ruin/jungle/interceptor/afthall)
 "Xy" = (
 /obj/structure/lattice,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "XB" = (
 /obj/structure/cable/orange{
@@ -6062,7 +6090,7 @@
 /area/ruin/jungle/interceptor/forehall)
 "XY" = (
 /obj/structure/frame/machine,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ya" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -6190,7 +6218,7 @@
 	icon_state = "lattice-127"
 	},
 /obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "YM" = (
 /obj/structure/cable/orange{
@@ -6260,11 +6288,11 @@
 "Za" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Zc" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Ze" = (
 /obj/structure/cable/green{
@@ -6288,7 +6316,7 @@
 /area/ruin/jungle/interceptor/starlauncherone)
 "Zl" = (
 /obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Zm" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -6304,12 +6332,12 @@
 	icon_state = "lattice-207"
 	},
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Zp" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Zt" = (
 /obj/structure/frame/computer{
@@ -6347,7 +6375,7 @@
 /area/ruin/jungle/interceptor/porthall)
 "ZO" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "ZU" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
@@ -6561,7 +6589,7 @@ Lh
 vl
 cL
 cL
-ne
+lm
 zm
 ll
 Tq
@@ -6653,12 +6681,12 @@ HK
 HK
 HK
 HK
-ne
+lm
 zm
 cL
 cL
 St
-ne
+lm
 wH
 wH
 nE
@@ -6709,7 +6737,7 @@ HK
 au
 Zl
 vl
-ne
+lm
 Cg
 Zc
 MO
@@ -6759,13 +6787,13 @@ HK
 HK
 HK
 cL
-ne
+lm
 wH
-ne
+lm
 au
 cL
 iw
-ne
+lm
 xw
 cj
 ny
@@ -6811,12 +6839,12 @@ HK
 HK
 HK
 cL
-ne
+lm
 St
-ne
+lm
 cL
-ne
-ne
+lm
+lm
 SU
 au
 cL
@@ -6834,12 +6862,12 @@ HR
 bo
 Kp
 UZ
-YY
+mM
 Tq
 cL
 zm
 cL
-ne
+lm
 Zc
 rX
 HK
@@ -6868,14 +6896,14 @@ cL
 vl
 Ut
 en
-ne
+lm
 au
 iw
 ZO
 vL
 UR
 cL
-ne
+lm
 dc
 Tq
 MO
@@ -6887,8 +6915,8 @@ fV
 ST
 gC
 ca
-ne
-ne
+lm
+lm
 Cg
 Tq
 cL
@@ -6921,8 +6949,8 @@ bl
 cL
 cL
 ll
-ne
-ne
+lm
+lm
 iw
 Zl
 MO
@@ -6975,13 +7003,13 @@ ll
 vl
 Ut
 cL
-ne
+lm
 eC
 TG
 sa
 px
 mY
-PS
+rO
 pu
 DC
 Gs
@@ -7075,7 +7103,7 @@ cL
 bC
 cL
 Zc
-ne
+lm
 vB
 Cj
 gq
@@ -7097,12 +7125,12 @@ rU
 dE
 qs
 OR
-ne
+lm
 fu
 Mw
 Zc
 au
-ne
+lm
 zm
 Zc
 cL
@@ -7206,7 +7234,7 @@ XY
 eE
 dQ
 MM
-ne
+lm
 Hv
 EK
 Zc
@@ -7241,7 +7269,7 @@ iO
 cL
 cL
 cL
-ne
+lm
 au
 Qp
 HB
@@ -7283,7 +7311,7 @@ HK
 HK
 HK
 HB
-ne
+lm
 ak
 cL
 cL
@@ -7295,7 +7323,7 @@ iO
 vl
 au
 St
-ne
+lm
 vl
 Ci
 dC
@@ -7315,7 +7343,7 @@ wf
 pJ
 NZ
 KY
-YY
+mM
 ZO
 cg
 Gi
@@ -7337,8 +7365,8 @@ HK
 Zl
 au
 bC
-YY
-ne
+mM
+lm
 au
 vl
 iO
@@ -7347,7 +7375,7 @@ vl
 vl
 HB
 cL
-ne
+lm
 dC
 Kk
 eQ
@@ -7365,14 +7393,14 @@ sc
 Hv
 aU
 Ja
-pM
+ri
 hw
 wH
 ds
 oJ
 ds
 qw
-ne
+lm
 HB
 cL
 au
@@ -7390,7 +7418,7 @@ bC
 cL
 vl
 vl
-YY
+mM
 Zc
 cL
 iO
@@ -7398,7 +7426,7 @@ iO
 vl
 cL
 vl
-YY
+mM
 cL
 dC
 qs
@@ -7419,14 +7447,14 @@ tD
 Mw
 Kr
 MO
-pM
+ri
 dy
-ty
+sV
 Dw
 DE
-ne
-YY
-ne
+lm
+mM
+lm
 dy
 wH
 "}
@@ -7440,7 +7468,7 @@ HK
 HK
 cL
 zm
-ne
+lm
 ll
 iw
 cL
@@ -7474,14 +7502,14 @@ OM
 cL
 fu
 cL
-ne
-ne
-ne
-YY
-ne
-YY
+lm
+lm
+lm
+mM
+lm
+mM
 ZO
-ne
+lm
 "}
 (22,1,1) = {"
 HK
@@ -7497,7 +7525,7 @@ cL
 cL
 zm
 au
-ne
+YY
 YY
 GZ
 Dr
@@ -7529,11 +7557,11 @@ yH
 vl
 au
 Xy
-ne
+lm
 HB
 wH
-ne
-YY
+lm
+mM
 Zl
 "}
 (23,1,1) = {"
@@ -7584,9 +7612,9 @@ zm
 iC
 cL
 cL
-ne
-ne
-ne
+lm
+lm
+lm
 wH
 "}
 (24,1,1) = {"
@@ -7625,7 +7653,7 @@ fi
 WP
 XD
 UD
-aG
+xn
 zt
 hv
 Ac
@@ -7636,10 +7664,10 @@ cL
 Tq
 Jx
 Gi
-ne
+lm
 bC
 wH
-ne
+lm
 HK
 "}
 (25,1,1) = {"
@@ -7740,10 +7768,10 @@ OO
 RG
 Ct
 mA
-ne
+lm
 cL
 ZO
-ne
+lm
 cL
 ak
 HK
@@ -7795,9 +7823,9 @@ Io
 pX
 Ut
 iC
-ne
+lm
 au
-ne
+lm
 bC
 HK
 "}
@@ -7846,8 +7874,8 @@ TI
 Yg
 oj
 Wh
-ne
-ne
+lm
+lm
 vl
 cL
 cL
@@ -7951,7 +7979,7 @@ ne
 ne
 HD
 MO
-ne
+lm
 bC
 cL
 cL
@@ -8002,9 +8030,9 @@ SC
 Mw
 EJ
 wH
-ty
+sV
 Mw
-GW
+Bb
 cL
 cL
 vl
@@ -8058,7 +8086,7 @@ bC
 cL
 wv
 wH
-ne
+lm
 au
 Zc
 kE
@@ -8111,7 +8139,7 @@ cL
 Cg
 fu
 aj
-ne
+lm
 iC
 ak
 wH
@@ -8165,7 +8193,7 @@ fu
 Ud
 Xh
 qG
-YY
+mM
 St
 HK
 HK
@@ -8217,7 +8245,7 @@ wH
 BH
 Kr
 yp
-ne
+lm
 ge
 vl
 HK
@@ -8325,7 +8353,7 @@ UU
 wz
 ds
 ak
-ne
+lm
 HK
 HK
 HK
@@ -8375,7 +8403,7 @@ Ym
 bP
 Br
 jB
-ne
+lm
 ll
 Zc
 wH
@@ -8431,7 +8459,7 @@ bA
 cL
 iO
 dy
-ne
+lm
 HK
 HK
 HK
@@ -8504,7 +8532,7 @@ sX
 cL
 cL
 bC
-ne
+lm
 au
 cL
 Zc
@@ -8528,11 +8556,11 @@ YT
 kP
 pC
 cL
-ne
+lm
 au
 zm
 au
-ne
+lm
 cL
 cL
 cL
@@ -8583,7 +8611,7 @@ DM
 XE
 cL
 cL
-YY
+mM
 HB
 au
 au
@@ -8637,7 +8665,7 @@ DM
 XE
 wO
 ll
-ne
+lm
 St
 vl
 vl
@@ -8828,7 +8856,7 @@ HK
 au
 Zc
 bC
-YY
+mM
 au
 au
 sX
@@ -8932,7 +8960,7 @@ HK
 HK
 HK
 St
-ne
+lm
 au
 iO
 vl


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
switches (most) of the jungle turfs to their lit variants, excluding some of the internal ones for dramatic effect, on the interceptor ruin.

![2023 01 13-18 42 08](https://user-images.githubusercontent.com/79304582/212385322-f388ee99-ba83-4835-be90-f420f8e89a35.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
the ruin is currently completely dark, inside and outside. this fixes that! 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed lighting on the jungle_interceptor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
