### PR TITLE
NT radio key reclamation lawsuit (band-aid fix TAKE TWO!)

### DIFF
--- a/_maps/configs/independent_box.json
+++ b/_maps/configs/independent_box.json
@@ -11,7 +11,10 @@
 	"prefix": "ISV",
 	"job_slots": {
 		"Chief Medical Officer": 1,
-		"Medical Doctor": 3,
+		"Medical Doctor": {
+			"outfit": "/datum/outfit/job/doctor",
+			"slots": 3
+		},
 		"Paramedic": 2,
 		"Assistant": 3
 	},

--- a/_maps/configs/independent_boyardee.json
+++ b/_maps/configs/independent_boyardee.json
@@ -10,7 +10,10 @@
 	"map_short_name": "Boyardee-class",
 	"map_path": "_maps/shuttles/shiptest/independent_boyardee.dmm",
 	"job_slots": {
-		"Bartender": 1,
+		"Bartender": {
+			"outfit": "/datum/outfit/job/bartender",
+			"slots": 1
+		},
 		"Cook": 3,
 		"Botanist": 2,
 		"Janitor": 1,

--- a/_maps/configs/independent_meta.json
+++ b/_maps/configs/independent_meta.json
@@ -12,7 +12,10 @@
 	"job_slots": {
 		"Captain": 1,
 		"Quartermaster": 1,
-		"Medical Doctor": 1,
+		"Medical Doctor": {
+			"outfit": "/datum/outfit/job/doctor",
+			"slots": 1
+		},
 		"Station Engineer": 1,
 		"Shaft Miner": 1,
 		"Assistant": 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nanotrasen higher-ups have recently discovered that a shipment (or three/twelve) of it's command staff headsets had been mistakenly ear-marked and sold to the makers of the following independant vessels and shared freely with the indicated staff positions.

meta-class freighter (medical doctor, shaft miner)
box-class hospital ship (medical doctor)
boyardee entertainment vessel (bartender)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistency is good and having faction command headsets being available to independents doesn't make any kind of sense.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: rewrote the config.jsons for the meta, boyardee and box-class ships to enforce proper headset pathing instead of resorting to default path, which is NT apparently?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
