### PR TITLE
Glaive Patchie and Shipturfs

### DIFF
--- a/_maps/shuttles/shiptest/independent_shepherd.dmm
+++ b/_maps/shuttles/shiptest/independent_shepherd.dmm
@@ -224,12 +224,12 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "cO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "cV" = (
 /obj/machinery/door/firedoor/border_only,
@@ -287,7 +287,7 @@
 /area/ship/hallway/fore)
 "db" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "dg" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -298,7 +298,7 @@
 /area/ship/crew/canteen)
 "du" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "dz" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -308,7 +308,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "dM" = (
 /turf/closed/wall,
@@ -382,7 +382,7 @@
 	color = "#332521";
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "el" = (
 /obj/machinery/door/firedoor/border_only{
@@ -429,7 +429,7 @@
 /area/ship/crew/chapel/office)
 "em" = (
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "ew" = (
 /obj/machinery/door/firedoor/border_only{
@@ -564,14 +564,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "fk" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/railing/corner/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -598,7 +598,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "fx" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -659,7 +659,7 @@
 /area/ship/hallway/starboard)
 "fJ" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/jungle/actuallydark,
+/turf/open/floor/plating/ship/water,
 /area/ship/crew/hydroponics)
 "fN" = (
 /obj/item/table_bell/brass{
@@ -698,12 +698,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "gd" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/closet/crate/wooden,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "go" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -718,7 +718,7 @@
 /area/ship/engineering/atmospherics)
 "gv" = (
 /obj/structure/railing/corner/wood,
-/turf/open/water/jungle/actuallydark,
+/turf/open/floor/plating/ship/water,
 /area/ship/crew/hydroponics)
 "gJ" = (
 /obj/machinery/mass_driver{
@@ -814,7 +814,7 @@
 "hj" = (
 /obj/structure/table/wood,
 /obj/item/candle/infinite,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "hm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -871,7 +871,7 @@
 /area/ship/hallway/fore)
 "hF" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "hL" = (
 /obj/structure/sink/kitchen{
@@ -909,7 +909,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "if" = (
 /obj/structure/cable{
@@ -930,7 +930,7 @@
 /area/ship/engineering/atmospherics)
 "iv" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "iD" = (
 /obj/structure/cable{
@@ -1049,7 +1049,7 @@
 "ji" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "jj" = (
 /obj/structure/railing/wood{
@@ -1081,7 +1081,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "jA" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1125,7 +1125,7 @@
 /area/ship/engineering/atmospherics)
 "kb" = (
 /obj/structure/railing/wood,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "kc" = (
 /turf/closed/wall/r_wall,
@@ -1139,7 +1139,7 @@
 /area/ship/crew/chapel)
 "kj" = (
 /obj/structure/railing/wood,
-/turf/open/water/jungle/actuallydark,
+/turf/open/floor/plating/ship/water,
 /area/ship/crew/hydroponics)
 "kp" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -1167,7 +1167,7 @@
 "kz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "kC" = (
 /turf/closed/wall/r_wall,
@@ -1178,7 +1178,7 @@
 /area/ship/crew/chapel/office)
 "kK" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "kR" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
@@ -1249,7 +1249,7 @@
 "lk" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "ll" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1283,7 +1283,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "lA" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -1294,7 +1294,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "lI" = (
 /obj/structure/cable{
@@ -1333,7 +1333,7 @@
 /area/ship/crew/toilet)
 "lY" = (
 /obj/structure/railing/corner/wood,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "lZ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1438,7 +1438,7 @@
 	dir = 8
 	},
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "nf" = (
 /obj/effect/turf_decal/spline/fancy/wood{
@@ -1487,14 +1487,14 @@
 "nI" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/railing/corner/wood,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "nJ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "nM" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1550,7 +1550,7 @@
 /obj/item/melee/flyswatter,
 /obj/item/clothing/suit/beekeeper_suit,
 /obj/item/reagent_containers/syringe,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "oh" = (
 /obj/structure/table/wood,
@@ -1642,7 +1642,7 @@
 /obj/structure/railing/corner/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "oL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1724,7 +1724,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "pE" = (
 /turf/closed/wall,
@@ -1756,7 +1756,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "pO" = (
 /turf/closed/wall,
@@ -1932,7 +1932,7 @@
 /turf/open/floor/wood,
 /area/ship/crew/chapel)
 "rl" = (
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "rm" = (
 /obj/structure/table/wood,
@@ -1954,12 +1954,12 @@
 "rB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "rH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "rI" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2051,7 +2051,7 @@
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/chapel)
 "sz" = (
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "sA" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2067,7 +2067,7 @@
 "sC" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "sH" = (
 /obj/structure/closet/wall{
@@ -2331,7 +2331,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "uS" = (
 /obj/structure/cable/yellow{
@@ -2405,7 +2405,7 @@
 "vC" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/canteen)
 "vE" = (
 /obj/machinery/door/window/northright,
@@ -2434,7 +2434,7 @@
 	color = "#332521";
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "vX" = (
 /obj/structure/cable{
@@ -2449,7 +2449,6 @@
 "wb" = (
 /obj/structure/flora/tree/chapel,
 /obj/effect/landmark/observer_start,
-/turf/open/floor/plating/grass/jungle/actuallydark,
 /area/ship/crew/hydroponics)
 "wc" = (
 /obj/structure/chair/pew/left{
@@ -2466,7 +2465,7 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/chapel)
 "wd" = (
-/turf/open/water/jungle/actuallydark,
+/turf/open/floor/plating/ship/water,
 /area/ship/crew/hydroponics)
 "we" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2486,7 +2485,7 @@
 /area/ship/bridge)
 "wh" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "wm" = (
 /obj/structure/cable/yellow{
@@ -2549,7 +2548,7 @@
 /area/ship/crew/chapel)
 "wR" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "wS" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2637,7 +2636,7 @@
 /area/ship/crew/dorm)
 "xh" = (
 /obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "xj" = (
 /turf/template_noop,
@@ -2645,7 +2644,7 @@
 "xn" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "xr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2661,7 +2660,7 @@
 "xu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "xv" = (
 /obj/structure/railing/wood{
@@ -2785,11 +2784,11 @@
 /area/ship/crew/chapel)
 "yz" = (
 /obj/structure/table/wood,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "yG" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "yO" = (
 /obj/machinery/door/firedoor/border_only,
@@ -2870,7 +2869,7 @@
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "zH" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2884,7 +2883,7 @@
 /area/ship/crew/library)
 "zJ" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "zL" = (
 /obj/machinery/door/firedoor/border_only{
@@ -3003,7 +3002,7 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "AZ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -3012,7 +3011,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Bd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3090,7 +3089,7 @@
 	dir = 4
 	},
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Ca" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3266,7 +3265,9 @@
 /obj/machinery/door/window/northleft{
 	req_one_access_txt = list("12","22","37")
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
+/area/ship/crew/hydroponics)
+"CX" = (
 /area/ship/crew/hydroponics)
 "CY" = (
 /obj/structure/catwalk,
@@ -3287,7 +3288,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Df" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3308,7 +3309,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Dp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3394,7 +3395,7 @@
 	pixel_y = 9
 	},
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "DI" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3519,7 +3520,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "EO" = (
 /obj/structure/sink/kitchen{
@@ -3561,7 +3562,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Fq" = (
 /obj/structure/railing/corner/wood{
@@ -3594,11 +3595,11 @@
 	dir = 1
 	},
 /obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "FB" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/canteen)
 "FJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -3610,7 +3611,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "FL" = (
 /obj/effect/turf_decal/siding/wood,
@@ -3692,7 +3693,7 @@
 "Gx" = (
 /obj/structure/destructible/tribal_torch,
 /obj/structure/railing/wood,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Gy" = (
 /obj/structure/curtain/bounty,
@@ -3733,7 +3734,7 @@
 /obj/structure/railing/corner/wood{
 	dir = 2
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Hc" = (
 /obj/structure/catwalk,
@@ -3787,7 +3788,7 @@
 	pixel_x = -8;
 	pixel_y = 18
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "HF" = (
 /obj/machinery/door/firedoor/border_only{
@@ -3802,7 +3803,7 @@
 "HM" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "HN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3839,7 +3840,7 @@
 "HT" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Ia" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -3949,7 +3950,7 @@
 /area/ship/crew/hydroponics)
 "Jj" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/water/jungle/actuallydark,
+/turf/open/floor/plating/ship/water,
 /area/ship/crew/hydroponics)
 "Jk" = (
 /obj/structure/cable{
@@ -4233,7 +4234,7 @@
 /area/ship/hallway/fore)
 "KZ" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Lf" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -4247,7 +4248,7 @@
 /area/ship/hallway/starboard)
 "Lg" = (
 /obj/structure/chair/wood,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/canteen)
 "Lh" = (
 /obj/structure/railing/corner/wood,
@@ -4276,6 +4277,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"Lq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/canteen)
 "LD" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#332521";
@@ -4341,13 +4346,13 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Mb" = (
 /obj/structure/railing/corner/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Mf" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4424,7 +4429,7 @@
 	pixel_x = -7;
 	pixel_y = 11
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/canteen)
 "MB" = (
 /obj/machinery/door/airlock{
@@ -4467,7 +4472,7 @@
 /obj/structure/railing/corner/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "MQ" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -4493,7 +4498,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Nm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -4510,7 +4515,7 @@
 /area/ship/crew/toilet)
 "Nr" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "ND" = (
 /obj/structure/cable{
@@ -4595,7 +4600,7 @@
 "OW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "OX" = (
 /obj/structure/cable{
@@ -4631,7 +4636,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space,
 /obj/item/clothing/suit/space,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/canteen)
 "Pq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4643,11 +4648,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Pu" = (
 /obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Pv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4786,7 +4791,7 @@
 /area/ship/hallway/starboard)
 "Qa" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4892,7 +4897,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "QE" = (
 /obj/structure/fermenting_barrel,
@@ -4931,6 +4936,9 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"QL" = (
+/obj/structure/flora/ausbushes/brflowers,
+/area/ship/crew/hydroponics)
 "QM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5115,7 +5123,7 @@
 /area/ship/hallway/starboard)
 "Sn" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Sr" = (
 /turf/open/floor/engine/hull,
@@ -5125,7 +5133,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Sz" = (
 /obj/structure/cable{
@@ -5149,7 +5157,7 @@
 /obj/structure/railing/corner/wood{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "SE" = (
 /obj/machinery/cryopod{
@@ -5223,7 +5231,7 @@
 /area/ship/crew/library)
 "Tj" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Tr" = (
 /obj/structure/sink/greyscale{
@@ -5283,7 +5291,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/canteen)
 "TW" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5306,7 +5314,7 @@
 "TZ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/cow,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Ub" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5369,7 +5377,7 @@
 /turf/open/floor/wood,
 /area/ship/hallway/port)
 "UA" = (
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "UC" = (
 /obj/effect/turf_decal/industrial/loading{
@@ -5430,14 +5438,14 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Vf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Vh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5478,7 +5486,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/hydroponics)
 "Vo" = (
 /obj/machinery/bookbinder,
@@ -5574,7 +5582,7 @@
 /area/ship/crew/chapel)
 "Wn" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Wp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5688,7 +5696,7 @@
 /area/ship/engineering/atmospherics)
 "Xw" = (
 /obj/structure/flora/ausbushes,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Xz" = (
 /obj/machinery/door/firedoor/border_only{
@@ -5798,7 +5806,7 @@
 /area/ship/crew/canteen)
 "YC" = (
 /obj/structure/destructible/tribal_torch,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "YK" = (
 /turf/closed/wall/r_wall,
@@ -5846,7 +5854,7 @@
 /area/ship/crew/dorm/dormtwo)
 "YY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 "Zd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -5920,7 +5928,7 @@
 "ZV" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/railing/wood,
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/hydroponics)
 
 (1,1,1) = {"
@@ -6702,9 +6710,9 @@ bj
 cJ
 SG
 Fa
-UA
-UA
-UA
+CX
+CX
+CX
 fe
 pZ
 ED
@@ -6742,9 +6750,9 @@ bj
 wR
 bj
 iv
-UA
+CX
 wb
-UA
+CX
 lx
 qX
 sz
@@ -6782,9 +6790,9 @@ sz
 ow
 XN
 lA
-UA
-UA
-UA
+CX
+CX
+CX
 Vj
 XN
 MC
@@ -6818,7 +6826,7 @@ QD
 uL
 Nr
 sz
-Sn
+QL
 wd
 wd
 mV
@@ -7135,7 +7143,7 @@ xh
 rl
 db
 rl
-db
+Lq
 vC
 Nr
 wR

--- a/_maps/shuttles/shiptest/srm_glaive.dmm
+++ b/_maps/shuttles/shiptest/srm_glaive.dmm
@@ -23,9 +23,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/chicken,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "ap" = (
 /obj/machinery/airalarm/directional/east,
@@ -69,9 +67,7 @@
 "aM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "aS" = (
 /obj/item/storage/box/masks,
@@ -99,9 +95,7 @@
 /area/ship/medical)
 "aY" = (
 /obj/structure/destructible/tribal_torch,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "bi" = (
 /obj/machinery/mineral/ore_redemption,
@@ -138,9 +132,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/closet/mob_capture,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "bW" = (
 /obj/structure/railing/corner{
@@ -150,9 +142,7 @@
 /obj/item/seeds/tower,
 /obj/item/seeds/tower,
 /obj/item/hatchet,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "bY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -181,18 +171,13 @@
 /mob/living/simple_animal/crab{
 	name = "Jannet"
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "cj" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "co" = (
 /obj/machinery/power/terminal,
@@ -262,15 +247,18 @@
 "dq" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew/toilet)
+"ds" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass/ship/jungle,
+/area/ship/roumain)
 "dV" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/hostile/retaliate/goat,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "eU" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -309,9 +297,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab/bear,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "fi" = (
 /turf/closed/wall/r_wall,
@@ -402,9 +388,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "go" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -422,6 +406,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"gK" = (
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
@@ -502,9 +492,7 @@
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/seeds/lavaland/puce,
 /obj/item/seeds/lavaland/puce,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "hT" = (
 /obj/structure/cable/orange{
@@ -547,9 +535,7 @@
 	pixel_x = 6;
 	pixel_y = 7
 	},
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "ir" = (
 /obj/structure/cable/orange{
@@ -599,10 +585,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "iR" = (
 /obj/structure/cable/orange{
@@ -627,7 +610,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "iY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -721,18 +704,14 @@
 	desc = "A sturdy oak tree imported directly from the homeworld of the Montagne who runs the ship it resides on. It is planted in soil from the same place.";
 	name = "Montagne's Oak"
 	},
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "ko" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/destructible/tribal_torch,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "kD" = (
 /obj/effect/turf_decal/siding/wood{
@@ -844,9 +823,7 @@
 	pixel_y = 9;
 	pixel_x = -4
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "lM" = (
 /obj/structure/railing/corner{
@@ -857,9 +834,7 @@
 /obj/item/seeds/cotton,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "lO" = (
 /obj/structure/cable/orange{
@@ -883,9 +858,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/kirbyplants/random,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "mr" = (
 /obj/structure/cable/orange{
@@ -943,9 +916,7 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "mS" = (
 /obj/structure/cable/orange{
@@ -965,9 +936,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/cow,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "nk" = (
 /obj/item/storage/box/emptysandbags,
@@ -1055,10 +1024,7 @@
 /area/ship/engineering/engine)
 "pd" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "pH" = (
 /obj/structure/cable/orange{
@@ -1119,17 +1085,13 @@
 /area/ship/storage)
 "qJ" = (
 /obj/structure/destructible/tribal_torch,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "qN" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "qQ" = (
 /obj/item/clothing/suit/space/hardsuit/mining/heavy,
@@ -1138,21 +1100,28 @@
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/mahogany,
 /area/ship/roumain)
+"qZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	name = "Body Shutters";
+	id = "body_shutters"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/roumain)
 "re" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "rj" = (
 /obj/structure/table/wood,
 /obj/item/slimepotion/slime/sentience,
 /obj/item/slimepotion/slime/sentience,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "rD" = (
 /obj/effect/turf_decal/siding/wood/end,
@@ -1162,15 +1131,11 @@
 /turf/open/floor/wood/yew,
 /area/ship/roumain)
 "rE" = (
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "rK" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "sb" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -1182,9 +1147,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "sr" = (
 /obj/machinery/door/airlock/mining{
@@ -1215,10 +1178,14 @@
 /obj/effect/turf_decal/stoneborder{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/toilet)
+"sA" = (
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "sD" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -1313,18 +1280,14 @@
 /area/ship/storage)
 "uI" = (
 /obj/structure/railing,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "uM" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/item/lighter,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "uP" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -1398,24 +1361,18 @@
 /area/ship/roumain)
 "ww" = (
 /obj/structure/sink/puddle,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/toilet)
 "wA" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "wD" = (
 /obj/vehicle/ridden/wheelchair,
 /obj/item/melee/transforming/cleaving_saw/old,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "wE" = (
 /obj/machinery/door/airlock/glass{
@@ -1471,25 +1428,18 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "xC" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "xD" = (
 /obj/structure/sink/puddle,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/medical)
 "yn" = (
 /obj/structure/cable/orange{
@@ -1550,9 +1500,7 @@
 "yN" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "yV" = (
 /obj/item/soap/deluxe,
@@ -1567,9 +1515,7 @@
 /obj/effect/turf_decal/stoneborder{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/crew/toilet)
 "yZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1650,12 +1596,17 @@
 /obj/item/clothing/mask/gas/hunter,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
+"Ac" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/kitchenspike,
+/turf/open/floor/ship/dirt/dark,
+/area/ship/roumain)
 "Ao" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Ar" = (
 /obj/structure/closet/crate/freezer,
@@ -1732,9 +1683,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/chicken,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Bu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1758,17 +1707,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Bz" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "BB" = (
 /obj/structure/table/wood,
@@ -1801,9 +1746,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/cow,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Cr" = (
 /obj/structure/cable/orange{
@@ -1833,9 +1776,7 @@
 /obj/structure/chair/pew{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "CF" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1860,6 +1801,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/roumain)
 "Dg" = (
@@ -1874,7 +1818,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plating/grass/jungle/actuallydark,
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Du" = (
 /obj/structure/cable/orange{
@@ -1889,12 +1833,11 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "Dz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/fermenting_barrel,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
+/obj/machinery/door/poddoor{
+	id = "glaive_body_blasts";
+	name = "Body Blast Door"
 	},
+/turf/open/floor/plasteel/dark,
 /area/ship/roumain)
 "DG" = (
 /turf/closed/wall/r_wall,
@@ -1919,16 +1862,12 @@
 "DS" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "DX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Et" = (
 /obj/structure/cable/orange{
@@ -2009,9 +1948,7 @@
 "EN" = (
 /obj/item/reagent_containers/glass/bottle/diethylamine,
 /obj/item/reagent_containers/glass/bottle/diethylamine,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/construction)
 "EO" = (
 /obj/structure/cable/orange{
@@ -2026,9 +1963,7 @@
 /area/ship/medical)
 "Fa" = (
 /obj/structure/railing/corner,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Fd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2074,10 +2009,8 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/obj/structure/kitchenspike,
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Fr" = (
 /obj/structure/table/wood,
@@ -2089,10 +2022,21 @@
 /obj/structure/railing/corner,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/kitchenspike,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = -5;
+	pixel_y = -26;
+	name = "Body Blast Door Control";
+	id = "glaive_body_blasts"
 	},
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	pixel_y = -25;
+	pixel_x = 6;
+	name = "Body Holofield Switch";
+	id = "glaive_body_holo"
+	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "FA" = (
 /turf/open/floor/engine/hull,
@@ -2144,10 +2088,14 @@
 "GP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/plush/snakeplushie,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
+"Ho" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Hw" = (
 /obj/effect/turf_decal/spline/fancy{
 	dir = 1
@@ -2172,12 +2120,18 @@
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "HB" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/kitchenspike,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 1;
+	id = "glaive_body_holo"
 	},
+/obj/machinery/door/poddoor{
+	id = "glaive_body_blasts";
+	name = "Body Blast Door"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/roumain)
 "HS" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -2190,6 +2144,19 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/ship/engineering)
+"Ii" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "glaive_body_holo"
+	},
+/obj/machinery/door/poddoor{
+	id = "glaive_body_blasts";
+	name = "Body Blast Door"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/roumain)
 "Il" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2255,6 +2222,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/stairs,
 /area/ship/storage)
+"Jx" = (
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Jy" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/orange{
@@ -2299,10 +2275,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "KX" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -2312,32 +2285,30 @@
 /mob/living/simple_animal/crab{
 	name = "Tracie"
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "Lj" = (
 /obj/structure/destructible/tribal_torch,
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Lk" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
+"LF" = (
+/obj/docking_port{
+	dwidth = 13;
+	dheight = 15
+	},
+/turf/template_noop,
+/area/template_noop)
 "LG" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "LL" = (
 /obj/structure/cable/orange{
@@ -2364,9 +2335,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "Ma" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
@@ -2562,9 +2531,7 @@
 	dir = 9
 	},
 /obj/item/kirbyplants/random,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Nd" = (
 /obj/machinery/door/airlock/glass{
@@ -2614,9 +2581,7 @@
 /obj/item/seeds/lavaland/porcini,
 /obj/item/seeds/lavaland/cactus,
 /obj/item/cultivator/rake,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "NE" = (
 /obj/structure/toilet{
@@ -2629,24 +2594,18 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/toilet)
 "NL" = (
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "NT" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "NV" = (
 /obj/item/reagent_containers/glass/bottle/mutagen,
 /obj/item/reagent_containers/glass/bottle/mutagen,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/construction)
 "NX" = (
 /obj/machinery/atmospherics/components/binary/pump,
@@ -2715,19 +2674,13 @@
 /obj/structure/railing{
 	dir = 9
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "Qm" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "QA" = (
 /obj/structure/cable/orange{
@@ -2788,9 +2741,7 @@
 /area/ship/construction)
 "QX" = (
 /obj/structure/bonfire/dense,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Ra" = (
 /obj/structure/cable/orange{
@@ -2806,10 +2757,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "Rn" = (
 /obj/structure/table/wood,
@@ -2837,9 +2785,7 @@
 /area/ship/roumain)
 "RJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "RT" = (
 /obj/structure/cable/orange{
@@ -2872,6 +2818,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"Sl" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/ship/dirt/dark,
+/area/ship/roumain)
 "Sx" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -2886,9 +2836,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/loom,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "SK" = (
 /obj/structure/railing/corner{
@@ -2959,19 +2907,14 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Ue" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "Ul" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2999,9 +2942,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "US" = (
 /obj/structure/cable/orange{
@@ -3020,9 +2961,7 @@
 /mob/living/simple_animal/pet/gondola{
 	name = "Grand Hunter Montagnes"
 	},
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/construction)
 "Vn" = (
 /obj/machinery/power/terminal,
@@ -3047,9 +2986,7 @@
 	dir = 1
 	},
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "VL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3070,9 +3007,7 @@
 /area/ship/roumain)
 "VQ" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "VX" = (
 /turf/open/floor/plasteel/tech,
@@ -3118,9 +3053,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Xp" = (
 /obj/structure/table/optable,
@@ -3135,24 +3068,17 @@
 /area/ship/medical)
 "Xq" = (
 /obj/item/seeds/cotton/durathread,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/construction)
 "Xt" = (
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "XB" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "XK" = (
 /obj/structure/cable/green,
@@ -3211,9 +3137,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "greenerdirt"
-	},
+/turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "YE" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -3247,17 +3171,17 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/kirbyplants/random,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
+/obj/structure/destructible/tribal_torch,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -6;
+	pixel_x = -31
 	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "YT" = (
 /obj/item/kirbyplants/random,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	icon_state = "junglegrass"
-	},
+/turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Zh" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -3282,10 +3206,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "ZK" = (
 /obj/structure/cable/orange{
@@ -3312,10 +3233,7 @@
 /area/ship/crew/dorm)
 "ZV" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/plating{
-	icon_state = "riverwater_motion";
-	name = "wet plating"
-	},
+/turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "ZW" = (
 /obj/structure/railing/corner{
@@ -3799,8 +3717,8 @@ sH
 cR
 yZ
 CH
-AN
-FA
+qZ
+sA
 sH
 sH
 sH
@@ -3811,7 +3729,7 @@ sH
 sH
 sH
 sH
-sH
+LF
 sH
 sH
 sH
@@ -3838,8 +3756,8 @@ Cr
 AN
 uY
 AN
-FA
-FA
+gK
+sA
 sH
 sH
 sH
@@ -3877,10 +3795,10 @@ wp
 ts
 wp
 wp
-FA
-FA
-FA
-FA
+Jx
+Ho
+Ho
+sA
 FA
 FA
 sH
@@ -3915,10 +3833,10 @@ lM
 aM
 Nq
 wp
-AN
-AN
-AN
-AN
+Ii
+Dz
+Dz
+HB
 wp
 FA
 FA
@@ -3953,9 +3871,9 @@ ko
 Lk
 aM
 YP
-qJ
-Dz
-HB
+ds
+aM
+aM
 Fu
 wp
 wp
@@ -3987,7 +3905,7 @@ AN
 AN
 AN
 cg
-XB
+Ac
 NL
 LG
 NL
@@ -4180,7 +4098,7 @@ ZE
 MZ
 qN
 NL
-NL
+Sl
 NL
 NL
 NL

--- a/code/game/MapData/shuttles/srm_glaive.dm
+++ b/code/game/MapData/shuttles/srm_glaive.dm
@@ -28,7 +28,8 @@
 	req_access = list(ACCESS_SECURITY)
 
 /obj/structure/closet/secure_closet/montagnes
-	name = "\proper head of security's locker"
+	name = "\proper Hunter Montagnes Locker"
+	desc = "The posessions of the owning Hunter Montagnes."
 	req_access = list(ACCESS_HOS)
 	icon_state = "hos"
 
@@ -36,19 +37,6 @@
 	name = "mining equipment locker"
 	desc = "The closet of mining equipment."
 	icon_state = "mining"
-
-/turf/open/floor/plating/dirt/jungle/dark/actuallydark
-	light_range = 0
-	light_power = 0
-	slowdown = 0
-
-/turf/open/floor/plating/grass/jungle/actuallydark
-	light_range = 0
-	light_power = 0
-
-/turf/open/water/jungle/actuallydark
-	light_range = 0
-	light_power = 0
 
 /area/ship/external/dark
 	name = "Dark External"

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -190,3 +190,122 @@
 	base_icon_state = "tcomms"
 	icon = 'icons/turf/floors/misc.dmi'
 	color = null
+
+//ship turfs
+/turf/open/floor/ship
+	name = "Ship Plating"
+	desc = "Report a bug if you see this."
+
+/turf/open/floor/ship/dirt
+	gender = PLURAL
+	name = "dirt"
+	desc = "Upon closer examination, it's still dirt."
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "dirt"
+	footstep = FOOTSTEP_SAND
+	barefootstep = FOOTSTEP_SAND
+	clawfootstep = FOOTSTEP_SAND
+	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	tiled_dirt = FALSE
+	var/ore_type = /obj/item/stack/ore/glass
+	var/turfverb = "dig up"
+	baseturfs = /turf/open/floor/plating
+
+/turf/open/floor/ship/dirt/attackby(obj/item/C, mob/user, params)
+	if((C.tool_behaviour == TOOL_SHOVEL) && params)
+		new ore_type(src, 2)
+		user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You [turfverb] [src].</span>")
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, TRUE)
+		make_plating()
+	if(..())
+		return
+
+/turf/open/floor/ship/dirt/dark
+	icon_state = "greenerdirt"
+
+/turf/open/floor/grass/ship
+	name = "grass"
+	desc = "A patch of grass."
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_GRASS)
+	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_GRASS)
+	layer = HIGH_TURF_LAYER
+	var/smooth_icon = 'icons/turf/floors/grass.dmi'
+	baseturfs = /turf/open/floor/ship/dirt
+
+/turf/open/floor/grass/ship/Initialize(mapload, inherited_virtual_z)
+	. = ..()
+	if(smoothing_flags)
+		var/matrix/translation = new
+		translation.Translate(-9, -9)
+		transform = translation
+		icon = smooth_icon
+
+/turf/open/floor/grass/ship/jungle
+	name = "jungle grass"
+	desc = "Greener on the other side."
+	icon_state = "junglegrass"
+	base_icon_state = "junglegrass"
+	baseturfs = /turf/open/floor/ship/dirt/dark
+	smooth_icon = 'icons/turf/floors/junglegrass.dmi'
+
+/turf/open/floor/plating/ship/water
+	name = "water"
+	desc = "Shallow water."
+	icon_state = "riverwater_motion"
+	baseturfs = /turf/open/floor/ship/dirt
+	slowdown = 1
+	bullet_sizzle = TRUE
+	bullet_bounce_sound = null //needs a splashing sound one day.
+
+	footstep = FOOTSTEP_WATER
+	barefootstep = FOOTSTEP_WATER
+	clawfootstep = FOOTSTEP_WATER
+	heavyfootstep = FOOTSTEP_WATER
+
+	var/datum/reagent/reagent_to_extract = /datum/reagent/water
+	var/extracted_reagent_visible_name = "water"
+
+/turf/open/floor/plating/ship/water/attackby(obj/item/tool, mob/user, params)
+	if(!reagent_to_extract)
+		return ..()
+	var/obj/item/reagent_containers/glass/container = tool
+	if(!istype(tool, /obj/item/reagent_containers))
+		return ..()
+	if(container.reagents.total_volume >= container.volume)
+		to_chat(user, "<span class='danger'>[container] is full.</span>")
+		return
+	container.reagents.add_reagent(reagent_to_extract, rand(5, 10))
+	user.visible_message("<span class='notice'>[user] scoops [extracted_reagent_visible_name] from the [src] with \the [container].</span>", "<span class='notice'>You scoop out [extracted_reagent_visible_name] from the [src] using \the [container].</span>")
+	return TRUE
+
+/turf/open/floor/plating/ship/water/can_have_cabling()
+	return FALSE
+
+/turf/open/floor/plating/ship/water/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	switch(the_rcd.mode)
+		if(RCD_FLOORWALL)
+			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
+	return FALSE
+
+/turf/open/floor/plating/ship/water/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	switch(passed_mode)
+		if(RCD_FLOORWALL)
+			to_chat(user, "<span class='notice'>You build a floor.</span>")
+			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+			return TRUE
+	return FALSE
+
+/turf/open/floor/plating/ship/water/beach
+	color = COLOR_CYAN
+
+/turf/open/floor/plating/ship/water/beach/deep
+	color = "#0099ff"
+
+/turf/open/floor/plating/ship/water/tar
+	name = "tar pit"
+	desc = "Shallow tar. Will slow you down significantly. You could use a beaker to scoop some out."
+	color = "#222424"
+	slowdown = 2
+	reagent_to_extract = /datum/reagent/asphalt
+	extracted_reagent_visible_name = "tar"

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -22,7 +22,7 @@
 	if(!reagent_to_extract)
 		return ..()
 	var/obj/item/reagent_containers/glass/container = tool
-	if(!container)
+	if(!istype(tool, /obj/item/reagent_containers))
 		return ..()
 	if(container.reagents.total_volume >= container.volume)
 		to_chat(user, "<span class='danger'>[container] is full.</span>")

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -151,7 +151,7 @@
 	suit = /obj/item/clothing/suit/armor/hos/roumain/montagne
 	head = /obj/item/clothing/head/HoS/cowboy/montagne
 	gloves = null
-	id = /obj/item/card/id/captains_spare
+	id = /obj/item/card/id/gold
 	duffelbag = /obj/item/storage/backpack/cultpack
 	courierbag = /obj/item/storage/backpack/cultpack
 	backpack_contents = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes ship specific turfs so we don't have /plating/ planetary turfs with infinite atmos.
Replaces planetary and plating turfs on the Glaive and Shepherd.
Swaps the captain's spare the Montagnes starts with for a gold ID.
Fixes a runtime caused by attacking water with anything that isn't a container.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We didn't have any proper planetary type turfs that could be used on ships. This caused infinite atmos issues and a bandaid patch that left "plating" and "wetplating" that don't have smoothing instead. Also minor patches for the ships this touches, and a fix to a water tile related runtime are good for the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:phoaly
add: Added shipturfs
del: Old planetary turf subtypes
fix: Fixed water turfs runtiming when hit with a bat
fix: Replaced tiles on the Glaive and Shepherd
tweak: Swapped the montagnes ID
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->