### PR TITLE
Changes the headsets some SolGov jobs wear

### DIFF
--- a/code/modules/clothing/outfits/solgov.dm
+++ b/code/modules/clothing/outfits/solgov.dm
@@ -62,7 +62,7 @@
 	id = /obj/item/card/id/solgov
 	uniform = /obj/item/clothing/under/solgov
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof/solgov
-	ears = /obj/item/radio/headset/solgov
+	ears = /obj/item/radio/headset/solgov/alt
 	gloves = /obj/item/clothing/gloves/combat
 	head = /obj/item/clothing/head/solgov/sonnensoldner
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol/solgov

--- a/code/modules/clothing/outfits/solgov.dm
+++ b/code/modules/clothing/outfits/solgov.dm
@@ -39,7 +39,7 @@
 	id = /obj/item/card/id/gold
 	belt = /obj/item/pda/captain
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/solgov
+	ears = /obj/item/radio/headset/solgov/alt/captain
 	uniform =  /obj/item/clothing/under/solgov/formal/captain
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof/solgov/captain
 	shoes = /obj/item/clothing/shoes/laceup
@@ -89,7 +89,7 @@
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat
 	gloves = /obj/item/clothing/gloves/color/white
 	shoes = /obj/item/clothing/shoes/laceup
-	ears = /obj/item/radio/headset/solgov
+	ears = /obj/item/radio/headset/solgov/captain
 	glasses = /obj/item/clothing/glasses/sunglasses
 	belt = /obj/item/pda/solgov
 
@@ -105,7 +105,7 @@
 
 	id = /obj/item/card/id/solgov
 	belt = /obj/item/pda/heads/head_of_personnel
-	ears = /obj/item/radio/headset/solgov
+	ears = /obj/item/radio/headset/solgov/captain
 	uniform = /obj/item/clothing/under/solgov/formal
 	head = /obj/item/clothing/head/solgov
 	neck = /obj/item/clothing/neck/cloak/overseer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

Captain now has a proper loudmode SolGov bowman.

Overseers and Representatives now use regular loudmode SolGov headsets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Feels fitting for the head of staff analogues that are presumably important enough, to use loudmode when needed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: PositiveEntropy
tweak: Changes the headsets that the SolGov captain, overseer, and representative use into loudmode versions of their original incarnations!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
