### PR TITLE
Adds some extra logging

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -64,6 +64,7 @@ SUBSYSTEM_DEF(shuttle)
 			else
 				var/obj/docking_port/mobile/M = requester
 				message_admins("Shuttle [M] repeatedly failed to create transit zone.")
+				log_runtime("Shuttle [M] repeatedly failed to create transit zone.")
 		if(MC_TICK_CHECK)
 			break
 

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -77,6 +77,7 @@
 	if(!..() || (!COOLDOWN_FINISHED(src, rename_cooldown) && !force))
 		return FALSE
 	message_admins("[key_name_admin(usr)] renamed vessel '[oldname]' to '[new_name]'")
+	log_admin("[key_name(src)] has renamed vessel '[oldname]' to '[new_name]'")
 	shuttle_port?.name = new_name
 	ship_account.account_holder = new_name
 	if(shipkey)


### PR DESCRIPTION
## About The Pull Request

Adds admin logging of ship renaming and runtime logging of ships failing to create a transit dock

## Why It's Good For The Game

Being able to go back and check these things is helpful

## Changelog

:cl:
admin: Renaming ships is now recorded in the admin log
/:cl:
