### PR TITLE
Adds handling for Github ratelimit errors

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -848,3 +848,10 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	var/start = findtext(text, ">")
 	var/end = findtext(text, "<", 2)
 	return strip_html(copytext_char(text, start, min(start + limit, end)))
+
+/proc/shuffletext(string)
+	. = ""
+	while(length(string))
+		var/pos = rand(1, length(string))
+		. += copytext(string, pos, pos+1)
+		string = splicetext(string, pos, pos+1, null)

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -42,6 +42,7 @@
 /datum/getrev/proc/GetTestMergeInfo(header = TRUE)
 	if(!testmerge.len)
 		return ""
+	var/static/regex/error_matcher = new("(?<=G)ITHUB(?= API ERROR)", "g")
 	. = header ? "The following pull requests are currently test merged:<br>" : ""
 	for(var/line in testmerge)
 		var/datum/tgs_revision_information/test_merge/tm = line
@@ -49,7 +50,7 @@
 		var/details = ": '" + html_encode(tm.title) + "' by " + html_encode(tm.author) + " at commit " + html_encode(copytext_char(cm, 1, 11))
 		if(details && findtext(details, "\[s\]") && (!usr || !usr.client.holder))
 			continue
-		. += "<a href=\"[CONFIG_GET(string/githuburl)]/pull/[tm.number]\">#[tm.number][details]</a><br>"
+		. += "<a href=\"[CONFIG_GET(string/githuburl)]/pull/[tm.number]\">#[tm.number][replacetext(details, error_matcher, /proc/shuffletext)]</a><br>"
 
 /client/verb/showrevinfo()
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request
Adds special handling for detecting and dealing with Gituhb's ratelimit errors, which have led to the testmerge readouts looking like this.
![image](https://user-images.githubusercontent.com/110272328/225116894-a4da9e64-da27-4da8-8a0e-3e120976f2c6.png)

## Why It's Good For The Game
Now it'll be clear that we're aware of the Gihtbu ratelimit errors and doing something to deal with them.