### PR TITLE
Stabilizes space_level handling, preventing overlapping planet generation/allocation

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -251,7 +251,9 @@ SUBSYSTEM_DEF(mapping)
 /// Creates basic physical levels so we dont have to do that during runtime every time, nothing bad will happen if this wont run, as allocation will handle adding new levels
 /datum/controller/subsystem/mapping/proc/init_reserved_levels()
 	add_new_zlevel("Free Allocation Level", allocation_type = ALLOCATION_FREE)
+	CHECK_TICK
 	add_new_zlevel("Quadrant Allocation Level", allocation_type = ALLOCATION_QUADRANT)
+	CHECK_TICK
 
 /datum/controller/subsystem/mapping/proc/preloadHolodeckTemplates()
 	for(var/item in subtypesof(/datum/map_template/holodeck))

--- a/code/modules/mapping/space_management/space_level.dm
+++ b/code/modules/mapping/space_management/space_level.dm
@@ -15,16 +15,14 @@
 	allocation_type = new_allocation_type
 
 /datum/space_level/proc/is_box_free(low_x, low_y, high_x, high_y)
-	. = TRUE
 	for(var/datum/virtual_level/vlevel as anything in virtual_levels)
 		if(low_x <= vlevel.high_x && vlevel.low_x <= high_x && low_y <= vlevel.high_y && vlevel.low_y <= high_y)
-			. = FALSE
-			break
+			return FALSE
 
 	for(var/datum/dummy_space_reservation/dlevel as anything in dummy_reservations)
 		if(low_x <= dlevel.high_x && dlevel.low_x <= high_x && low_y <= dlevel.high_y && dlevel.low_y <= high_y)
-			. = FALSE
-			break
+			return FALSE
+	return TRUE
 
 /// Datum used for safeguarding a reservation in case of asynchronous operations
 /datum/dummy_space_reservation

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -22,12 +22,14 @@
 
 /// Adds new physical space level. DO NOT USE THIS TO LOAD SOMETHING NEW. SSmapping.get_free_allocation() will create any levels nessecary and pass you coordinates to create a new virtual level
 /datum/controller/subsystem/mapping/proc/add_new_zlevel(name, z_type = /datum/space_level, allocation_type = ALLOCATION_FREE)
+	SHOULD_NOT_SLEEP(TRUE)
+	// This proc used to sleep. It caused an infuriating desynchronization: new_z would calculate, the max z would be increased, and then the proc used CHECK_TICK.
+	// As a result, two space_levels could be added to the z_list, each believing itself to reside at the same z-coodinate.
+	// Watch your fucking race conditions.
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_Z, args)
 	var/new_z = z_list.len + 1
 	if (world.maxz < new_z)
 		world.incrementMaxZ()
-		CHECK_TICK
-	// TODO: sleep here if the Z level needs to be cleared
 	var/datum/space_level/S = new z_type(new_z, name, allocation_type)
 	z_list += S
 	return S


### PR DESCRIPTION
## About The Pull Request

During a recent uptime, the bottom-left corner of a z-level became "cursed". New planets would all generate there, regardless of whether a previous planet already had. When any of the planets unloaded themselves, they would unload their reserve with them, deleting the planet unexpectedly. The other planets which had also generated in the same spot were left behind, appearing to be empty space: in truth, they were the gap left behind after a virtual level is cleared.

As I wasn't able to diagnose the exact cause of the bug during the round it occurred, this PR is admittedly a little bit of a shot in the dark. My initial guess was that there was a null living in the list of virtual_levels on that space_level. Although there weren't runtimes to back this up, I've preemptively fixed that potential bug anyway. Another possibility, which I have also addressed, was downstream of a race condition resulting from the presence of a CHECK_TICK in add_new_zlevel: I have eliminated the race condition by removing the sleep.

## Why It's Good For The Game

Planets overwriting other planets, and deleting people's ships, is bad. That shouldn't happen.

## Changelog

:cl:
fix: Different planets should hopefully no longer repeatedly generate in the exact same part of the map, overwriting each other and causing double-dock SGTs.
/:cl:
