### PR TITLE
Fixes Plasteel Stairs Being Colorless

### DIFF
--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -171,6 +171,7 @@
 	icon_state = "stairs"
 	base_icon_state = "stairs"
 	tiled_dirt = FALSE
+	color = COLOR_FLOORTILE_GRAY
 
 /turf/open/floor/plasteel/stairs/left
 	icon_state = "stairs-l"


### PR DESCRIPTION
## About The Pull Request
#1882 removed the base color from plasteel tiles, which was inherited by plasteel stairs, making plasteel stairs colorless. this PR fixes that

## Why It's Good For The Game

soul re-added

## Changelog

:cl:
fix: Plasteel stairs have regained their shade.
/:cl:
