### PR TITLE
Replaces Bar Tables in maps

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
@@ -11,7 +11,7 @@
 /turf/open/floor/carpet,
 /area/ruin/beach)
 "av" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/cubancarp{
 	pixel_y = 6;
 	pixel_x = 11
@@ -970,7 +970,7 @@
 /turf/open/water/beach/deep,
 /area/ruin/beach)
 "MT" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/fishfry{
 	pixel_y = 8;
 	pixel_x = 2
@@ -1027,7 +1027,7 @@
 /turf/open/floor/plating/asteroid/sand,
 /area/ruin/beach)
 "Pj" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
 /obj/item/binoculars{
 	pixel_x = -1;
@@ -1215,7 +1215,7 @@
 /turf/open/floor/plastic,
 /area/ruin/beach)
 "WP" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_carp{
 	pixel_y = 7;
 	pixel_x = 9
@@ -1247,7 +1247,7 @@
 /turf/open/water/beach/deep,
 /area/ruin/beach)
 "Xr" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_y = 8
 	},

--- a/_maps/RandomRuins/BeachRuins/beach_ocean_town.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_ocean_town.dmm
@@ -370,11 +370,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/beach/oceantown/bar)
-"eI" = (
-/obj/structure/table/wood/bar,
-/obj/item/flashlight/lamp,
-/turf/open/floor/carpet,
-/area/ruin/beach/oceantown)
 "eJ" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -1625,10 +1620,6 @@
 	light_range = 2
 	},
 /area/ruin/beach/oceantown)
-"vn" = (
-/obj/structure/table/wood/bar,
-/turf/open/floor/carpet/green,
-/area/ruin/beach/oceantown)
 "vp" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -1896,7 +1887,7 @@
 	},
 /area/ruin/beach/oceantown)
 "yC" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/green,
 /area/ruin/beach/oceantown)
@@ -2508,7 +2499,7 @@
 	},
 /area/ruin/beach/oceantown)
 "EX" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/book/manual/ripley_build_and_repair,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -2651,7 +2642,7 @@
 	},
 /area/ruin/beach/oceantown)
 "Gz" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/book/manual/wiki/medical_cloning,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood,
@@ -3045,7 +3036,7 @@
 	},
 /area/ruin/beach/oceantown)
 "Kr" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp,
 /turf/open/floor/carpet,
 /area/ruin/beach/oceantown)
@@ -3766,7 +3757,7 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ruin/beach/oceantown/shop)
 "SV" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/green,
 /area/ruin/beach/oceantown)
@@ -9008,7 +8999,7 @@ Wl
 xh
 ar
 UA
-vn
+vI
 EH
 Ns
 mu
@@ -9704,7 +9695,7 @@ im
 xh
 QI
 OW
-eI
+FI
 xh
 YU
 YU

--- a/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
@@ -98,7 +98,7 @@
 /turf/open/floor/plating/rust,
 /area/ruin/jungle/interceptor/porthall)
 "bb" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -1720,7 +1720,7 @@
 /turf/open/floor/plating/rust,
 /area/ruin/jungle/interceptor/starlaunchertwo)
 "oz" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -2336,7 +2336,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/jungle/interceptor/afthall)
 "tQ" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -2457,7 +2457,7 @@
 /turf/open/floor/plating/dirt/jungle/dark/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "uR" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
@@ -2761,7 +2761,7 @@
 /turf/open/floor/plating/grass/jungle/lit,
 /area/ruin/jungle/interceptor/porthall)
 "xa" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -4075,7 +4075,7 @@
 /turf/open/floor/plating/dirt/jungle/lit,
 /area/ruin/jungle/interceptor/crashsite)
 "Je" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -4938,7 +4938,7 @@
 /turf/open/floor/plating,
 /area/ruin/jungle/interceptor/porthall)
 "Qf" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -6007,7 +6007,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/jungle/interceptor/starlauncherone)
 "XQ" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,

--- a/_maps/RandomRuins/SpaceRuins/spacemall.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacemall.dmm
@@ -2737,7 +2737,7 @@
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/spacemall/shop)
 "ko" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5191,7 +5191,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/spacemall/shop)
 "td" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -11930,7 +11930,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/spacemall)
 "Sm" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/paystand,
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2375,7 +2375,7 @@
 /turf/open/floor/grass,
 /area/wizard_station)
 "ayM" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/structure/safe/floor,
 /obj/item/seeds/cherry/bomb,
 /turf/open/floor/wood,
@@ -5208,7 +5208,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "aTq" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/storage/toolbox/mechanical,
@@ -5264,7 +5264,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/holding)
 "aTK" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/structure/mirror{
 	pixel_y = 28
 	},

--- a/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
@@ -4322,7 +4322,7 @@
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)
 "zs" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/food/drinks/modglass/large,
 /obj/item/reagent_containers/food/drinks/modglass/large,

--- a/_maps/templates/holodeck_lounge.dmm
+++ b/_maps/templates/holodeck_lounge.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag{
 	pixel_x = 10;
 	pixel_y = 1
@@ -30,7 +30,7 @@
 	},
 /area/template_noop)
 "d" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"
@@ -53,7 +53,7 @@
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "i" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -114,7 +114,7 @@
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "t" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -181,7 +181,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/item/storage/box/cups,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -291,7 +291,7 @@
 	},
 /area/template_noop)
 "Y" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9

--- a/tools/UpdatePaths/Scripts/2064_replace_bartables.txt
+++ b/tools/UpdatePaths/Scripts/2064_replace_bartables.txt
@@ -1,0 +1,1 @@
+/obj/structure/table/wood/bar : /obj/structure/table/wood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces Bar Tables in all maps with standard Wooden Tables, as requested by #1981 (permission and method suggested by Erika). Bar Tables are still intact in code, and the method used was via the UpdatePaths tool.

## Why It's Good For The Game

Prevents people from getting randomly flung around in ruin maps. Notably due to the fact that the Bar Table isn't widely being used or acknowledged anymore.
fixed #1981 

## Changelog

:cl:
tweak: Replaced Bar Tables in all maps where present
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
