### PR TITLE
Fixes mining vendors not having scanners

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -35,6 +35,8 @@
 		/obj/item/wormhole_jaunter = 3,
 		/obj/item/kinetic_crusher = 1,
 		/obj/item/gun/energy/kinetic_accelerator = 3,
+		/obj/item/mining_scanner = 5,
+		/obj/item/t_scanner/adv_mining_scanner = 2,
 		/obj/item/resonator = 3,
 		/obj/item/extraction_pack = 3,
 		/obj/item/lazarus_injector = 1,


### PR DESCRIPTION

## About The Pull Request
re-adds mining scanners to normal vendor
they were accidentally removed and not replaced during deep core removal, oops!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
things are nice
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Mining vendors have scanners again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
