### PR TITLE
Update vote.dm

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -84,7 +84,7 @@ SUBSYSTEM_DEF(vote)
 						factor = 1.2
 					else
 						factor = 1.4
-				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
+				choices["Initiate Bluespace Jump"] += round(non_voters.len * factor)
 
 	//get all options with that many votes and return them in a list
 	. = list()
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(vote)
 					else
 						GLOB.master_mode = .
 			if("transfer")
-				if(. == "Initiate Crew Transfer")
+				if(. == "Initiate Bluespace Jump")
 					SSshuttle.request_jump()
 
 	if(restart)
@@ -197,7 +197,7 @@ SUBSYSTEM_DEF(vote)
 			if("transfer")
 				if(SSshuttle.jump_mode != BS_JUMP_IDLE)
 					return FALSE
-				choices.Add("Initiate Crew Transfer","Continue Playing")
+				choices.Add("Initiate Bluespace Jump","Continue Playing")
 			if("custom")
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

"Initiate Bluespace Jump" instead of "Initiate Crew Transfer" per round end vote.

## Why It's Good For The Game

Because... WHY CREW TRANSFER?

## Changelog

:cl:
fix: transfer vote now has option "Initiate Bluespace Jump" instead of "Initiate Crew Transfer"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
