### PR TITLE
Squishes the Cricket

### DIFF
--- a/_maps/configs/solgov_cricket.json
+++ b/_maps/configs/solgov_cricket.json
@@ -14,5 +14,5 @@
 		"Cook": 1,
 		"Assistant": 3
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the cricket an adminspawn ship, for the time being.

## Why It's Good For The Game

The Cricket is something of a relic, based on one of the very first iterations of a faction that's been reworked at least twice since then and which still does not have any assets that reflect the current lore. On top of that, it's an antiquated design that reflects a fairly early period in Shiptest balance and which is sorely in need of a complete overhaul or outright replacement.

What makes this a particularly pressing issue is the fact that the Cricket is one of vanishingly few ships that has an omni-lathe, and as such it's been getting increasing amounts of play as more players catch onto this. Which is to say, it has Luxembourg Syndrome and is causing players to latch onto an image of Solgov that's completely incorrect on top of it all.

## Changelog

:cl:
del: Disabled the Cricket
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
