### PR TITLE
Fixes Kepori and Vox prosthetics when spawning

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2368,9 +2368,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		pref_species = new /datum/species/human
 		save_character()
 
-	if(pref_species.id != "ipc") /// if triggered ipc arm, and legs sprites brake,prosthetics work for vox and kepori and update just fine for everyone
-		character.dna.features = features.Copy()
-		character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
+	//prosthetics work for vox and kepori and update just fine for everyone
+	character.dna.features = features.Copy()
+	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 
 	for(var/pros_limbs in prosthetic_limbs)
 		var/obj/item/bodypart/old_part = character.get_bodypart(pros_limbs)
@@ -2389,8 +2389,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(PROSTHETIC_ROBOTIC)
 				var/obj/item/bodypart/prosthetic
 				var/typepath
-				if(pref_species.unique_prosthesis) // Checks for if the species has a unique limb type, otherwise defaults to human
-					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus/[pref_species.id]")
+				if(character.dna.species.unique_prosthesis) // Checks for if the species has a unique limb type, otherwise defaults to human
+					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus/[character.dna.species.id]")
 				else
 					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus")
 				if(!ispath(typepath))
@@ -2401,8 +2401,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(old_part)
 					qdel(old_part)
 
-	if(pref_species.id == "ipc")
-		character.dna.features = features.Copy()// if triggered vox and kepori arm do not spawn in. but ipcs sprites wont brake,though they still dont immiditly update prosthetic for the ipc still
+	if(pref_species.id == "ipc")// if triggered vox and kepori arm do not spawn in. but ipcs sprites brake without it
 		character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 	//Because of how set_species replaces all bodyparts with new ones, hair needs to be set AFTER species.
 	character.dna.real_name = character.real_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2361,7 +2361,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(!character.equip_to_slot_or_del(G.spawn_item(character, character), G.slot))
 					continue
 
-
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type
 	if(roundstart_checks && !(pref_species.id in GLOB.roundstart_races) && !(pref_species.id in (CONFIG_GET(keyed_list/roundstart_no_hard_check))))
@@ -2369,8 +2368,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		pref_species = new /datum/species/human
 		save_character()
 
-	character.dna.features = features.Copy()
-	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)//turns out having something checking for a species that was not set brakes things
+	if(pref_species.id != "ipc") /// if triggered ipc arm, and legs sprites brake,prosthetics work for vox and kepori and update just fine for everyone
+		character.dna.features = features.Copy()
+		character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 
 	for(var/pros_limbs in prosthetic_limbs)
 		var/obj/item/bodypart/old_part = character.get_bodypart(pros_limbs)
@@ -2389,8 +2389,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(PROSTHETIC_ROBOTIC)
 				var/obj/item/bodypart/prosthetic
 				var/typepath
-				if(character.dna.species.unique_prosthesis) // Checks for if the species has a unique limb type, otherwise defaults to human
-					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus/[character.dna.species.id]")
+				if(pref_species.unique_prosthesis) // Checks for if the species has a unique limb type, otherwise defaults to human
+					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus/[pref_species.id]")
 				else
 					typepath = text2path("/obj/item/bodypart/[pros_limbs]/robot/surplus")
 				if(!ispath(typepath))
@@ -2401,7 +2401,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(old_part)
 					qdel(old_part)
 
-
+	if(pref_species.id == "ipc")
+		character.dna.features = features.Copy()// if triggered vox and kepori arm do not spawn in. but ipcs sprites wont brake,though they still dont immiditly update prosthetic for the ipc still
+		character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 	//Because of how set_species replaces all bodyparts with new ones, hair needs to be set AFTER species.
 	character.dna.real_name = character.real_name
 	character.hair_color = hair_color
@@ -2419,7 +2421,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		character.update_body()
 		character.update_hair()
 		character.update_body_parts(TRUE)
-
 	character.dna.update_body_size()
 
 /datum/preferences/proc/get_default_name(name_id)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -233,7 +233,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		dat += "<div class='notice'>Please create an account to save your preferences</div>"
 
 	dat += "</center>"
-
 	dat += "<HR>"
 
 	switch(current_tab)
@@ -2362,8 +2361,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(!character.equip_to_slot_or_del(G.spawn_item(character, character), G.slot))
 					continue
 
-	character.dna.features = features.Copy()
-	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)//turns out having something checking for a species that was not set brakes things
 
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type
@@ -2371,6 +2368,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		chosen_species = /datum/species/human
 		pref_species = new /datum/species/human
 		save_character()
+
+	character.dna.features = features.Copy()
+	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)//turns out having something checking for a species that was not set brakes things
 
 	for(var/pros_limbs in prosthetic_limbs)
 		var/obj/item/bodypart/old_part = character.get_bodypart(pros_limbs)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2401,7 +2401,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(old_part)
 					qdel(old_part)
 
-	if(pref_species.id == "ipc")// if triggered vox and kepori arm do not spawn in. but ipcs sprites brake without it
+	if(pref_species.id == "ipc") // If triggered, vox and kepori arms do not spawn in but ipcs sprites break without it as the code for setting the right prosthetics for them is in set_species().
 		character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 	//Because of how set_species replaces all bodyparts with new ones, hair needs to be set AFTER species.
 	character.dna.real_name = character.real_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2362,6 +2362,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(!character.equip_to_slot_or_del(G.spawn_item(character, character), G.slot))
 					continue
 
+	character.dna.features = features.Copy()
+	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)//turns out having something checking for a species that was not set brakes things
+
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type
 	if(roundstart_checks && !(pref_species.id in GLOB.roundstart_races) && !(pref_species.id in (CONFIG_GET(keyed_list/roundstart_no_hard_check))))
@@ -2398,8 +2401,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(old_part)
 					qdel(old_part)
 
-	character.dna.features = features.Copy()
-	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
+
 	//Because of how set_species replaces all bodyparts with new ones, hair needs to be set AFTER species.
 	character.dna.real_name = character.real_name
 	character.hair_color = hair_color


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: https://github.com/shiptest-ss13/Shiptest/issues/1426

Apparently, checking for a species before it is set doesn't work, imagine if we had known this 6 months ago...
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
allows people to use  prosthetics on their Kepori and Vox instead of spawning with human limbs
## Changelog

:cl:
fix: fixed Kepori and Vox prosthetics when spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
