### PR TITLE
Adds observer starter spots to all ships (that did not already have them)

### DIFF
--- a/_maps/shuttles/shiptest/independent_box.dmm
+++ b/_maps/shuttles/shiptest/independent_box.dmm
@@ -2209,6 +2209,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
 "xP" = (

--- a/_maps/shuttles/shiptest/independent_bubble.dmm
+++ b/_maps/shuttles/shiptest/independent_bubble.dmm
@@ -92,6 +92,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/science)
+"ga" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel/mono,
+/area/ship/hallway/central)
 "gl" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -1368,7 +1381,7 @@ VQ
 VQ
 VQ
 jA
-im
+ga
 HH
 nH
 ny

--- a/_maps/shuttles/shiptest/independent_byo.dmm
+++ b/_maps/shuttles/shiptest/independent_byo.dmm
@@ -371,6 +371,7 @@
 /obj/item/toy/crayon/spraycan/infinite{
 	name = "stencil tool"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plating,
 /area/ship/construction)
 "HK" = (

--- a/_maps/shuttles/shiptest/independent_caravan.dmm
+++ b/_maps/shuttles/shiptest/independent_caravan.dmm
@@ -325,6 +325,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew)
 "fv" = (

--- a/_maps/shuttles/shiptest/independent_dwayne.dmm
+++ b/_maps/shuttles/shiptest/independent_dwayne.dmm
@@ -578,7 +578,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/reagent_containers/glass/beaker{
-	list_reagents = list(/datum/reagent/fuel = 50)
+	list_reagents = list(/datum/reagent/fuel=50)
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)

--- a/_maps/shuttles/shiptest/independent_halftrack.dmm
+++ b/_maps/shuttles/shiptest/independent_halftrack.dmm
@@ -1001,6 +1001,19 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
+"yY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ship/hallway/aft)
 "zg" = (
 /obj/machinery/light{
 	dir = 1
@@ -2466,7 +2479,7 @@ RW
 dH
 uq
 ur
-go
+yY
 ur
 ur
 ur

--- a/_maps/shuttles/shiptest/independent_hightide.dmm
+++ b/_maps/shuttles/shiptest/independent_hightide.dmm
@@ -988,6 +988,14 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
+"MP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plating,
+/area/ship/maintenance/central)
 "MS" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -1608,7 +1616,7 @@ nT
 wj
 yo
 Wn
-lC
+MP
 bA
 qn
 PP

--- a/_maps/shuttles/shiptest/independent_kilo.dmm
+++ b/_maps/shuttles/shiptest/independent_kilo.dmm
@@ -2211,6 +2211,7 @@
 	dir = 4;
 	pixel_x = -27
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ship/cargo)
 "Vd" = (

--- a/_maps/shuttles/shiptest/independent_lagoon.dmm
+++ b/_maps/shuttles/shiptest/independent_lagoon.dmm
@@ -1019,6 +1019,14 @@
 	},
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew/canteen)
+"gr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
 "gz" = (
 /obj/machinery/pdapainter,
 /turf/open/floor/plasteel/telecomms_floor,
@@ -8660,7 +8668,7 @@ lN
 yg
 vf
 Kr
-WS
+gr
 Kr
 WS
 TL

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -1557,6 +1557,14 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Hv" = (
+/obj/effect/turf_decal/corner/opaque/red/full,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel,
+/area/ship/hallway/aft)
 "HF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2913,7 +2921,7 @@ dH
 uq
 ur
 go
-Bl
+Hv
 Bl
 rh
 BN

--- a/_maps/shuttles/shiptest/independent_meta.dmm
+++ b/_maps/shuttles/shiptest/independent_meta.dmm
@@ -3445,6 +3445,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
+"SM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
 "Un" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4
@@ -3660,7 +3675,7 @@ bn
 bB
 bL
 bW
-bW
+SM
 nT
 wM
 cR

--- a/_maps/shuttles/shiptest/independent_metis.dmm
+++ b/_maps/shuttles/shiptest/independent_metis.dmm
@@ -3670,6 +3670,7 @@
 /obj/machinery/turretid{
 	pixel_y = -25
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/circuit/green,
 /area/ship/science/ai_chamber)
 "Vj" = (

--- a/_maps/shuttles/shiptest/independent_nemo.dmm
+++ b/_maps/shuttles/shiptest/independent_nemo.dmm
@@ -1930,6 +1930,13 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"AH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
 "AN" = (
 /obj/structure/window/plasma/reinforced/spawner,
 /obj/structure/window/plasma/reinforced/spawner/west,
@@ -4096,7 +4103,7 @@ Pd
 iZ
 xR
 ju
-Pn
+AH
 hu
 rh
 jg

--- a/_maps/shuttles/shiptest/independent_pillbottle.dmm
+++ b/_maps/shuttles/shiptest/independent_pillbottle.dmm
@@ -1154,6 +1154,17 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
+"tn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel,
+/area/ship/hallway/fore)
 "tr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3737,7 +3748,7 @@ RJ
 MB
 MB
 BK
-Ud
+tn
 Ud
 gp
 Ze

--- a/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
+++ b/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
@@ -3916,6 +3916,7 @@
 /area/ship/crew/dorm)
 "LC" = (
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "LF" = (

--- a/_maps/shuttles/shiptest/independent_scav.dmm
+++ b/_maps/shuttles/shiptest/independent_scav.dmm
@@ -366,6 +366,7 @@
 /area/ship/cargo)
 "ls" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/cargo)
 "ml" = (

--- a/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
+++ b/_maps/shuttles/shiptest/independent_schmiedeberg.dmm
@@ -1349,6 +1349,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/medical)
 "tA" = (

--- a/_maps/shuttles/shiptest/independent_shepherd.dmm
+++ b/_maps/shuttles/shiptest/independent_shepherd.dmm
@@ -2448,6 +2448,7 @@
 /area/ship/engineering/electrical)
 "wb" = (
 /obj/structure/flora/tree/chapel,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plating/grass/jungle/actuallydark,
 /area/ship/crew/hydroponics)
 "wc" = (

--- a/_maps/shuttles/shiptest/independent_solar.dmm
+++ b/_maps/shuttles/shiptest/independent_solar.dmm
@@ -1303,6 +1303,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/hallway)
+"zh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel/mono,
+/area/ship/hallway)
 "zq" = (
 /obj/effect/turf_decal/corner/opaque/blue{
 	dir = 8
@@ -2904,7 +2917,7 @@ uI
 yG
 EZ
 tv
-mx
+zh
 Oa
 hj
 OQ

--- a/_maps/shuttles/shiptest/independent_tide.dmm
+++ b/_maps/shuttles/shiptest/independent_tide.dmm
@@ -285,6 +285,7 @@
 /area/ship/maintenance/fore)
 "rG" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sd" = (

--- a/_maps/shuttles/shiptest/independent_tranquility.dmm
+++ b/_maps/shuttles/shiptest/independent_tranquility.dmm
@@ -2306,6 +2306,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/wood/birch,
 /area/ship/crew/crewtwo)
+"sg" = (
+/obj/effect/landmark/observer_start,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/canteen)
 "sr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7361,7 +7365,7 @@ Px
 Ky
 yL
 vV
-vx
+sg
 bg
 Cd
 Nj

--- a/_maps/shuttles/shiptest/independent_trunktide.dmm
+++ b/_maps/shuttles/shiptest/independent_trunktide.dmm
@@ -594,6 +594,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plating/rust,
 /area/ship/crew)
 "vk" = (

--- a/_maps/shuttles/shiptest/minutemen_asclepius.dmm
+++ b/_maps/shuttles/shiptest/minutemen_asclepius.dmm
@@ -813,6 +813,7 @@
 "hM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/minutemen/middle,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/patterned/dirty,
 /area/ship/cargo)
 "hN" = (

--- a/_maps/shuttles/shiptest/minutemen_cepheus.dmm
+++ b/_maps/shuttles/shiptest/minutemen_cepheus.dmm
@@ -1059,6 +1059,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "lR" = (

--- a/_maps/shuttles/shiptest/minutemen_corvus.dmm
+++ b/_maps/shuttles/shiptest/minutemen_corvus.dmm
@@ -2453,6 +2453,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/hallway/central)
 "Um" = (

--- a/_maps/shuttles/shiptest/nanotrasen_delta.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_delta.dmm
@@ -1018,6 +1018,7 @@
 /obj/effect/turf_decal/corner/opaque/blue/border{
 	dir = 8
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "ck" = (

--- a/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
@@ -8054,6 +8054,17 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/crew/cryo)
+"UJ" = (
+/obj/structure/chair/greyscale,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel,
+/area/ship/security/prison)
 "UL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9585,7 +9596,7 @@ qy
 dw
 DR
 xR
-oU
+UJ
 hm
 MU
 PP

--- a/_maps/shuttles/shiptest/nanotrasen_powerrangers.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_powerrangers.dmm
@@ -4953,6 +4953,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ub" = (

--- a/_maps/shuttles/shiptest/nanotrasen_skipper.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_skipper.dmm
@@ -5509,6 +5509,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/cryo)
 "UT" = (

--- a/_maps/shuttles/shiptest/pirate_noderider.dmm
+++ b/_maps/shuttles/shiptest/pirate_noderider.dmm
@@ -2972,6 +2972,7 @@
 "Ss" = (
 /obj/machinery/ai_slipper,
 /obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "SP" = (

--- a/_maps/shuttles/shiptest/radio_funny.dmm
+++ b/_maps/shuttles/shiptest/radio_funny.dmm
@@ -120,6 +120,7 @@
 /area/ship/bridge)
 "th" = (
 /obj/machinery/light/floor,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/bridge)
 "tv" = (

--- a/_maps/shuttles/shiptest/solgov_cricket.dmm
+++ b/_maps/shuttles/shiptest/solgov_cricket.dmm
@@ -1727,6 +1727,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "uJ" = (

--- a/_maps/shuttles/shiptest/srm_glaive.dmm
+++ b/_maps/shuttles/shiptest/srm_glaive.dmm
@@ -1009,6 +1009,15 @@
 /obj/item/clothing/head/welding,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
+"nY" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plating{
+	icon_state = "greenerdirt"
+	},
+/area/ship/roumain)
 "nZ" = (
 /obj/structure/fence{
 	dir = 4
@@ -4094,7 +4103,7 @@ GP
 NL
 NL
 NL
-NT
+nY
 Lj
 uM
 CC

--- a/_maps/shuttles/shiptest/syndicate_aegis.dmm
+++ b/_maps/shuttles/shiptest/syndicate_aegis.dmm
@@ -4131,6 +4131,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
 "ME" = (

--- a/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
+++ b/_maps/shuttles/shiptest/syndicate_cybersun_kansatsu.dmm
@@ -1173,6 +1173,7 @@
 /area/ship/engineering)
 "BS" = (
 /obj/machinery/light/small,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Cr" = (

--- a/_maps/shuttles/shiptest/syndicate_gec_lugol.dmm
+++ b/_maps/shuttles/shiptest/syndicate_gec_lugol.dmm
@@ -5288,6 +5288,12 @@
 "RI" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
+"RN" = (
+/obj/effect/turf_decal/corner/transparent/bar/diagonal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
 "RS" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -6781,7 +6787,7 @@ iU
 Qs
 WK
 Lo
-Os
+RN
 sf
 xh
 lL

--- a/_maps/shuttles/shiptest/syndicate_gorlex_hyena.dmm
+++ b/_maps/shuttles/shiptest/syndicate_gorlex_hyena.dmm
@@ -772,6 +772,14 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"nQ" = (
+/obj/effect/turf_decal/corner/transparent/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/bar,
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel,
+/area/ship/crew)
 "nR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/cola/sodie,
@@ -2104,7 +2112,7 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/suit_storage_unit/inherit/industrial{
 	req_access = null;
-	req_one_access = list(48, 56)
+	req_one_access = list(48,56)
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
@@ -2986,7 +2994,7 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/suit_storage_unit/inherit/industrial{
 	req_access = null;
-	req_one_access = list(48, 56)
+	req_one_access = list(48,56)
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
@@ -3524,7 +3532,7 @@ mX
 rP
 vi
 UI
-vN
+nQ
 Ai
 UX
 Ms

--- a/_maps/shuttles/shiptest/syndicate_gorlex_komodo.dmm
+++ b/_maps/shuttles/shiptest/syndicate_gorlex_komodo.dmm
@@ -3191,6 +3191,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
 "Fi" = (

--- a/_maps/shuttles/shiptest/syndicate_luxembourg.dmm
+++ b/_maps/shuttles/shiptest/syndicate_luxembourg.dmm
@@ -1321,6 +1321,7 @@
 	location = "lux_shopfloor"
 	},
 /obj/machinery/holopad/emergency/cargo,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "zc" = (

--- a/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
+++ b/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
@@ -8217,6 +8217,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/red,
 /area/ship/crew/office)
 "Xs" = (

--- a/_maps/shuttles/shiptest/wizard_lamia.dmm
+++ b/_maps/shuttles/shiptest/wizard_lamia.dmm
@@ -2505,6 +2505,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/observer_start,
 /turf/open/floor/carpet/green,
 /area/ship/hallway/central)
 "Yx" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request adds `/obj/effect/landmark/observer_start` instances to every ship that is currently in the shiptest folder and that didn't have them already. also strongdmm automatically formatted a variable while i was checking the dwayne if that's worth saying

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
observers will spawn on the ships. also bjarl asked for it

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added observer_start landmarks to all ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
