### PR TITLE
Stationary ports can now be placed in space on ship map files

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -343,6 +343,7 @@ SUBSYSTEM_DEF(shuttle)
 	new_shuttle.current_ship = parent //for any ships that spawn on top of us
 
 	for(var/obj/docking_port/stationary/S in stationary_ports)
+		S.owner_ship = new_shuttle
 		S.load_roundstart()
 
 	var/obj/docking_port/mobile/transit_dock = generate_transit_dock(new_shuttle)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -207,6 +207,9 @@
 
 	var/last_dock_time
 
+	//The ship that has this port as a docking_point, ships docked to this port will be towed by the owner_ship
+	var/obj/docking_port/mobile/owner_ship
+
 	var/datum/map_template/shuttle/roundstart_template
 	var/json_key
 	//Setting this to false will prevent the roundstart_template from being loaded on Initiallize(). You should set this to false if this loads a subship on a ship map template


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mappers can now place stationary docking ports anywhere on their map, including on space, and they will follow the ship. Any subship docked to these stationary ports will be follow the ship as well of course.

Here's an example of it working in action with a pill and modified masinyane (just for testing, not included in this PR of course):

https://user-images.githubusercontent.com/51838176/230705780-9ba42fb5-7e57-4986-b76a-051159740927.mp4

(The overmap screen turning black is likely a bug with aghost-ing, nothing in this PR touches the overmap)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allow mappers to have more freedom when placing docking points for subships. Previously, the docking port itself had to be on the ship, meaning you had to do fully or atleast partially internal docking bays. Now, for example, you can place a stationary port right next to an airlock, so subships connect with but don't overlap with the mothership.

~~If you want to get really wacky, you could place these completely disconnected from the mothership to allow for convoys of ships~~

Mappers be warned, if you add a stationary port with bounds that extend outside the map file, some bad things might happen if a large subship docks to your ship in transit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Stationary ports and docked subships loaded by a ship mapload will follow that ship even if it is in space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
