### PR TITLE
Pops the Bubble

### DIFF
--- a/_maps/configs/independent_bubble.json
+++ b/_maps/configs/independent_bubble.json
@@ -11,5 +11,5 @@
 		"Shaft Miner": 1,
 		"Assistant": 3
 	},
-	"enabled": true
+	"enabled": false
 }

--- a/_maps/configs/independent_bubble.json
+++ b/_maps/configs/independent_bubble.json
@@ -3,6 +3,7 @@
 	"map_name": "Bubble-class Colonial Ship",
 	"map_short_name": "Bubble-class",
 	"map_path": "_maps/shuttles/shiptest/independent_bubble.dmm",
+	"limit": 1,
 	"job_slots": {
 		"Captain": 1,
 		"Scientist": 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the Bubble adminspawn-only.

## Why It's Good For The Game

rounds with three or more bubbles are still happening and players are using the Bubble to powergame... again. The game can only reasonably accomodate a single colony (provided the players actually build one in the first place), so projects like this should probably get stamped by an admin who will be willing to throw traffic or events at a colony if it pans out.

## Changelog

:cl:
tweak: Limited the Bubble-class colony ship to admin spawn only.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
