### PR TITLE
Tones down giant spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -164,11 +164,11 @@
 	icon_state = "hunter"
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
-	maxHealth = 120
-	health = 120
+	maxHealth = 80
+	health = 80
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 10
+	poison_per_bite = 5
 	move_to_delay = 5
 	gold_core_spawnable = NO_SPAWN
 
@@ -181,9 +181,9 @@
 	icon_dead = "viper_dead"
 	maxHealth = 40
 	health = 40
-	melee_damage_lower = 1
-	melee_damage_upper = 1
-	poison_per_bite = 12
+	melee_damage_lower = 3
+	melee_damage_upper = 8
+	poison_per_bite = 2
 	move_to_delay = 4
 	poison_type = /datum/reagent/toxin/venom //all in venom, glass cannon. you bite 5 times and they are DEFINITELY dead, but 40 health and you are extremely obvious. Ambush, maybe?
 	speed = 1
@@ -195,10 +195,10 @@
 	icon_state = "tarantula"
 	icon_living = "tarantula"
 	icon_dead = "tarantula_dead"
-	maxHealth = 300 // woah nelly
-	health = 300
-	melee_damage_lower = 35
-	melee_damage_upper = 40
+	maxHealth = 225 // woah nelly
+	health = 225
+	melee_damage_lower = 25
+	melee_damage_upper = 35
 	poison_per_bite = 0
 	move_to_delay = 8
 	speed = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

## Why It's Good For The Game

Spiders are incredibly strong for no good reason, one bite from a normal hunter spider would do around 15 brute and ~30 toxin. One bite from a viper spider would kill you, as Venom has a very low metabolism rate, adds Histamine with a chance per tick, and they'd bite you several times even though just one is guaranteed to kill you. Tarantulas and Hunter spiders could eat an entire energy gun plus some, which may be more fine for tarantulas but definitely not the base variants.

## Changelog

:cl:
balance: Giant spiders should not be horrendously strong anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
