### PR TITLE
Fixes the Independent Litieguai organ freezer

### DIFF
--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -225,21 +225,8 @@
 "fn" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/airalarm/directional/south,
-/obj/structure/closet/crate/freezer/surplus_limbs{
-	name = "organ freezer"
-	},
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/lungs,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
 /obj/effect/turf_decal/industrial/hatch/red,
+/obj/structure/closet/crate/freezer/surplus_limbs/organs,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/medical)
 "fp" = (

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -175,6 +175,24 @@
 	new /obj/item/bodypart/leg/left/robot/surplus/vox(src)
 	new /obj/item/bodypart/leg/right/robot/surplus/vox(src)
 
+/obj/structure/closet/crate/freezer/surplus_limbs/organs
+	name = "organ freezer"
+	desc = "A crate containing a variety of spare limbs and organs."
+
+/obj/structure/closet/crate/freezer/surplus_limbs/organs/PopulateContents()
+	. = ..()
+	new /obj/item/organ/stomach(src)
+	new /obj/item/organ/stomach(src)
+	new /obj/item/organ/lungs(src)
+	new /obj/item/organ/liver(src)
+	new /obj/item/organ/liver(src)
+	new /obj/item/organ/eyes(src)
+	new /obj/item/organ/eyes(src)
+	new /obj/item/organ/heart(src)
+	new /obj/item/organ/heart(src)
+	new /obj/item/organ/ears(src)
+	new /obj/item/organ/ears(src)
+
 /obj/structure/closet/crate/radiation
 	desc = "A crate with a radiation sign on it."
 	name = "radiation crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TLDR - The Litieguai's provided organs now decay as you would expect, pausing when in the shut freezer crate.

As to the nature of the bug, just in case there's a more generalized solution anyone could suggest:
Freezer crates work by toggling the decay state of organs, whenever the crate is opened or closed, as well as when the crate is initialized- in order to freeze any organs that are inside when created.

However, currently the organs are just dropped onto the same tile as the crate, and picked up on a 0 second timer (so after the freeze toggle), which leads to the organs having an inverted decay state- only decaying when the box is closed, and stopping their decay when the box is opened and even when picked up or moved to the floor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix bugs! Also turn an interesting snowflake crate into a proper subtype, perhaps encouraging it to be used elsewhere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Independent Litieguai's organ freezer now properly freezes the provided organs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
