### PR TITLE
Freshens up the Shuttle Manipulator Menu

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -413,13 +413,26 @@ SUBSYSTEM_DEF(shuttle)
 	data["shuttles"] = list()
 	for(var/obj/docking_port/mobile/M as anything in mobile)
 		var/list/L = list()
+
+		if(M.current_ship)
+			L["type"] = "[M.current_ship.source_template ? (M.current_ship.source_template.short_name ? M.current_ship.source_template.short_name : M.current_ship.source_template.name) : "Custom"]"
+		else
+			L["type"] = "???"
+
 		L["name"] = M.name
 		L["id"] = REF(M)
 		L["timer"] = M.timer
 		L["can_fly"] = TRUE
 		if (M.mode != SHUTTLE_IDLE)
 			L["mode"] = capitalize(M.mode)
-		L["status"] = M.getDbgStatusText()
+
+		if(M.current_ship)
+			if(M.current_ship.docked_to)
+				L["position"] = "Docked at [M.current_ship.docked_to.name] ([M.current_ship.docked_to.x], [M.current_ship.docked_to.y])"
+			else
+				L["position"] = "Flying At ([M.current_ship.x], [M.current_ship.y])"
+		else
+			L["position"] = "???"
 
 		data["shuttles"] += list(L)
 

--- a/tgui/packages/tgui/interfaces/ShuttleManipulator.js
+++ b/tgui/packages/tgui/interfaces/ShuttleManipulator.js
@@ -86,8 +86,8 @@ export const ShuttleManipulatorStatus = (props, context) => {
               />
             </Table.Cell>
             <Table.Cell>{shuttle.name}</Table.Cell>
-            <Table.Cell>{shuttle.id}</Table.Cell>
-            <Table.Cell>{shuttle.status}</Table.Cell>
+            <Table.Cell>{shuttle.type}</Table.Cell>
+            <Table.Cell>{shuttle.position}</Table.Cell>
           </Table.Row>
         ))}
       </Table>

--- a/tgui/packages/tgui/interfaces/ShuttleManipulator.js
+++ b/tgui/packages/tgui/interfaces/ShuttleManipulator.js
@@ -88,9 +88,6 @@ export const ShuttleManipulatorStatus = (props, context) => {
             <Table.Cell>{shuttle.name}</Table.Cell>
             <Table.Cell>{shuttle.id}</Table.Cell>
             <Table.Cell>{shuttle.status}</Table.Cell>
-            <Table.Cell>{shuttle.name}</Table.Cell>
-            <Table.Cell>{shuttle.id}</Table.Cell>
-            <Table.Cell>{shuttle.status}</Table.Cell>
           </Table.Row>
         ))}
       </Table>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the (unintended?) repeat of information in the shuttle manipulator window, I don't know why this was here

Also adds location data, ship type data, and hides unnecessary information like the hex address to the ship and the status of the ship (either `(transit to) nowhere` or `Uncharted Space` from my testing)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More concise information for our admins is always better

### Before
![tL80JiFfTS](https://github.com/shiptest-ss13/Shiptest/assets/30960302/60449f08-8df7-41eb-ab24-a8c7947ef633)

???

### After

![image](https://github.com/shiptest-ss13/Shiptest/assets/30960302/0925a5d6-b5cc-4c3f-a1d3-2ebf13e57da3)

😌

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: added more admin-relevant features to the Shuttle Manipulator
fix: removed repeat in the Shuttle Manipulator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
