### PR TITLE
Alt-Click door assemblies to rotate them

### DIFF
--- a/code/game/gamemodes/sandbox/airlock_maker.dm
+++ b/code/game/gamemodes/sandbox/airlock_maker.dm
@@ -14,6 +14,13 @@
 	if(maker)
 		maker.interact()
 
+/obj/structure/door_assembly/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+
+/obj/structure/door_assembly/proc/can_be_rotated(mob/user, rotation_type)
+	return !anchored
+
 /datum/airlock_maker
 	var/obj/structure/door_assembly/linked = null
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1483,6 +1483,7 @@
 		A.previous_assembly = previous_airlock
 		A.update_name()
 		A.update_icon()
+		A.dir = dir
 
 		if(!disassembled)
 			if(A)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -65,6 +65,7 @@
 		assembly.update_name()
 		assembly.update_icon()
 		assembly.welded = TRUE
+		assembly.dir = dir
 		new /obj/item/electronics/airlock(loc)
 	qdel(src)
 

--- a/code/game/objects/structures/poddoor_assembly.dm
+++ b/code/game/objects/structures/poddoor_assembly.dm
@@ -24,6 +24,13 @@
 	update_icon()
 	update_door_name()
 
+/obj/structure/poddoor_assembly/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+
+/obj/structure/poddoor_assembly/proc/can_be_rotated(mob/user, rotation_type)
+	return !anchored
+
 /obj/structure/poddoor_assembly/examine(mob/user)
 	. = ..()
 	var/doorname = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
see title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
construction qol
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: you can rotate door assemblies with alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
