### PR TITLE
Bugfix for filled big mortars

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/big_mortar.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/big_mortar.dm
@@ -70,7 +70,7 @@
 				to_chat(user, "<span class='warning'>[target] is empty.</span>")
 				return COMPONENT_NO_AFTERATTACK
 
-			if(reagents.holder_full())
+			if(attacking_item.reagents.holder_full())
 				to_chat(user, "<span class='warning'>[attacking_item] is full.</span>")
 				return COMPONENT_NO_AFTERATTACK
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes big mortar logic so they now properly check if the item they're dispensing to is full.

## Why It's Good For The Game

Big mortars try to check if the container they're filling is full to decide if they should dispense reagents or not. The only problem is this check wasn't working correctly, and was instead checking if the _mortar_ is full, meaning if you stuffed it full of plants and let it rip, it'd fill up the mortar and then essentially lock all those reagents inside itself since it would think every container you wanted to dispense to was full. Now they properly check if the target container is full, and your precious "medicinal herbs" are accessible once more.

## Changelog

:cl:
fix: big mortars now check the correct container for fullness before refusing to fill said container
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
