### PR TITLE
fixes cryo area sprite

### DIFF
--- a/code/game/area/ship_areas.dm
+++ b/code/game/area/ship_areas.dm
@@ -130,7 +130,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/ship/crew/cryo
 	name = "Cryopod Room"
-	icon_state = "cryopod"
+	icon_state = "cryo"
 	lighting_colour_tube = "#e3ffff"
 	lighting_colour_bulb = "#d5ffff"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
currently, the cryo area shows up as a blank square (that cannot be interacted with in the mapper easily)
This PR fixes this issue. How?
the current icon state is listed as "cryopod". The actual icon state is called "cryo". This PR removed the pod, so the sprite loads in. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
errors = bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed Cryo Area sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
