### PR TITLE
STG band-aid fix for the colossus and talos.

### DIFF
--- a/_maps/shuttles/shiptest/inteq_colossus.dmm
+++ b/_maps/shuttles/shiptest/inteq_colossus.dmm
@@ -2491,7 +2491,7 @@
 /obj/item/storage/firstaid/medical{
 	pixel_x = -5
 	},
-/obj/structure/table/rolling,
+/obj/structure/table,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "AB" = (
@@ -2788,7 +2788,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/structure/table/rolling,
 /obj/item/gun/energy/laser/practice{
 	pixel_y = 10
 	},
@@ -2804,6 +2803,7 @@
 	desc = "A sign marking time passed since the last cargo bay decompression. It's a new record!";
 	pixel_y = 32
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Dq" = (

--- a/_maps/shuttles/shiptest/inteq_talos.dmm
+++ b/_maps/shuttles/shiptest/inteq_talos.dmm
@@ -2157,7 +2157,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "oi" = (
-/obj/structure/table/rolling,
 /obj/item/storage/firstaid/medical{
 	pixel_x = -5
 	},
@@ -2168,6 +2167,7 @@
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "ok" = (


### PR DESCRIPTION
Removes rolling tables and replaces them with normal ones on the talos and colossus integ ships to isolate problematic ship-devouring structures.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's something inherently screwy with rolling tables and they've started eating ships. I'm not experienced with byond coding enough to determine the cause at this time, but I can at least do this for a temporary solution until a later date.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
reduces admin headaches and player screeching. And also...

![errors](https://user-images.githubusercontent.com/98575308/231302241-10f60197-6559-4efc-b49f-01928dd5676d.gif)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

del: removed some rolling tables
add: replaced the empty spots with non-eldritch tables.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
