### PR TITLE
Blast doors and shutters above windows

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -58,11 +58,9 @@
 #define BELOW_OBJ_LAYER 2.9
 #define LOW_ITEM_LAYER 2.95
 //#define OBJ_LAYER 3 //For easy recordkeeping; this is a byond define
-#define CLOSED_BLASTDOOR_LAYER 3.05
 #define UNDERDOOR 3.09 //Just under a closed door
 #define CLOSED_DOOR_LAYER 3.1
 #define CLOSED_FIREDOOR_LAYER 3.11
-#define SHUTTER_LAYER 3.12 // HERE BE DRAGONS
 #define ABOVE_OBJ_LAYER 3.2
 #define ABOVE_WINDOW_LAYER 3.3
 #define SIGN_LAYER 3.4

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -5,7 +5,7 @@
 	icon_state = "closed"
 	var/id = 1
 	layer = BLASTDOOR_LAYER
-	closingLayer = CLOSED_BLASTDOOR_LAYER
+	closingLayer = ABOVE_WINDOW_LAYER
 	sub_door = TRUE
 	explosion_block = 3
 	heat_proof = TRUE

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -3,8 +3,8 @@
 	name = "shutters"
 	desc = "Heavy duty metal shutters that open mechanically."
 	icon = 'icons/obj/doors/shutters.dmi'
-	layer = SHUTTER_LAYER
-	closingLayer = SHUTTER_LAYER
+	layer = ABOVE_WINDOW_LAYER
+	closingLayer = ABOVE_WINDOW_LAYER
 	damage_deflection = 20
 	open_sound = 'sound/machines/shutters_open.ogg'
 	close_sound = 'sound/machines/shutters_close.ogg'
@@ -28,8 +28,8 @@
 	name = "gate"
 	desc = "A gate made out of hard metal."
 	icon = 'icons/obj/doors/gates.dmi'
-	layer = SHUTTER_LAYER
-	closingLayer = SHUTTER_LAYER
+	layer = ABOVE_WINDOW_LAYER
+	closingLayer = ABOVE_WINDOW_LAYER
 	damage_deflection = 20
 	open_sound = 'sound/machines/gate.ogg'
 	close_sound = 'sound/machines/gate.ogg'

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -130,8 +130,8 @@
 	desc = "A gate made out of hard metal. Opens with a key."
 	icon = 'icons/obj/doors/gates.dmi'
 	icon_state = "closed"
-	layer = SHUTTER_LAYER
-	closingLayer = SHUTTER_LAYER
+	layer = ABOVE_WINDOW_LAYER
+	closingLayer = ABOVE_WINDOW_LAYER
 	var/open_sound = 'sound/machines/gate.ogg'
 	var/close_sound = 'sound/machines/gate.ogg'
 	glass = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes blast doors and shutters layer to cover windows
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shutters being between window and grille didn't make any sense. Blast doors can be actually used for protection of the ship, rather than a fancy curtain,
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: bast doors and shutters protect windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
