### PR TITLE
Adds sanitization redundancy for 3-hex colours

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -78,9 +78,9 @@
 
 	if(length_char(.) != desired_format)
 		if(desired_format == 6 && length_char(.) == 3) //doing this quickly rather than elegantly
-			var/red = oldvalue[1]
-			var/green = oldvalue[2]
-			var/blue = oldvalue[3]
+			var/red = .[1]
+			var/green = .[2]
+			var/blue = .[3]
 			return crunch + "[red][red][green][green][blue][blue]"
 		if(default)
 			return default

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -77,6 +77,11 @@
 			i += length(color[i])
 
 	if(length_char(.) != desired_format)
+		if(desired_format == 6 && length_char(.) == 3) //doing this quickly rather than elegantly
+			var/red = oldvalue[1]
+			var/green = oldvalue[2]
+			var/blue = oldvalue[3]
+			return crunch + "[red][red][green][green][blue][blue]"
 		if(default)
 			return default
 		return crunch + repeat_string(desired_format, "0")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hopefully makes it so that players with three-hex-code colour values automatically convert to six-hex-code colours.

## Why It's Good For The Game
you don't lose your colours

## Changelog

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
