### PR TITLE
INFINITE HYPERFUSION stopgap measures

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -35,13 +35,20 @@ Ask ninjanomnom if they're around
 #define RAD_MOB_KNOCKDOWN_PROB 1 // Chance of knockdown per tick when over threshold
 #define RAD_MOB_KNOCKDOWN_AMOUNT 3 // Amount of knockdown when it occurs
 
-#define RAD_NO_INSULATION 1.0 // For things that shouldn't become irradiated for whatever reason
-#define RAD_VERY_LIGHT_INSULATION 0.9 // What girders have
+// For things that shouldn't become irradiated for whatever reason
+#define RAD_NO_INSULATION 1.0
+// What girders have
+#define RAD_VERY_LIGHT_INSULATION 0.9
+// Holofirelocks
 #define RAD_LIGHT_INSULATION 0.8
-#define RAD_MEDIUM_INSULATION 0.7 // What common walls have
-#define RAD_HEAVY_INSULATION 0.6 // What reinforced walls have
-#define RAD_EXTREME_INSULATION 0.5 // What rad collectors have
-#define RAD_FULL_INSULATION 0 // Unused
+// What common walls have
+#define RAD_MEDIUM_INSULATION 0.7
+// What reinforced walls have
+#define RAD_HEAVY_INSULATION 0.6
+// What rad collectors have
+#define RAD_EXTREME_INSULATION 0.5
+// Unused
+#define RAD_FULL_INSULATION 0
 
 // WARNING: The defines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
 // contamination_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -23,6 +23,9 @@
 		processing_list += thing.contents
 
 /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
+	// fusion will never ever be balanced. god bless it
+	intensity = min(intensity, INFINITY)
+
 	if(!SSradiation.can_fire)
 		return
 	for(var/dir in GLOB.cardinals)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -12,7 +12,8 @@
 	var/can_contaminate
 
 /datum/component/radioactive/Initialize(_strength=0, _source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE)
-	strength = _strength
+	// shouldn't ever happen, but it pays to be a little careful
+	strength = min(_strength, INFINITY)
 	source = _source
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
@@ -76,11 +77,11 @@
 		out += "The air around [master] feels warm"
 	switch(strength)
 		if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
-			out += "[length(out) ? " and it " : "[master] "]feels weird to look at."
+			out += "[length(out) ? " and it " : "[master] "]feels weird to look at"
 		if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
-			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit."
+			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit"
 		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
-			out += "[length(out) ? " and it " : "[master] "]hurts to look at."
+			out += "[length(out) ? " and it " : "[master] "]hurts to look at"
 	if(!LAZYLEN(out))
 		return
 	out += "."

--- a/code/datums/map_zones.dm
+++ b/code/datums/map_zones.dm
@@ -564,6 +564,9 @@
 	icon_state = "black"
 	layer = SPACE_LAYER
 	plane = FLOOR_PLANE
+	rad_insulation = RAD_FULL_INSULATION
+	rad_fullblocker = TRUE
+
 	var/destination_z
 	var/destination_x
 	var/destination_y

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -67,6 +67,10 @@
 	// ID of the virtual level we're in
 	var/virtual_z = 0
 
+	/// If TRUE, radiation waves will qdelete if they step forwards into this turf, and stop propagating sideways if they encounter it.
+	/// Used to stop radiation from travelling across virtual z-levels such as transit zones and planetary encounters.
+	var/rad_fullblocker = FALSE
+
 	///the holodeck can load onto this turf if TRUE
 	var/holodeck_compatible = FALSE
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -420,15 +420,12 @@
 	cached_results["fire"] = min(total_fuel, oxidation_power) * 2
 	return cached_results["fire"] ? REACTING : NO_REACTION
 
-//fusion: a terrible idea that was fun but broken. Now reworked to be less broken and more interesting. Again (and again, and again). Again!
+//fusion: a terrible idea that was fun but broken. Now reworked to be "less" broken and more interesting. Again (and again, and again). Again!
 //Fusion Rework Counter: Please increment this if you make a major overhaul to this system again.
 //6 reworks
 
 /proc/fusion_ball(datum/holder, reaction_energy, standard_energy)
 	var/turf/open/location
-
-	// fusion will never ever be balanced. god bless it
-	standard_energy = min(standard_energy, INFINITY)
 
 	if (istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
 		var/datum/pipeline/fusion_pipenet = holder

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -426,6 +426,10 @@
 
 /proc/fusion_ball(datum/holder, reaction_energy, standard_energy)
 	var/turf/open/location
+
+	// fusion will never ever be balanced. god bless it
+	standard_energy = min(standard_energy, INFINITY)
+
 	if (istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
 		var/datum/pipeline/fusion_pipenet = holder
 		location = get_turf(pick(fusion_pipenet.members))


### PR DESCRIPTION
## About The Pull Request

makes some basic changes to radiation to stop Big Oopsies from irradiating the galaxy (stops it from propagating across virtual z-levels, and caps rad wave / contamination strength at INFINITY)

## Why It's Good For The Game

i do not want this to happen every round

## Changelog

:cl:
fix: Radiation can no longer cross z-levels.
fix: Radiation waves and contamination can no longer reach infinite power. Hopefully.
/:cl: