### PR TITLE
Slightly more robust holopads

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -11,6 +11,9 @@
 
 /mob/camera/aiEye/remote/holo
 	use_static = USE_STATIC_NONE
+	acceleration = FALSE
+	max_sprint = 10
+	sprint = 5
 
 /mob/camera/aiEye/remote/holo/update_remote_sight(mob/living/user)
 	user.sight = NONE

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -168,6 +168,7 @@
 	name = "Inactive Camera Eye"
 	ai_detector_visible = FALSE
 	var/sprint = 10
+	var/max_sprint = 50
 	var/cooldown = 0
 	var/acceleration = 1
 	var/mob/living/eye_user = null
@@ -216,7 +217,6 @@
 
 /mob/camera/aiEye/remote/relaymove(mob/living/user, direction)
 	var/initial = initial(sprint)
-	var/max_sprint = 50
 
 	if(cooldown && cooldown < world.timeofday) // 3 seconds
 		sprint = initial
@@ -226,7 +226,7 @@
 		if(step)
 			setLoc(step)
 
-	cooldown = world.timeofday + 5
+	cooldown = world.timeofday + 3 SECONDS
 	if(acceleration)
 		sprint = min(sprint + 0.5, max_sprint)
 	else

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -472,6 +472,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/clear_holo(mob/living/user)
 	qdel(masters[user]) // Get rid of user's hologram
+	masters -= user
 	unset_holo(user)
 	return TRUE
 
@@ -524,7 +525,10 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		var/transfered = FALSE
 		if(!validate_location(new_turf))
 			if(!transfer_to_nearby_pad(new_turf,user))
-				holo.HC.eye.setLoc(get_turf(src))
+				if(HC)
+					holo.HC.eye.setLoc(get_turf(src))
+					return FALSE
+				clear_holo(user)
 				return FALSE
 			else
 				transfered = TRUE

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -525,7 +525,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		var/transfered = FALSE
 		if(!validate_location(new_turf))
 			if(!transfer_to_nearby_pad(new_turf,user))
-				if(HC)
+				if(holo.HC)
 					holo.HC.eye.setLoc(get_turf(src))
 					return FALSE
 				clear_holo(user)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -524,7 +524,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		var/transfered = FALSE
 		if(!validate_location(new_turf))
 			if(!transfer_to_nearby_pad(new_turf,user))
-				clear_holo(user)
+				holo.HC.eye.setLoc(get_turf(src))
 				return FALSE
 			else
 				transfered = TRUE
@@ -668,6 +668,11 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/proc/record_clear()
 	if(disk && disk.record)
 		QDEL_NULL(disk.record)
+
+/obj/machinery/holopad/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock, list/obj/docking_port/mobile/towed_shuttles)
+	. = ..()
+	for(var/datum/holocall/holocall in holo_calls)
+		holocall.eye.setLoc(newT, TRUE)
 
 /obj/effect/overlay/holo_pad_hologram
 	initial_language_holder = /datum/language_holder/universal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so holocalls aren't interrupted by the target shuttle docking, or the hologram leaving the projection range. It'll just send them to the source tile if either happen. Also tries to slow down movement a little, but there's only so much I can do.

## Why It's Good For The Game

Holopads are probably one of the most important communication methods in the game, since it's one of the few reliable inter-ship ones.

## Changelog

:cl:
tweak: Holocalls now persist even if the target ship docks or the hologram leaves the projection area.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
