### PR TITLE
11 new emergency holopads

### DIFF
--- a/_maps/shuttles/shiptest/independent_boyardee.dmm
+++ b/_maps/shuttles/shiptest/independent_boyardee.dmm
@@ -1005,10 +1005,10 @@
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "wm" = (
-/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad/emergency/kitchen,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "wn" = (
@@ -1118,7 +1118,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=0,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A regular chicken, nothing weird about this one .";
 	name = "Cluckens"
 	},
@@ -1733,7 +1733,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad/emergency/botany,
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
 "In" = (

--- a/_maps/shuttles/shiptest/independent_hightide.dmm
+++ b/_maps/shuttles/shiptest/independent_hightide.dmm
@@ -380,7 +380,7 @@
 /area/ship/maintenance/central)
 "nK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/holopad/emergency/command,
+/obj/machinery/holopad/emergency/buddy,
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "nT" = (

--- a/_maps/shuttles/shiptest/independent_midway.dmm
+++ b/_maps/shuttles/shiptest/independent_midway.dmm
@@ -1260,6 +1260,7 @@
 /obj/machinery/atmospherics/pipe/simple/green{
 	dir = 1
 	},
+/obj/machinery/holopad/emergency/atmos,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering/atmospherics)
 "xa" = (
@@ -2215,7 +2216,7 @@
 /obj/item/storage/belt/medical,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/glass/bottle{
-	list_reagents = list(/datum/reagent/medicine/thializid = 30);
+	list_reagents = list(/datum/reagent/medicine/thializid=30);
 	name = "thializid bottle"
 	},
 /obj/item/reagent_containers/glass/bottle/formaldehyde{

--- a/_maps/shuttles/shiptest/independent_nemo.dmm
+++ b/_maps/shuttles/shiptest/independent_nemo.dmm
@@ -115,7 +115,7 @@
 	},
 /obj/machinery/computer/atmos_control/incinerator{
 	dir = 4;
-	sensors = list("nemo_incinerator_sensor" = "Incinerator Chamber")
+	sensors = list("nemo_incinerator_sensor"="Incinerator Chamber")
 	},
 /obj/effect/turf_decal/trimline/opaque/blue/line{
 	dir = 6
@@ -1603,7 +1603,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 8;
-	sensors = list("nemo_air_sensor" = "Air Mix Tank")
+	sensors = list("nemo_air_sensor"="Air Mix Tank")
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering/atmospherics)
@@ -2022,7 +2022,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("nemo_tox_sensor" = "Plasma Tank")
+	sensors = list("nemo_tox_sensor"="Plasma Tank")
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
@@ -2636,7 +2636,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 8;
-	sensors = list("nemo_o2_sensor" = "Oxygen Tank")
+	sensors = list("nemo_o2_sensor"="Oxygen Tank")
 	},
 /obj/structure/fireaxecabinet{
 	dir = 8;
@@ -2758,7 +2758,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 8;
-	sensors = list("nemo_n2_sensor" = "Nitrogen Tank")
+	sensors = list("nemo_n2_sensor"="Nitrogen Tank")
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering/atmospherics)
@@ -3507,6 +3507,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/holopad/emergency/engineering,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Yt" = (

--- a/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
+++ b/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
@@ -254,7 +254,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "cs" = (
-/obj/machinery/holopad/emergency/engineering,
+/obj/machinery/holopad/emergency/buddy,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen)
 "ct" = (
@@ -1903,10 +1903,10 @@
 /area/ship/engineering/atmospherics)
 "sl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer2,
-/obj/machinery/holopad/emergency/engineering,
 /obj/effect/turf_decal/industrial/radiation{
 	dir = 8
 	},
+/obj/machinery/holopad/emergency/atmos,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "sn" = (
@@ -2732,7 +2732,7 @@
 "zE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4;
-	filter_types = list("o2", "n2")
+	filter_types = list("o2","n2")
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/atmospherics)

--- a/_maps/shuttles/shiptest/independent_scav.dmm
+++ b/_maps/shuttles/shiptest/independent_scav.dmm
@@ -434,10 +434,10 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "nN" = (
-/obj/machinery/holopad/emergency,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "nS" = (

--- a/_maps/shuttles/shiptest/independent_tide.dmm
+++ b/_maps/shuttles/shiptest/independent_tide.dmm
@@ -280,7 +280,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/holopad/emergency/command,
+/obj/machinery/holopad/emergency/buddy,
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "rG" = (
@@ -661,7 +661,7 @@
 /obj/item/reagent_containers/food/snacks/burger/rat,
 /obj/item/cigbutt,
 /obj/item/reagent_containers/food/drinks/sillycup/smallcarton{
-	list_reagents = list(/datum/reagent/consumable/ethanol/vodka = 100)
+	list_reagents = list(/datum/reagent/consumable/ethanol/vodka=100)
 	},
 /obj/machinery/computer/cryopod{
 	pixel_y = 25

--- a/_maps/shuttles/shiptest/independent_tranquility.dmm
+++ b/_maps/shuttles/shiptest/independent_tranquility.dmm
@@ -2119,7 +2119,6 @@
 /turf/open/floor/plating,
 /area/ship/crew/dorm/dormfive)
 "qT" = (
-/obj/machinery/holopad/emergency/command,
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
@@ -3623,7 +3622,7 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/glass/bottle{
-	list_reagents = list(/datum/reagent/medicine/thializid = 30);
+	list_reagents = list(/datum/reagent/medicine/thializid=30);
 	name = "thializid bottle"
 	},
 /obj/item/reagent_containers/syringe,
@@ -5221,7 +5220,7 @@
 "Of" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/mug{
-	list_reagents = list(/datum/reagent/consumable/coffee = 30);
+	list_reagents = list(/datum/reagent/consumable/coffee=30);
 	pixel_x = -5;
 	pixel_y = 8
 	},
@@ -5230,7 +5229,7 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/drinks/mug{
-	list_reagents = list(/datum/reagent/consumable/coffee = 30);
+	list_reagents = list(/datum/reagent/consumable/coffee=30);
 	pixel_x = -2;
 	pixel_y = 1
 	},

--- a/_maps/shuttles/shiptest/independent_trunktide.dmm
+++ b/_maps/shuttles/shiptest/independent_trunktide.dmm
@@ -974,13 +974,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/holopad/emergency/buddy,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "DM" = (

--- a/_maps/shuttles/shiptest/independent_wright.dmm
+++ b/_maps/shuttles/shiptest/independent_wright.dmm
@@ -240,7 +240,7 @@
 "hz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	list_reagents = list(/datum/reagent/consumable/ethanol/sugar_rush = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/sugar_rush=30);
 	pixel_x = 3;
 	pixel_y = 4
 	},
@@ -570,7 +570,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey=30);
 	pixel_x = -2;
 	pixel_y = 4
 	},
@@ -2265,7 +2265,6 @@
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/office)
 "ZK" = (
-/obj/machinery/holopad/emergency/command,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2278,6 +2277,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/holopad/emergency/detective,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/law_office)
 "ZO" = (

--- a/_maps/shuttles/shiptest/inteq_colossus.dmm
+++ b/_maps/shuttles/shiptest/inteq_colossus.dmm
@@ -1941,7 +1941,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/carpet/orange,
 /area/ship/bridge)
 "tR" = (
@@ -2238,7 +2238,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "wW" = (
-/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2247,6 +2246,7 @@
 	codes_txt = "patrol;next_patrol=hall";
 	location = "office"
 	},
+/obj/machinery/holopad/emergency/security,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/office)
 "xd" = (

--- a/_maps/shuttles/shiptest/inteq_hound.dmm
+++ b/_maps/shuttles/shiptest/inteq_hound.dmm
@@ -193,7 +193,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "fq" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "fI" = (

--- a/_maps/shuttles/shiptest/minutemen_cepheus.dmm
+++ b/_maps/shuttles/shiptest/minutemen_cepheus.dmm
@@ -863,7 +863,6 @@
 "kA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/steeldecal/steel_decals4,
-/obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
@@ -873,6 +872,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/holopad/emergency/engineering,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
 "kC" = (

--- a/_maps/shuttles/shiptest/minutemen_corvus.dmm
+++ b/_maps/shuttles/shiptest/minutemen_corvus.dmm
@@ -1189,7 +1189,6 @@
 /turf/open/floor/carpet/nanoweave,
 /area/ship/hallway/central)
 "tp" = (
-/obj/machinery/holopad/emergency/command,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable/yellow{
@@ -1198,6 +1197,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad/emergency/engineering,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "tt" = (

--- a/_maps/shuttles/shiptest/nanotrasen_goon.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_goon.dmm
@@ -146,7 +146,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "hh" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/emergency/science,
 /turf/open/floor/mineral/titanium/purple,
 /area/ship/crew)
 "iy" = (

--- a/_maps/shuttles/shiptest/nanotrasen_powerrangers.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_powerrangers.dmm
@@ -1313,7 +1313,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "kh" = (
-/obj/machinery/holopad/emergency,
+/obj/machinery/holopad/emergency/science,
 /turf/open/floor/plasteel/dark,
 /area/ship/science)
 "kj" = (
@@ -1554,12 +1554,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/storage)
 "ng" = (
-/obj/machinery/holopad/emergency,
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -27;
 	pixel_y = 8
 	},
+/obj/machinery/holopad/emergency/medical,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "nh" = (
@@ -4041,10 +4041,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "9-10"
 	},
-/obj/machinery/holopad/emergency,
 /obj/effect/turf_decal/trimline/opaque/mauve/filled/line{
 	dir = 8
 	},
+/obj/machinery/holopad/emergency/security,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Kv" = (
@@ -5443,13 +5443,13 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 8
 	},
-/obj/machinery/holopad/emergency,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "Yy" = (

--- a/_maps/shuttles/shiptest/radio_funny.dmm
+++ b/_maps/shuttles/shiptest/radio_funny.dmm
@@ -349,10 +349,10 @@
 /obj/machinery/door/window/westright{
 	dir = 2
 	},
-/obj/machinery/holopad,
 /obj/structure/chair/comfy/teal{
 	dir = 1
 	},
+/obj/machinery/holopad/emergency/clown,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/bridge)
 "Yx" = (

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -3775,7 +3775,7 @@
 /turf/template_noop,
 /area/ship/external)
 "RA" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/wood,
 /area/ship/crew/solgov)
 "RC" = (

--- a/_maps/shuttles/shiptest/syndicate_aegis.dmm
+++ b/_maps/shuttles/shiptest/syndicate_aegis.dmm
@@ -1509,6 +1509,7 @@
 /obj/effect/turf_decal/trimline/opaque/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/holopad/emergency/kitchen,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen/kitchen)
 "mN" = (

--- a/_maps/shuttles/shiptest/syndicate_boyardee_b.dmm
+++ b/_maps/shuttles/shiptest/syndicate_boyardee_b.dmm
@@ -371,10 +371,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"hQ" = (
-/obj/structure/chair/stool,
-/turf/open/floor/carpet/black,
-/area/ship/crew/canteen)
 "ie" = (
 /obj/machinery/advanced_airlock_controller{
 	locked = 0;
@@ -568,10 +564,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/holopad,
 /obj/structure/chair/wood{
 	dir = 4
 	},
+/obj/machinery/holopad/emergency/buddy,
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)
 "ly" = (
@@ -1592,7 +1588,7 @@
 	},
 /area/ship/crew/canteen/kitchen)
 "Ia" = (
-/obj/machinery/holopad/emergency/command,
+/obj/machinery/holopad/emergency/kitchen,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "In" = (
@@ -2897,7 +2893,7 @@ Kh
 dl
 IW
 ZT
-hQ
+zD
 wF
 xO
 xO

--- a/_maps/shuttles/shiptest/syndicate_gec_lugol.dmm
+++ b/_maps/shuttles/shiptest/syndicate_gec_lugol.dmm
@@ -642,6 +642,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"eY" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad/emergency/atmos,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/atmospherics)
 "fa" = (
 /obj/effect/turf_decal/corner/transparent/solgovgold{
 	dir = 10
@@ -6423,7 +6430,7 @@ Qs
 Qs
 Wy
 sU
-IN
+eY
 gZ
 XD
 TG

--- a/_maps/shuttles/shiptest/syndicate_luxembourg.dmm
+++ b/_maps/shuttles/shiptest/syndicate_luxembourg.dmm
@@ -1322,6 +1322,7 @@
 	codes_txt = "patrol;next_patrol=lux_kitchen";
 	location = "lux_shopfloor"
 	},
+/obj/machinery/holopad/emergency/cargo,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "zc" = (

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -117,6 +117,15 @@
 	new /obj/item/t_scanner(src)
 	new /obj/item/extinguisher/mini(src)
 
+/obj/item/storage/belt/utility/atmostech/hologram/PopulateContents()
+	new /obj/item/screwdriver(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool(src)
+	new /obj/item/crowbar(src)
+	new /obj/item/wirecutters(src)
+	new /obj/item/t_scanner(src)
+	new /obj/item/pipe_dispenser(src)
+
 /obj/item/storage/belt/utility/syndicate/PopulateContents()
 	new /obj/item/screwdriver/nuke(src)
 	new /obj/item/wrench/combat(src)
@@ -629,6 +638,14 @@
 		/obj/item/shovel/spade,
 		/obj/item/gun/energy/floragun
 	))
+
+/obj/item/storage/belt/plant/full/PopulateContents()
+	new /obj/item/plant_analyzer(src)
+	new /obj/item/cultivator(src)
+	new /obj/item/hatchet(src)
+	new /obj/item/shovel/spade(src)
+	new /obj/item/reagent_containers/spray/pestspray(src)
+	new /obj/item/reagent_containers/spray/plantbgone(src)
 
 /obj/item/storage/belt/bandolier
 	name = "bandolier"

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -1,4 +1,4 @@
-/*WS Edit - Fuck Psychologists.
+//psychologist back :)
 /datum/job/psychologist
 	name = "Psychologist"
 	total_positions = 1
@@ -23,13 +23,10 @@
 	pda_slot = ITEM_SLOT_BELT
 	l_hand = /obj/item/clipboard
 
-	backpack_contents = list(/obj/item/storage/pill_bottle/mannitol, /obj/item/storage/pill_bottle/psicodine, /obj/item/storage/pill_bottle/paxpsych, /obj/item/storage/pill_bottle/happinesspsych, /obj/item/storage/pill_bottle/lsdpsych)
-
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 
-*/
 //Shiptest Outfits
 
 /datum/outfit/job/psychologist/syndicate/nsv

--- a/code/modules/mob/living/carbon/hologram/em_holopads.dm
+++ b/code/modules/mob/living/carbon/hologram/em_holopads.dm
@@ -168,8 +168,8 @@
 	em_spawn_type = /mob/living/simple_animal/hologram/security
 
 /obj/machinery/holopad/emergency/cargo
-	name = "advanced logisctics holopad"
-	em_name = "logisctics"
+	name = "advanced logistics holopad"
+	em_name = "logistics"
 	em_spawn_type = /mob/living/simple_animal/hologram/cargo
 
 /obj/machinery/holopad/emergency/clown

--- a/code/modules/mob/living/carbon/hologram/em_holopads.dm
+++ b/code/modules/mob/living/carbon/hologram/em_holopads.dm
@@ -136,3 +136,58 @@
 	name = "advanced command holopad"
 	em_name = "command"
 	em_spawn_type = /mob/living/simple_animal/hologram/command
+
+/obj/machinery/holopad/emergency/kitchen
+	name = "advanced kitchen holopad"
+	em_name = "culinary"
+	em_spawn_type = /mob/living/simple_animal/hologram/kitchen
+
+/obj/machinery/holopad/emergency/botany
+	name = "advanced botany holopad"
+	em_name = "botanical"
+	em_spawn_type = /mob/living/simple_animal/hologram/botany
+
+/obj/machinery/holopad/emergency/counselor
+	name = "advanced counseling holopad"
+	em_name = "counseling"
+	em_spawn_type = /mob/living/simple_animal/hologram/psychologist
+
+/obj/machinery/holopad/emergency/atmos
+	name = "advanced atmospheric holopad"
+	em_name = "atmospheric"
+	em_spawn_type = /mob/living/simple_animal/hologram/atmos
+
+/obj/machinery/holopad/emergency/janitor
+	name = "advanced custodial holopad"
+	em_name = "custodial"
+	em_spawn_type = /mob/living/simple_animal/hologram/janitor
+
+/obj/machinery/holopad/emergency/security
+	name = "advanced security holopad"
+	em_name = "security"
+	em_spawn_type = /mob/living/simple_animal/hologram/security
+
+/obj/machinery/holopad/emergency/cargo
+	name = "advanced logisctics holopad"
+	em_name = "logisctics"
+	em_spawn_type = /mob/living/simple_animal/hologram/cargo
+
+/obj/machinery/holopad/emergency/clown
+	name = "advanced comedy holopad"
+	em_name = "comedy"
+	em_spawn_type = /mob/living/simple_animal/hologram/clown
+
+/obj/machinery/holopad/emergency/detective
+	name = "advanced forensics holopad"
+	em_name = "forensics"
+	em_spawn_type = /mob/living/simple_animal/hologram/detective
+
+/obj/machinery/holopad/emergency/curator
+	name = "advanced literacy holopad"
+	em_name = "literacy"
+	em_spawn_type = /mob/living/simple_animal/hologram/curator
+
+/obj/machinery/holopad/emergency/buddy
+	name = "advanced company holopad"
+	em_name = "company"
+	em_spawn_type = /mob/living/simple_animal/hologram/assistant

--- a/code/modules/mob/living/carbon/hologram/hologram.dm
+++ b/code/modules/mob/living/carbon/hologram/hologram.dm
@@ -285,4 +285,48 @@
 	job_type = new /datum/job/head_of_personnel
 	dex_item = /obj/item/card/id/silver/hologram
 
+/mob/living/simple_animal/hologram/kitchen
+	job_type = new /datum/job/cook
+	dex_item = /obj/item/storage/box/ingredients/wildcard
+
+/mob/living/simple_animal/hologram/botany
+	job_type = new /datum/job/hydro
+	dex_item = /obj/item/storage/belt/plant/full
+
+/mob/living/simple_animal/hologram/security
+	job_type = new /datum/job/officer
+	dex_item = /obj/item/gun/energy/disabler
+
+/mob/living/simple_animal/hologram/psychologist
+	job_type = new /datum/job/psychologist
+	dex_item = /obj/item/toy/plush/lizardplushie
+
+/mob/living/simple_animal/hologram/atmos
+	job_type = new /datum/job/atmos
+	dex_item = /obj/item/storage/belt/utility/atmostech/hologram
+
+/mob/living/simple_animal/hologram/janitor
+	job_type = new /datum/job/janitor
+	dex_item = /obj/item/storage/belt/janitor/full
+
+/mob/living/simple_animal/hologram/cargo
+	job_type = new /datum/job/qm
+	dex_item = /obj/item/export_scanner
+
+/mob/living/simple_animal/hologram/clown
+	job_type = new /datum/job/clown
+	dex_item = /obj/item/reagent_containers/spray/waterflower/lube
+
+/mob/living/simple_animal/hologram/detective
+	job_type = new /datum/job/detective
+	dex_item = /obj/item/detective_scanner
+
+/mob/living/simple_animal/hologram/curator
+	job_type = new /datum/job/curator
+	dex_item = /obj/item/taperecorder
+
+/mob/living/simple_animal/hologram/assistant
+	job_type = new /datum/job/assistant
+	dex_item = /obj/item/storage/cans/sixbeer
+
 #undef HOLOGRAM_CYCLE_COLORS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds 11 new emergency holopad jobs and replaces some existing holopads on ships with the appropriate ones

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
moar holopad options for the outpost and such
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added 11 new emergency holopad jobs
tweak: replaced some ship holopads with emergency holopads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
