### PR TITLE
IMV ship prefix

### DIFF
--- a/_maps/configs/independent_box.json
+++ b/_maps/configs/independent_box.json
@@ -8,7 +8,7 @@
 		"SPACE",
 		"NATURAL"
 	],
-	"prefix": "ISV",
+	"prefix": "IMV",
 	"job_slots": {
 		"Chief Medical Officer": 1,
 		"Medical Doctor": {

--- a/_maps/configs/independent_litieguai.json
+++ b/_maps/configs/independent_litieguai.json
@@ -3,6 +3,7 @@
 	"map_name": "Li Tieguai-class Rescue Ship",
 	"map_short_name": "Li Tieguai-class",
 	"map_path": "_maps/shuttles/shiptest/independent_litieguai.dmm",
+	"prefix": "IMV",
 	"namelists": [
 		"SPACE",
 		"BEASTS",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
gives the box and li tieguai class the IMV prefix
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i saw a ship in need of medical help get forced to do ghetto surgery because they could not distinguish the one li-tieguai from all the other ISVs. the crew of the li tieguai did not know that changing the prefix is important and as such missed a ship interaction opportunity 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: the box and li-tieguai class ships now have the IMV (independent medical vessel) prefix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
