### PR TITLE
removes the seed vendor restock from mimir

### DIFF
--- a/code/game/MapData/shuttles/nanotrasen_mimir.dm
+++ b/code/game/MapData/shuttles/nanotrasen_mimir.dm
@@ -9,7 +9,6 @@
 
 /obj/item/storage/backpack/satchel/flat/mimir_refill/PopulateContents()
 	new /obj/item/vending_refill/hydronutrients(src)
-	new /obj/item/vending_refill/hydroseeds(src)
 
 /obj/item/storage/backpack/satchel/flat/mimir_transfer/PopulateContents()
 	new /obj/item/reagent_containers/food/drinks/bottle/whiskey(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
no ship should have a seed vendor. This PR removes it from a smuggler satchel on the mimir
thanks to Gorionus#1146 for pointing it out!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
seed vendors shouldn't be on ships
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Removed seed vendor restock from the mimir class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
