### PR TITLE
[DRAFT] Reworks some mining stuff 

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -116,7 +116,7 @@
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/stack/ore))
 	STR.max_w_class = WEIGHT_CLASS_HUGE
-	STR.max_combined_stack_amount = 50
+	STR.max_combined_stack_amount = 100
 
 /obj/item/storage/bag/ore/equipped(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Im going to change how some mining stuff works. Right now the only thing on this PR is an increase in the amount of ore mining bags can hold.
Things I hope to do with this PR:
- [ ] Rework the KPA into a sort of crank-charged energy gun with an internal magazine (instead of a generic infinite mining gun) and some neat new modkits
- [ ] Change how the Crusher functions slightly and make it able to be used as a pickaxe
- [ ] Fix mining vendors falsely displaying most of their items as FREE despite retaining their normal price (If anyone knows how to do this PLEASE tell me so I can fix it)
- [ ] Maybe mess with the loot pools for tendrils to be more useful and less powergame-y
- [ ] Probably nuke pulsating tumors from orbit so that elites can have their own maps and arenas instead of being miner fodder
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slaying the ghosts of lavaland balance's past would probably make the game more enjoyable. Mining equipment is simply a pain in the ass to balance effectively.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: I'll do this later.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
