### PR TITLE
fixes inability to spawn new ships on localhost

### DIFF
--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -25,9 +25,13 @@ GLOBAL_PROTECT(exp_to_update)
 	return TRUE
 
 /datum/map_template/shuttle/proc/get_req_spawn_minutes()
+	if(!CONFIG_GET(flag/use_exp_tracking) || !SSdbcore.Connect())
+		return 0
 	return spawn_time_coeff * CONFIG_GET(number/ship_spawn_base_exp_min)
 
 /datum/map_template/shuttle/proc/get_req_officer_minutes()
+	if(!CONFIG_GET(flag/use_exp_tracking) || !SSdbcore.Connect())
+		return 0
 	return officer_time_coeff * CONFIG_GET(number/officer_join_base_exp_min)
 
 /client/proc/is_playtime_restriction_eligible()


### PR DESCRIPTION
## About The Pull Request

turns out i forgot to disable playtime checking on the TGUI window itself when the conditions for it activating weren't met (an active database and the USE_EXP_TRACKING config value set). oops! that's fixed now

## Why It's Good For The Game

how can we ship tests if our devs can't even test ships

## Changelog

:cl:
fix: The roundstart join menu now correctly ignores playtime restrictions if USE_EXP_TRACKING is disabled or no database is found.
/:cl:
