### PR TITLE
Stops ships from accelerating when nobody is at a helm

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -349,8 +349,12 @@
 	// Unregister map objects
 	if(current_ship)
 		user.client?.clear_map(current_ship.token.map_name)
+		if(current_ship.burn_direction > BURN_NONE && !length(concurrent_users) && !viewer) // If accelerating with nobody else to stop it
+			say("Pilot absence detected, engaging acceleration safeties.")
+			current_ship.change_heading(BURN_NONE)
+
 	// Turn off the console
-	if(length(concurrent_users) == 0 && is_living)
+	if(!length(concurrent_users) && is_living)
 		playsound(src, 'sound/machines/terminal_off.ogg', 25, FALSE)
 		use_power(0)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops ships from accelerating if the last person stops looking at a particular helm console. Yes, this means there will be some interference if there's multiple helms (NOT including viewscreens, I accounted for those) but I don't care, better safe than sorry.

Doesn't stop de-celeration burns or start de-celeration, just stops thrusting.

![image](https://github.com/shiptest-ss13/Shiptest/assets/29362068/3e14126c-ccfa-4cb4-9585-b7c072856252)

## Why It's Good For The Game

Lots of people have been disconnected or otherwise dragged away from their consoles while accelerating, leading to insane amounts of speed that they didn't intend. This should help.

## Changelog

:cl:
tweak: Ships will stop increasing speed whenever the last person stops looking at a helm console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
