### PR TITLE
fixes the command and security CMM undersuit

### DIFF
--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -155,3 +155,4 @@
 	desc = "A uniform used by officers of the Colonial Minutemen."
 	icon_state = "minuteman_officer"
 	item_state = "g_suit"
+	can_adjust = FALSE

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -289,6 +289,7 @@
 	desc = "A jumpsuit worn by low ranking members of the Colonial Minutemen."
 	icon_state = "minuteman"
 	item_state = "b_suit"
+	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/officer/camo
 	name = "fatigues"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Both suits currently have an alt version in the code, despite not having a sprite, making them turn into errors when switching styles. This PR makes them unable to switch styles (I'm not spriting new styles)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
errors = bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixes /obj/item/clothing/under/rank/command/minutemen having an alt-state
fix: fixes /obj/item/clothing/under/rank/security/officer/minutemen having an alt-state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
