### PR TITLE
Twink Tweaks

### DIFF
--- a/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
+++ b/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
@@ -14,7 +14,9 @@
 /area/ship/engineering/atmospherics)
 "ab" = (
 /obj/structure/sign/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/atmospherics)
 "ad" = (
 /obj/machinery/light/directional/north,
@@ -118,11 +120,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"aU" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_fullblocker = 1
-	},
-/area/ship/engineering/engine)
 "aX" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/full,
 /obj/effect/turf_decal/syndicateemblem/middle/middle{
@@ -1157,7 +1154,9 @@
 /area/ship/medical)
 "ho" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/communications)
 "hr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -1184,7 +1183,9 @@
 	dir = 10;
 	faction = list("PlayerSyndicate")
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "hw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1792,7 +1793,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "kS" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/atmospherics)
 "kT" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2056,7 +2059,9 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "mQ" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/medical)
 "mS" = (
 /obj/structure/cable/yellow{
@@ -2250,7 +2255,9 @@
 	dir = 6;
 	faction = list("PlayerSyndicate")
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "oc" = (
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
@@ -2270,7 +2277,9 @@
 	dir = 9;
 	faction = list("PlayerSyndicate")
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "oi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2899,7 +2908,9 @@
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "ro" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/janitor)
 "rq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -2923,7 +2934,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "rP" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/cargo)
 "rQ" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
@@ -2955,7 +2968,9 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/ship/bridge)
 "sb" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/canteen)
 "sc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -3389,7 +3404,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "vb" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/cryo)
 "vl" = (
 /obj/machinery/sleeper/syndie{
@@ -3815,7 +3832,9 @@
 	dir = 5;
 	faction = list("PlayerSyndicate")
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "xq" = (
 /obj/machinery/light/directional/south,
@@ -3855,7 +3874,9 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/medical)
 "xv" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/security/armory)
 "xw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -3891,7 +3912,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "xG" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering)
 "xH" = (
 /obj/machinery/door/poddoor{
@@ -4193,7 +4216,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "zD" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/dorm)
 "zG" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
@@ -4282,7 +4307,9 @@
 /area/ship/engineering/engine)
 "zT" = (
 /obj/structure/sign/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "zZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4640,7 +4667,9 @@
 /area/ship/medical/surgery)
 "CG" = (
 /obj/structure/sign/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/cryo)
 "CH" = (
 /obj/structure/reflector/box{
@@ -4978,7 +5007,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "EN" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/hallway/central)
 "EO" = (
 /obj/structure/cable/yellow{
@@ -5208,7 +5239,9 @@
 	dir = 4;
 	pixel_y = -4
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/medical)
 "Gj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5842,7 +5875,9 @@
 	dir = 4;
 	pixel_y = -4
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/medical)
 "Jk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -6325,7 +6360,9 @@
 /obj/structure/sign/poster/contraband/atmosia_independence{
 	pixel_x = -32
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/communications)
 "LX" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -6430,7 +6467,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "MQ" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/engine)
 "MU" = (
 /obj/machinery/telecomms/bus/preset_three{
@@ -6996,7 +7035,9 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "QF" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/dorm/dormtwo)
 "QI" = (
 /obj/machinery/suit_storage_unit/syndicate{
@@ -7100,7 +7141,9 @@
 /area/ship/engineering/atmospherics)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering)
 "Ru" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -7152,7 +7195,9 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "RC" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/office)
 "RE" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -7233,7 +7278,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Sc" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/medical/surgery)
 "Sd" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/border{
@@ -7406,7 +7453,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "SL" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/bridge)
 "SM" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -7721,7 +7770,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Vf" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/engineering/communications)
 "Vj" = (
 /obj/item/radio/intercom/directional/west,
@@ -7752,7 +7803,9 @@
 /area/ship/engineering/atmospherics)
 "Vw" = (
 /obj/structure/sign/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/cargo)
 "Vy" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -8450,7 +8503,9 @@
 /area/ship/bridge)
 "Zr" = (
 /obj/structure/sign/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/crew/office)
 "Zt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -8522,7 +8577,9 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/janitor)
 "ZH" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/syndicate/nodiagonal{
+	rad_insulation = 0
+	},
 /area/ship/security)
 "ZJ" = (
 /obj/structure/cable/yellow{
@@ -9220,19 +9277,19 @@ Qa
 Jd
 sb
 Jz
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
+MQ
 xv
 Si
 si

--- a/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
+++ b/_maps/shuttles/shiptest/syndicate_twinkleshine.dmm
@@ -120,7 +120,7 @@
 /area/ship/engineering/atmospherics)
 "aU" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0.3
+	rad_fullblocker = 1
 	},
 /area/ship/engineering/engine)
 "aX" = (
@@ -248,7 +248,8 @@
 /obj/item/paper_bin/carbon,
 /obj/item/pen/edagger,
 /obj/item/storage/secure/safe/intel{
-	pixel_x = -24
+	pixel_x = -30;
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow{
@@ -375,11 +376,11 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "cr" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/opaque/orange/filled/corner,
 /obj/effect/turf_decal/trimline/opaque/orange/line{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "cw" = (
@@ -593,7 +594,7 @@
 	pixel_x = -10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "dE" = (
@@ -771,10 +772,6 @@
 	pixel_x = 8
 	},
 /obj/item/clothing/glasses/hud/health/night,
-/obj/item/gun/medbeam{
-	pixel_y = -7;
-	pixel_x = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "eQ" = (
@@ -1393,13 +1390,16 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "iv" = (
-/obj/structure/rack,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/soap/syndie,
-/obj/item/soap/syndie,
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 10;
+	pixel_y = -5
+	},
+/obj/item/mop{
+	pixel_x = -7
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/janitor)
@@ -2891,6 +2891,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
+"rj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/structure/sign/warning/nosmoking/burnt{
+	pixel_x = -32
+	},
+/turf/open/floor/engine,
+/area/ship/engineering/engine)
 "ro" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/crew/janitor)
@@ -3580,7 +3587,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "wC" = (
-/obj/machinery/vending/security,
+/obj/structure/rack,
+/obj/item/storage/box/handcuffs{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/obj/item/storage/box/flashes{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -2
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "wF" = (
@@ -4541,7 +4559,8 @@
 "BT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing{
-	dir = 1
+	dir = 1;
+	layer = 2.79
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -5794,6 +5813,10 @@
 /obj/effect/turf_decal/corner/opaque/syndiered/border{
 	dir = 1
 	},
+/obj/machinery/nuclearbomb/beer{
+	desc = "It's an old, decommissioned bomb, previously used by Nuclear Operatives during the Corporate War. It seems to have a tap drilled in.";
+	name = "\improper nuclear fission explosive"
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Jf" = (
@@ -6559,8 +6582,8 @@
 	},
 /obj/item/clothing/under/suit/waiter/syndicate,
 /obj/item/circuitboard/machine/deep_fryer,
-/obj/item/circuitboard/machine/processor,
 /obj/item/circuitboard/machine/gibber,
+/obj/item/cutting_board,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "NT" = (
@@ -7246,7 +7269,7 @@
 /area/ship/crew/canteen)
 "Sl" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Sp" = (
@@ -7402,10 +7425,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/corner/opaque/syndiered/border,
-/obj/machinery/nuclearbomb/beer{
-	desc = "It's an old, decommissioned bomb, previously used by Nuclear Operatives during the Corporate War. It seems to have a tap drilled in.";
-	name = "\improper nuclear fission explosive"
-	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "SR" = (
@@ -8170,12 +8189,14 @@
 /area/ship/engineering/atmospherics)
 "XR" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
@@ -8479,15 +8500,25 @@
 /area/ship/cargo)
 "ZE" = (
 /obj/machinery/light/directional/south,
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/soap/syndie{
+	pixel_y = -3;
+	pixel_x = -2
+	},
+/obj/item/soap/syndie{
+	pixel_y = -6;
+	pixel_x = 2
+	},
+/obj/item/storage/bag/trash{
+	pixel_x = -6
+	},
+/obj/item/storage/bag/trash,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/janitor)
 "ZH" = (
@@ -9091,7 +9122,7 @@ kJ
 iB
 Ih
 lI
-gU
+rj
 wi
 kJ
 xo
@@ -9189,8 +9220,6 @@ Qa
 Jd
 sb
 Jz
-MQ
-MQ
 aU
 aU
 aU
@@ -9200,8 +9229,10 @@ aU
 aU
 aU
 aU
-MQ
-MQ
+aU
+aU
+aU
+aU
 xv
 Si
 si

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -71,7 +71,7 @@
 	icon_state = "syndicate"
 	strip_delay = 60
 
-/obj/item/clothing/mask/gas/syndicate/vc
+/obj/item/clothing/mask/gas/syndicate/voicechanger
 	var/voice_change = 1
 
 /obj/item/clothing/mask/gas/clown_hat

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -71,6 +71,9 @@
 	icon_state = "syndicate"
 	strip_delay = 60
 
+/obj/item/clothing/mask/gas/syndicate/vc
+	var/voice_change = 1
+
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -150,14 +150,14 @@ Assistant
 /datum/outfit/job/assistant/syndicate/sbc
 	name = "Deck Assistant (Twinkleshine)"
 
-	uniform = /obj/item/clothing/under/syndicate/intern
+	uniform = /obj/item/clothing/under/syndicate
+	alt_uniform = /obj/item/clothing/under/syndicate/intern
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	back = /obj/item/storage/backpack
-	belt = /obj/item/storage/belt/military/assault
 	implants = list(/obj/item/implant/weapons_auth)
 	id = /obj/item/card/id/syndicate_command/crew_id
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -155,7 +155,7 @@ Assistant
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	back = /obj/item/storage/backpack
 	implants = list(/obj/item/implant/weapons_auth)

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -44,7 +44,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/white
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	belt = /obj/item/storage/belt/bandolier
 	implants = list(/obj/item/implant/weapons_auth)
 	id = /obj/item/card/id/syndicate_command/crew_id

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -44,7 +44,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/white
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	belt = /obj/item/storage/belt/bandolier
 	implants = list(/obj/item/implant/weapons_auth)
 	id = /obj/item/card/id/syndicate_command/crew_id

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -63,7 +63,7 @@
 	suit_store =  null
 	head = null
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	id = /obj/item/card/id/syndicate_command/crew_id/med
 	implants = list(/obj/item/implant/weapons_auth)
 	backpack_contents = list(/obj/item/pda/brig_phys)

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -51,6 +51,7 @@
 /datum/outfit/job/brig_phys/syndicate/sbc
 	name = "Medic (Twinkleshine)"
 
+	uniform = /obj/item/clothing/under/rank/medical/doctor/red
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil
 	alt_uniform = /obj/item/clothing/under/syndicate/cybersun
 	glasses = /obj/item/clothing/glasses/hud/health
@@ -60,8 +61,9 @@
 	suit = /obj/item/clothing/suit/longcoat/roboblack
 	alt_suit = /obj/item/clothing/suit/toggle/labcoat
 	suit_store =  null
+	head = null
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	id = /obj/item/card/id/syndicate_command/crew_id/med
 	implants = list(/obj/item/implant/weapons_auth)
 	backpack_contents = list(/obj/item/pda/brig_phys)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -105,7 +105,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
 	ears = /obj/item/radio/headset/syndicate/alt/captain
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	l_pocket = /obj/item/melee/transforming/energy/sword/saber/red
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/syndicate
 	suit_store = /obj/item/gun/ballistic/revolver/mateba

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -105,7 +105,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
 	ears = /obj/item/radio/headset/syndicate/alt/captain
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	l_pocket = /obj/item/melee/transforming/energy/sword/saber/red
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/syndicate
 	suit_store = /obj/item/gun/ballistic/revolver/mateba

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	name = "Operative (Twinkleshine)"
 	uniform = /obj/item/clothing/under/syndicate/combat
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	name = "Operative (Twinkleshine)"
 	uniform = /obj/item/clothing/under/syndicate/combat
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -109,7 +109,7 @@
 	glasses = /obj/item/clothing/glasses/meson/night
 	gloves = /obj/item/clothing/gloves/explorer
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	belt = /obj/item/storage/belt/mining/alt
 	implants = list(/obj/item/implant/weapons_auth)

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -109,7 +109,7 @@
 	glasses = /obj/item/clothing/glasses/meson/night
 	gloves = /obj/item/clothing/gloves/explorer
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	belt = /obj/item/storage/belt/mining/alt
 	implants = list(/obj/item/implant/weapons_auth)

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -183,7 +183,7 @@
 	head = /obj/item/clothing/head/hardhat/orange
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	back = /obj/item/storage/backpack/industrial
 	belt = /obj/item/storage/belt/utility/syndicate
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -183,7 +183,7 @@
 	head = /obj/item/clothing/head/hardhat/orange
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	ears = /obj/item/radio/headset/syndicate
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	back = /obj/item/storage/backpack/industrial
 	belt = /obj/item/storage/belt/utility/syndicate
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -117,7 +117,7 @@
 	uniform = /obj/item/clothing/under/syndicate/aclf
 	head = /obj/item/clothing/head/HoS/beret/syndicate
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/gas/syndicate/vc
+	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	gloves = /obj/item/clothing/gloves/combat
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/kitchen/knife/combat/survival

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -117,7 +117,7 @@
 	uniform = /obj/item/clothing/under/syndicate/aclf
 	head = /obj/item/clothing/head/HoS/beret/syndicate
 	ears = /obj/item/radio/headset/syndicate/alt
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/gas/syndicate/vc
 	gloves = /obj/item/clothing/gloves/combat
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/kitchen/knife/combat/survival


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the SecTech, fixes a couple of extinguishers, adds a variant of the Syndicate mask that has a VC, so you don't see syndicate crews walking around with horse masks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Vouches can be redeemed in sectech to get NT weapons. Also, you don't see syndicate crews walking around with horse masks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Syndicate Voice Changer masks.
tweak: Removed the SecTech from the Twinkleshine, and changed the masks that the crews get.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
