### PR TITLE
Makes the brigphysjacket (leaddoctor armour) not invisible

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -480,7 +480,7 @@
 /obj/item/clothing/suit/armor/vest/security/brig_phys
 	name = "brig physician's jacket"
 	desc = "A black jacket with dark blue and silver accents, for the brig physician to prove they're a real member of security in style."
-	icon_state = "brigphysjacket"
+	icon_state = "armor_brigphysjacket"
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/armor/frontier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
invalid icon path, this fixes that
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
invisible clothes bad 😳 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: brig phys jacket no longer invisible (otherwise known as Lead Doctors jacket on the AEGIS)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
