### PR TITLE
Adds crafting recipes for crates

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1136,3 +1136,11 @@
 	time = 4 SECONDS
 	reqs = list(/obj/item/strange_crystal = 2)
 	category = CAT_MISC
+
+/datum/crafting_recipe/freezer
+	name = "Freezer"
+	result = /obj/structure/closet/crate/freezer
+	time = 2 SECONDS
+	reqs = list(/datum/reagent/consumable/ice = 25,
+	/obj/item/stack/sheet/metal = 2)
+	category = CAT_MISC

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -46,6 +46,15 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		new/datum/stack_recipe("radiation closet", /obj/structure/closet/radiation/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE)
 		)),
 	null, \
+		new/datum/stack_recipe_list("crates", list(
+		new/datum/stack_recipe("crate", /obj/structure/closet/crate, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("internals crate", /obj/structure/closet/crate/internals, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("engineering crate", /obj/structure/closet/crate/engineering, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("medical crate", /obj/structure/closet/crate/medical, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("science crate", /obj/structure/closet/crate/science, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
+		new/datum/stack_recipe("hydroponics crate", /obj/structure/closet/crate/hydroponics, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE)
+		)),
+	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("plasteel floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \


### PR DESCRIPTION
## About The Pull Request

Crates, internal crates, engineering crates, medical crates, science crates and hydroponics crates can be constructed with 2 metal

Freezers are constructed with 2 metal and 25 ice (freezers prevent organ decay! would feel Unbalanced to be able to construct them with just 2 metal, this should limit freezers to mostly Medical Ships, hopefully.)

## Why It's Good For The Game

Hauling around Loot and Cargo in a Large Metal Closet is inconvenient. And More Storage Variety.

## Changelog

:cl:
add: Metal crafting recipes for crates.
add: Freezers can be constructed with 25 ice and 2 metal.
/:cl:
