### PR TITLE
Adds buckling to adjacent objects and fixes a bug when climbing tables you are already on

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -41,7 +41,7 @@
 
 /atom/movable/proc/mouse_buckle_handling(mob/living/M, mob/living/user)
 	if(can_buckle && istype(M) && istype(user))
-		if(user_buckle_mob(M, user))
+		if(user_buckle_mob(M, user, check_loc = FALSE))
 			return TRUE
 
 /atom/movable/proc/has_buckled_mobs()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -48,6 +48,8 @@
 	. = ..()
 	if(!climbable)
 		return
+	if(get_turf(src) == O.loc) //makes so you can't drag yourself into the same structure to climb again, making you move off it.
+		return
 	if(user == O && isliving(O))
 		var/mob/living/L = O
 		if(isanimal(L))

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -47,7 +47,7 @@
 			unbuckle_mob(M)
 			add_fingerprint(user)
 
-/obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/living/user)
+/obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/living/user, check_loc = FALSE)
 	if (!ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.incapacitated() || M.buckled)
 		return
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -91,7 +91,7 @@
 
 
 
-/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user) //Don't want them getting put on the rack other than by spiking
+/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user, check_loc = FALSE) //Don't want them getting put on the rack other than by spiking
 	return
 
 /obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -585,7 +585,7 @@
 	smoothing_groups = null
 	canSmoothWith = null
 	can_buckle = 1
-	buckle_lying = NO_BUCKLE_LYING
+	buckle_lying = 90 //I don't see why you wouldn't be lying down while buckled to it
 	buckle_requires_restraints = FALSE
 	can_flip = FALSE
 	var/mob/living/carbon/human/patient = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -597,7 +597,7 @@
 
 //ANIMAL RIDING
 
-/mob/living/simple_animal/user_buckle_mob(mob/living/M, mob/user)
+/mob/living/simple_animal/user_buckle_mob(mob/living/M, mob/user, check_loc = FALSE)
 	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding)
 	if(riding_datum)
 		if(user.incapacitated())

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -79,7 +79,7 @@ It is possible to destroy the net by the occupant or someone else.
 /obj/structure/energy_net/attack_paw(mob/user)
 	return attack_hand()
 
-/obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)
+/obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user, check_loc = FALSE)
 	return//We only want our target to be buckled
 
 /obj/structure/energy_net/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -397,7 +397,7 @@
 	auto.Remove(buckled_mob)
 	. = ..()
 
-/obj/machinery/power/emitter/prototype/user_buckle_mob(mob/living/M, mob/living/carbon/user)
+/obj/machinery/power/emitter/prototype/user_buckle_mob(mob/living/M, mob/living/carbon/user, check_loc = FALSE)
 	if(user.incapacitated() || !istype(user))
 		return
 	for(var/atom/movable/A in get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it possible to buckle to things from the tile next to it. Also fixes a bug where you can climb tables twice, resulting in being moved off it even while buckled.

Similar to https://github.com/tgstation/tgstation/pull/55741

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more suffering to sit down in a chair while your char sprite is completely blocking the other sprite, instead we are able to just buckle from the adjacent tile!
![dreamseeker_aqVxvqkkwG](https://github.com/shiptest-ss13/Shiptest/assets/132854285/56478162-4011-4670-a3e0-d052d788e52d)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: you can now buckle to things while on adjacent tiles
fix: fixed a bug where you could climb the table you are standing on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
