### PR TITLE
Adds the Syndicate gas mask as a loadout option.

### DIFF
--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -102,3 +102,8 @@
 	display_name = "face with tears of joy mask"
 	path = /obj/item/clothing/mask/joy
 	slot = ITEM_SLOT_MASK
+
+/datum/gear/accessory/syndiemask
+	display_name = "Syndicate gas mask"
+	path = /obj/item/clothing/mask/gas/syndicate
+	slot = ITEM_SLOT_MASK


### PR DESCRIPTION
## About The Pull Request

Tosses the Syndicate gas mask (the red and black one) on the loadout as an option under accessories.
## Why It's Good For The Game

 It's otherwise lacking on some ships that might have it and is drippy (the emoji meme mask also acts as a gas mask for the same function so I don't consider this out of pocket for a cosmetic.)

## Changelog

:cl:
add: Adds the Syndicate gas mask (the red and black one) to the loadout menu as an accessory.
/:cl: