### PR TITLE
Adds an addiction threshold to cement

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2597,6 +2597,7 @@
 	name = "Cement"
 	description = "A sophisticated binding agent used to produce concrete."
 	color = "#c4c0bc"
+	addiction_threshold = 25
 	taste_description = "cement"
 	harmful = TRUE
 	var/potency = 2


### PR DESCRIPTION
## About The Pull Request

Cement is now addictive.

## Why It's Good For The Game



## Changelog

:cl:
tweak: Cement now has a 25 unit addiction threshold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
