### PR TITLE
Shuttle creator now properly assigns ship to ship area.

### DIFF
--- a/code/game/area/ship_areas.dm
+++ b/code/game/area/ship_areas.dm
@@ -112,6 +112,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/ship/proc/link_to_shuttle(obj/docking_port/mobile/M)
 	mobile_port = M
 
+/area/ship/connect_to_shuttle(obj/docking_port/mobile/M)
+	link_to_shuttle(M)
+
 /area/ship/virtual_z()
 	if(mobile_port)
 		return mobile_port.virtual_z()

--- a/code/game/objects/items/shuttle_creator.dm
+++ b/code/game/objects/items/shuttle_creator.dm
@@ -144,7 +144,6 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.port_direction = 2
 	port.preferred_direction = 4
 	port.area_type = recorded_shuttle_area
-	recorded_shuttle_area.mobile_port = port
 
 	var/portDirection = getNonShuttleDirection(get_turf(port))
 	var/invertedDir = REVERSE_DIR(portDirection)

--- a/code/game/objects/items/shuttle_creator.dm
+++ b/code/game/objects/items/shuttle_creator.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	var/ready = TRUE
-	var/area/recorded_shuttle_area
+	var/area/ship/recorded_shuttle_area
 	var/list/loggedTurfs = list()
 	var/area/loggedOldArea
 
@@ -144,6 +144,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.port_direction = 2
 	port.preferred_direction = 4
 	port.area_type = recorded_shuttle_area
+	recorded_shuttle_area.mobile_port = port
 
 	var/portDirection = getNonShuttleDirection(get_turf(port))
 	var/invertedDir = REVERSE_DIR(portDirection)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The ship area of a newly created custom shuttle didn't have its mobile_port var assigned, which was causing runtimes and SGTs when trying to fly the custom shuttle. This PR properly sets that var by making area/ship/connect_to_shuttle() call link_to_shuttle(), where this was previously handled.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes custom shuttles usable again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Fixed a bug causing custom shuttles to runtime and SGT when taking off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
