### PR TITLE
Hotspots no longer ignite reinforced floors

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -1,3 +1,7 @@
+#define IGNITE_TURF_CHANCE 30
+#define IGNITE_TURF_LOW_POWER 8
+#define IGNITE_TURF_HIGH_POWER 22
+
 /turf/open
 	plane = FLOOR_PLANE
 
@@ -175,6 +179,12 @@
 	air.set_temperature(air.return_temperature() + temp)
 	air_update_turf()
 
+/turf/open/temperature_expose()
+	if(prob(IGNITE_TURF_CHANCE))
+		var/turf/my_turf = loc
+		my_turf.IgniteTurf(rand(IGNITE_TURF_LOW_POWER,IGNITE_TURF_HIGH_POWER))
+	return ..()
+
 /turf/open/proc/freon_gas_act()
 	for(var/obj/I in contents)
 		if(I.resistance_flags & FREEZE_PROOF)
@@ -271,3 +281,7 @@
 	if(isgroundlessturf(src))
 		return
 	new /obj/effect/abstract/turf_fire(src, power, fire_color)
+
+#undef IGNITE_TURF_CHANCE
+#undef IGNITE_TURF_LOW_POWER
+#undef IGNITE_TURF_HIGH_POWER

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -32,6 +32,9 @@
 		..()
 	return //unplateable
 
+/turf/open/floor/engine/temperature_expose()
+	return //inflammable
+
 /turf/open/floor/engine/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
 

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -48,10 +48,6 @@
 	var/bypassing = FALSE
 	var/visual_update_tick = 0
 
-#define IGNITE_TURF_CHANCE 30
-#define IGNITE_TURF_LOW_POWER 8
-#define IGNITE_TURF_HIGH_POWER 22
-
 /obj/effect/hotspot/Initialize(mapload, starting_volume, starting_temperature)
 	. = ..()
 	SSair.hotspots += src
@@ -67,14 +63,6 @@
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
-
-	if(prob(IGNITE_TURF_CHANCE))
-		var/turf/my_turf = loc
-		my_turf.IgniteTurf(rand(IGNITE_TURF_LOW_POWER,IGNITE_TURF_HIGH_POWER))
-
-#undef IGNITE_TURF_CHANCE
-#undef IGNITE_TURF_LOW_POWER
-#undef IGNITE_TURF_HIGH_POWER
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/open/location = loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hotspots can no longer cause turf fires on reinforced floors. Flamethrowers and other things that ignite the turf directly will still work, however.

## Why It's Good For The Game

Currently, the way turf fires work creates a lot of strange issues with certain gas reactions. TEG burn chambers can generate large amounts of CO2 from nothing (regardless of whether the combustion reaction used even makes CO2 at all) while consuming a large portion of the oxygen meant for whichever fuel you're using, which means you sometimes get a lot less out of your fuel than you should.

The CO2 from turf fires also causes problems with fusion. Because of how fusion works, adding more of it makes it much more likely to cool down and kill the reaction, making it more difficult to start than it needs to be.

My solution for this is simple: make hotspots unable to ignite reinforced floors, since they're already used mostly for burn chambers and such due to being fireproof. Flamethrowers and anything else that directly creates turf fires still work on them.

## Changelog

:cl:
tweak: reinforced floors can no longer ignited by hotspots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
