### PR TITLE
Shrinks the Kilo crew count

### DIFF
--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -11,10 +11,6 @@
 			"officer": true,
 			"slots": 1
 		},
-		"Foreman": {
-			"outfit": "/datum/outfit/job/quartermaster/western",
-			"slots": 1
-		},
 		"Ship's Doctor": {
 			"outfit": "/datum/outfit/job/doctor",
 			"slots": 1
@@ -25,11 +21,11 @@
 		},
 		"Asteroid Miner": {
 			"outfit": "/datum/outfit/job/miner/hazard",
-			"slots": 2
+			"slots": 1
 		},
 		"Deckhand": {
 			"outfit": "/datum/outfit/job/assistant",
-			"slots": 2
+			"slots": 1
 		}
 	},
 	"enabled": true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deletes the Foreman position, and takes the Miner and Deckhand counts from 2 to 1 respectively.

## Why It's Good For The Game

The Kilo in its current state, with no adjustments by the captain, spawns EIGHT CREW. Ships with similar footprints and missions like the Tide and Scav spawn 4 or 5. Eight crew on the Kilo is an absolute sardine can. In the interest of sparing future Kilo captains of any more grey hairs, this PR takes it down to 5 crew, assuming the captain doesn't open up any more roles. The Foreman got the axe since it felt kind of redundant on such a small ship. I considered removing the Doctor as well since the Kilo lacks any medical facilities, but removing the only guy with actual medical supplies might be too heavy of a hit to balance.

## Changelog

:cl:
tweak: reduced Kilo crew count from 8 to 5, removed Foreman
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
