### PR TITLE
Hunter Montagne fix

### DIFF
--- a/_maps/configs/srm_glaive.json
+++ b/_maps/configs/srm_glaive.json
@@ -11,7 +11,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Hunter Montagne": {
-			"outfit": "/datum/outfit/job/chaplain/roumain",
+			"outfit": "/datum/outfit/job/hos/roumain",
 			"officer": true,
 			"slots": 1
 		},

--- a/code/game/MapData/shuttles/srm_glaive.dm
+++ b/code/game/MapData/shuttles/srm_glaive.dm
@@ -48,7 +48,7 @@
 	icon_state = "Sleep"
 
 /datum/preset_holoimage/montagne
-	outfit_type = /datum/outfit/job/chaplain/roumain
+	outfit_type = /datum/outfit/job/hos/roumain
 
 /obj/item/disk/holodisk/roumain
 	name = "Grand Ideology Sermon"

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -142,19 +142,3 @@
 	name = "Chaplain (Rabbi)"
 	head = /obj/item/clothing/head/kippah
 	l_hand = /obj/item/storage/book/bible/torah
-
-/datum/outfit/job/chaplain/roumain
-	name = "Hunter Montagne (Saint-Roumain Militia)"
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
-	shoes = /obj/item/clothing/shoes/workboots/mining
-	suit = /obj/item/clothing/suit/armor/hos/roumain/montagne
-	head = /obj/item/clothing/head/HoS/cowboy/montagne
-	gloves = null
-	id = /obj/item/card/id/gold
-	duffelbag = /obj/item/storage/backpack/cultpack
-	courierbag = /obj/item/storage/backpack/cultpack
-	backpack_contents = list(
-		/obj/item/stamp/chap = 1,
-		/obj/item/melee/classic_baton/telescopic=1
-		)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -96,3 +96,38 @@
 	gloves = /obj/item/clothing/gloves/combat
 	backpack_contents = list(/obj/item/melee/baton/loaded=1)
 	suit_store = null
+
+/datum/outfit/job/hos/roumain
+	jobtype = /datum/job/hos/roumain
+	name = "Hunter Montagne (Saint-Roumain Militia)"
+	ears = /obj/item/radio/headset/headset_com
+	uniform = /obj/item/clothing/under/suit/roumain
+	alt_uniform = null
+	shoes = /obj/item/clothing/shoes/workboots/mining
+	suit = /obj/item/clothing/suit/armor/hos/roumain/montagne
+	alt_suit = null
+	dcoat = null
+	head = /obj/item/clothing/head/HoS/cowboy/montagne
+	gloves = null
+	id = /obj/item/card/id/silver
+	belt = null
+	glasses = null
+	suit_store = null
+	r_pocket = null
+	l_pocket = null
+	duffelbag = /obj/item/storage/backpack/cultpack
+	courierbag = /obj/item/storage/backpack/cultpack
+	backpack = /obj/item/storage/backpack/cultpack
+	satchel = /obj/item/storage/backpack/cultpack
+	box = null
+	implants = null
+	chameleon_extras = null
+	backpack_contents = list(
+		/obj/item/book/manual/srmlore,
+		/obj/item/stamp/chap = 1,
+		/obj/item/melee/classic_baton/telescopic=1
+		)
+
+/datum/job/hos/roumain
+	outfit = /datum/outfit/job/hos/roumain
+	mind_traits = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I originally thought that the Hunter Montagne locker not unlocking was an issue with job overrides in the json. I was super wrong oopsies.
This changes the montagne job and outfit to be a subtype of the hos, and strips away the hossy stuff that shouldn't be there.
![image](https://github.com/shiptest-ss13/Shiptest/assets/55075747/ec5dae34-80a2-4adb-ad95-deb6b957b895)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The hunter montagne now has proper access.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:phoaly
tweak: tweaks the Hunter Montagne job outfit and job datum
fix: Fixes #2101 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
