### PR TITLE
fixes lighting on jungle_surface_coffinpirate / jungle_seedling / jungle_surface_shrine / jungle_spider

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_seedling.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_seedling.dmm
@@ -5,41 +5,41 @@
 /area/ruin/powered)
 "dT" = (
 /obj/structure/flora/stump,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "fj" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "iB" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "iJ" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "iX" = (
 /obj/structure/fence/cut/large{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "kj" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "mh" = (
 /obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "ms" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "mt" = (
 /obj/item/storage/bag/medical,
@@ -70,45 +70,45 @@
 /area/ruin/powered)
 "rN" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "rZ" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/food/tomato_smudge,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "so" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "uY" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/ruin/powered)
 "vZ" = (
 /obj/structure/fence/door,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "wa" = (
 /obj/structure/flora/rock/pile,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "wT" = (
 /obj/structure/fence/end{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "wW" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "xV" = (
 /obj/structure/flora/rock/pile,
-/turf/open/floor/plating/dirt/jungle/wasteland,
+/turf/open/floor/plating/dirt/jungle/wasteland/lit,
 /area/ruin/unpowered)
 "zA" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Ef" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -116,7 +116,7 @@
 /area/ruin/unpowered)
 "FT" = (
 /obj/item/scythe,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Io" = (
 /turf/closed/mineral,
@@ -129,7 +129,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered)
 "Lt" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Nj" = (
 /mob/living/simple_animal/bot/medbot/rockplanet,
@@ -142,50 +142,50 @@
 /area/ruin/powered)
 "Py" = (
 /obj/structure/fence,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Qe" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/food/snacks/salad/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "QF" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "QG" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "QV" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "SA" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "SI" = (
 /obj/effect/turf_decal/dept/medical,
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/ruin/powered)
 "TD" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "TM" = (
 /obj/item/cultivator/rake,
 /mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Uv" = (
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Vf" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Vu" = (
 /obj/structure/frame/machine,
@@ -200,10 +200,10 @@
 /area/ruin/powered)
 "WR" = (
 /obj/structure/flora/rock,
-/turf/open/floor/plating/dirt/jungle/wasteland,
+/turf/open/floor/plating/dirt/jungle/wasteland/lit,
 /area/ruin/unpowered)
 "ZE" = (
-/turf/open/floor/plating/dirt/jungle/wasteland,
+/turf/open/floor/plating/dirt/jungle/wasteland/lit,
 /area/ruin/unpowered)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/JungleRuins/jungle_spider.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_spider.dmm
@@ -4,25 +4,25 @@
 /area/template_noop)
 "c" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "e" = (
 /obj/structure/spider/stickyweb,
 /obj/item/reagent_containers/food/snacks/spidereggs,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "f" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "g" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/door/airlock/research,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "i" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "j" = (
 /obj/effect/decal/cleanable/glass,
@@ -39,24 +39,24 @@
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/spider/spiderling,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "m" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "q" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/barricade/wooden,
 /obj/structure/grille/broken,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "r" = (
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "s" = (
 /obj/item/paper/guides/jobs/medical/cloning,
@@ -64,12 +64,12 @@
 /area/ruin/unpowered)
 "t" = (
 /obj/structure/spider/spiderling,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "u" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "v" = (
 /obj/structure/spider/spiderling,
@@ -79,7 +79,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/circuitboard/machine/dnascanner,
 /obj/item/circuitboard/computer/cloning,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "w" = (
 /obj/machinery/clonepod,
@@ -91,7 +91,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "y" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "A" = (
 /obj/structure/closet/wardrobe/genetics_white,
@@ -100,7 +100,7 @@
 /area/ruin/unpowered)
 "C" = (
 /obj/item/storage/belt/security/webbing,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "D" = (
 /obj/effect/decal/cleanable/ash/large,
@@ -129,22 +129,22 @@
 /obj/structure/barricade/wooden,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "M" = (
 /obj/structure/spider/spiderling,
 /obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "N" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "O" = (
 /obj/item/melee/flyswatter,
 /obj/item/reagent_containers/spray/pestspray,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "P" = (
 /obj/effect/decal/cleanable/glass,
@@ -166,17 +166,17 @@
 "U" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "V" = (
 /obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating/dirt/jungle,
+/turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/unpowered)
 "W" = (
 /obj/item/flamethrower,
 /obj/item/tank/internals/plasma/full,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "X" = (
 /obj/effect/decal/cleanable/cobweb,

--- a/_maps/RandomRuins/JungleRuins/jungle_surface_coffinpirate.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_surface_coffinpirate.dmm
@@ -8,12 +8,12 @@
 "c" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/clothing/head/hooded/cloakhood/bone,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "d" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "e" = (
 /obj/structure/table/wood,
@@ -30,14 +30,14 @@
 /obj/structure/mineral_door/wood,
 /obj/item/grown/bananapeel,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "h" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "i" = (
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "j" = (
 /obj/structure/table/wood,
@@ -57,7 +57,7 @@
 "m" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/table/wood,
@@ -67,15 +67,15 @@
 "q" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "r" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "s" = (
 /obj/structure/sink/puddle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "u" = (
 /obj/structure/closet/crate/coffin,
@@ -83,7 +83,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "v" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "w" = (
 /obj/structure/closet/crate/coffin,
@@ -98,7 +98,7 @@
 /area/ruin/unpowered)
 "y" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "z" = (
 /obj/structure/closet/cabinet,
@@ -122,12 +122,12 @@
 /obj/item/stack/sheet/bone,
 /obj/item/stack/sheet/bone,
 /obj/item/stack/sheet/bone,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "C" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/stack/sheet/bone,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "E" = (
 /obj/structure/closet/crate/coffin,
@@ -139,11 +139,11 @@
 /area/ruin/unpowered)
 "F" = (
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "G" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "H" = (
 /obj/structure/closet/crate/coffin,
@@ -185,7 +185,7 @@
 "K" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/food/snacks/monkeycube,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "L" = (
 /obj/structure/mineral_door/wood,
@@ -195,12 +195,12 @@
 /obj/structure/closet/crate/coffin,
 /obj/item/stack/sheet/bone,
 /obj/item/stack/sheet/bone,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "N" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/melee/baseball_bat/bone,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "P" = (
 /obj/structure/closet/crate/coffin,
@@ -211,7 +211,7 @@
 "Q" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "R" = (
 /obj/structure/bed/dogbed{
@@ -234,7 +234,7 @@
 /area/ruin/unpowered)
 "T" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "U" = (
 /obj/structure/bed,
@@ -254,7 +254,7 @@
 "W" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/food/snacks/sugarcookie/spookyskull,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "Y" = (
 /obj/structure/closet/crate/coffin,
@@ -266,7 +266,7 @@
 /area/ruin/unpowered)
 "Z" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/JungleRuins/jungle_surface_ninjashrine.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_surface_ninjashrine.dmm
@@ -1,18 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "c" = (
 /obj/item/throwing_star/ninja{
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "d" = (
 /obj/item/reagent_containers/food/snacks/grown/rice,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "f" = (
 /obj/item/reagent_containers/food/snacks/fortunecookie,
@@ -33,18 +33,18 @@
 /area/space)
 "i" = (
 /mob/living/simple_animal/hostile/jungle/mega_arachnid,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "j" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "k" = (
 /obj/item/throwing_star/ninja{
 	pixel_x = -8;
 	pixel_y = -4
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "l" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -53,7 +53,7 @@
 /area/ruin/unpowered)
 "q" = (
 /obj/structure/spider/cocoon,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "s" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62,7 +62,7 @@
 /area/ruin/unpowered)
 "t" = (
 /obj/item/reagent_containers/food/snacks/spiderling,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "u" = (
 /obj/item/clothing/suit/shrine_maiden,
@@ -70,7 +70,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
 /obj/item/gohei,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "v" = (
 /obj/item/reagent_containers/food/snacks/spiderling,
@@ -81,11 +81,11 @@
 /area/ruin/unpowered)
 "x" = (
 /obj/structure/mineral_door/paperframe,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "y" = (
 /obj/item/seeds/wheat/rice,
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "z" = (
 /obj/effect/decal/cleanable/dirt,
@@ -105,21 +105,21 @@
 /obj/item/reagent_containers/food/drinks/bottle/sake{
 	pixel_x = 12
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "G" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/yew,
 /area/ruin/unpowered)
 "H" = (
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "I" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/rice_hat{
 	pixel_y = 6
 	},
-/turf/open/water/jungle,
+/turf/open/water/jungle/lit,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -127,7 +127,7 @@
 /area/ruin/unpowered)
 "K" = (
 /obj/item/toy/plush/spider,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "M" = (
 /obj/structure/rack,
@@ -137,7 +137,7 @@
 /obj/item/katana{
 	pixel_x = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "N" = (
 /obj/effect/decal/remains/human,
@@ -164,7 +164,7 @@
 /turf/open/floor/wood/yew,
 /area/ruin/unpowered)
 "R" = (
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "S" = (
 /obj/item/clothing/under/color/black,
@@ -172,7 +172,7 @@
 /area/ruin/unpowered)
 "T" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/unpowered)
 "U" = (
 /obj/structure/mineral_door/paperframe,
@@ -185,18 +185,18 @@
 	name = "Ninja Vanish"
 	},
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "X" = (
 /obj/item/throwing_star/ninja{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 "Y" = (
 /obj/item/reagent_containers/food/snacks/spiderlollipop,
-/turf/open/floor/plating/dirt/jungle/dark,
+/turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/unpowered)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes lighting on the ruins listed in the PR name. This is the third PR fixing lighting
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game
Lighting Errors = bad!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed lighting on jungle_surface_coffinpirate
fix: fixed lighting on jungle_seedling
fix: fixed lighting on jungle_surface_shrine
fix: fixed lighting on jungle_spider
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
