### PR TITLE
potentially fixes incorrect ruin turf icon_states

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -20,7 +20,8 @@
 	intact = TRUE
 	tiled_dirt = TRUE
 
-	var/icon_plating = "plating"
+	// initiailized as null to stop turfs that update_icon() before Initialize() (in late ruin loading) from getting "stuck" as plating
+	var/icon_plating = null
 	var/broken = FALSE
 	var/burnt = FALSE
 	var/floor_tile = null //tile that this floor drops

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -130,17 +130,6 @@
 /turf/open/floor/proc/crush()
 	break_tile()
 
-/turf/open/floor/ChangeTurf(path, new_baseturf, flags)
-	if(!isfloorturf(src))
-		return ..() //fucking turfs switch the fucking src of the fucking running procs
-	if(!ispath(path, /turf/open/floor))
-		return ..()
-	var/old_dir = dir
-	var/turf/open/floor/W = ..()
-	W.setDir(old_dir)
-	W.update_icon()
-	return W
-
 /turf/open/floor/attackby(obj/item/C, mob/user, params)
 	if(!C || !user)
 		return 1

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -47,7 +47,7 @@
 /turf/open/floor/plating/update_icon()
 	if(!..())
 		return
-	if(!broken && !burnt)
+	if(!broken && !burnt && icon_plating)
 		icon_state = icon_plating //Because asteroids are 'platings' too.
 
 /turf/open/floor/plating/attackby(obj/item/C, mob/user, params)
@@ -107,7 +107,8 @@
 	..()
 	if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
 		to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
-		icon_state = icon_plating
+		if(icon_plating)
+			icon_state = icon_plating
 		burnt = FALSE
 		broken = FALSE
 


### PR DESCRIPTION
## About The Pull Request

ruin turfs (specifically dirt, but also some others) were occasionally generating in ruins with incorrect icon states (either plating or blank tiles). i'm not entirely sure why that happens, but my guess is that it involved an odd race condition where update_icon() was called on turfs that hadn't had Initialize() called yet, causing icon_state and icon_plating to get stuck in "plating" (which, if a turf's icon file doesn't include a "plating" state, would lead to a blank appearance). making icon_plating default to null, and checking to see if it isn't null before swapping to it, should hopefully defuse this bug

## Why It's Good For The Game

ruins that look how they're supposed to look are better than ones that don't

## Changelog

:cl:
fix: hopefully fixed certain incorrect ruin floor turf icons
/:cl:
