### PR TITLE
Add's missing APCs to the Osprey

### DIFF
--- a/_maps/shuttles/shiptest/nanotrasen_osprey.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_osprey.dmm
@@ -556,6 +556,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/cryo)
 "eh" = (
@@ -782,6 +783,7 @@
 /obj/item/assembly/flash/handheld{
 	pixel_x = -5
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "fJ" = (
@@ -1284,6 +1286,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "ja" = (
@@ -2989,6 +2992,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew/toilet)
 "tp" = (
@@ -4612,6 +4616,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "DE" = (
@@ -4720,6 +4725,7 @@
 /obj/item/clothing/suit/toggle/labcoat,
 /obj/item/storage/belt/medical,
 /obj/item/clothing/glasses/hud/health,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Ek" = (
@@ -6200,6 +6206,7 @@
 	},
 /obj/structure/cable,
 /obj/item/holosign_creator/janibarrier,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plasteel,
 /area/ship/crew/janitor)
 "OA" = (
@@ -6832,6 +6839,7 @@
 /obj/item/clothing/gloves/fingerless,
 /obj/item/megaphone/cargo,
 /obj/item/clothing/head/safety_helmet,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plasteel,
 /area/ship/cargo/office)
 "SK" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some strange reason, the Osprey only has 4 APCs, and many of its areas are missing them, this gives the areas infinite power with no usage. There were underfloor wires that lead to blank walls, presumably where APCs used to be, so I've added them back to their original locations.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the Osprey function as I'd assume was intended, makes areas no longer have infinite power.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Added Missing APCs to the Osprey
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
