### PR TITLE
fixes drum mags loading without the correct sprite

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -86,14 +86,18 @@
 	caliber = ".45"
 	max_ammo = 24
 
+/obj/item/ammo_box/magazine/smgm45/update_icon() //This is stupid (whenever ammo is spent, it updates the icon path)
+	..()
+	icon_state = "c20r45-[round(ammo_count(),2)]"
+
 /obj/item/ammo_box/magazine/smgm45/drum
 	name = "drum magazine (.45)"
 	icon_state = "drum45"
 	max_ammo = 50
 
-/obj/item/ammo_box/magazine/smgm45/update_icon()
-	..()
-	icon_state = "c20r45-[round(ammo_count(),2)]"
+/obj/item/ammo_box/magazine/smgm45/drum/update_icon() //Causes the mag to NOT inherit the parent's update_icon oooh the misery
+	. = ..()
+	icon_state = "drum45"
 
 /obj/item/ammo_box/magazine/pistol556mm
 	name = "handgun magazine (5.56mm HITP caseless)"


### PR DESCRIPTION
thanks #tmtmtl30#8815

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
okay so, code stuff bad
![image](https://user-images.githubusercontent.com/79304582/231992682-be0b93f9-4fb5-4faf-88b5-30e392160d11.png)

update_icon was overriding the drum mags special sprite, making it load with  "c20r45-50" instead of "drum45"
This PR adds another "update_icon" that overrides it for the drum mag or "whatevs'"
thanks tmtmtl30 for the help!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
errors = bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed the drum45's sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
