### PR TITLE
bedsheet/random fix, cleans up special dorms bedsheet list, replaces random bedsheets in most maps

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
@@ -40,7 +40,7 @@
 "fD" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/bubblegum,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "fQ" = (
@@ -464,7 +464,7 @@
 /area/icemoon/underground/explored)
 "LZ" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "Nq" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_icecropolis.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_icecropolis.dmm
@@ -95,7 +95,7 @@
 /area/ruin/unpowered/icecropolis)
 "bO" = (
 /obj/structure/bed/roller,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood/icecropolis,
 /area/ruin/unpowered/icecropolis/reach)
 "bR" = (
@@ -611,7 +611,7 @@
 /area/ruin/unpowered/icecropolis)
 "ml" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood/icecropolis,
 /area/ruin/unpowered/icecropolis/russia)
 "mo" = (
@@ -1209,7 +1209,7 @@
 /area/ruin/unpowered/icecropolis)
 "wO" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood/icecropolis,
 /area/ruin/unpowered/icecropolis/reach)
 "wP" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_slimelab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_slimelab.dmm
@@ -2561,7 +2561,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/powered/slimelab/lava)
 "Bu" = (
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/bed,
 /obj/structure/curtain,
 /obj/effect/mob_spawn/human/slime_rancher,

--- a/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -986,7 +986,7 @@
 /obj/structure/bed{
 	icon_state = "dirty_mattress"
 	},
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
 	color = "#A47449";
@@ -1452,7 +1452,7 @@
 	dir = 4;
 	layer = 3.9
 	},
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/cable/yellow{
 	icon_state = "1-9"
 	},
@@ -3231,7 +3231,7 @@
 /obj/structure/bed{
 	icon_state = "dirty_mattress"
 	},
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/cable/yellow{
 	icon_state = "0-5"
 	},
@@ -7228,7 +7228,7 @@
 /obj/structure/bed{
 	icon_state = "dirty_mattress"
 	},
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood/walnut,
 /area/ruin/jungle/paradise/dorms)
 "UC" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_dwarffortress.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_dwarffortress.dmm
@@ -118,7 +118,7 @@
 /area/lavaland/surface/outdoors)
 "wm" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plating/asteroid/basalt,
 /area/ruin/unpowered)
 "xi" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -622,7 +622,7 @@
 "lt" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/ruin/powered/golem_ship)
@@ -1089,7 +1089,7 @@
 "wJ" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
@@ -1680,7 +1680,7 @@
 /area/ruin/powered/golem_ship)
 "KH" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/ruin/powered/golem_ship)
 "KO" = (

--- a/_maps/RandomRuins/SpaceRuins/excavator_DK.dmm
+++ b/_maps/RandomRuins/SpaceRuins/excavator_DK.dmm
@@ -2,7 +2,7 @@
 "dN" = (
 /obj/item/shard,
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plating,
 /area/ruin/space/derelict)
 "eo" = (
@@ -256,7 +256,7 @@
 /area/ruin/space/derelict)
 "La" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plating,
 /area/ruin/space/derelict)
 "Lg" = (
@@ -320,7 +320,7 @@
 /area/ruin/space/derelict)
 "Wc" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict)
 "Wm" = (
@@ -345,7 +345,7 @@
 "XP" = (
 /obj/machinery/light/broken/directional/south,
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict)
 "YF" = (

--- a/_maps/deprecated/Ships/syndicate_kugelblitz.dmm
+++ b/_maps/deprecated/Ships/syndicate_kugelblitz.dmm
@@ -1590,7 +1590,7 @@
 /area/ship/science/robotics)
 "zR" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/machinery/airalarm/directional/north,
 /obj/item/mecha_parts/mecha_equipment/drill,
@@ -2571,7 +2571,7 @@
 /area/ship/engineering/atmospherics)
 "SZ" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/item/toy/plush/beeplushie,
 /obj/machinery/light/directional/north,

--- a/_maps/shuttles/shiptest/independent_boyardee.dmm
+++ b/_maps/shuttles/shiptest/independent_boyardee.dmm
@@ -410,7 +410,7 @@
 /area/ship/crew)
 "hL" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -868,7 +868,7 @@
 /area/ship/maintenance)
 "qZ" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1;
@@ -2339,7 +2339,7 @@
 /area/ship/bridge)
 "RU" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#543C30";

--- a/_maps/shuttles/shiptest/independent_rigger.dmm
+++ b/_maps/shuttles/shiptest/independent_rigger.dmm
@@ -2308,7 +2308,7 @@
 /area/ship/engineering)
 "AH" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
@@ -2869,7 +2869,7 @@
 /area/ship/engineering/atmospherics)
 "Hn" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32

--- a/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
+++ b/_maps/shuttles/shiptest/independent_rube_goldberg.dmm
@@ -3779,7 +3779,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "KK" = (
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/bed,
 /obj/item/toy/plush/goatplushie,
 /obj/structure/window/reinforced/tinted,

--- a/_maps/shuttles/shiptest/independent_shetland.dmm
+++ b/_maps/shuttles/shiptest/independent_shetland.dmm
@@ -2599,7 +2599,7 @@
 /area/ship/engineering/engine)
 "AF" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
@@ -4467,7 +4467,7 @@
 /area/ship/hallway/starboard)
 "SU" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)

--- a/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
+++ b/_maps/shuttles/shiptest/nanotrasen_mimir.dmm
@@ -4805,7 +4805,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/item/bedsheet/random,
+/obj/item/bedsheet/dorms,
 /obj/structure/curtain/cloth/grey,
 /obj/machinery/light_switch{
 	dir = 8;

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -399,7 +399,7 @@ LINEN BINS
 	name = "random dorms double bedsheet"
 	desc = "If you're reading this description ingame, something has gone wrong! Honk!"
 
-/obj/item/bedsheet/dorms/Initialize()
+/obj/item/bedsheet/dorms/double/Initialize()
 	..()
 	var/type = pickweight(list("Colors" = 80, "Special" = 20))
 	switch(type)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -394,6 +394,31 @@ LINEN BINS
 	new type(loc)
 	return INITIALIZE_HINT_QDEL
 
+/obj/item/bedsheet/dorms/double
+	icon_state = "double_sheetrainbow"
+	name = "random dorms double bedsheet"
+	desc = "If you're reading this description ingame, something has gone wrong! Honk!"
+
+/obj/item/bedsheet/dorms/Initialize()
+	..()
+	var/type = pickweight(list("Colors" = 80, "Special" = 20))
+	switch(type)
+		if("Colors")
+			type = pick(list(/obj/item/bedsheet/double,
+				/obj/item/bedsheet/double/blue,
+				/obj/item/bedsheet/double/green,
+				/obj/item/bedsheet/double/grey,
+				/obj/item/bedsheet/double/orange,
+				/obj/item/bedsheet/double/purple,
+				/obj/item/bedsheet/double/red,
+				/obj/item/bedsheet/double/yellow,
+				/obj/item/bedsheet/double/brown,
+				/obj/item/bedsheet/double/black))
+		if("Special")
+			type = /obj/item/bedsheet/double/rainbow
+	new type(loc)
+	return INITIALIZE_HINT_QDEL
+
 /obj/structure/bedsheetbin
 	name = "linen bin"
 	desc = "It looks rather cosy."

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -365,7 +365,7 @@ LINEN BINS
 
 /obj/item/bedsheet/random/Initialize()
 	..()
-	var/type = pick(typesof(/obj/item/bedsheet) - /obj/item/bedsheet/random)
+	var/type = pick(typesof(/obj/item/bedsheet) - (typesof(/obj/item/bedsheet/double) + /obj/item/bedsheet/random))
 	new type(loc)
 	return INITIALIZE_HINT_QDEL
 
@@ -390,11 +390,7 @@ LINEN BINS
 				/obj/item/bedsheet/brown,
 				/obj/item/bedsheet/black))
 		if("Special")
-			type = pick(list(/obj/item/bedsheet/patriot,
-				/obj/item/bedsheet/rainbow,
-				/obj/item/bedsheet/ian,
-				/obj/item/bedsheet/cosmos,
-				/obj/item/bedsheet/nanotrasen))
+			type = /obj/item/bedsheet/rainbow
 	new type(loc)
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
## About The Pull Request
bedsheet/dorms no longer spawns american, ian, cosmos and nanotrasen bedsheets. this is because i am a killjoy
bedsheet/random no longer spawns double bedsheets. thank you to tmt for helping me figure this one out.
most instances of bedsheet/random have been swapped out for dorms because they were most likely unintended 
dorms bedsheets now have a double bedsheet version.

## Why It's Good For The Game
bedsheets are more consistent & lore-facing 
no more nar'sian and double bedsheets in the riggs crew quarters

## Changelog

:cl:
tweak: reduced the spawn list for dorm bedsheets 
fix: random bedsheets no longer include double bedsheets
fix: random bedsheets have been replaced with dorms bedsheets in most maps
/:cl: