### PR TITLE
Updates plated catwalks to use the correct icon states

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -27,15 +27,17 @@
 
 /obj/structure/catwalk/over/plated_catwalk
 	name = "plated catwalk"
-	icon_state = "catwalk_platedwhite"
+	icon_state = "catwalk_plated"
 	plated_tile = /obj/item/stack/tile/plasteel
 
 /obj/structure/catwalk/over/plated_catwalk/dark
 	plated_tile = /obj/item/stack/tile/plasteel/dark
+	icon_state = "catwalk_plateddark"
 
 /obj/structure/catwalk/over/plated_catwalk/white
 	name = "plated catwalk"
 	plated_tile = /obj/item/stack/tile/plasteel/white
+	icon_state = "catwalk_platedwhite"
 
 /obj/structure/catwalk/update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request

![catwalk](https://user-images.githubusercontent.com/118859017/215590395-7ce717bd-2b97-4055-a39c-06157c81e265.png)

## Why It's Good For The Game

It always bugged me how plated catwalks were all White in sdmm. which made it very Difficult to differentiate between them. this should fix that!

## Changelog

:cl:
tweak: Variations of plated catwalks now have icon states
/:cl:
