### PR TITLE
Removes putting machines in walls

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -49,8 +49,9 @@
 				opening = FALSE
 				return
 		for(var/obj/machinery/machine in srcturf)
-			opening = FALSE
-			return
+			if(machine != istype(machine, /obj/machinery/atmospherics))
+				opening = FALSE
+				return
 	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
 
 /obj/structure/falsewall/proc/toggle_open()

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -40,8 +40,15 @@
 	opening = TRUE
 	update_icon()
 	if(!density)
-		var/srcturf = get_turf(src)
+		var/turf/srcturf = get_turf(src)
 		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
+			opening = FALSE
+			return
+		for(var/obj/structure/structure in srcturf)
+			if(structure != src)
+				opening = FALSE
+				return
+		for(var/obj/machinery/machine in srcturf)
 			opening = FALSE
 			return
 	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -41,17 +41,14 @@
 	update_icon()
 	if(!density)
 		var/turf/srcturf = get_turf(src)
-		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
+		if(locate(/mob/living) in srcturf) //Stop people from using this as a shield
 			opening = FALSE
 			return
-		for(var/obj/structure/structure in srcturf)
-			if(structure != src | structure != istype(structure, /obj/structure/cable))
-				opening = FALSE
-				return
-		for(var/obj/machinery/machine in srcturf)
-			if(machine != istype(machine, /obj/machinery/atmospherics))
-				opening = FALSE
-				return
+		for(var/atom/blocker as anything in srcturf)
+			if(!blocker.density) //Doesn't block
+				continue
+			opening = FALSE
+			return
 	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
 
 /obj/structure/falsewall/proc/toggle_open()

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -45,7 +45,7 @@
 			opening = FALSE
 			return
 		for(var/obj/structure/structure in srcturf)
-			if(structure != src)
+			if(structure != src | structure != istype(structure, /obj/structure/cable))
 				opening = FALSE
 				return
 		for(var/obj/machinery/machine in srcturf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
False walls will now only close if their tile is completely clear. (unless it's atmospheric machinery or cables. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops some troll logicing machinery into walls, making open space more of a premium than it currently is
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: you can no longer close falsewalls on tiles with machines or structures on them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
