### PR TITLE
Gives engineering cyborgs shuttle blueprints

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -383,6 +383,11 @@
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")
 	return TRUE
 
+/obj/item/areaeditor/shuttle/cyborg
+	name = "ship structure schematics"
+	desc = "A digital copy of the local ship blueprints and zoning stored in your memory, used to expand flying shuttles."
+	fluffnotice = "For use in engineering cyborgs only. Wipe from memory upon disabling."
+
 // VERY EXPENSIVE (I think)
 /obj/docking_port/mobile/proc/recalculate_bounds()
 	if(!istype(src, /obj/docking_port/mobile))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -452,7 +452,7 @@
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,
 		/obj/item/assembly/signaler/cyborg,
-		/obj/item/areaeditor/blueprints/cyborg,
+		/obj/item/areaeditor/shuttle/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, engineering cyborgs have a basically useless station blueprints which can only modify areas that do not move. This PR adds a new `ship structure schematics` for engineering borgs so they can actually edit ship areas now without leaving things behind, and replaces the old one with it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One more step towards the cyborg singularity point.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Gave engineering cyborgs their own shuttle manipulation blueprints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
