### PR TITLE
ORM QOL: input/output directions can now be changed separately

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -126,3 +126,8 @@
 //these flags are used to tell the DNA modifier if a plant gene cannot be extracted or modified.
 #define PLANT_GENE_REMOVABLE (1<<0)
 #define PLANT_GENE_EXTRACTABLE (1<<1)
+
+//used to determine what rotation mode the ore redemption machine is in
+#define ORM_BOTH 0
+#define ORM_INPUT 1
+#define ORM_OUTPUT 2

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -23,7 +23,7 @@
 	var/datum/techweb/stored_research
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/remote_materials/materials
-	var/direction_to_edit = 0 //1 is input, 2 is output, any other value is both (default) (should only ever be either 0, 1, or 2, but won't completely break if something weird happens and it becomes >2 or <0)
+	var/direction_to_edit = ORM_BOTH //ORM_INPUT is 1, ORM_OUTPUT is 2, any other value is ORM_BOTH (defaults to 0) (should only ever be either 0, 1, or 2, but won't completely break if something weird happens and it becomes >2 or <0)
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -50,12 +50,13 @@
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Smelting <b>[ore_multiplier]</b> sheet(s) per piece of ore.<br>Reward point generation at <b>[point_upgrade*100]%</b>.</span>"
 	if(panel_open)
-		if(direction_to_edit == 1)
+		if(direction_to_edit == ORM_INPUT)
 			. += "<span class='notice'>Alt-click to rotate the input direction.</span>"
-		else if (direction_to_edit == 2)
+		else if (direction_to_edit == ORM_OUTPUT)
 			. += "<span class='notice'>Alt-click to rotate the output direction.</span>"
-		else
+		else //defaults to both
 			. += "<span class='notice'>Alt-click to rotate the input and output direction.</span>"
+		. += "<span class='notice'>Use a multitool to change the rotation mode.</span>"
 
 /obj/machinery/mineral/ore_redemption/proc/smelt_ore(obj/item/stack/ore/O)
 	if(QDELETED(O))
@@ -154,13 +155,13 @@
 	if(istype(W, /obj/item/multitool))
 		if(panel_open)
 			direction_to_edit++ //toggles through whether alt+click will rotate input AND output, or either input OR output
-			if(direction_to_edit > 2)
-				direction_to_edit = 0
-			if(direction_to_edit == 1)
+			if(direction_to_edit > ORM_OUTPUT)
+				direction_to_edit = ORM_BOTH
+			if(direction_to_edit == ORM_INPUT)
 				to_chat(user, "<span class='notice'>You change [src]'s I/O settings. you will now only change the input direction.</span>")
-			else if(direction_to_edit == 2)
+			else if(direction_to_edit == ORM_OUTPUT)
 				to_chat(user, "<span class='notice'>You change [src]'s I/O settings, you will now only change the output direction.</span>")
-			else
+			else //defaults to both
 				to_chat(user, "<span class='notice'>You change [src]'s I/O settings, you will now change the input and output directions.</span>")
 			return
 
@@ -182,13 +183,13 @@
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	if(panel_open)
-		if(direction_to_edit == 1)
+		if(direction_to_edit == ORM_INPUT)
 			input_dir = turn(input_dir, -90)
 			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)].</span>")
-		else if(direction_to_edit == 2)
+		else if(direction_to_edit == ORM_OUTPUT)
 			output_dir = turn(output_dir, -90)
 			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the output to [dir2text(output_dir)].</span>")
-		else
+		else //defaults to both
 			input_dir = turn(input_dir, -90)
 			output_dir = turn(output_dir, -90)
 			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -23,6 +23,7 @@
 	var/datum/techweb/stored_research
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/remote_materials/materials
+	var/direction_to_edit = 0 //1 is input, 2 is output, any other value is both (default) (should only ever be either 0, 1, or 2, but won't completely break if something weird happens and it becomes >2 or <0)
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -49,7 +50,12 @@
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Smelting <b>[ore_multiplier]</b> sheet(s) per piece of ore.<br>Reward point generation at <b>[point_upgrade*100]%</b>.</span>"
 	if(panel_open)
-		. += "<span class='notice'>Alt-click to rotate the input and output direction.</span>"
+		if(direction_to_edit == 1)
+			. += "<span class='notice'>Alt-click to rotate the input direction.</span>"
+		else if (direction_to_edit == 2)
+			. += "<span class='notice'>Alt-click to rotate the output direction.</span>"
+		else
+			. += "<span class='notice'>Alt-click to rotate the input and output direction.</span>"
 
 /obj/machinery/mineral/ore_redemption/proc/smelt_ore(obj/item/stack/ore/O)
 	if(QDELETED(O))
@@ -145,6 +151,19 @@
 	if(!powered())
 		return ..()
 
+	if(istype(W, /obj/item/multitool))
+		if(panel_open)
+			direction_to_edit++ //toggles through whether alt+click will rotate input AND output, or either input OR output
+			if(direction_to_edit > 2)
+				direction_to_edit = 0
+			if(direction_to_edit == 1)
+				to_chat(user, "<span class='notice'>You change [src]'s I/O settings. you will now only change the input direction.</span>")
+			else if(direction_to_edit == 2)
+				to_chat(user, "<span class='notice'>You change [src]'s I/O settings, you will now only change the output direction.</span>")
+			else
+				to_chat(user, "<span class='notice'>You change [src]'s I/O settings, you will now change the input and output directions.</span>")
+			return
+
 	if(istype(W, /obj/item/disk/design_disk))
 		if(user.transferItemToLoc(W, src))
 			inserted_disk = W
@@ -163,9 +182,16 @@
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	if(panel_open)
-		input_dir = turn(input_dir, -90)
-		output_dir = turn(output_dir, -90)
-		to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")
+		if(direction_to_edit == 1)
+			input_dir = turn(input_dir, -90)
+			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)].</span>")
+		else if(direction_to_edit == 2)
+			output_dir = turn(output_dir, -90)
+			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the output to [dir2text(output_dir)].</span>")
+		else
+			input_dir = turn(input_dir, -90)
+			output_dir = turn(output_dir, -90)
+			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")
 		unregister_input_turf() // someone just rotated the input and output directions, unregister the old turf
 		register_input_turf() // register the new one
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability to whack an ORM with a multitool while its panel is open to change whether or not alt+clicking it will rotate the input direction, output direction, or both. Default functionality on a fresh or mapped ORM is still both.

## Why It's Good For The Game

Currently ORMs can only output on the tile directly opposite the tile they take in ore from. This worked fine back on a station, but on a ship space is limited, and the crewmember mining might be the crewmember needing those materials immediately afterward.

Now, shiptesters no longer have to fear ORMs spitting their contents into walls or furniture when building one in a corner, dead end, or other spot where having the input/output tiles be directly opposite each other posed logistical problems.

## Changelog

:cl:
code: multitools now change the alt+click behavior of an ORM
tweak: ORMs can now have their input and output tiles onto the same tile, or two tiles at a right angle, as well as the old behavior of having them on opposite sides of the machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
