### PR TITLE
Pixel shifting out of the way port from Skyrat

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -21,9 +21,9 @@
 		if(.) //not dead
 			handle_blood()
 
-//		if(isLivingSSD())//if you're disconnected, you're going to sleep
-//			if(AmountSleeping() < 20)
-//				AdjustSleeping(20)//adjust every 10 seconds
+		if(isLivingSSD())//if you're disconnected, you're going to sleep
+			if(AmountSleeping() < 20)
+				AdjustSleeping(20)//adjust every 10 seconds
 
 		if(stat != DEAD)
 			var/bprv = handle_bodyparts()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -21,9 +21,9 @@
 		if(.) //not dead
 			handle_blood()
 
-		if(isLivingSSD())//if you're disconnected, you're going to sleep
-			if(AmountSleeping() < 20)
-				AdjustSleeping(20)//adjust every 10 seconds
+//		if(isLivingSSD())//if you're disconnected, you're going to sleep
+//			if(AmountSleeping() < 20)
+//				AdjustSleeping(20)//adjust every 10 seconds
 
 		if(stat != DEAD)
 			var/bprv = handle_bodyparts()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -228,3 +228,6 @@
 
 	///Is the mob actively shifting?
 	var/shifting
+
+	/// Takes the four cardinal direction defines. Any atoms moving into this atom's tile will be allowed to from the added directions.
+	var/passthroughable = NONE

--- a/code/modules/pixelshifting/pixelshift.dm
+++ b/code/modules/pixelshifting/pixelshift.dm
@@ -63,7 +63,7 @@
 
 /mob/living/CanAllowThrough(atom/movable/mover, border_dir)
 	// Make sure to not allow projectiles of any kind past where they normally wouldn't.
-	if(!istype(mover, /obj/projectile) && !mover.throwing && passthroughable & border_dir)
+	if(!istype(mover, /obj/projectile) && !mover.throwing && passthroughable & get_dir(src, border_dir))
 		return TRUE
 	return ..()
 

--- a/code/modules/pixelshifting/pixelshift.dm
+++ b/code/modules/pixelshifting/pixelshift.dm
@@ -1,3 +1,6 @@
+#define MAXIMUM_PIXEL_SHIFT 16
+#define PASSABLE_SHIFT_THRESHOLD 8
+
 /mob/proc/unpixel_shift()
 	return
 
@@ -5,34 +8,64 @@
 	return
 
 /mob/living/unpixel_shift()
+	. = ..()
+	passthroughable = NONE
 	if(is_shifted)
 		is_shifted = FALSE
 		pixel_x = body_pixel_x_offset + base_pixel_x
 		pixel_y = body_pixel_y_offset + base_pixel_y
+/mob/living/set_pull_offsets(mob/living/pull_target, grab_state)
+	pull_target.unpixel_shift()
+	return ..()
+
+/mob/living/reset_pull_offsets(mob/living/pull_target, override)
+	pull_target.unpixel_shift()
+	return ..()
 
 /mob/living/pixel_shift(direction)
+	passthroughable = NONE
 	switch(direction)
 		if(NORTH)
 			if(!canface())
 				return FALSE
-			if(pixel_y <= 16 + base_pixel_y)
+			if(pixel_y <= MAXIMUM_PIXEL_SHIFT + base_pixel_y)
 				pixel_y++
 				is_shifted = TRUE
 		if(EAST)
 			if(!canface())
 				return FALSE
-			if(pixel_x <= 16 + base_pixel_x)
+			if(pixel_x <= MAXIMUM_PIXEL_SHIFT + base_pixel_x)
 				pixel_x++
 				is_shifted = TRUE
 		if(SOUTH)
 			if(!canface())
 				return FALSE
-			if(pixel_y >= -16 + base_pixel_y)
+			if(pixel_y >= -MAXIMUM_PIXEL_SHIFT + base_pixel_y)
 				pixel_y--
 				is_shifted = TRUE
 		if(WEST)
 			if(!canface())
 				return FALSE
-			if(pixel_x >= -16 + base_pixel_x)
+			if(pixel_x >= -MAXIMUM_PIXEL_SHIFT + base_pixel_x)
 				pixel_x--
 				is_shifted = TRUE
+
+	// Yes, I know this sets it to true for everything if more than one is matched.
+	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
+	if(pixel_y > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= EAST | SOUTH | WEST
+	if(pixel_x > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | SOUTH | WEST
+	if(pixel_y < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | WEST
+	if(pixel_x < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | SOUTH
+
+/mob/living/CanAllowThrough(atom/movable/mover, border_dir)
+	// Make sure to not allow projectiles of any kind past where they normally wouldn't.
+	if(!istype(mover, /obj/projectile) && !mover.throwing && passthroughable & border_dir)
+		return TRUE
+	return ..()
+
+#undef MAXIMUM_PIXEL_SHIFT
+#undef PASSABLE_SHIFT_THRESHOLD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports pixel shifting out of the way from skyrat.
https://github.com/Skyrat-SS13/Skyrat-tg/pull/15175
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes it way more convenient to players that are pixel shifted won't get pushed around except from the direction they shifted in. This makes so those players that usually talking near a wall don't block the way or gets their RP interrupted.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Allows pixel shifted players to not be pushed around depending on direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
