### PR TITLE
Adds Recently Added Weapons To The Chronicle

### DIFF
--- a/_maps/shuttles/shiptest/solgov_chronicle.dmm
+++ b/_maps/shuttles/shiptest/solgov_chronicle.dmm
@@ -270,6 +270,9 @@
 /obj/item/stamp/solgov,
 /obj/item/clothing/suit/armor/solgov_trenchcoat,
 /obj/item/spacecash/bundle/loadsamoney,
+/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/ammo_box/magazine/modelh,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
 "cg" = (
@@ -3356,7 +3359,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/obj/structure/fluff/hedge/opaque,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Hb" = (
@@ -3701,6 +3704,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
+/obj/item/gun/ballistic/automatic/powered/gauss/claris,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Kv" = (
@@ -4526,11 +4530,18 @@
 /turf/open/floor/plasteel/white,
 /area/ship/engineering)
 "Tr" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/techfloor/corner,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/closet/cabinet{
+	name = "ammunition"
+	},
+/obj/item/ammo_box/amagpellet_claris,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "TA" = (

--- a/_maps/shuttles/shiptest/solgov_chronicle.dmm
+++ b/_maps/shuttles/shiptest/solgov_chronicle.dmm
@@ -2537,7 +2537,10 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/fluff/hedge/opaque,
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "zq" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
To elaborate more on the title, the Chronicle-class now has:

- A Claris with a spare speedloader
- A Model H with two cartridges
- Four 5.56 magazines for the Pistole Cs.
- A recharger for the new gauss weapons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A small aspect of my frustration with the Chronicle was how it felt on the weaker side weapons-wise compared to ships that are of similar size. Considering it is still an adminspawn, I felt it was prudent to test how effective these new weapons are and if these changes I'm proposing are justified or downright bonkers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: PositiveEntropy
balance: The Chronicle-class has been supplied with many new weapons fresh from the solarian armory!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
