### PR TITLE
Moves poor cryo pod behavior onto base cryo pods.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -420,8 +420,8 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(60)
-	sleepyhead.set_disgust(55)
-	sleepyhead.set_nutrition(150)
+	sleepyhead.set_disgust(57) // puke maybe once maybe twice
+	sleepyhead.set_nutrition(200)
 	to_chat(sleepyhead, "<span class='userdanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
 
 /obj/machinery/cryopod/poor
@@ -430,6 +430,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(80)
-	sleepyhead.set_disgust(75)
+	sleepyhead.set_disgust(75) //nasty
 	sleepyhead.set_nutrition(70)
 	to_chat(sleepyhead, "<span class='userdanger'>The low-quality cryo pod ejects you unceremoniously, you feel REALLY sick...</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -428,7 +428,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	name = "low quality cryogenic freezer"
 	desc = "Keeps crew frozen in cryostasis until they are needed in order to cut down on supply usage. This one seems cheaply made."
 
-/obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+/obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(50)
 	sleepyhead.set_disgust(120)
 	sleepyhead.set_nutrition(70)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -420,7 +420,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(50)
-	sleepyhead.set_disgust(60)
+	sleepyhead.set_disgust(55)
 	sleepyhead.set_nutrition(150)
 	to_chat(sleepyhead, "<span class='bolddanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
 
@@ -430,6 +430,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(50)
-	sleepyhead.set_disgust(120)
+	sleepyhead.set_disgust(75)
 	sleepyhead.set_nutrition(70)
 	to_chat(sleepyhead, "<span class='bolddanger'>The low-quality cryo pod ejects you unceremoniously, you feel REALLY sick...</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -419,17 +419,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	linked_ship.spawn_points += src
 
 /obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
-	sleepyhead.SetSleeping(50)
-	sleepyhead.set_disgust(53)
+	sleepyhead.SetSleeping(60)
+	sleepyhead.set_disgust(55)
 	sleepyhead.set_nutrition(150)
-	to_chat(sleepyhead, "<span class='bolddanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
+	to_chat(sleepyhead, "<span class='userdanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
 
 /obj/machinery/cryopod/poor
 	name = "low quality cryogenic freezer"
 	desc = "Keeps crew frozen in cryostasis until they are needed in order to cut down on supply usage. This one seems cheaply made."
 
 /obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
-	sleepyhead.SetSleeping(50)
+	sleepyhead.SetSleeping(80)
 	sleepyhead.set_disgust(75)
 	sleepyhead.set_nutrition(70)
-	to_chat(sleepyhead, "<span class='bolddanger'>The low-quality cryo pod ejects you unceremoniously, you feel REALLY sick...</span>")
+	to_chat(sleepyhead, "<span class='userdanger'>The low-quality cryo pod ejects you unceremoniously, you feel REALLY sick...</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -418,12 +418,12 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	linked_ship = port
 	linked_ship.spawn_points += src
 
+/obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+	sleepyhead.SetSleeping(50)
+	sleepyhead.set_disgust(60)
+	sleepyhead.set_nutrition(150)
+	to_chat(sleepyhead, "<span class='bolddanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
+
 /obj/machinery/cryopod/poor
 	name = "low quality cryogenic freezer"
 	desc = "Keeps crew frozen in cryostasis until they are needed in order to cut down on supply usage. This one seems cheaply made."
-
-/obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
-	sleepyhead.SetSleeping(50)
-	sleepyhead.set_disgust(60)
-	sleepyhead.set_nutrition(160)
-	to_chat(sleepyhead, "<span class='bolddanger'>A very bad headache wakes you up from cryosleep...</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -427,3 +427,9 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 /obj/machinery/cryopod/poor
 	name = "low quality cryogenic freezer"
 	desc = "Keeps crew frozen in cryostasis until they are needed in order to cut down on supply usage. This one seems cheaply made."
+
+/obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+	sleepyhead.SetSleeping(50)
+	sleepyhead.set_disgust(120)
+	sleepyhead.set_nutrition(70)
+	to_chat(sleepyhead, "<span class='bolddanger'>The low-quality cryo pod ejects you unceremoniously, you feel REALLY sick...</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -420,7 +420,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(50)
-	sleepyhead.set_disgust(55)
+	sleepyhead.set_disgust(53)
 	sleepyhead.set_nutrition(150)
 	to_chat(sleepyhead, "<span class='bolddanger'>A wave of nausea comes over you, brought on by cryosleep...</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the nausea, hunger, and bit of extra sleep off of the poor cryopod subtype and to the base type. Had this idea floating around for a bit and I'd like to see how it fares
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's certainly more interesting, and thematically cool
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Cryo sleep will now make you nauseous and hungry when you wake up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
