### PR TITLE
tiny colossus fixes

### DIFF
--- a/_maps/shuttles/shiptest/inteq_colossus.dmm
+++ b/_maps/shuttles/shiptest/inteq_colossus.dmm
@@ -3552,6 +3552,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed,
 /obj/structure/curtain/bounty,
+/obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
 /area/ship/crew)
 "Ou" = (
@@ -4030,11 +4031,11 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "Tz" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/opaque/yellow,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "TF" = (
@@ -4287,6 +4288,7 @@
 	pixel_y = -32
 	},
 /obj/structure/curtain/bounty,
+/obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
 /area/ship/crew)
 "Xb" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a couple of oversights from the colossus update. Adds bedsheets to the beds in dorms and replaces the autolathe in the armory with a security techfab. Also removes a single compact pickaxe.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: removed a single pickaxe from the Colossus
fix: added missing bedsheets and techfab to the Colossus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
