### PR TITLE
fixes industrial_loading

### DIFF
--- a/code/game/objects/effects/decals/turfdecal/flooring_decals.dm
+++ b/code/game/objects/effects/decals/turfdecal/flooring_decals.dm
@@ -371,13 +371,15 @@ TURF_DECAL_COLOR_HELPER(transparent/inteqbrown, "#4b2a18", 140)
 	name = "loading area"
 	icon_state = "loadingarea"
 	alpha = 229
-	detail_overlay = "loadingarea_stripes"
+	detail_overlay = "loadingarea"
 
 /obj/effect/turf_decal/industrial/loading/red
 	detail_color = COLOR_RED_GRAY
+	detail_overlay = "loadingarea_stripes"
 
 /obj/effect/turf_decal/industrial/loading/white
 	detail_color = COLOR_WHITE
+	detail_overlay = "loadingarea_stripes"
 
 /obj/effect/turf_decal/industrial/caution
 	icon_state = "caution"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i don't really understand why, but industrial_loading fails to use the correct sprite, due to a "detail_overlay = loadingarea_stripes", which caused it to load in as white. This just changes it to "loadingarea", and moves loadingarea_stripes to the two subtypes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
decals should work like intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed /obj/effect/turf_decal/industrial/loading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
