### PR TITLE
Make plasma sheets produce 10x more gas when ignited.

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 		return ..()
 
 /obj/item/stack/sheet/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
-	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
+	atmos_spawn_air("plasma=[amount*100];TEMP=[exposed_temperature]")
 	qdel(src)
 
 /obj/item/stack/sheet/mineral/plasma/fifty


### PR DESCRIPTION
## About The Pull Request

Right now plasma sheet produce 10 mol of gas when ignited, with this pr they will produce 100mol.

## Why It's Good For The Game

### The balance argument
I think it would be cool if people vaporized plasma crystal to power their ship but right now you need about 1040 crystals to fill a tank (see image) to round start level (10398.4 mol).

With this pr 104 crystals will be required which I think is still kind of a lot considering where we want to take mining but still balanced.

**TLDR;** it would allow plasma sheets to be a real source of gas.

### Physics/lore argument
I also think this pr cool have cool implications lore wise since :

With this pr we could fill  a **10kL** tank **of gas**(see image) with ~100 sheets of plasma so **~2kL of crystal**. which would mean lore wise that crystal is a more effective (but perhaps less safe).

On the contrary it means that **without this** pr gas is the superior way of storing plasma being **2x more effective than crystal**, which is weird since most of the time storing matter as a solid is more efficient than storing it as a gas (expect for water because water like to crystalize weird).

**TLDR;** Right now plasma crystal is less dense than plasma gas in tank and that's weird we should change it.
![orange2](https://github.com/shiptest-ss13/Shiptest/assets/41831966/f28df243-4f97-4950-b8bc-04e86609a87c)


## Changelog

:cl:
tweak: Plasma produce 10x more plasma gas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
