### PR TITLE
Fixed a bunch of warnings on init, alien tools have working icon states

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -713,30 +713,35 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	name = "alien scalpel"
 	desc = "It's a gleaming sharp knife made out of silvery-green metal."
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "scalpel"
 	toolspeed = 0.25
 
 /obj/item/hemostat/alien
 	name = "alien hemostat"
 	desc = "You've never seen this before."
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "hemostat"
 	toolspeed = 0.25
 
 /obj/item/retractor/alien
 	name = "alien retractor"
 	desc = "You're not sure if you want the veil pulled back."
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "retractor"
 	toolspeed = 0.25
 
 /obj/item/circular_saw/alien
 	name = "alien saw"
 	desc = "Do the aliens also lose this, and need to find an alien hatchet?"
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "saw"
 	toolspeed = 0.25
 
 /obj/item/surgicaldrill/alien
 	name = "alien drill"
 	desc = "Maybe alien surgeons have finally found a use for the drill."
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "drill"
 	toolspeed = 0.25
 
 /obj/item/cautery/alien
@@ -744,6 +749,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	desc = "Why would bloodless aliens have a tool to stop bleeding? \
 		Unless..."
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "cautery"
 	toolspeed = 0.25
 
 /obj/item/clothing/head/helmet/abductor

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -287,7 +287,8 @@
 					warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 					continue
 			catch
-				SEND_TEXT(world.log, "Tried to load icon [icon_file] for design [D] but it doesn't exist.") // Remove later
+				SEND_TEXT(world.log, "Tried to load icon [icon_file] with icon state [icon_state] for design [D] but something went wrong!") // Remove later
+				continue
 
 			I = icon(icon_file, icon_state, SOUTH)
 

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -282,15 +282,9 @@
 		if(initial(D.research_icon) && initial(D.research_icon_state)) //If the design has an icon replacement skip the rest
 			icon_file = initial(D.research_icon)
 			icon_state = initial(D.research_icon_state)
-			try
-				if(!(icon_state in icon_states(icon_file)))
-					warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
-					continue
-			catch(exception/e)
-				SEND_TEXT(world.log, "Tried to load icon '[icon_file]' with icon state '[icon_state]' for design [D] but something went wrong!") // Remove later
-				SEND_TEXT(world.log, "Exception: [e.desc]") // Remove later
+			if(!(icon_state in icon_states(icon_file)))
+				warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 				continue
-
 			I = icon(icon_file, icon_state, SOUTH)
 
 		else

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -282,9 +282,13 @@
 		if(initial(D.research_icon) && initial(D.research_icon_state)) //If the design has an icon replacement skip the rest
 			icon_file = initial(D.research_icon)
 			icon_state = initial(D.research_icon_state)
-			if(!(icon_state in icon_states(icon_file)))
-				warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
-				continue
+			try
+				if(!(icon_state in icon_states(icon_file)))
+					warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
+					continue
+			catch
+				SEND_TEXT(world.log, "Tried to load icon [icon_file] for design [D] but it doesn't exist.") // Remove later
+
 			I = icon(icon_file, icon_state, SOUTH)
 
 		else

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -286,8 +286,9 @@
 				if(!(icon_state in icon_states(icon_file)))
 					warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 					continue
-			catch
-				SEND_TEXT(world.log, "Tried to load icon [icon_file] with icon state [icon_state] for design [D] but something went wrong!") // Remove later
+			catch(exception/e)
+				SEND_TEXT(world.log, "Tried to load icon '[icon_file]' with icon state '[icon_state]' for design [D] but something went wrong!") // Remove later
+				SEND_TEXT(world.log, "Exception: [e.desc]") // Remove later
 				continue
 
 			I = icon(icon_file, icon_state, SOUTH)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2,7 +2,7 @@
 /datum/design/borg
 	build_type = MECHFAB
 	category = list("Cyborg")
-	research_icon = "icons/mob/augmentation/augments.dmi"
+	research_icon = 'icons/mob/augmentation/augments.dmi'
 
 /datum/design/borg/suit
 	name = "Cyborg Endoskeleton"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1,144 +1,136 @@
 //Cyborg
-/datum/design/borg_suit
+/datum/design/borg
+	build_type = MECHFAB
+	category = list("Cyborg")
+	research_icon = "icons/mob/augmentation/augments.dmi"
+
+/datum/design/borg/suit
 	name = "Cyborg Endoskeleton"
 	id = "borg_suit"
-	build_type = MECHFAB
+	research_icon_state = "robo_suit"
 	build_path = /obj/item/robot_suit
 	materials = list(/datum/material/iron=15000)
 	construction_time = 500
-	category = list("Cyborg")
 
-/datum/design/borg_chest
+/datum/design/borg/chest
 	name = "Cyborg Torso"
 	id = "borg_chest"
-	build_type = MECHFAB
+	research_icon_state = "borg_chest"
 	build_path = /obj/item/bodypart/chest/robot
 	materials = list(/datum/material/iron=40000)
 	construction_time = 350
-	category = list("Cyborg")
 
-/datum/design/borg_head
+/datum/design/borg/head
 	name = "Cyborg Head"
 	id = "borg_head"
-	build_type = MECHFAB
+	research_icon_state = "borg_head"
 	build_path = /obj/item/bodypart/head/robot
 	materials = list(/datum/material/iron=5000)
 	construction_time = 350
-	category = list("Cyborg")
 
-/datum/design/borg_l_arm
+/datum/design/borg/l_arm
 	name = "Cyborg Left Arm"
 	id = "borg_l_arm"
-	build_type = MECHFAB
+	research_icon_state = "borg_l_arm"
 	build_path = /obj/item/bodypart/l_arm/robot
 	materials = list(/datum/material/iron=10000)
 	construction_time = 200
-	category = list("Cyborg")
 
-/datum/design/borg_r_arm
+/datum/design/borg/r_arm
 	name = "Cyborg Right Arm"
 	id = "borg_r_arm"
-	build_type = MECHFAB
+	research_icon_state = "borg_r_arm"
 	build_path = /obj/item/bodypart/r_arm/robot
 	materials = list(/datum/material/iron=10000)
 	construction_time = 200
-	category = list("Cyborg")
 
-/datum/design/borg_l_leg
+/datum/design/borg/l_leg
 	name = "Cyborg Left Leg"
 	id = "borg_l_leg"
-	build_type = MECHFAB
+	research_icon_state = "borg_l_leg"
 	build_path = /obj/item/bodypart/leg/left/robot
 	materials = list(/datum/material/iron=10000)
 	construction_time = 200
-	category = list("Cyborg")
 
-/datum/design/borg_r_leg
+/datum/design/borg/r_leg
 	name = "Cyborg Right Leg"
 	id = "borg_r_leg"
-	build_type = MECHFAB
+	research_icon_state = "borg_r_leg"
 	build_path = /obj/item/bodypart/leg/right/robot
 	materials = list(/datum/material/iron=10000)
-	construction_time = 200
-	category = list("Cyborg")
+
 
 //Prosthetics
-/datum/design/prosthetic_l_arm
+/datum/design/prosthetic
+	research_icon = 'icons/mob/augmentation/augments.dmi'
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 5 SECONDS
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	materials = list(/datum/material/iron=3000)
+	category = list("Misc", "Medical Designs")
+
+/datum/design/prosthetic/l_arm
 	name = "Surplus Prosthetic Left Arm"
 	id = "prosthetic_l_arm"
-	build_type = PROTOLATHE | MECHFAB
+	research_icon_state = "borg_l_arm"
 	build_path = /obj/item/bodypart/l_arm/robot/surplus
-	materials = list(/datum/material/iron=3000)
-	construction_time = 5 SECONDS
-	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/prosthetic_r_arm
+/datum/design/prosthetic/r_arm
 	name = "Surplus Prosthetic Right Arm"
 	id = "prosthetic_r_arm"
-	build_type = PROTOLATHE | MECHFAB
+	research_icon_state = "borg_r_arm"
 	build_path = /obj/item/bodypart/r_arm/robot/surplus
-	materials = list(/datum/material/iron=3000)
-	construction_time = 5 SECONDS
-	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/prosthetic_l_leg
+/datum/design/prosthetic/l_leg
 	name = "Surplus Prosthetic Left Leg"
 	id = "prosthetic_l_leg"
-	build_type = PROTOLATHE | MECHFAB
+	research_icon_state = "borg_l_leg"
 	build_path = /obj/item/bodypart/leg/left/robot/surplus
-	materials = list(/datum/material/iron=3000)
-	construction_time = 5 SECONDS
-	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/prosthetic_r_leg
+/datum/design/prosthetic/r_leg
 	name = "Surplus Prosthetic Right Leg"
 	id = "prosthetic_r_leg"
-	build_type = PROTOLATHE | MECHFAB
+	research_icon_state = "borg_r_leg"
 	build_path = /obj/item/bodypart/leg/right/robot/surplus
-	materials = list(/datum/material/iron=3000)
-	construction_time = 5 SECONDS
-	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/prosthetic_l_arm/kepori
+// Kepori
+/datum/design/prosthetic/l_arm/kepori
 	name = "Surplus Prosthetic Kepori Left Arm"
 	id = "kprosthetic_l_arm"
 	build_path = /obj/item/bodypart/l_arm/robot/surplus/kepori
 
-/datum/design/prosthetic_r_arm/kepori
+/datum/design/prosthetic/r_arm/kepori
 	name = "Surplus Prosthetic Kepori Right Arm"
 	id = "kprosthetic_r_arm"
 	build_path = /obj/item/bodypart/r_arm/robot/surplus/kepori
 
-/datum/design/prosthetic_l_leg/kepori
+/datum/design/prosthetic/l_leg/kepori
 	name = "Surplus Prosthetic Kepori Left Leg"
 	id = "kprosthetic_l_leg"
 	build_path = /obj/item/bodypart/leg/left/robot/surplus/kepori
 
-/datum/design/prosthetic_r_leg/kepori
+/datum/design/prosthetic/r_leg/kepori
 	name = "Surplus Prosthetic Kepori Right Leg"
 	id = "kprosthetic_r_leg"
 	build_path = /obj/item/bodypart/leg/right/robot/surplus/kepori
 
-/datum/design/prosthetic_l_arm/vox
+// Vox
+/datum/design/prosthetic/l_arm/vox
 	name = "Surplus Prosthetic Vox Left Arm"
 	id = "vprosthetic_l_arm"
 	build_path = /obj/item/bodypart/l_arm/robot/surplus/vox
 
-/datum/design/prosthetic_r_arm/vox
+/datum/design/prosthetic/r_arm/vox
 	name = "Surplus Prosthetic Vox Right Arm"
 	id = "vprosthetic_r_arm"
 	build_path = /obj/item/bodypart/r_arm/robot/surplus/vox
 
-/datum/design/prosthetic_l_leg/vox
+/datum/design/prosthetic/l_leg/vox
 	name = "Surplus Prosthetic Vox Left Leg"
 	id = "vprosthetic_l_leg"
 	build_path = /obj/item/bodypart/leg/left/robot/surplus/vox
 
-/datum/design/prosthetic_r_leg/vox
+/datum/design/prosthetic/r_leg/vox
 	name = "Surplus Prosthetic Vox Right Leg"
 	id = "vprosthetic_r_leg"
 	build_path = /obj/item/bodypart/leg/right/robot/surplus/vox

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -2,7 +2,7 @@
 /obj/item/bodypart/chest
 	name = BODY_ZONE_CHEST
 	desc = "It's impolite to stare at a person's chest."
-	icon_state = "default_human_chest"
+	icon_state = "human_chest"
 	max_damage = 200
 	body_zone = BODY_ZONE_CHEST
 	body_part = CHEST
@@ -61,7 +61,7 @@
 		Latin 'sinestra' (left hand), because the left hand was supposed to \
 		be possessed by the devil? This arm appears to be possessed by no \
 		one though."
-	icon_state = "default_human_l_arm"
+	icon_state = "human_l_arm"
 	attack_verb = list("slaps", "punches")
 	max_damage = 50
 	max_stamina_damage = 50
@@ -163,7 +163,7 @@
 	name = "right arm"
 	desc = "Over 87% of humans are right handed. That figure is much lower \
 		among humans missing their right arm."
-	icon_state = "default_human_r_arm"
+	icon_state = "human_r_arm"
 	attack_verb = list("slaps", "punches")
 	max_damage = 50
 	body_zone = BODY_ZONE_R_ARM
@@ -265,7 +265,7 @@
 	name = "left leg"
 	desc = "Some athletes prefer to tie their left shoelaces first for good \
 		luck. In this instance, it probably would not have helped."
-	icon_state = "default_human_l_leg"
+	icon_state = "human_l_leg"
 	attack_verb = list("kicks", "stomps")
 	max_damage = 50
 	body_zone = BODY_ZONE_L_LEG
@@ -358,7 +358,7 @@
 		shake it all about. And apparently then it detaches.\n\
 		The hokey pokey has certainly changed a lot since space colonisation."
 	// alternative spellings of 'pokey' are available
-	icon_state = "default_human_r_leg"
+	icon_state = "human_r_leg"
 	attack_verb = list("kicks", "stomps")
 	max_damage = 50
 	body_zone = BODY_ZONE_R_LEG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -118,7 +118,7 @@
 	name = "cyborg torso"
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
+	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = null
 	limb_id = "robotic"
 	flags_1 = CONDUCT_1

--- a/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
@@ -31,12 +31,14 @@
 
 /obj/item/bodypart/leg/left/digitigrade
 	icon = 'icons/mob/species/lizard/bodyparts.dmi'
+	icon_state = "digitigrade_l_leg"
 	uses_mutcolor = TRUE
 	limb_id = "digitigrade"
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/leg/right/digitigrade
 	icon = 'icons/mob/species/lizard/bodyparts.dmi'
+	icon_state = "digitigrade_r_leg"
 	uses_mutcolor = TRUE
 	limb_id = "digitigrade"
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE


### PR DESCRIPTION
## About The Pull Request
See title. It was mostly around fabrication designs not having icons or icon states. Also some good OOD. 

## Why It's Good For The Game
Warnings shouldn't be ignored, they're warnings for a reason!

## Changelog
:cl:
fix: alien tools have working icon states
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
