### PR TITLE
cools down lava planets

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -25,9 +25,9 @@
 	// fires start at 100C; occasionally, there would be a perma-plasmafire, too tiny to notice.
 	// even worse, occasionally there would be a perma-TRITFIRE, if oxygen
 	// concentration was high enough. this caused a bunch of lag and added nothing to the game whatsoever
-	// thus, the temperatures were reduced to 70-99 C
+	// thus, the temperatures were reduced to 70-90 C
 	minimum_temp = T20C + 50
-	maximum_temp = T20C + 79
+	maximum_temp = T20C + 70
 
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -21,8 +21,13 @@
 	minimum_pressure = WARNING_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
-	minimum_temp = T20C + 80
-	maximum_temp = T20C + 120
+	// temperature range USED to be 100-140 C. this was bad, because
+	// fires start at 100C; occasionally, there would be a perma-plasmafire, too tiny to notice.
+	// even worse, occasionally there would be a perma-TRITFIRE, if oxygen
+	// concentration was high enough. this caused a bunch of lag and added nothing to the game whatsoever
+	// thus, the temperatures were reduced to 70-99 C
+	minimum_temp = T20C + 50
+	maximum_temp = T20C + 79
 
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS


### PR DESCRIPTION
## About The Pull Request

Lava planets have a randomized atmosphere determined at roundstart. This atmosphere may contain plasma, and was always hot enough to ignite. This plasma would burn perpetually, constantly recycled by the planetary atmosphere, at concentrations too low to be visible or to have meaningful game impact. If the atmosphere also generated with sufficient oxygen, the plasma would burn to tritium, which would itself burn before being removed by the atmosphere, generating tiny radiation pulses too minor to be detected with a Geiger counter in testing.

This is a likely candidate for some persistent lag and bugs with SSradiation on the game server. This PR lowers the atmospheric temperature range of lavaland below plasma's ignition temperature; it shouldn't be able to combust on its own, and any fires that do appear should be dragged below the ignition temperature by the planetary atmosphere.

This might have some weird niche balance implications for body temperature interactions. I don't really care that much, though.

## Why It's Good For The Game

infinite tiny tritfires are bad for the server

## Changelog

:cl:
tweak: Lava planets have been cooled below plasma's ignition temperature.
/:cl: