### PR TITLE
Takes the Hound out behind the shed

### DIFF
--- a/_maps/configs/inteq_hound.json
+++ b/_maps/configs/inteq_hound.json
@@ -30,5 +30,5 @@
 			"slots": 3
 		}
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the Hound, making it only available for admin spawns.

## Why It's Good For The Game

The Hound has proven itself to be a favorite of soloshippers and players with little to no interest in roleplay, and can typically be found derelict and riddled with asteroid holes after a new player blew out the cargo bay. Even when this doesn't happen, it effectively plays like a tiny Colossus with very little roleplay potential and too much firepower. It's not very interesting and doesn't encourage the kind of gameplay we want.

## Changelog

:cl:
del: Removed the Hound from the ship spawn menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
