### PR TITLE
Fixes lighting on jungle_surface_bombmakers / jungle_syndicate / jungle_demon

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
@@ -27,7 +27,7 @@
 /area/ruin/powered)
 "dt" = (
 /obj/effect/mob_spawn/human/corpse/assistant,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "dV" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -35,7 +35,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "eO" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "fm" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -47,11 +47,11 @@
 	name = "Demonic Foreman";
 	resize = 1.25
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "fv" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "fL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -90,7 +90,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "iB" = (
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "iC" = (
 /obj/structure/chair/office,
@@ -137,14 +137,14 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "mY" = (
 /turf/template_noop,
 /area/template_noop)
 "nC" = (
 /obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "nJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -162,13 +162,13 @@
 /area/ruin/powered)
 "pE" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "qD" = (
 /obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "qE" = (
 /obj/effect/decal/cleanable/glass,
@@ -176,7 +176,7 @@
 /area/ruin/powered)
 "rc" = (
 /obj/structure/closet/crate/grave,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "rx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -200,7 +200,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "sK" = (
 /obj/structure/chair/office/light{
@@ -262,7 +262,7 @@
 /area/ruin/powered)
 "wS" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "xe" = (
 /mob/living/simple_animal/hostile/cult_demon,
@@ -270,7 +270,7 @@
 /area/ruin/powered)
 "xK" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "xY" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -287,7 +287,7 @@
 /area/ruin/powered)
 "AI" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "AU" = (
 /obj/structure/table/reinforced,
@@ -304,7 +304,7 @@
 /area/ruin/powered)
 "Dd" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "DC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -316,7 +316,7 @@
 /area/ruin/powered)
 "Ew" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "EY" = (
 /turf/closed/wall/rust,
@@ -383,25 +383,25 @@
 /area/ruin/powered)
 "Ir" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "Jx" = (
 /obj/structure/fence,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "JB" = (
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "JI" = (
 /obj/effect/mob_spawn/human/corpse/pirate,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "KA" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "KV" = (
 /obj/machinery/light/floor,
@@ -426,14 +426,14 @@
 /area/ruin/powered)
 "LV" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "LW" = (
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "Mk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Mq" = (
 /obj/structure/table/reinforced,
@@ -476,11 +476,11 @@
 /area/ruin/powered)
 "NU" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "OU" = (
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "Pe" = (
 /obj/effect/decal/cleanable/ash,
@@ -531,7 +531,7 @@
 /area/ruin/powered)
 "SV" = (
 /obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Ta" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -586,7 +586,7 @@
 /area/ruin/powered)
 "XB" = (
 /obj/effect/decal/remains/xeno,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "XS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -599,7 +599,7 @@
 /area/ruin/powered)
 "YL" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "YX" = (
 /obj/effect/decal/cleanable/cobweb,

--- a/_maps/RandomRuins/JungleRuins/jungle_surface_bombmakers_cabin.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_surface_bombmakers_cabin.dmm
@@ -31,7 +31,7 @@
 /area/ruin/powered)
 "eG" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "eX" = (
 /mob/living/simple_animal/hostile/rat{
@@ -79,7 +79,7 @@
 /area/ruin/powered)
 "gO" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "hD" = (
 /obj/machinery/light/small,
@@ -99,17 +99,17 @@
 "kn" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/corn,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "ky" = (
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "kL" = (
 /obj/structure/fence/cut/medium,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "lN" = (
 /obj/structure/table/wood,
@@ -142,7 +142,7 @@
 /obj/structure/fence/corner{
 	dir = 5
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "qp" = (
 /obj/structure/noticeboard{
@@ -179,7 +179,7 @@
 /area/ruin/powered)
 "so" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "sV" = (
 /obj/structure/chair/comfy/black,
@@ -192,15 +192,15 @@
 /area/ruin/powered)
 "tc" = (
 /obj/structure/fence,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "uH" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "vs" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "wq" = (
 /obj/structure/table/wood,
@@ -219,7 +219,7 @@
 /area/ruin/powered)
 "wz" = (
 /obj/structure/floodlight_frame,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "wK" = (
 /obj/structure/table/wood,
@@ -241,7 +241,7 @@
 /area/ruin/powered)
 "xQ" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "yu" = (
 /turf/closed/wall/mineral/wood,
@@ -290,7 +290,7 @@
 /area/ruin/powered)
 "Dy" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "DU" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion{
@@ -328,11 +328,11 @@
 /obj/structure/fence/cut/large{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "It" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "Jd" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton{
@@ -343,21 +343,21 @@
 /area/ruin/powered)
 "Je" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Na" = (
 /obj/item/reagent_containers/food/snacks/grown/corn,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Oe" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "Qb" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Qj" = (
 /obj/item/grown/corncob,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Rc" = (
 /obj/structure/chair/plastic{
@@ -389,7 +389,7 @@
 /area/ruin/powered)
 "Tb" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "TB" = (
 /turf/open/floor/wood,
@@ -424,7 +424,7 @@
 /area/ruin/powered)
 "WO" = (
 /obj/item/seeds/corn/snapcorn,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "WW" = (
 /obj/structure/table/wood,
@@ -472,17 +472,17 @@
 /area/ruin/powered)
 "ZH" = (
 /mob/living/simple_animal/hostile/cockroach/glockroach,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "ZL" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/food/snacks/grown/corn,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "ZX" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/grown/corncob,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/JungleRuins/jungle_syndicate.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_syndicate.dmm
@@ -16,14 +16,14 @@
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "aF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "bs" = (
 /obj/structure/cable{
@@ -43,11 +43,11 @@
 "bS" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "bV" = (
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "bW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -60,43 +60,43 @@
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "cO" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "cS" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "cX" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "dw" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "dF" = (
 /obj/structure/flora/rock,
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "dK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "dO" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "dP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -115,18 +115,18 @@
 "es" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "ex" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "eH" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "eR" = (
 /obj/structure/closet/crate/secure/science,
@@ -146,7 +146,7 @@
 /turf/open/floor/plating,
 /area/ruin/jungle/syndifort)
 "eX" = (
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "fe" = (
 /turf/closed/wall,
@@ -157,11 +157,11 @@
 "fn" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "fE" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "fS" = (
 /mob/living/simple_animal/hostile/syndicate{
@@ -172,14 +172,14 @@
 /area/ruin/jungle/syndifort)
 "fZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "gb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "gf" = (
 /obj/structure/closet/crate/secure/gear,
@@ -203,7 +203,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "gK" = (
 /obj/structure/cable{
@@ -323,14 +323,14 @@
 /area/ruin/jungle/syndifort)
 "jh" = (
 /obj/structure/spacevine,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "jr" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "jy" = (
 /obj/item/trash/plate,
@@ -376,13 +376,13 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "kJ" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "kP" = (
 /obj/structure/cable{
@@ -399,12 +399,12 @@
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "lq" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "lH" = (
 /obj/item/trash/candle{
@@ -418,7 +418,7 @@
 /area/ruin/jungle/syndifort)
 "mq" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "mt" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -433,17 +433,17 @@
 "mN" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "mO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "np" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "nH" = (
 /turf/closed/wall/rust,
@@ -505,10 +505,10 @@
 "qq" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "qx" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "qA" = (
 /obj/structure/cable{
@@ -577,7 +577,7 @@
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "tt" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -593,12 +593,12 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "tL" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "tZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -639,7 +639,7 @@
 /area/ruin/jungle/syndifort)
 "ux" = (
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "uB" = (
 /obj/structure/closet/crate/freezer,
@@ -653,19 +653,19 @@
 /area/ruin/jungle/syndifort)
 "ve" = (
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "vh" = (
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "vs" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "vt" = (
 /turf/closed/wall/r_wall,
@@ -674,28 +674,32 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "vJ" = (
 /obj/structure/bed,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plating,
 /area/ruin/jungle/syndifort)
+"vN" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle)
 "vX" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "wd" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "wh" = (
 /obj/structure/flora/rock/pile,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "wo" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -758,7 +762,7 @@
 /obj/structure/cable{
 	icon_state = "4-10"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "xC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -779,7 +783,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "ys" = (
 /obj/structure/cable{
@@ -812,7 +816,7 @@
 "yM" = (
 /obj/structure/spacevine,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "yZ" = (
 /turf/template_noop,
@@ -821,25 +825,25 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "zH" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "zK" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "zM" = (
 /turf/closed/wall/r_wall,
 /area/ruin/jungle/syndifort/jerry)
 "Aa" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Ai" = (
 /turf/closed/wall/r_wall/rust,
@@ -860,12 +864,12 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Au" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "AB" = (
 /obj/machinery/computer/security{
@@ -887,7 +891,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Bv" = (
 /obj/machinery/suit_storage_unit/open,
@@ -901,7 +905,7 @@
 "By" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "BC" = (
 /obj/structure/chair/plastic,
@@ -936,7 +940,7 @@
 "DL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Ee" = (
 /obj/structure/cable{
@@ -954,7 +958,7 @@
 /area/ruin/jungle/syndifort)
 "Eq" = (
 /obj/structure/flora/stump,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Es" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -965,7 +969,7 @@
 	icon_state = "4-9"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "ER" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1008,19 +1012,19 @@
 "Gb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Gs" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "GK" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "GR" = (
 /obj/structure/cable{
@@ -1031,7 +1035,7 @@
 "GU" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Hb" = (
 /obj/structure/cable{
@@ -1057,19 +1061,19 @@
 	pixel_x = 3;
 	pixel_y = -9
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "HB" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "HR" = (
 /obj/structure/chair/plastic,
 /mob/living/simple_animal/hostile/syndicate/ranged{
 	unsuitable_atmos_damage = 0
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Il" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1098,7 +1102,7 @@
 "Jg" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Ji" = (
 /obj/structure/closet/crate/secure/plasma,
@@ -1106,6 +1110,10 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/jungle/syndifort)
+"Jt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt/jungle/lit,
+/area/ruin/jungle)
 "Jv" = (
 /turf/open/floor/plating,
 /area/ruin/jungle/syndifort)
@@ -1113,7 +1121,7 @@
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/rock/pile,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "JY" = (
 /turf/open/floor/plating/rust,
@@ -1123,15 +1131,15 @@
 	icon_state = "6-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Kw" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "KP" = (
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "KV" = (
 /obj/item/trash/chips{
@@ -1168,7 +1176,10 @@
 "LG" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
+/area/ruin/jungle)
+"LK" = (
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "Ma" = (
 /obj/effect/decal/remains/human,
@@ -1197,12 +1208,12 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Ny" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Nz" = (
 /obj/structure/cable{
@@ -1256,7 +1267,7 @@
 /area/ruin/jungle/syndifort)
 "Ol" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Oq" = (
 /obj/structure/cable{
@@ -1296,18 +1307,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Pq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "PX" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Qi" = (
 /obj/structure/cable{
@@ -1316,7 +1327,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Qr" = (
 /obj/structure/table,
@@ -1335,12 +1346,12 @@
 "Qx" = (
 /obj/structure/flora/junglebush,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "QE" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "QT" = (
 /obj/item/ammo_casing/spent{
@@ -1360,7 +1371,7 @@
 "Rl" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Rw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1378,7 +1389,7 @@
 /obj/structure/spacevine/dense,
 /obj/structure/spacevine/dense,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "RT" = (
 /obj/structure/toilet{
@@ -1397,28 +1408,28 @@
 /area/ruin/jungle/syndifort)
 "Sf" = (
 /obj/structure/spacevine/dense,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "SO" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "ST" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "SX" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Tb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Td" = (
 /obj/item/ammo_casing/spent{
@@ -1446,12 +1457,12 @@
 /area/ruin/jungle/syndifort/jerry)
 "TK" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "TV" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Uc" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1482,13 +1493,13 @@
 	icon_state = "6-9"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "UK" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "UQ" = (
 /obj/structure/cable{
@@ -1499,7 +1510,7 @@
 "UZ" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Vf" = (
 /obj/machinery/suit_storage_unit/syndicate{
@@ -1525,30 +1536,30 @@
 /area/ruin/jungle/syndifort/jerry)
 "VV" = (
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Wj" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Wl" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Wm" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Wz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "WF" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
@@ -1564,33 +1575,33 @@
 "WT" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Xc" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "Xx" = (
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle)
 "XE" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/jungle/syndifort)
 "XM" = (
 /obj/structure/flora/rock/pile,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "XZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Ya" = (
 /obj/item/trash/syndi_cakes,
@@ -1600,6 +1611,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/jungle/syndifort/jerry)
+"Yj" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
+/area/ruin/jungle)
 "Yk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -1623,17 +1638,17 @@
 "YM" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "YO" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "YP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "Zo" = (
 /obj/item/ammo_casing/spent{
@@ -1655,12 +1670,12 @@
 "ZF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle)
 "ZG" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle)
 "ZU" = (
 /obj/item/ammo_casing/spent{
@@ -1733,7 +1748,7 @@ yZ
 yZ
 yZ
 eX
-eX
+LK
 "}
 (3,1,1) = {"
 yZ
@@ -1747,8 +1762,8 @@ dw
 dw
 qq
 es
-eX
-eX
+LK
+LK
 ux
 SO
 gG
@@ -1764,8 +1779,8 @@ yZ
 yZ
 yZ
 eX
-Eq
-eX
+vN
+LK
 "}
 (4,1,1) = {"
 yZ
@@ -1780,8 +1795,8 @@ YM
 eX
 eX
 eX
-eX
-eX
+LK
+LK
 eX
 SO
 Wm
@@ -1795,9 +1810,9 @@ yZ
 yZ
 yZ
 SX
-eX
-eX
-eX
+LK
+LK
+LK
 "}
 (5,1,1) = {"
 yZ
@@ -1818,7 +1833,7 @@ zM
 eX
 dw
 ce
-fZ
+Jt
 eX
 Gs
 yh
@@ -1827,8 +1842,8 @@ yZ
 yZ
 Sf
 eX
-eX
-SX
+LK
+Yj
 yZ
 "}
 (6,1,1) = {"
@@ -1840,7 +1855,7 @@ yZ
 yZ
 dw
 dO
-eX
+LK
 zM
 gU
 AB
@@ -1860,7 +1875,7 @@ Sf
 Sf
 eX
 eX
-eX
+LK
 yZ
 "}
 (7,1,1) = {"
@@ -1872,7 +1887,7 @@ yZ
 yZ
 yZ
 dO
-eX
+LK
 ER
 Iv
 gx
@@ -1880,11 +1895,11 @@ gO
 yD
 TC
 zM
-eX
+LK
 eX
 ii
 ve
-fZ
+Jt
 GK
 zu
 eX
@@ -1914,11 +1929,11 @@ rN
 zM
 eX
 xv
-eX
+LK
 ve
 eX
 lc
-fZ
+Jt
 eX
 jh
 jh
@@ -1950,8 +1965,8 @@ eX
 eX
 eX
 eX
-fZ
-fZ
+Jt
+Jt
 SX
 eX
 yZ
@@ -1982,8 +1997,8 @@ Uc
 vt
 vt
 eX
-fZ
-fZ
+Jt
+Jt
 eX
 jh
 yZ
@@ -2080,8 +2095,8 @@ Ug
 vt
 eX
 eX
-eX
-fZ
+LK
+Jt
 eX
 jh
 yZ
@@ -2093,7 +2108,7 @@ yZ
 wh
 ve
 ve
-fZ
+Jt
 Kw
 eX
 tt
@@ -2126,7 +2141,7 @@ By
 ve
 Vn
 eX
-fZ
+Jt
 FP
 mt
 bW
@@ -2206,12 +2221,12 @@ al
 ks
 fi
 vt
-eX
-eX
+LK
+LK
 jh
 eX
 jh
-eX
+LK
 Ol
 yZ
 "}
@@ -2238,12 +2253,12 @@ Nz
 Zo
 Mo
 vt
-eX
+LK
 fn
 UZ
 jr
 eX
-eX
+LK
 eX
 yZ
 "}
@@ -2320,7 +2335,7 @@ qx
 Aa
 eX
 vh
-Eq
+vN
 fe
 nH
 fe
@@ -2331,7 +2346,7 @@ Al
 nH
 eX
 Wz
-eX
+LK
 eX
 XM
 vs
@@ -2363,7 +2378,7 @@ Ef
 fe
 qx
 vh
-eX
+LK
 ve
 TK
 TK
@@ -2448,11 +2463,11 @@ UQ
 Lu
 nH
 Qi
-fZ
+Jt
 eX
 vF
-fZ
-fZ
+Jt
+Jt
 yM
 VV
 VV
@@ -2515,8 +2530,8 @@ kB
 eX
 eX
 Kf
-eX
-fZ
+LK
+Jt
 eX
 ux
 eX
@@ -2546,7 +2561,7 @@ XM
 XM
 yZ
 eX
-eX
+LK
 Ew
 Eq
 lq


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
a lot of ruins use the unlit type of turfs still when they should be the lit variant. This is PR one out of many that go through these ruins.  (also makes some tiles on the jungle_syndicate the dark" still lit" variant so it matches up)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
Lighting errors = bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed jungle_syndicate lighting and changes some of the dirt
fix: fixed jungle_surface_bombmakers lighting
fix: fixed jungle_demon lighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
