### PR TITLE
Enables Kansatsu + Minor Changes

### DIFF
--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -30,5 +30,5 @@
 			"slots": 2
 		}
 	},
-	"enabled": false
+	"enabled": true
 }

--- a/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
+++ b/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
@@ -114,14 +114,6 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
 	dir = 1
 	},
-/obj/docking_port/mobile{
-	callTime = 250;
-	dir = 2;
-	launch_status = 0;
-	name = "Scout Courier";
-	port_direction = 8;
-	preferred_direction = 4
-	},
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/white,
 /area/ship/engineering)
@@ -1191,6 +1183,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/docking_port/mobile{
+	callTime = 250;
+	launch_status = 0;
+	name = "Scout Courier";
+	port_direction = 4;
+	preferred_direction = 4;
+	dheight = 2
+	},
 /turf/open/floor/plating,
 /area/ship/cargo)
 "CP" = (
@@ -1324,6 +1324,14 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
+"Gj" = (
+/obj/docking_port/stationary{
+	height = 15;
+	dwidth = 15;
+	width = 30
+	},
+/turf/template_noop,
+/area/template_noop)
 "GG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/computer/security{
@@ -2060,6 +2068,7 @@
 /area/ship/engineering)
 
 (1,1,1) = {"
+YQ
 aV
 YQ
 YQ
@@ -2077,6 +2086,7 @@ YQ
 CR
 "}
 (2,1,1) = {"
+YQ
 ru
 ru
 ru
@@ -2094,6 +2104,7 @@ ru
 ru
 "}
 (3,1,1) = {"
+YQ
 ru
 XJ
 YG
@@ -2111,6 +2122,7 @@ Ul
 ru
 "}
 (4,1,1) = {"
+YQ
 ru
 dj
 OD
@@ -2128,6 +2140,7 @@ SH
 ru
 "}
 (5,1,1) = {"
+Gj
 cu
 yw
 aQ
@@ -2145,6 +2158,7 @@ Qy
 ru
 "}
 (6,1,1) = {"
+YQ
 ru
 ru
 gj
@@ -2162,6 +2176,7 @@ Od
 nO
 "}
 (7,1,1) = {"
+YQ
 YQ
 yJ
 kM
@@ -2181,6 +2196,7 @@ YQ
 (8,1,1) = {"
 YQ
 YQ
+YQ
 kM
 MH
 RX
@@ -2196,6 +2212,7 @@ YQ
 YQ
 "}
 (9,1,1) = {"
+YQ
 YQ
 YQ
 kM
@@ -2215,6 +2232,7 @@ YQ
 (10,1,1) = {"
 YQ
 YQ
+YQ
 kM
 Vw
 Fw
@@ -2230,6 +2248,7 @@ YQ
 YQ
 "}
 (11,1,1) = {"
+YQ
 YQ
 YQ
 kM
@@ -2249,6 +2268,7 @@ YQ
 (12,1,1) = {"
 YQ
 YQ
+YQ
 kM
 in
 EX
@@ -2264,6 +2284,7 @@ YQ
 YQ
 "}
 (13,1,1) = {"
+YQ
 YQ
 YQ
 kM
@@ -2284,6 +2305,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 qA
 Jp
 QN
@@ -2301,6 +2323,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 Av
 CP
 Hd
@@ -2315,6 +2338,7 @@ YQ
 YQ
 "}
 (16,1,1) = {"
+YQ
 YQ
 YQ
 YQ
@@ -2336,6 +2360,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 qA
 hT
 qA
@@ -2353,6 +2378,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 qA
 Lr
 AM
@@ -2366,6 +2392,7 @@ YQ
 YQ
 "}
 (19,1,1) = {"
+YQ
 YQ
 YQ
 YQ
@@ -2388,6 +2415,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 bn
 vN
 aa
@@ -2400,6 +2428,7 @@ YQ
 YQ
 "}
 (21,1,1) = {"
+YQ
 YQ
 YQ
 YQ
@@ -2422,6 +2451,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 bO
 ZI
 DL
@@ -2434,6 +2464,7 @@ YQ
 YQ
 "}
 (23,1,1) = {"
+YQ
 YQ
 YQ
 YQ
@@ -2457,6 +2488,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 Rz
 JI
 uq
@@ -2468,6 +2500,7 @@ YQ
 YQ
 "}
 (25,1,1) = {"
+YQ
 YQ
 YQ
 YQ
@@ -2491,6 +2524,7 @@ YQ
 YQ
 YQ
 YQ
+YQ
 Rz
 Rz
 Rz
@@ -2502,6 +2536,7 @@ YQ
 YQ
 "}
 (27,1,1) = {"
+YQ
 YQ
 YQ
 YQ

--- a/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
+++ b/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
@@ -40,6 +40,7 @@
 	dir = 10
 	},
 /obj/machinery/holopad/emergency/command,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "aV" = (
@@ -204,7 +205,8 @@
 /area/ship/crew)
 "dA" = (
 /obj/machinery/door/airlock/command{
-	name = "Bridge"
+	name = "Bridge";
+	req_access = "19"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "intelfucky"
@@ -245,11 +247,10 @@
 /obj/effect/turf_decal/trimline/opaque/bar/filled/corner{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 4
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -556,6 +557,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "nu" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "nA" = (
@@ -712,7 +714,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
 /obj/item/tank/jetpack/oxygen/harness,
@@ -721,6 +722,7 @@
 	},
 /obj/item/clothing/mask/gas/syndicate,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/suit_storage_unit/inherit/industrial,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
 "qA" = (
@@ -901,10 +903,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/central)
+"tQ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "intelfucky"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ship/bridge)
 "uq" = (
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "vk" = (
@@ -1223,12 +1235,14 @@
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "DL" = (
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "DU" = (
@@ -1243,6 +1257,7 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/bar,
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "EX" = (
@@ -1419,7 +1434,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "JI" = (
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
@@ -1491,6 +1506,19 @@
 "Nu" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
+"NG" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "NR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1498,12 +1526,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/tank/jetpack/oxygen/harness,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/suit_storage_unit/inherit/industrial,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
 "NU" = (
@@ -1640,6 +1668,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Ql" = (
@@ -1676,7 +1705,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "QO" = (
 /obj/structure/table/reinforced,
@@ -1934,6 +1963,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Xc" = (
@@ -1982,6 +2012,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Zs" = (
@@ -2071,8 +2102,8 @@ Va
 Sx
 Sx
 NW
-Sx
-Sx
+NG
+NG
 Sx
 bI
 km
@@ -2411,7 +2442,7 @@ YQ
 bO
 Xw
 Xc
-Xc
+tQ
 Xw
 bO
 YQ

--- a/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
+++ b/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
@@ -102,7 +102,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/structure/closet/wall/white{
 	dir = 1;
-	pixel_y = -32;
+	pixel_y = -28;
 	name = "Medical Supplies"
 	},
 /turf/open/floor/plasteel/dark,
@@ -170,7 +170,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -344,6 +344,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "im" = (
@@ -379,13 +380,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "iN" = (
 /obj/effect/turf_decal/industrial/stand_clear{
@@ -407,7 +402,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small,
 /obj/effect/turf_decal/spline/fancy/transparent/grey,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -474,10 +468,11 @@
 /obj/item/stack/sheet/mineral/wood{
 	amount = 3
 	},
-/obj/item/stack/sheet/metal/ten,
-/obj/item/stack/sheet/metal/ten,
 /obj/item/stack/sheet/glass/five,
 /obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/metal/twenty{
+	pixel_x = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "kL" = (
@@ -561,8 +556,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "nu" = (
-/obj/structure/sign/departments/engineering,
-/turf/closed/wall/mineral/plastitanium,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "nA" = (
 /obj/item/paper_bin,
@@ -572,6 +566,7 @@
 	},
 /obj/item/storage/box/rxglasses/spyglasskit,
 /obj/item/kitchen/knife/letter_opener,
+/obj/item/paper/crumpled,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/office)
 "nF" = (
@@ -792,9 +787,9 @@
 	id = "scengine";
 	name = "Engine Blast Shutters";
 	dir = 8;
-	pixel_x = -8
+	pixel_x = 24
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "rR" = (
 /obj/structure/table,
@@ -820,6 +815,9 @@
 	},
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -1064,6 +1062,9 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
@@ -1594,7 +1595,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -1642,7 +1643,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Ql" = (
-/obj/effect/turf_decal/atmos/air,
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 8
 	},
@@ -1894,9 +1894,6 @@
 /obj/item/reagent_containers/pill/cyanide,
 /obj/item/reagent_containers/pill/cyanide,
 /obj/item/reagent_containers/pill/cyanide,
-/obj/item/paper/crumpled{
-	info = "Hand this stuff out to the field agents. They'll have a blast."
-	},
 /obj/item/clothing/mask/chameleon,
 /obj/item/card/id/syndicate/anyone,
 /obj/item/card/id/syndicate/anyone,
@@ -2012,12 +2009,6 @@
 "Zv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/transparent/grey{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Enables the Kansatsu for player spawning. Also files off some of the edges.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I have yet to see a case where it's been worth having as an adminspawn, to the point of the last 'Syndicate Intel Gathering Mission' I saw in game using the Komodo, because it's too small for a big gimmick, and I'd rather keep it than remove it (for now).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: The Kansatsu-Class is now available for spawning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
