### PR TITLE
Access restricts the Aegis bridge

### DIFF
--- a/_maps/shuttles/shiptest/syndicate_aegis.dmm
+++ b/_maps/shuttles/shiptest/syndicate_aegis.dmm
@@ -1719,6 +1719,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/mineral/plastitanium/red{
 	icon_state = "plastitanium"
 	},
@@ -3558,6 +3559,10 @@
 	name = "Cheri"
 	},
 /obj/item/toy/cattoy,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/bridge)
 "HV" = (
@@ -4173,7 +4178,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/walnut,
 /area/ship/bridge)
@@ -4797,12 +4801,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "UI" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/bridge)
@@ -5954,7 +5957,7 @@ hR
 FY
 nK
 UI
-uM
+gW
 tW
 uo
 Gx
@@ -6022,7 +6025,7 @@ hR
 Lc
 aJ
 NB
-uM
+gW
 hA
 te
 GZ

--- a/_maps/shuttles/shiptest/syndicate_aegis.dmm
+++ b/_maps/shuttles/shiptest/syndicate_aegis.dmm
@@ -774,8 +774,8 @@
 "fY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch{
-	name = "Bathroom";
-	dir = 4
+	dir = 4;
+	name = "Bathroom"
 	},
 /obj/effect/turf_decal/techfloor/hole/right,
 /obj/effect/turf_decal/techfloor/hole,
@@ -1673,12 +1673,19 @@
 	pixel_y = 1
 	},
 /obj/machinery/button/door{
+	id = "aegis_bridge";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
 	pixel_x = -6;
 	pixel_y = 6;
-	name = "bridge lock";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "aegis_bridge";
+	name = "Door Control";
 	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	id = "aegis"
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
 /area/ship/bridge)
@@ -1883,8 +1890,8 @@
 /area/ship/engineering)
 "qf" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Psychology Office";
-	id_tag = "psyc"
+	id_tag = "psyc";
+	name = "Psychology Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2023,8 +2030,8 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/storage/box/bodybags{
-	pixel_y = 3;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 3
 	},
 /obj/item/tank/internals/anesthetic,
 /obj/effect/turf_decal/trimline/opaque/blue/filled/line,
@@ -2162,8 +2169,8 @@
 /obj/machinery/button/door{
 	id = "engine";
 	name = "Engine shutter control";
-	pixel_y = 22;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 22
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2658,8 +2665,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
+	id_tag = "aegis_bridge";
 	name = "Bridge";
-	id_tag = "aegis"
+	req_access_txt = "19"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
@@ -2942,8 +2953,8 @@
 	name = "Secure Med Storage"
 	},
 /obj/item/storage/box/syringes{
-	pixel_y = 2;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
@@ -3166,10 +3177,10 @@
 /area/ship/crew/canteen)
 "Ew" = (
 /obj/docking_port/stationary{
+	dir = 8;
 	dwidth = 7;
-	width = 15;
 	height = 15;
-	dir = 8
+	width = 15
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -3435,10 +3446,10 @@
 	},
 /obj/docking_port/mobile{
 	can_move_docking_ports = 1;
-	launch_status = 0;
-	port_direction = 4;
+	dheight = 2;
 	dir = 8;
-	dheight = 2
+	launch_status = 0;
+	port_direction = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
@@ -3499,10 +3510,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
-	pixel_x = -28;
-	specialfunctions = 4;
 	id = "psyc";
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	pixel_x = -28;
+	specialfunctions = 4
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/office)
@@ -5010,8 +5021,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north{
-	pixel_y = 31;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 31
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew/canteen)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin- adds access restrictions and finer door controls to the Aegis's bridge. The Aegis still has a larger rework on the horizon when SUNS content is finished, but for now this is just a quick fix to a recurring issue.

## Why It's Good For The Game

Bridges, as a rule, should be access restricted to officer roles on any ship of sufficient size so it doesn't just turn into another assistant den. The Aegis is no exception.

## Changelog

:cl:
tweak: Added access restrictions to the bridge on the Aegis
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
