### PR TITLE
Sets engine prechargers to 5kw charge by default.

### DIFF
--- a/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -133,7 +133,7 @@
 	name = "electric engine precharger"
 	desc = "A medium-capacity, high transfer superconducting magnetic energy storage unit specially made for use with shuttle engines."
 	icon = 'icons/obj/shuttle.dmi'
-	input_level = 0
+	input_level = 5000
 	input_level_max = 50000
 	output_level = 50000
 	circuit = /obj/item/circuitboard/machine/shuttle/smes
@@ -145,9 +145,6 @@
 	name = "micro electric engine precharger"
 	desc = "A low-capacity, high transfer superconducting magnetic energy storage unit specially made for use with compact shuttle engines."
 	icon = 'icons/obj/shuttle.dmi'
-	input_level = 0
-	input_level_max = 50000
-	output_level = 50000
 	circuit = /obj/item/circuitboard/machine/shuttle/smes/micro
 	density = 0
 	capacity = 1e6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This information isn't conveyed through anything other than word of mouth really and I've seen quite a few new players run into issues. Until we have less sort-of-abstract ship mechanics I feel this is a good change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Engine prechargers now start with a 5kw charge leve.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
