### PR TITLE
Adds an extra check to prevent admins from spawning planets on top of others

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -837,16 +837,23 @@
 			else
 				var/selected_ruin = tgui_input_list(usr, "Which ruin?", "Spawn Ruin", select_from, 60 SECONDS)
 				if(!selected_ruin)
-					if(tgui_alert(usr, "Did you mean to not have a ruin?", "Spawn Planet/Ruin", list("Yes", "No"), 10) != "Yes")
+					if(tgui_alert(usr, "Did you mean to not have a ruin?", "Spawn Planet/Ruin", list("Yes", "No"), 10 SECONDS) != "Yes")
 						return
 				else
 					ruin_target = select_from[selected_ruin]
 
-	message_admins("Generating a new Planet, this may take some time!")
-	var/list/position = SSovermap.get_unused_overmap_square()
-	if(!position)
-		if(tgui_alert(usr,"Failed to find unused overmap space! Continue?", "Force planet spawning?", list("Yes","No"), 10) != "Yes")
+	var/list/position
+	if(tgui_alert(usr, "Where do you want to spawn your Planet/Ruin?", "Spawn Planet/Ruin", list("Pick a location", "Random")) == "Pick a location")
+		position["x"] = input(usr, "Choose your X coordinate", "Pick a location", rand(1,SSovermap.size)) as num
+		position["y"] = input(usr, "Choose your Y coordinate", "Pick a location", rand(1,SSovermap.size)) as num
+		if(locate /datum/overmap in SSovermap.overmap_container[location.["x"]][location["y"]] && tgui_alert(usr, "There is already an overmap object in that location! Continue anyway?","Pick a location", list("Yes","No"), 10 SECONDS) != "Yes")
 			return
+	else
+		position = SSovermap.get_unused_overmap_square()
+
+	message_admins("Generating a new Planet, this may take some time!")
+	if(!position && tgui_alert(usr, "Failed to spawn in an empty overmap space! Continue?", "Spawn Planet/Ruin", list("Yes","No"), 10 SECONDS) != "Yes")
+		return
 	var/datum/overmap/dynamic/encounter = new(position, FALSE)
 	encounter.force_encounter = planet_type
 	encounter.template = ruin_target

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -846,7 +846,7 @@
 	if(tgui_alert(usr, "Where do you want to spawn your Planet/Ruin?", "Spawn Planet/Ruin", list("Pick a location", "Random")) == "Pick a location")
 		position["x"] = input(usr, "Choose your X coordinate", "Pick a location", rand(1,SSovermap.size)) as num
 		position["y"] = input(usr, "Choose your Y coordinate", "Pick a location", rand(1,SSovermap.size)) as num
-		if(locate /datum/overmap in SSovermap.overmap_container[location.["x"]][location["y"]] && tgui_alert(usr, "There is already an overmap object in that location! Continue anyway?","Pick a location", list("Yes","No"), 10 SECONDS) != "Yes")
+		if(locate(/datum/overmap) in SSovermap.overmap_container[position["x"]][position["y"]] && tgui_alert(usr, "There is already an overmap object in that location! Continue anyway?","Pick a location", list("Yes","No"), 10 SECONDS) != "Yes")
 			return
 	else
 		position = SSovermap.get_unused_overmap_square()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -847,7 +847,6 @@
 	if(!position)
 		if(tgui_alert(usr,"Failed to find unused overmap space! Continue?", "Force planet spawning?", list("Yes","No"), 10) != "Yes")
 			return
-		position = SSovermap.get_unused_overmap_square(force = TRUE)
 	var/datum/overmap/dynamic/encounter = new(position, FALSE)
 	encounter.force_encounter = planet_type
 	encounter.template = ruin_target

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -843,7 +843,12 @@
 					ruin_target = select_from[selected_ruin]
 
 	message_admins("Generating a new Planet, this may take some time!")
-	var/datum/overmap/dynamic/encounter = new(null, FALSE)
+	var/list/position = SSovermap.get_unused_overmap_square()
+	if(!position)
+		if(tgui_alert(usr,"Failed to find unused overmap space! Continue?", "Force planet spawning?", list("Yes","No"), 10) != "Yes")
+			return
+		position = SSovermap.get_unused_overmap_square(force = TRUE)
+	var/datum/overmap/dynamic/encounter = new(position, FALSE)
 	encounter.force_encounter = planet_type
 	encounter.template = ruin_target
 	encounter.choose_level_type(FALSE)


### PR DESCRIPTION
## About The Pull Request

Lets admins choose an overmap position or force a random position when spawning planets/ruins.

## Why It's Good For The Game

Potentially fixes #1746 
Giving admins the ability to choose a location for their planets and ruins is probably cool.

## Changelog

:cl:
fix: Potentially fixed an issue with planets swapping type
admin: Added the option for admins to choose the location of new planets
/:cl: