### PR TITLE
changes the rig heat suit to use its own helmet

### DIFF
--- a/code/game/MapData/shuttles/nanotrasen_powerrangers.dm
+++ b/code/game/MapData/shuttles/nanotrasen_powerrangers.dm
@@ -367,7 +367,7 @@
 	name = "RIG heat suit"
 	desc = "A fully heat resistance suit based on an early RIG hardsuit prototype. It sacrifices armor of any kind for intricate heatsinks. It remains rather bulky as a result."
 	armor = list("melee" = 1, "bullet" = 1, "laser" = 1, "energy" = 1, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 75)
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ancient
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/lp
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = ACID_PROOF | FIRE_PROOF


### PR DESCRIPTION
## About The Pull Request
the RIG heat suit used the prototype rig suit's helmet instead of its own. considering it has its own helmet in the code above it, i dont think this is intended. 
this PR serves to correct that
![image](https://github.com/shiptest-ss13/Shiptest/assets/33011256/7a5717df-e54e-4ac1-8463-e751bb648f20)

## Why It's Good For The Game
a hardsuit helmet fix! my first time using pull requests for this so let me know if i screwed up somewhere

## Changelog

:cl:
fix: changed the RIG heat suit to use its own helmet instead of the prototype's
/:cl:
