### PR TITLE
Schmiedeberg Tweaks And Fixes

### DIFF
--- a/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
+++ b/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
@@ -657,11 +657,13 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/hydroponics,
-/obj/item/seeds/apple,
 /obj/item/seeds/ambrosia,
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/random,
+/obj/item/seeds/replicapod,
+/obj/item/seeds/aloe,
 /obj/item/seeds/coffee,
+/obj/item/seeds/corn,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/hydroponics)
 "il" = (
@@ -2379,7 +2381,7 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/door_remote/chief_medical_officer,
 /obj/item/pet_carrier,
-/obj/item/wallframe/defib_mount,
+/obj/item/areaeditor/shuttle,
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/reagent_containers/glass/bottle/vial/large,
 /obj/item/reagent_containers/glass/bottle/vial/large,
@@ -2887,7 +2889,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/machinery/plumbing/pill_press,
+/obj/machinery/plumbing/pill_press{
+	dir = 1
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -28
@@ -3501,7 +3505,6 @@
 "ZS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1

--- a/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
+++ b/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
@@ -660,7 +660,7 @@
 /obj/item/seeds/ambrosia,
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/random,
-/obj/item/seeds/replicapod,
+/obj/item/seeds/cabbage,
 /obj/item/seeds/aloe,
 /obj/item/seeds/coffee,
 /obj/item/seeds/corn,


### PR DESCRIPTION
## About The Pull Request

Added a shuttle expansion permit to chief pharmacist's locker
Added more seeds to the seed crate (replica pods, aloe, corn)
There is no longer a Random Defib Mount in the chief pharmacist's locker
The chemical press is now Rotated Correctly 

## Why It's Good For The Game

tweaks r good. 

## Changelog

:cl:
tweak: The Schmiedeberg now has shuttle expansion permit, extra seeds have been added to the seed crate.
/:cl:
