### PR TITLE
Fixes the "Spawn Planet/Ruin" verb in the Fun tab

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -843,7 +843,7 @@
 				else
 					ruin_target = select_from[selected_ruin]
 
-	var/list/position
+	var/list/position = list()
 	if(tgui_alert(usr, "Where do you want to spawn your Planet/Ruin?", "Spawn Planet/Ruin", list("Pick a location", "Random")) == "Pick a location")
 		position["x"] = input(usr, "Choose your X coordinate", "Pick a location", rand(1,SSovermap.size)) as num
 		position["y"] = input(usr, "Choose your Y coordinate", "Pick a location", rand(1,SSovermap.size)) as num


### PR DESCRIPTION
## About The Pull Request

A 7 character fix ( var/list/position -> var/list/position = list() )
Basically, the code segment wasn't executing past the X coordinate input due to the list not being properly initialized (i'm not really sure how this even got past testing. was it tested?).

## Why It's Good For The Game

Fixes the verb to spawn Ruins on the overmap. 
fixes #1841 

## Changelog

:cl:
fix: "Spawn Planet/Ruin" Admin verb
/:cl: