### PR TITLE
Fixes AI APC Override

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -145,6 +145,9 @@
 				to_chat(src, "<span class='notice'>Receiving control information from APC.</span>")
 				sleep(2)
 				apc_override = 1
+				//Force-set APC to "on"
+				theAPC.equipment = 2
+				theAPC.update()
 				theAPC.ui_interact(src)
 				apc_override = 0
 				setAiRestorePowerRoutine(POWER_RESTORATION_APC_FOUND)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #1468

## Why It's Good For The Game
Fixes a feature that's rather important for AI on shiptest, as APCs are a bit more turbulent on ships than they are in an AI sat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: AI APC emergency overriding should work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
