### PR TITLE
Mining equipment & Fauna slight rebalance

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -169,7 +169,6 @@
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 15, "bomb" = 20, "bio" = 100, "rad" = 20, "fire" = 50, "acid" = 30)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/pinpointer/deepcore)
 	resistance_flags = FIRE_PROOF
-	slowdown = -0.3//finally, a reason for shiptesters to steal this
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
 
 /obj/item/clothing/head/hooded/survivor_hood

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -13,7 +13,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 5
 	throw_speed = 4
-	armour_penetration = 10
+	armour_penetration = 5
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
@@ -27,8 +27,8 @@
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
-	var/detonation_damage = 25
-	var/backstab_bonus = 30
+	var/detonation_damage = 20
+	var/backstab_bonus = 10
 	var/wielded = FALSE // track wielded status on item
 
 /obj/item/kinetic_crusher/Initialize()
@@ -39,7 +39,7 @@
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=15)
 
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)
@@ -730,6 +730,7 @@
 	desc = "During the early design process of the Kinetic Accelerator, a great deal of money and time was invested in magnetic distruption technology. \
 	Though eventually replaced with concussive blasts, the ever-practical NT designed a second mining tool. \
 	Only a few were ever produced, mostly for NT research institutions, and they are a valulable relic in the postwar age."
+	detonation_damage = 10
 	slowdown = 0.5//hevy
 	attack_verb = list("mashed", "flattened", "bisected", "eradicated","destroyed")
 
@@ -740,7 +741,7 @@
 /obj/item/kinetic_crusher/old/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110)
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=45)//big choppa!
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=25)//big choppa!
 
 /obj/item/kinetic_crusher/old/melee_attack_chain(mob/user, atom/target, params)
 	..()
@@ -778,15 +779,15 @@
 	custom_price = 7500//a rare syndicate prototype.
 	charged = TRUE
 	charge_time = 15
-	detonation_damage = 20
-	backstab_bonus = 30
+	detonation_damage = 35
+	backstab_bonus = 15
 	wielded = FALSE // track wielded status on item
 	actions_types = list()
 
 /obj/item/kinetic_crusher/syndie_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 150)
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=35)
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=10)
 
 /// triggered on wield of two handed item
 /obj/item/kinetic_crusher/syndie_crusher/on_wield(obj/item/source, mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -23,7 +23,7 @@
 	maxHealth = 60
 	health = 60
 	speed = 0
-
+	mob_size = MOB_SIZE_LARGE
 	obj_damage = 60
 	melee_damage_lower = 20
 	melee_damage_upper = 30

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -53,6 +53,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	footstep_type = FOOTSTEP_MOB_CLAW
+	mob_size = MOB_SIZE_LARGE
 	var/playable_spider = FALSE
 	var/datum/action/innate/spider/lay_web/lay_web
 	var/directive = "" //Message passed down to children, to relay the creator's orders
@@ -195,15 +196,14 @@
 	icon_state = "tarantula"
 	icon_living = "tarantula"
 	icon_dead = "tarantula_dead"
-	maxHealth = 225 // woah nelly
-	health = 225
+	maxHealth = 150 // woah nelly
+	health = 150
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	poison_per_bite = 0
 	move_to_delay = 8
-	speed = 7
+	speed = 9
 	status_flags = NONE
-	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 	var/slowed_by_webs = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -161,7 +161,7 @@
 /mob/living/simple_animal/hostile/asteroid/basilisk/whitesands/bullet_act(obj/projectile/P)
 	shell_damage(BULLET_SHELL_DAMAGE)
 	if(has_shell)
-		playsound(get_turf(P), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 85, TRUE)
 		visible_message("<span class='notice'>The [P] is absorbed by the [src]'s shell, dealing minimal damage!</span>") //make it less confusing when bullets do no damage
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -116,7 +116,9 @@
 	attack_same = TRUE		// So we'll attack watchers
 	butcher_results = list(/obj/item/stack/sheet/sinew = 4, /obj/item/stack/sheet/bone = 2)
 	lava_drinker = FALSE
-	var/shell_health = 50
+	maxHealth = 40
+	health = 40
+	var/shell_health = 80 //Tough to crack, easy to kill.
 	var/has_shell = TRUE
 	var/list/shell_loot = list(/obj/item/stack/ore/diamond, /obj/item/stack/ore/diamond)
 	var/shell_snap_message = FALSE
@@ -159,6 +161,7 @@
 /mob/living/simple_animal/hostile/asteroid/basilisk/whitesands/bullet_act(obj/projectile/P)
 	shell_damage(BULLET_SHELL_DAMAGE)
 	if(has_shell)
+		playsound(get_turf(P), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
 		visible_message("<span class='notice'>The [P] is absorbed by the [src]'s shell, dealing minimal damage!</span>") //make it less confusing when bullets do no damage
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -20,9 +20,9 @@
 	speak_emote = list("bellows")
 	speed = 3
 	throw_deflection = 10
-	maxHealth = 200
-	health = 200
-	armor = list("melee" = 30, "bullet" = 15, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
+	maxHealth = 80
+	health = 80
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 50, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10) //Thick carapace, weak to AP ammo.
 	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage_lower = 12
@@ -246,8 +246,8 @@
 	icon_living = "ancient_goliath"
 	icon_aggro = "ancient_goliath_alert"
 	icon_dead = "ancient_goliath_dead"
-	maxHealth = 350
-	health = 350
+	maxHealth = 180
+	health = 180
 	speed = 4
 	crusher_loot = /obj/item/crusher_trophy/elder_tentacle
 	pre_attack_icon = "ancient_goliath_preattack"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -386,8 +386,6 @@
 					backpack_contents += list(/obj/item/reagent_containers/hypospray/medipen/survival = pickweight(list(1 = 3, 2 = 2, 3 = 1)))
 				if(prob(30))
 					backpack_contents += /obj/item/gun/energy/kinetic_accelerator
-			else
-				back = /obj/item/kinetic_crusher
 		if("Oldminer")
 			suit = /obj/item/clothing/suit/hooded/explorer/old
 			mask = /obj/item/clothing/mask/gas/explorer/old

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
@@ -18,8 +18,9 @@
 	ranged_cooldown_time = 30
 	minimum_distance = 4
 	retreat_distance = 3
-	maxHealth = 150
-	health = 150
+	maxHealth = 80
+	health = 80
+	armor = list("melee" = 20, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	obj_damage = 40
 	melee_damage_lower = 15
 	melee_damage_upper = 15

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice whelp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice whelp.dm
@@ -14,8 +14,9 @@
 	move_to_delay = 20
 	ranged = TRUE
 	ranged_cooldown_time = 200
-	maxHealth = 300
-	health = 300
+	maxHealth = 80
+	health = 80
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 50, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	obj_damage = 15
 	melee_damage_lower = 20
 	melee_damage_upper = 20

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -12,8 +12,9 @@
 	speak_emote = list("growls")
 	speed = 12
 	move_to_delay = 12
-	maxHealth = 200
-	health = 200
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 20, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 50, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	obj_damage = 40
 	melee_damage_lower = 25
 	melee_damage_upper = 25

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -22,6 +22,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/stock_parts/cell/gun/mini
 	small_gun = TRUE
+	throwforce = 11 //This is funny, trust me.
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = FALSE // Can't attach or detach the flashlight, and override it's icon update


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Knocks crushers off legion loot table (leaves old crusher)
Tweaks how crushers apply their damage, slightly. Slightly weaker overall (no trophy touching yet)
Increases throw force of mini egun to 11 for reasons. Find out in game!

## Why It's Good For The Game

Ammo good. Crusher bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Goliaths, Ice whelps, and Whitesands basilisks should be easier to kill now. Try AP ammo.
balance: Crushers no longer drop from legion bodies, only old crushers.
balance: Tweaked how crushers distribute their damage.
balance: Survivor suits no longer make you run at hyperspeed
balance: Laser weaponry should be a little more effective versus most common fauna.
fix: Added a sound to help show when a whitesands basilisk absorbs a bullet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
