### PR TITLE
fixes lighting on jungle_botany / jungle_surface_weedshack / jungle_pirate / jungle_witch

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_botany.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_botany.dmm
@@ -152,7 +152,7 @@
 "nJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "nS" = (
 /obj/structure/cable{
@@ -228,7 +228,7 @@
 "uK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "uM" = (
 /obj/structure/cable{
@@ -267,7 +267,7 @@
 /area/ruin/powered)
 "wU" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "yr" = (
 /obj/structure/cable{
@@ -301,7 +301,7 @@
 "zm" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Aq" = (
 /obj/structure/table,
@@ -394,7 +394,7 @@
 /area/ruin/powered)
 "HQ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Ia" = (
 /obj/machinery/hydroponics/constructable,
@@ -528,7 +528,7 @@
 /area/ruin/powered)
 "Sh" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/powered)
 "Ss" = (
 /obj/machinery/power/terminal{

--- a/_maps/RandomRuins/JungleRuins/jungle_pirate.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_pirate.dmm
@@ -72,7 +72,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "kh" = (
 /turf/closed/wall/mineral/wood,
@@ -138,17 +138,17 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "tG" = (
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "uf" = (
 /obj/structure/closet/crate/goldcrate,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "xd" = (
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "xT" = (
 /obj/structure/bonfire/prelit,
@@ -174,11 +174,11 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "BV" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "CG" = (
 /obj/structure/curtain/bounty,
@@ -189,7 +189,7 @@
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 4
 	},
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "DC" = (
 /obj/structure/railing,
@@ -208,7 +208,7 @@
 /area/ruin/unpowered)
 "DV" = (
 /obj/vehicle/ridden/lavaboat,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "Er" = (
 /obj/structure/dresser,
@@ -228,7 +228,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "IH" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
@@ -239,7 +239,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "Kl" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "KD" = (
 /obj/machinery/grill,
@@ -264,7 +264,7 @@
 /area/ruin/unpowered)
 "Nq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "NY" = (
 /obj/structure/railing,
@@ -335,7 +335,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "UX" = (
 /mob/living/simple_animal/hostile/pirate/melee,

--- a/_maps/RandomRuins/JungleRuins/jungle_surface_weed_shack.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_surface_weed_shack.dmm
@@ -212,7 +212,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "sW" = (
 /obj/item/cigbutt/roach,
@@ -231,7 +231,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "wn" = (
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/template_noop)
 "xh" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -377,7 +377,7 @@
 /area/template_noop)
 "JY" = (
 /mob/living/simple_animal/hostile/cockroach/glockroach,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/template_noop)
 "Kg" = (
 /obj/structure/cable{
@@ -557,7 +557,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/template_noop)
 "Xd" = (
 /obj/machinery/hydroponics/constructable,

--- a/_maps/RandomRuins/JungleRuins/jungle_witch.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_witch.dmm
@@ -27,7 +27,7 @@
 /area/ruin/powered)
 "el" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "ev" = (
 /obj/structure/table/wood/fancy/cyan,
@@ -79,7 +79,7 @@
 /area/ruin/powered)
 "nW" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "oL" = (
 /obj/item/flashlight/lamp/bananalamp,
@@ -92,11 +92,11 @@
 /area/ruin/powered)
 "qM" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "rr" = (
 /obj/structure/trap/fire,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "rM" = (
 /obj/structure/table/wood,
@@ -126,7 +126,7 @@
 /area/ruin/powered)
 "sP" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "sT" = (
 /obj/effect/decal/cleanable/crayon,
@@ -164,7 +164,7 @@
 /turf/open/floor/wood,
 /area/ruin/powered)
 "wI" = (
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "wL" = (
 /obj/item/chair/wood,
@@ -172,7 +172,7 @@
 /area/ruin/powered)
 "yj" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "ym" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -184,7 +184,7 @@
 /area/ruin/powered)
 "zZ" = (
 /obj/structure/flora/rock,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "AG" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -196,10 +196,10 @@
 /area/ruin/powered)
 "Cc" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "CN" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Dr" = (
 /obj/effect/decal/cleanable/generic,
@@ -227,7 +227,7 @@
 /area/ruin/powered)
 "FG" = (
 /obj/structure/trap/chill,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "Go" = (
 /mob/living/simple_animal/hostile/dark_wizard,
@@ -244,7 +244,7 @@
 /area/ruin/powered)
 "KA" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "LK" = (
 /obj/structure/barricade/wooden/crude,
@@ -254,7 +254,7 @@
 "NP" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/item/clothing/head/helmet/chaplain,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "Ps" = (
 /obj/item/chair/wood{
@@ -266,7 +266,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/item/clothing/suit/armor/riot/chaplain,
 /obj/item/claymore/weak,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "SZ" = (
 /obj/item/clothing/suit/armor/riot/chaplain/witchhunter,
@@ -274,7 +274,7 @@
 /obj/item/claymore/weak,
 /obj/item/bodypart/head,
 /obj/effect/decal/cleanable/blood/gibs/bubblegum,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "Uy" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -289,7 +289,7 @@
 /area/ruin/powered)
 "Xl" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "YG" = (
 /obj/item/clothing/suit/wizrobe/marisa,
@@ -313,7 +313,7 @@
 /area/ruin/powered)
 "ZL" = (
 /obj/structure/trap/damage,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "ZW" = (
 /obj/effect/mob_spawn/human/corpse,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes lighting on the ruins listed in the name.  This is the second PR fixing lighting
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
Lighting Errors = no good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed jungle_botany lighting
fix: fixed jungle_surface_weedshack lighting
fix: fixed jungle_pirate lighting
fix: fixed jungle_witch lighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
