### PR TITLE
Snowflake-Class Drone Ship

### DIFF
--- a/_maps/configs/nanotrasen_snowflake.json
+++ b/_maps/configs/nanotrasen_snowflake.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
+	"map_name": "Snowflake Automated Droneship",
+	"map_short_name": "Snowflake-Class",
+	"prefix": "NTSV",
+	"namelists": ["GENERAL", "SPACE", "ENGINEERING"],
+	"map_path": "_maps/shuttles/shiptest/nanotrasen_snowflake.dmm",
+	"limit": 1,
+	"job_slots": {
+		"Caretaker": {
+			"outfit": "/datum/outfit/job/ce/engineeringcoordinator",
+			"officer": true,
+			"slots": 1
+		}
+	},
+	"enabled": true
+}

--- a/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
@@ -497,7 +497,7 @@
 "DS" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband,
-/obj/item/spacecash/bundle/c1000
+/obj/item/spacecash/bundle/c1000,
 /obj/item/clothing/head/caphat/cowboy,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
@@ -497,7 +497,7 @@
 "DS" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband,
-/obj/item/stack/spacecash/bundle/c1000
+/obj/item/spacecash/bundle/c1000
 /obj/item/clothing/head/caphat/cowboy,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
@@ -1,0 +1,1117 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ar" = (
+/obj/machinery/ore_silo,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/item/circuitboard/machine/ore_redemption,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"bY" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "leftdrone"
+	},
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/structure/cable/pink,
+/turf/open/floor/plating,
+/area/ship/crew)
+"dS" = (
+/obj/item/clothing/head/beanie/rasta,
+/obj/item/clothing/head/beanie/black,
+/obj/item/clothing/head/beanie/christmas,
+/obj/item/clothing/head/beanie/waldo,
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/head/beret/vintage,
+/obj/item/clothing/head/bomb_hood,
+/obj/item/clothing/head/bunnyhead,
+/obj/item/clothing/head/cardborg,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/festive,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/jester,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/head/papersack,
+/obj/item/clothing/head/rabbitears,
+/obj/item/clothing/head/snowman,
+/obj/item/clothing/head/sombrero,
+/obj/item/clothing/head/wig,
+/obj/item/clothing/head/wizard/fake,
+/obj/item/clothing/head/wizard/santa,
+/obj/item/clothing/head/xenos,
+/obj/structure/sign/poster/official/moth/hardhats{
+	pixel_x = -32
+	},
+/obj/item/clothing/head/hardhat/pumpkinhead,
+/obj/item/clothing/head/hardhat,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/head/helmet/chaplain/cage,
+/obj/item/clothing/head/helmet/chaplain,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/head/helmet/chaplain/witchunter_hat,
+/obj/structure/closet/crate/critter{
+	desc = "A crate designed for safe transport of hats. It has an oxygen tank for safe transport in space.";
+	name = "hat crate"
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"fs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/pink{
+	icon_state = "0-2"
+	},
+/obj/effect/mob_spawn/drone/snowflake,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"ga" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"gR" = (
+/turf/open/floor/plasteel/patterned/monofloor{
+	dir = 1
+	},
+/area/ship/bridge)
+"hi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"iR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"ki" = (
+/obj/item/pipe_dispenser,
+/obj/item/clothing/gloves/color/latex/engineering,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/accessory/medal/gold/heroism{
+	desc = "An extremely rare golden medal awarded only by the Caretaker. To receive such a medal is the highest honor and as such, very few exist.";
+	name = "medal of exceptional behavior"
+	},
+/obj/item/extinguisher/advanced,
+/obj/item/construction/rcd/loaded,
+/obj/item/rcd_ammo,
+/obj/structure/closet/secure_closet{
+	icon_state = "ce";
+	name = "Caretakers locker"
+	},
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/obj/item/areaeditor/shuttle,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/gun/energy/laser,
+/obj/item/gps/engineering,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"kD" = (
+/obj/machinery/autolathe,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/item/disk/design_disk/ammo_38_hunting,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"la" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "dronebot"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/patterned/monofloor,
+/area/ship/bridge)
+"lF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"lU" = (
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_x = 32
+	},
+/obj/item/slime_cookie/purple,
+/obj/item/slime_cookie/purple,
+/obj/item/slime_cookie/cerulean,
+/obj/item/slime_cookie/cerulean,
+/obj/item/slime_cookie/yellow,
+/obj/item/slime_cookie/yellow,
+/obj/item/slime_cookie/sepia,
+/obj/item/slime_cookie/sepia,
+/obj/item/toy/plush/knight,
+/obj/item/toy/plush/hornet,
+/obj/structure/closet/crate/wooden/toy,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"mc" = (
+/mob/living/simple_animal/bot/medbot{
+	stationary_mode = 1;
+	health = 100;
+	name = "Dr. Cana PHD"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-5"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"md" = (
+/obj/structure/marker_beacon,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"mB" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "rightdrone"
+	},
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/structure/cable/pink,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
+"nl" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 2
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"nC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-10"
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"nR" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"nW" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/patterned/monofloor{
+	dir = 1
+	},
+/area/ship/bridge)
+"ox" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-5"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"oM" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"oR" = (
+/obj/machinery/droneDispenser/preloaded,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"oW" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "dronemid"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"pM" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"qr" = (
+/obj/machinery/computer/helm{
+	allow_ai_control = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"qM" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/machinery/power/terminal,
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_x = 32
+	},
+/obj/structure/cable/pink{
+	icon_state = "0-9"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-9"
+	},
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"rt" = (
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"rQ" = (
+/obj/structure/cable/pink{
+	icon_state = "6-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad/emergency/command,
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"uD" = (
+/turf/open/floor/eighties,
+/area/ship/crew)
+"uV" = (
+/obj/structure/sign/poster/contraband/free_drone{
+	pixel_y = 32
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"vG" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/light/floor,
+/obj/structure/cable/pink,
+/turf/open/floor/plasteel/patterned/monofloor{
+	dir = 1
+	},
+/area/ship/bridge)
+"vI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/pink{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"vK" = (
+/obj/machinery/button/door{
+	dir = 1;
+	id = "rightdrone";
+	name = "thruster doors";
+	pixel_y = -24
+	},
+/obj/structure/sink/kitchen{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"vU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"zF" = (
+/obj/structure/cable/pink{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/warning/full,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"zU" = (
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/turf/closed/wall/mineral/iron,
+/area/ship/crew)
+"zW" = (
+/obj/machinery/door/airlock{
+	id_tag = "humanlock";
+	name = "Drone Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew)
+"AY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "1-4"
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"Bs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"BP" = (
+/turf/closed/wall/mineral/iron,
+/area/ship/crew)
+"BU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Cc" = (
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"Cp" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1;
+	piping_layer = 2
+	},
+/obj/structure/curtain/cloth/grey,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Dv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable/cyan{
+	icon_state = "0-5"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"DB" = (
+/obj/machinery/power/shuttle/engine/electric/premium{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/crew)
+"DF" = (
+/obj/machinery/power/shuttle/engine/electric/premium{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/crew/dorm)
+"DS" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband,
+/obj/item/stack/spacecash/c1000{
+	amount = 5
+	},
+/obj/item/clothing/head/caphat/cowboy,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"EL" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters{
+	id = "dronebot"
+	},
+/turf/open/floor/plasteel/patterned/monofloor,
+/area/ship/bridge)
+"Fd" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -5
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 5
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	id = "leftdrone";
+	name = "thruster doors";
+	pixel_y = -24
+	},
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gun/ballistic/derringer,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"Fx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "dronemid";
+	name = "Bridge Shutters";
+	pixel_x = -7
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Hd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 31
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"Hl" = (
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"IP" = (
+/obj/structure/rack,
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/structure/curtain/cloth/grey,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "dronebot";
+	pixel_x = 24
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"JD" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/airless,
+/area/ship/external)
+"Kv" = (
+/obj/structure/bed,
+/obj/structure/curtain/cloth/grey,
+/obj/item/bedsheet/ce,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/item/toy/plush/plushvar,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"Le" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"Md" = (
+/turf/closed/wall/mineral/iron,
+/area/ship/bridge)
+"MF" = (
+/obj/machinery/door/airlock{
+	name = "Caretakers Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/dorm)
+"MH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/pink{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-4"
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"Qo" = (
+/turf/template_noop,
+/area)
+"Rc" = (
+/obj/machinery/power/terminal,
+/obj/structure/closet/syndicate/resources{
+	icon_state = "cabinet";
+	name = "Spare Materials";
+	open_sound = 'sound/machines/wooden_closet_open.ogg';
+	close_sound = 'sound/machines/wooden_closet_close.ogg'
+	},
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty,
+/obj/structure/cable/pink{
+	icon_state = "0-5"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-5"
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 15
+	},
+/turf/open/floor/eighties,
+/area/ship/crew)
+"Ro" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-10"
+	},
+/obj/structure/cable/pink{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Rz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"RK" = (
+/obj/machinery/door/window/survival_pod{
+	opacity = 1
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
+	},
+/obj/structure/toilet{
+	pixel_x = -1
+	},
+/obj/structure/curtain,
+/mob/living/simple_animal/bot/hygienebot{
+	name = "The Basic Cleanliness"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/crew/dorm)
+"RS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"TM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"UX" = (
+/turf/closed/wall/mineral/iron,
+/area/ship/crew/dorm)
+"WA" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "dronemid"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Xm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/power/terminal,
+/obj/machinery/button/door{
+	id = "humanlock";
+	name = "Door Lock";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 8;
+	specialfunctions = 4;
+	dir = 8
+	},
+/obj/structure/cable/pink,
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/item/modular_computer/tablet,
+/obj/item/modular_computer/tablet,
+/obj/item/modular_computer/tablet,
+/obj/item/dronespeak_manual,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"XO" = (
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"Ye" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-10"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Yl" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/plaques/kiddie/perfect_drone{
+	pixel_x = -32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable/pink,
+/obj/structure/cable/pink{
+	icon_state = "1-2"
+	},
+/obj/item/storage/firstaid/medical,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"Yu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light,
+/obj/item/weldingtool/experimental,
+/obj/item/screwdriver/power,
+/obj/item/crowbar/power,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/turf/open/floor/eighties,
+/area/ship/crew)
+"YJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-10"
+	},
+/obj/effect/turf_decal/corner/opaque/blue{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Zc" = (
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile,
+/obj/machinery/door/poddoor/shutters{
+	id = "dronebot"
+	},
+/turf/open/floor/plasteel/patterned/monofloor,
+/area/ship/bridge)
+"Zx" = (
+/obj/machinery/cryopod{
+	close_state = "bscanner_green";
+	icon_state = "bscanner_open";
+	open_state = "bscanner_open"
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 26
+	},
+/obj/structure/sign/poster/official/build{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+
+(1,1,1) = {"
+Qo
+Qo
+Qo
+BP
+BP
+BP
+Qo
+Qo
+JD
+JD
+JD
+Qo
+Qo
+"}
+(2,1,1) = {"
+Qo
+Qo
+BP
+BP
+dS
+BP
+BP
+Hl
+JD
+Qo
+JD
+JD
+Qo
+"}
+(3,1,1) = {"
+Qo
+Qo
+BP
+oR
+uD
+Rc
+bY
+DB
+Qo
+Qo
+Qo
+JD
+md
+"}
+(4,1,1) = {"
+Qo
+Qo
+zU
+uV
+nC
+Fd
+BP
+Qo
+JD
+JD
+JD
+Qo
+Qo
+"}
+(5,1,1) = {"
+Qo
+Hl
+BP
+fs
+AY
+Yu
+BP
+JD
+JD
+Qo
+JD
+md
+Qo
+"}
+(6,1,1) = {"
+Qo
+Hl
+BP
+lU
+MH
+Xm
+bY
+DB
+Qo
+Qo
+Qo
+Qo
+Qo
+"}
+(7,1,1) = {"
+Qo
+Qo
+BP
+BP
+zW
+BP
+BP
+BP
+Md
+Qo
+Qo
+Qo
+Qo
+"}
+(8,1,1) = {"
+nl
+WA
+WA
+ar
+hi
+TM
+Dv
+Cp
+Md
+Md
+Hd
+md
+Qo
+"}
+(9,1,1) = {"
+Qo
+oW
+Fx
+Bs
+rt
+YJ
+ox
+Cc
+nW
+la
+JD
+Qo
+Qo
+"}
+(10,1,1) = {"
+Qo
+oW
+qr
+BU
+rQ
+Ye
+mc
+Cc
+gR
+Zc
+Qo
+Qo
+Qo
+"}
+(11,1,1) = {"
+Qo
+oW
+DS
+RS
+nR
+Ro
+oM
+XO
+vG
+EL
+JD
+Qo
+Qo
+"}
+(12,1,1) = {"
+Qo
+oW
+oW
+kD
+ga
+lF
+zF
+IP
+Md
+Md
+Hd
+md
+Qo
+"}
+(13,1,1) = {"
+Qo
+Qo
+UX
+UX
+MF
+UX
+UX
+UX
+Md
+Qo
+Qo
+Qo
+Qo
+"}
+(14,1,1) = {"
+Qo
+Hl
+UX
+RK
+vU
+Yl
+mB
+DF
+Qo
+Qo
+Qo
+Qo
+Qo
+"}
+(15,1,1) = {"
+Qo
+Hl
+UX
+vI
+iR
+Rz
+UX
+JD
+JD
+Qo
+JD
+md
+Qo
+"}
+(16,1,1) = {"
+Qo
+Qo
+UX
+ki
+Le
+vK
+UX
+Qo
+JD
+JD
+JD
+Qo
+Qo
+"}
+(17,1,1) = {"
+Qo
+Qo
+UX
+Kv
+pM
+qM
+mB
+DF
+Qo
+Qo
+Qo
+JD
+md
+"}
+(18,1,1) = {"
+Qo
+Qo
+UX
+UX
+Zx
+UX
+UX
+Hl
+JD
+Qo
+JD
+JD
+Qo
+"}
+(19,1,1) = {"
+Qo
+Qo
+Qo
+UX
+UX
+UX
+Qo
+Qo
+JD
+JD
+JD
+Qo
+Qo
+"}

--- a/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
@@ -497,7 +497,7 @@
 "DS" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband,
-/obj/item/stack/spacecash/bundle/c1000{
+/obj/item/stack/spacecash/bundle/c1000
 /obj/item/clothing/head/caphat/cowboy,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_snowflake.dmm
@@ -416,6 +416,12 @@
 /obj/structure/cable/pink{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew)
@@ -491,9 +497,7 @@
 "DS" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband,
-/obj/item/stack/spacecash/c1000{
-	amount = 5
-	},
+/obj/item/stack/spacecash/bundle/c1000{
 /obj/item/clothing/head/caphat/cowboy,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Snowflake Automated Drone Ship is a ship entirely about drones and one non-drone working together to conquer the sector. It comes with two rooms, one for the Caretaker, a Nanotrasen Chief Engineer tasked with keeping the drones under their watch happy and loyal, it is stocked with food, equipment, your very own hygiene-bot, a gun, and a cool plushie, and the other room is for the drones, full of drone related items such as tools and tool belts, spray paint, tablet computers, a gun, and most importantly, hats!
The drones room also has a drone fabricator, that, if fed the right materials can make a drone. Also, comes with one special Snowflake Drone™ that can holographically wear whatever hat they desire. Even if the ship is abandoned on purchase, it can still be completely piloted by drones even if only one drone activates making sure the ship has a resilience that not many other ships have. 

![2023 03 14-20 33 01](https://user-images.githubusercontent.com/42253218/225199360-143a0513-06cd-4416-9b92-8c35537dd33b.png)
![2023 03 14-20 42 00](https://user-images.githubusercontent.com/42253218/225200612-8564981a-fce2-426e-829f-2c10a8205df1.png)

## Why It's Good For The Game
 
Currently the only ship that utilizes drones to any extent is the Metis, a ship based around them is a neat concept to me, letting ghosts to always have a ship to go to if they are just completely unreachable by their crew. I made it around the idea of expansion and building with the help of drones, but it is flexible and could be whatever the crew wants it to be.

## Changelog

:cl:
add: Snowflake.dmm
add: Snowflake.json
/:cl:
