### PR TITLE
Painting fixes

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -231,7 +231,7 @@
 	icon_state = "frame-empty"
 	buildable_sign = FALSE
 	var/obj/item/canvas/C
-	var/persistence_id
+	var/persistence_id = "general"
 
 /obj/structure/sign/painting/Initialize(mapload, dir, building)
 	. = ..()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -242,6 +242,9 @@
 	if(building)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -30 : 30)
 		pixel_y = (dir & 3)? (dir ==1 ? -30 : 30) : 0
+	//The painting is being loaded by the maploader and SSpersistence has already run. Load a painting ourselves.
+	if(mapload && SSpersistence.initialized)
+		load_persistent()
 
 /obj/structure/sign/painting/Destroy()
 	. = ..()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -229,7 +229,6 @@
 	desc = "Art or \"Art\"? You decide."
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "frame-empty"
-	buildable_sign = FALSE
 	var/obj/item/canvas/C
 	var/persistence_id = "general"
 
@@ -262,6 +261,12 @@
 	. = ..()
 	if(C)
 		C.ui_interact(user)
+
+/obj/structure/sign/painting/wrench_act(mob/living/user, obj/item/wrench/I)
+	if(!C)
+		return ..()
+	to_chat(user, "<span class='warning'>Remove the painting first!</span>")
+	return TRUE
 
 /obj/structure/sign/painting/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -61,6 +61,9 @@
 
 /obj/structure/sign/wrench_act(mob/living/user, obj/item/wrench/I)
 	. = ..()
+	//If it's not buildable, just make them hit it with the wrench.
+	if(!buildable_sign)
+		return FALSE
 	user.visible_message(
 		"<span class='notice'>[user] starts removing [src]...</span>", \
 		"<span class='notice'>You start unfastening [src].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #1625

Also should make it so that all painting frames save and load even outside of the few libraries that exist.

## Why It's Good For The Game
Paintings take quite a while, and it must suck when they get completely obliterated. This fixes that as well as tweaks it so more paintings are saved.

## Changelog

:cl:
fix: Paintings are no longer deleted when their frames are unwrenched.
tweak: Paintings should save even if they're outside of libraries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
