### PR TITLE
Fixes tritium fires

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -19,7 +19,7 @@
 
 #define NITRYL_FORMATION_ENERGY 100000
 #define NITROUS_FORMATION_ENERGY 10000
-#define TRITIUM_BURN_OXY_FACTOR 100
+#define TRITIUM_BURN_OXY_FACTOR 2 // how many moles per tritium mole are needed for optimal burn rate
 #define TRITIUM_BURN_TRIT_FACTOR 10
 #define TRITIUM_BURN_RADIOACTIVITY_FACTOR 5000 //The neutrons gotta go somewhere. Completely arbitrary number.
 #define TRITIUM_MINIMUM_RADIATION_ENERGY 0.1 //minimum 0.01 moles trit or 10 moles oxygen to start producing rads

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -149,23 +149,15 @@
 	cached_results["fire"] = 0
 	var/turf/open/location = isturf(holder) ? holder : null
 
-	var/burned_fuel = 0
-	if(air.get_moles(GAS_O2) < air.get_moles(GAS_TRITIUM))
-		burned_fuel = air.get_moles(GAS_O2)/TRITIUM_BURN_OXY_FACTOR
+	var/burned_fuel = max(min(air.get_moles(GAS_TRITIUM), air.get_moles(GAS_O2) / TRITIUM_BURN_OXY_FACTOR), 0) / TRITIUM_BURN_TRIT_FACTOR
+	if(burned_fuel > 0)
 		air.adjust_moles(GAS_TRITIUM, -burned_fuel)
-	else
-		burned_fuel = air.get_moles(GAS_TRITIUM)*TRITIUM_BURN_TRIT_FACTOR
-		air.adjust_moles(GAS_TRITIUM, -air.get_moles(GAS_TRITIUM)/TRITIUM_BURN_TRIT_FACTOR)
-		air.adjust_moles(GAS_O2,-air.get_moles(GAS_TRITIUM))
-
-	if(burned_fuel)
+		air.adjust_moles(GAS_O2, -burned_fuel / 2)
+		air.adjust_moles(GAS_H2O, burned_fuel)
 		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)
+		cached_results["fire"] += burned_fuel
 		if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
 			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
-
-		air.adjust_moles(GAS_H2O, burned_fuel/TRITIUM_BURN_OXY_FACTOR)
-
-		cached_results["fire"] += burned_fuel
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tritium fires no longer break conservation of mass by consuming far more oxygen than intended. The burn rate has also been changed to scale with oxygen-fuel ratio instead of being a binary fast/slow reaction.

This also fixes some strange interactions with plasma combustion that were caused by it consuming so much extra oxygen.

## Why It's Good For The Game

Fire makes sense now, TEG power output is less inconsistent.

## Changelog

:cl:
tweak: tritium burn rate is based on oxygen-fuel ratio instead of being binary fast/slow
fix: fixed tritium fires breaking conservation of mass and consuming too much oxygen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
