### PR TITLE
Ship factions are now in their tags.

### DIFF
--- a/_maps/configs/independent_beluga.json
+++ b/_maps/configs/independent_beluga.json
@@ -7,6 +7,7 @@
 	"map_path": "_maps/shuttles/shiptest/independent_beluga.dmm",
 	"description": "The Beluga-Class is a transport vessel for those with especially rich blood. Featuring a modest kitchen, hired Inteq security, and luxurious decoration, the Beluga is a first choice pick for many wealthy spacers trying to get from point A to B. The independent ship features several rooms for its guests and a well furnished meeting room for any corporate occassion.",
 	"tags": [
+		"Non-Aligned",
 		"RP Focus",
 		"Riot",
 		"Service"

--- a/_maps/configs/independent_box.json
+++ b/_maps/configs/independent_box.json
@@ -4,6 +4,7 @@
 	"map_short_name": "Box-class",
 	"description": "An early exemplar of several modern shipbuilding techniques that have since become standard, the Box is effectively a tiny spaceborne hospital, loaded with medical equipment that can often be difficult to source in Frontier space. Unusually, Boxes come equipped with medical cryo tubes, which have become a particular rarity on the Frontier due to their delicate nature and steep upkeep costs. Boxes are often found in surprisingly good repair for their age, and they have received several upgrades over the decades that have kept them well abreast of advances in medical science.",
 	"tags": [
+		"Non-Aligned",
 		"Medical"
 	],
 	"map_path": "_maps/shuttles/shiptest/independent_box.dmm",

--- a/_maps/configs/independent_boyardee.json
+++ b/_maps/configs/independent_boyardee.json
@@ -4,6 +4,7 @@
 	"prefix": "ISV",
 	"description": "Named for an ancient Solarian folk hero known for providing food to the masses shortly after the Night of Fire, the Boyardee-class is a remarkably popular civilian vessel, and a welcome sight to any weary travelers tired of synthesized tap water and stale rations for breakfast, lunch and dinner every day. The Boyardee-class features a full bar, an advanced hydroponics setup, a large kitchen and an expansive seating area, perfect for serving hungry customers and thirsty colonists. During the early days of the Syndicate, associated organizations would often create their own retrofits of the Boyardee to serve as recruiting centers or “shore-leave” posts, though these variants have mostly ceased to exist in the Frontier.",
 	"tags": [
+		"Non-Aligned",
 		"Service",
 		"Botany",
 		"RP Focus"

--- a/_maps/configs/independent_bubble.json
+++ b/_maps/configs/independent_bubble.json
@@ -5,6 +5,7 @@
 	"map_path": "_maps/shuttles/shiptest/independent_bubble.dmm",
 	"description": "While the most famous colony ships were hulking, highly-advanced affairs designed to ferry hundreds-if-not-thousands of settlers to far-off worlds and create cities in a matter of months – the Kalixcian Moonlight, the Candor, the First Train to Fort Sol – the Bubble-class is designed to cater to homesteaders aiming to establish a small ranch or village out in the great vastness of space. The Bubble-class is highly compact but complete with all the necessities for colony creation – extensive R&D equipment, robust mining gear, and a small selection of personal arms for fending off hostile fauna. While the Bubble-class has been historically utilized by the Solarian Federation for colony efforts, their proprietary version has recently been phased out of operation.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist",
 		"Construction"
 	],

--- a/_maps/configs/independent_byo.json
+++ b/_maps/configs/independent_byo.json
@@ -5,6 +5,7 @@
 	"map_path": "_maps/shuttles/shiptest/independent_byo.dmm",
 	"description": "The BYO can barely be considered a “ship” when initially deployed; more of a construction platform launched hazardously into space. The only thing that separates crews on a BYO from breathable safety and the cold vacuum of space are typically little airtight flaps of plastic. Equipped with a plethora of building material and tools fit for construction, BYO vessels are seen in a variety of shapes and sizes, and almost never with any consistency of form.",
 	"tags": [
+		"Non-Aligned",
 		"Engineering",
 		"Construction"
 	],

--- a/_maps/configs/independent_caravan.json
+++ b/_maps/configs/independent_caravan.json
@@ -6,6 +6,7 @@
 	"prefix": "ISV",
 	"description": "The Caravan is a relatively new freighter pattern, designed around a modular pod system that enables the ship to serve in a variety of roles beyond simple transportation. These pods are designed around a quick-release mechanism that allows the main hull to bluespace jump in, detach the pods, and load a new set of empty Caravan-type pods in a matter of minutes. While impressive in theory, the lack of empty compatible cargo pods in Frontier space renders the quick-detach system useless. Additionally, the modular attachment system is prone to wear and tear, necessitating more frequent and costly maintenance than other freighters. Despite these shortcomings, the Caravan has still earned a reputation as a versatile platform for a variety of missions. The main hull features a robust power pack and respectable crew accommodations, and most examples on the Frontier carry pods loaded for mining and survey duties.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist",
 		"Engineering"
 	],

--- a/_maps/configs/independent_dwayne.json
+++ b/_maps/configs/independent_dwayne.json
@@ -12,6 +12,7 @@
 	"map_path": "_maps/shuttles/shiptest/independent_dwayne.dmm",
 	"description": "The Dwayne is one of the older classes of ships commonly seen on the Frontier, and one of the few such classes that doesn’t also carry a reputation for nightmarish conditions or high accident rates. Originally conceived of as a “mothership” for Nanotrasen mining shuttles that could enable long-duration mining missions at minimal cost, severe budget overruns and issues with the mining shuttle docking system left Nanotrasen with a massive number of mostly-completed hulls upon the project’s cancellation. These hulls were then quickly refurbished and sold on the civilian market, where they proved an immediate success on the Frontier. Contemporary Dwaynes can typically be found carrying a variety of mining equipment and extensive modifications unique to their captains. Recently-available aftermarket modifications have solved the Dwayne’s longstanding shuttle dock issues, allowing modern Dwaynes to finally serve their original design purpose, provided the captain is able to source a shuttle.",
 	"tags": [
+		"Non-Aligned",
 		"Mining",
 		"Generalist"
 	],

--- a/_maps/configs/independent_halftrack.json
+++ b/_maps/configs/independent_halftrack.json
@@ -9,6 +9,7 @@
 	"map_short_name": "Halftrack-Class",
 	"description": "A rare sight in the Frontier (but a welcome one), the Halftrack-class is a heavily retrofitted variant of the Li Tieguai-class Rescue Ship, used as a mobile firearms shop by enterprising arms dealers everywhere. While initial variants of the vessel were more obviously just the Li Tieguai with the medical fixtures stripped out and replaced with gun racks and ammunition lockers, the modern iteration of the Halftrack comes complete with a firing range, an Inteq-certified security compliment and a centralized sales floor perfect for showing off the wares while keeping them safe at the same time.",
 	"tags": [
+	"Non-Aligned",
 	"Combat",
 	"Cargo"
 	],

--- a/_maps/configs/independent_junker.json
+++ b/_maps/configs/independent_junker.json
@@ -9,6 +9,7 @@
 	"map_short_name": "Junker-class",
 	"description": "The Junker-class is not an official class, but rather the name for a general group of designs crafted from the ruins of old ships or stations. These ships became a common sight during the ICW, as deserters fled areas of conflict on these 'junkers', unprepared for the challenges of spacer life. They have since become a rare sight, and the few surviving crews of these ships typically bear a sense of disdain to ordinary power structures, and usually have no defined captain, or even owner, of the vessel.",
 	"tags": [
+		"Non-Aligned",
 		"Survival Challenge"
 	],
 	"starting_funds": 0,

--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -3,6 +3,7 @@
 	"map_name": "Kilo-class Mining Ship",
 	"description": "The Kilo-class is a miniscule mining ship that stretches the definition of an independently-capable spacecraft. Beginning life long ago as a series of purpose-built mining shuttles intended for use on Frontier outposts, progressive cycles of over-engineering for a longer mission duration eventually produced the lumpen, claustrophobic Kilo seen today. Once quite numerous, Kilos are still a common “barn find” on abandoned stations and forgotten storage bays, and their extreme age and poor storage conditions typically leaves them in especially poor condition. Kilo crews are often considered to be quite eccentric even by Frontier standards, and some spacers insist even a well-balanced spacer will quickly come unglued in the Kilo’s “unique” environment.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist"
 	],
 	"prefix": "ISV",

--- a/_maps/configs/independent_lagoon.json
+++ b/_maps/configs/independent_lagoon.json
@@ -4,6 +4,7 @@
 	"prefix": "ISV",
 	"description": "An unusual sight in the relatively impoverished Frontier, the Lagoon-class is a large pleasure vessel dedicated to transporting its passengers to any number of exotic locales. Lagoons found on the Frontier tend to contain crews and passengers of a particularly daring – or foolhardy – character, willing to pay out the nose for a tour of some of the most dangerous regions in known space. Accordingly, Lagoons in these regions typically include a small but respectably equipped security contingent to protect (and, when necessary, rein in) the passengers, and come with a surprisingly powerful thermo-electric generator to move the ship’s prodigious bulk across vast expanses of space.",
 	"tags": [
+		"Non-Aligned",
 		"RP Focus",
 		"Service",
 		"Engineering"

--- a/_maps/configs/independent_litieguai.json
+++ b/_maps/configs/independent_litieguai.json
@@ -4,6 +4,7 @@
 	"map_short_name": "Li Tieguai-class",
 	"description": "A small, nimble, and exceptionally well-built medical response vessel, the Li Tieguai is a recent addition to Cybersun’s fleet, forming a critical component of their Frontier stabilization program. Li Tieguais come equipped with high-end medical equipment, including a selection of Cybersun augments and prosthetics, as well as weaponry and armor sufficient to protect its personnel in the often-dangerous Frontier sectors, so that they can offer premium healthcare (at premium prices) in even the most dangerous of scenarios.",
 	"tags": [
+		"Non-Aligned",
 		"Medical"
 	],
 	"map_path": "_maps/shuttles/shiptest/independent_litieguai.dmm",

--- a/_maps/configs/independent_masinyane.json
+++ b/_maps/configs/independent_masinyane.json
@@ -4,6 +4,7 @@
 	"map_short_name": "Masinyane-Class",
 	"description": "The Masinyane is the sports car of space, with the price tag to match. Staggeringly fast and equipped with top of the line gear, Masinyanes are generally found in the hands of lone pilots with far more money than sense. The Masinyane was only ever produced in very limited numbers, and a series of fraud investigations involving a complex web of production contractors and shell companies have effectively put a halt to any further production. As such, they are exceedingly rare even in the core worlds – on the Frontier, they are practically non-existent.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist"
 	],
 	"prefix": "ISV",

--- a/_maps/configs/independent_meta.json
+++ b/_maps/configs/independent_meta.json
@@ -5,6 +5,7 @@
 	"map_short_name": "Meta-class",
 	"description": "The Meta-class is a small freight vessel, and even before the ICW was a common sight on the Frontier as a tramp freighter, running independent contracts between the myriad outposts of the area (with, occasionally, some smuggling or mining on the side). Since the collapse of Nanotrasen’s logistics network in the Frontier region, Meta-classes operating in this capacity have exploded in popularity, and are likely to remain a very common sight wherever larger corporations such as Donk! Co. have yet to establish market dominance.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist",
 		"Cargo"
 	],

--- a/_maps/configs/independent_nemo.json
+++ b/_maps/configs/independent_nemo.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Nemo-class",
 	"description": "The Nemo-Class is an eccentric collector’s dream vessel, perfectly suited to all the journalists, antiquarians and kooks of the Frontier. Featuring a comfortable study, a full robotics workshop (perfectly suited to building yourself some assistants!) and a host of esoteric weapons suitable for hunting creatures to mount above your fireplace. Other highlights include a compact-yet-functional medical bay, a reasonably well-designed engineering bay and a large array of mining equipment.",
 	"tags": [
+		"Non-Aligned",
 		"Engineering",
 		"Mining",
 		"Robotics"

--- a/_maps/configs/independent_pill.json
+++ b/_maps/configs/independent_pill.json
@@ -9,6 +9,8 @@
 	"map_short_name": "Pillbottle-class",
 	"description": "The “Pillbottle,” as a class, should not rightfully exist. Tell-tale signs indicate that these ships originated as bulk carriers and tugs, but they have since been haphazardly converted into a carrier of sorts for a wing of Pill-class escape pods. As with the Pills, Pillbottles are crewed entirely by escaped prisoners, and as a rule, they operate in a state of complete anarchy. The only consistent aspect of Pillbottle crews is their inconsistency, but the realities of prison life tend to make the worst out of anyone.",
 	"tags": [
+		"Non-Aligned",
+		"Survival Challenge",
 		"Specialist"
 	],
 	"map_path": "_maps/shuttles/shiptest/independent_pillbottle.dmm",

--- a/_maps/configs/independent_rigger.json
+++ b/_maps/configs/independent_rigger.json
@@ -11,6 +11,7 @@
 	"map_short_name": "Riggs-class",
 	"description": "The Rigger-class is Kasagi-Fischer Partnership’s mainstay in the independent ship market. Spacious, affordable, and versatile, Riggers offer basic capabilities for everything a Frontier spacer might need in a convenient, easy-to-modify platform, and by default come equipped with a basic medbay, a small security office, atmospherics recycling and equipment to support an APLU utility mech. Thanks to this versatility, Riggers have become extremely popular among moderately-wealthy independent captains, and can be found doing everything from mining to shipping to surveying Frontier planets.",
 	"tags": [
+		"Non-Aligned",
 		"Mining",
 		"Medical",
 		"Robotics",

--- a/_maps/configs/independent_rube_goldberg.json
+++ b/_maps/configs/independent_rube_goldberg.json
@@ -8,7 +8,7 @@
 	"map_name": "Rube Goldberg-class Engineering Project",
 	"map_short_name": "Rube Goldberg-class",
 	"description": "The Rube Goldberg-class Engineering Project is an experience, and a monument to insanity. Featuring a powerful supermatter engine in combination with an Escher-esque structural layout, complicated pipe and wire network, and utter disregard for basic safety procedures and common sense, this ship is a disaster waiting to happen.",
-	"tags": ["Engineering", "Construction"],
+	"tags": ["Non-Aligned", "Engineering", "Construction"],
 	"map_path": "_maps/shuttles/shiptest/independent_rube_goldberg.dmm",
 	"limit": 1,
 	"job_slots": {

--- a/_maps/configs/independent_scav.json
+++ b/_maps/configs/independent_scav.json
@@ -5,6 +5,7 @@
 	"prefix": "ISV",
 	"description": "One of the cheapest (and yet, inexplicably popular) offerings from Miskilamo Spacefaring, the Scav-class is a compact, speedy vessel purpose-built for enterprising scrappers and looters looking to salvage bombed-out ruins and harvest boatloads of ore. Featuring an ‘innovative’ open-floor plan, a charitable supply of EVA/ruin raiding equipment, and some exotic implements of healing or death-dealing, the Scav-class just keeps on chuggin’!",
 	"tags": [
+		"Non-Aligned",
 		"Generalist"
 	],
 	"namelists": [

--- a/_maps/configs/independent_schmiedeberg.json
+++ b/_maps/configs/independent_schmiedeberg.json
@@ -5,6 +5,7 @@
 	"map_short_name": "Schmiedeberg-class",
 	"description": "Interested in pharmacological science, but tired of sitting in front of a chemistry dispenser and pushing buttons all day? Eager to combine the culinary arts with the narcotic ones? Hoping to combine all of these qualities with the most important activity of all: making fat stacks of dosh? Then the Schmiedeberg-class is for you! Host to a robust ghetto chemistry lab, a high-efficiency botanical set-up and a complete kitchen-and-storefront, the Schmiedeberg is perfect for back-alley chemists and botanists everywhere.",
 	"tags": [
+		"Non-Aligned",
 		"Botany",
 		"Medical",
 		"Chemistry"

--- a/_maps/configs/independent_shepherd.json
+++ b/_maps/configs/independent_shepherd.json
@@ -4,6 +4,7 @@
 	"map_short_name": "Shepherd-class",
 	"description": "Best suited to the vast array of the galaxy’s pilgrims, proselytizers and prophets, the Shephard-class is, in essence, a massive mobile monastery. With a great grassy grove dominating the center of the ship, a torturously tempered temple and a brutalist, yet bountiful botany set-up, the Shepherd is well suited to a large crew eager to preach, purify and pull in new followers.",
 	"tags": [
+		"Non-Aligned",
 		"RP Focus",
 		"Botany",
 		"Service"

--- a/_maps/configs/independent_shetland.json
+++ b/_maps/configs/independent_shetland.json
@@ -9,6 +9,7 @@
 	"map_short_name": "Shetland-class",
 	"description": "The Shetland is Miskilamo Spacefaring’s flagship offer and one of their only truly original designs: A huge frigate offering a diverse array of facilities with ample room for expansion at a fraction of the price of the competition. Optimistic customers soon discover the haphazard workmanship and extreme cost-cutting measures common to Miskilamo ships. While Shetlands have plenty of room and a theoretically diverse array of facilities, they come with the minimal amount of equipment needed for those facilities, and a wide array of design deficiencies have given them a grim reputation for driving their crews to paranoid extremes. The waste disposal catapult is a frequent feature of such tales, and supposedly a great many Shetland crewmates have met their end by ejection.",
 	"tags": [
+		"Non-Aligned",
 		"Generalist",
 		"Service",
 		"Medical"

--- a/_maps/configs/independent_tranquility.json
+++ b/_maps/configs/independent_tranquility.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Tranquility-class",
 	"description": "While most vessels have some form of clear utility in mind – research, mining, cargo hauling, and so on – the Tranquility-class is a notable exception to this rule. The Tranquility is, fittingly, a fairly calm and level-headed affair, modeled around traditional apartment complexes. Fitted with several independent quarters, a large communal canteen and very little in the way of industrial equipment or self-defense tools, Tranquility-classes are often found cruising lazily around the Frontier, getting up to sitcom-esque antics and eschewing the more focused approach of many of their contemporaries.",
 	"tags": [
+		"Non-Aligned",
 		"RP Focus",
 		"Service",
 		"Generalist"

--- a/_maps/configs/inteq_colossus.json
+++ b/_maps/configs/inteq_colossus.json
@@ -4,6 +4,7 @@
 	"prefix": "IRMV",
 	"description": "The mainstay of Inteq’s mercenary fleet, the Colossus is a professionally-militarized freighter like most of Inteq’s ships, and is designed to operate independently for some time, serving IRMG’s interests and providing vital mercenary services wherever they are needed. Key features include a secure and well-stocked armory and ample crew space, as well as a spacious cargo bay, which crews often refurbish into additional recreational or training space.",
 	"tags": [
+		"Inteq Risk Management",
 		"Combat",
 		"Riot"
 	],

--- a/_maps/configs/inteq_hound.json
+++ b/_maps/configs/inteq_hound.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Hound-class",
 	"description": "A light, fast picket and interceptor ship operated by Inteq Risk Management, the Hound offers modest crew space sufficient for a 3-man fireteam of Inteq enforcers, a small cargo bay, powerful engines, a well-stocked armory for its size, and little else. Hounds can typically be found on picket and patrol duty, escorting larger and more vulnerable IRMG ships, or performing any duty that calls for a lightning-fast ship and a handful of very well-armed individuals.",
 	"tags": [
+		"Inteq Risk Management",
 		"Combat"
 	],
 	"map_path": "_maps/shuttles/shiptest/inteq_hound.dmm",

--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -4,6 +4,7 @@
 	"prefix": "IRMV",
 	"description": "The Talos is a command and support ship, and a rare example of a purpose-built Inteq ship. Outfitted with an abundance of construction and engineering equipment and a private bluespace communications suite capable of networking IRMG ships across any given system, Taloses are often the lynchpin of coordinated IRMG operations in a system, and offer construction and repair services as part of IRMG’s mercenary offerings. As Talos crews place a larger emphasis on support personnel, they tend to be less well-armed than other Inteq crews. One unusual feature of the Talos is its depressurized “wings” filled with redundant baffles, intended to provide extra durability in the case of impacts or weapons fire. They also double as auxiliary storage space and potential room for modification by their enterprising Artificer crews.",
 	"tags": [
+		"Inteq Risk Management",
 		"Engineer",
 		"Telecomms"
 	],

--- a/_maps/configs/minutemen_asclepius.json
+++ b/_maps/configs/minutemen_asclepius.json
@@ -4,6 +4,7 @@
 	"prefix": "CMSV",
 	"description": "The Asclepius is a medical vessel employed by the CMM. Much in CMM fashion it features tight hallways and moderately sized personal quarters. Well stocked in medical supplies, this vessel is known for its capability of fulfilling extensive treatment for patients in sectors where such treatment is otherwise scarce. Stocked with a cryo lab, a morgue, a chemlab, and surgery room, the Asclepius rarely finds difficulty when provided all measures both preventative and restorative.",
 	"tags": [
+		"Colonial Minutemen",
 		"Medical",
 		"Chemistry"
 	],

--- a/_maps/configs/minutemen_cepheus.json
+++ b/_maps/configs/minutemen_cepheus.json
@@ -4,6 +4,7 @@
 	"prefix": "CMSV",
 	"description": "The Cepheus is the go-to for the CMM whenever it wishes to deploy vessels capable of creating anything in the realm robotica. These vessels are deployed to sectors full of scrap and salvageable material, stocked with armament for their salvagers and a mechanical laboratory for their mechanical engineers. Crews on Cepheus ships are typically treated to somewhat crammed together quarters and tight schedules of collection and production.",
 	"tags": [
+		"Colonial Minutemen",
 		"Robotics"
 	],
 	"namelists": [

--- a/_maps/configs/minutemen_corvus.json
+++ b/_maps/configs/minutemen_corvus.json
@@ -4,6 +4,7 @@
 	"prefix": "CMSV",
 	"description": "A lightly equipped patrol vessel used by the Minutemen for extended operations in the Frontier. In many systems, a lone Corvus is the only sign of Minutemen presence, an image that is not helped by their widespread usage.  The Corvus was originally a light personal vessel retrofitted for combat usage by the Colonial Militia, which was later adopted as their official remote infantry patrol ship as a symbol of colonial ingenuity and grit.  First designated the Wallaby-class, until the crew of a now-legendary Wallaby-class known as the CMSV Corvus single handedly destroyed a Frontiersmen capital ship in 392.",
 	"tags": [
+		"Colonial Minutemen",
 		"Combot",
 		"Riot"
 	],

--- a/_maps/configs/minutemen_vela.json
+++ b/_maps/configs/minutemen_vela.json
@@ -5,6 +5,7 @@
 	"namelists": ["GENERAL", "MYTHOLOGICAL", "BEASTS"],
 	"description": "The Vela-Class is the designation for a series of semi-modular industrial cruisers created by the Colonial Minutemen in the early 440s. While the original design was created almost exclusively for extracting minerals from asteroid belts, modern examples tend to take on a multi-mission role, with the most common configuration being a mech hanger, and research pod. The ship itself often sees long deployments that encourage modification, leading to Velas taking on a personality as their crews leave their mark.",
 	"tags": [
+		"Colonial Minutemen",
 		"Robotics",
 		"Construction",
 		"Science"

--- a/_maps/configs/nanotrasen_delta.json
+++ b/_maps/configs/nanotrasen_delta.json
@@ -12,6 +12,7 @@
 	"map_short_name": "Delta-class",
 	"description": "The Delta is a compact and advanced mining ship that supplements its comparatively small organic crew with a full suite of robotics facilities, including an AI and a host of mining and logistics drones and cyborgs. While much-loved by Nanotrasen logisticians for their minimal upkeep and high cost efficiency, Deltas are far less popular among the crews chosen to operate them, as they are severely lacking in crew accommodations and defensive armament.",
 	"tags": [
+		"Nanotrasen",
 		"Science",
 		"Robotics"
 	],

--- a/_maps/configs/nanotrasen_gecko.json
+++ b/_maps/configs/nanotrasen_gecko.json
@@ -11,6 +11,7 @@
 	"map_path": "_maps/shuttles/shiptest/nanotrasen_gecko.dmm",
 	"description": "A bulky, robust, and exceedingly ugly salvage ship. The Gecko is nothing less than a flying brick full of redundant maintenance spaces and open-to-space salvage bays, powered by a temperamental TEG system, with a cramped crew space sandwiched in between. Due to its deeply obsolete design and the dangerous nature of salvage work, Geckos are often the final resting point for the careers of officers that have stepped on too many toes in the corporate world without doing anything outright criminal. Despite these shortcomings, Geckos offer a large amount of open space and a good supply of engineering equipment, which is all an enterprising engineer truly needs.",
 	"tags": [
+		"Nanotrasen",
 		"Mining",
 		"Engineering"
 	],

--- a/_maps/configs/nanotrasen_mimir.json
+++ b/_maps/configs/nanotrasen_mimir.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Mimir-class",
 	"description": "The Mimir-class are Nanotrasen “patient” transfer and holding ships. Nanotrasen deploys Mimirs to hold those they’ve interned, often in ruined or otherwise out-of-the-way sectors. This both minimizes the chances of the “patients” escaping and drastically lowers the incentive to do so in the first place, as it keeps them stuck in the middle of nowhere until Central Command is ready to pick them up and process them. While “patients” are largely kept in cryogenic storage, regulations and medical necessity both require occasional thawing. As such, the Mimir comes with a host of “rehabilitative” activities for the “patients” as well as a light security detail to manage them.",
 	"tags": [
+		"Nanotrasen",
 		"Riot",
 		"Service",
 		"Generalist",

--- a/_maps/configs/nanotrasen_osprey.json
+++ b/_maps/configs/nanotrasen_osprey.json
@@ -11,7 +11,7 @@
 	"map_short_name": "Osprey-class",
 	"map_path": "_maps/shuttles/shiptest/nanotrasen_osprey.dmm",
 	"description": "Some of the most modern ships in Nanotrasen’s fleet and a prestigious assignment for their captains, the famed Osprey of the ICW’s most dramatic astronautical engagements lives on as a very well-appointed exploration ship. Extensively refurbished from their origins as Bluespace Artillery platforms, the contemporary Osprey repurposes military-grade sensor equipment and AI systems for exploration and scientific work. Features include respectably-equipped medical, culinary, and scientific facilities and an AI core, as well as a ship-wide disposals and delivery system and a very spacious cargo bay. However, the powerful (if temperamental) supermatter engines that powered the initial batch of Ospreys were stripped out during their rebuilds, and the replacement generator banks have left contemporary Ospreys somewhat power-starved.",
-	"tags": ["Cargo", "Robotics", "Nanotrasen", "Generalist"],
+	"tags": ["Nanotrasen", "Cargo", "Robotics", "Generalist"],
 	"limit": 1,
 	"starting_funds": 4000,
 	"job_slots": {

--- a/_maps/configs/nanotrasen_osprey.json
+++ b/_maps/configs/nanotrasen_osprey.json
@@ -11,7 +11,7 @@
 	"map_short_name": "Osprey-class",
 	"map_path": "_maps/shuttles/shiptest/nanotrasen_osprey.dmm",
 	"description": "Some of the most modern ships in Nanotrasen’s fleet and a prestigious assignment for their captains, the famed Osprey of the ICW’s most dramatic astronautical engagements lives on as a very well-appointed exploration ship. Extensively refurbished from their origins as Bluespace Artillery platforms, the contemporary Osprey repurposes military-grade sensor equipment and AI systems for exploration and scientific work. Features include respectably-equipped medical, culinary, and scientific facilities and an AI core, as well as a ship-wide disposals and delivery system and a very spacious cargo bay. However, the powerful (if temperamental) supermatter engines that powered the initial batch of Ospreys were stripped out during their rebuilds, and the replacement generator banks have left contemporary Ospreys somewhat power-starved.",
-	"tags": ["Cargo", "Robotics", "Generalist"],
+	"tags": ["Cargo", "Robotics", "Nanotrasen", "Generalist"],
 	"limit": 1,
 	"starting_funds": 4000,
 	"job_slots": {

--- a/_maps/configs/nanotrasen_powerrangers.json
+++ b/_maps/configs/nanotrasen_powerrangers.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Ranger-class",
 	"description": "A Nanotrasen rescue and aid vessel. Equipped with an AI core, moderate combat gear, and equipment fit for rescue and general aid operations. Nanotrasen often deploys these ships in lieu of a proper ERT to aid their allies in the Frontier without committing their full might. The shipowner is the Lieutenant of a Loss Prevention squad, with a Commissioner to aid with operations on the ship proper.",
 	"tags": [
+		"Nanotrasen",
 		"Combat",
 		"Riot",
 		"Robotics",

--- a/_maps/configs/nanotrasen_skipper.json
+++ b/_maps/configs/nanotrasen_skipper.json
@@ -13,8 +13,9 @@
 	"map_path": "_maps/shuttles/shiptest/nanotrasen_skipper.dmm",
 	"description": "An example of one of Nanotrasen’s “standard-pattern” cruisers. The Skipper-class is well-equipped by Frontier standards, with ample room for engineering equipment, well-appointed crew accommodations, and a decent supply of defensive weaponry. Notably, the Skipper comes with a larger command section than average, and the officers on Skippers tend to be better-equipped than their peers. Though not as prestigious as a position aboard an Osprey, few Nanotrasen captains would turn down a position commanding a Skipper.",
 	"tags": [
-	"Engineering",
-	"Mining"
+		"Nanotrasen",
+		"Engineering",
+		"Mining"
 	],
 	"starting_funds": 4000,
 	"roundstart": true,

--- a/_maps/configs/pirate_ember.json
+++ b/_maps/configs/pirate_ember.json
@@ -10,6 +10,7 @@
 	"map_path": "_maps/shuttles/shiptest/pirate_ember.dmm",
 	"description": "The Ember class is a red flag in any sector. A giant, slow moving, safety hazard of a ship, makeshift in almost every regard, finds itself favored amongst the most ruthless and cutthroat of pirates and scoundrels galaxy-wide. Simply to be willing to exist on one of these ships shows a hardiness not typically found in most spacers. The best way to deal with Ember vessels is to simply give them a wide berth.",
 	"tags": [
+		"Pirate (Frontiersmen)",
 		"Combat",
 		"Riot",
 		"Combat",

--- a/_maps/configs/pirate_libertatia.json
+++ b/_maps/configs/pirate_libertatia.json
@@ -5,6 +5,7 @@
 	"map_path": "_maps/shuttles/shiptest/pirate_libertatia.dmm",
 	"description": "A widely-available and dirt-cheap courier ship by Miskilamo Spacefaring, Libertatias are shoddy overhauls of old civilian atmospheric ships or the burned-out wrecks of other Libertatias, made nominally space worthy and capable of carrying a modest cargo at blistering speeds. While marketed as courier ships and short-range cargo shuttles, the Libertatia found its true target market in the hands of smugglers, blockade runners, and pirates, who find its speed, low sensor signature, and rock-bottom price point extremely attractive. In recent years, it’s become far more common to see Libertatias captained by pirates than anyone else, especially in the loosely-patrolled Frontier sectors. Surprisingly enough, the more organized Frontiersmen pirate group shows little love for the humble Libertatia, instead preferring larger and more threatening ships.",
 	"tags": [
+		"Pirate (Non-Aligned)",
 		"Combat"
 	],
 	"prefix": "ISV",

--- a/_maps/configs/pirate_noderider.json
+++ b/_maps/configs/pirate_noderider.json
@@ -10,6 +10,7 @@
 	"map_path": "_maps/shuttles/shiptest/pirate_noderider.dmm",
 	"description": "The Jupiter-class Stormrider is a specialist design originating from the Silicon Elevation Council, typically used for sustained missions in the Frontier. While habitable to organic life (typically as a matter of convenience), the ship is designed with silicons in mind, and features an AI core built into its hull. Many captains have been quoted as being “frightened” (although “piss-pants scared” was the exact statement) by one suddenly appearing out of a storm, IFF loudly declaring who they were, or in worse conditions, not functioning at all. Some examples have been known to find their way into pirate hands, who leverage the ship to spring ambushes on unsuspecting traders.",
 	"tags": [
+		"Pirate (Non-Aligned)",
 		"Robotics",
 		"Specialist",
 		"Riot",

--- a/_maps/configs/radio.json
+++ b/_maps/configs/radio.json
@@ -4,7 +4,7 @@
 	"map_short_name": "Radio-class",
 	"map_path": "_maps/shuttles/shiptest/radio_funny.dmm",
 	"description": "Whether through divine intervention or hellish creation by the hands of sapient-kind, reports of this “ship” plague some sectors more than others. The Radio Broadcasting Ship is an anomalous thing in its own right. It is  a “ship” equipped with nothing but radios and reality warping engines. There exist many reports of this vessel being totally destroyed and showing back up in a sector just hours later. The only thing you can do about these vessels is pray the pilot doesn’t have bad taste.",
-	"tags": ["Specialist"],
+	"tags": ["Non-Aligned", "Specialist"],
 	"job_slots": {
 		"Assistant": {
 			"outfit": "/datum/outfit/job/assistant",

--- a/_maps/configs/solgov_chronicle.json
+++ b/_maps/configs/solgov_chronicle.json
@@ -12,6 +12,7 @@
 	"map_path": "_maps/shuttles/shiptest/solgov_chronicle.dmm",
 	"description": "Equipped with a sophisticated sensors suite and powerful data utilities, the Chronicle is a clerical workhorse, able to collect and process vast amounts of information. Often employed for census duties and interstellar exploration, the Chronicle is also a favorite of Evidenzkompanien, employed often for intelligence operations. With this fact in mind, Chronicle-class vessels are often placed under increased scrutiny by patrols, somewhat mitigating their effectiveness as a spymaster's tool.",
 	"tags": [
+		"Solar Confederation",
 		"Specialist"
 	],
 	"limit": 1,

--- a/_maps/configs/solgov_paracelsus.json
+++ b/_maps/configs/solgov_paracelsus.json
@@ -10,7 +10,7 @@
 	],
 	"map_short_name": "Paracelsus-class",
 	"description": "Fulfilling its role as a medicinal powerhouse of the Solarian Navy, the Paracelsus-class is a specially designed corvette to assist solarian fleets in medical troubles, as well as supplying such vessels with medication. Scribes pursuing a medical degree often work in these ships to shadow trained medical doctors to complete their residency.",
-	"tags": ["RP Focus", "Medical", "Chemistry"],
+	"tags": ["Solar Confederation", "RP Focus", "Medical", "Chemistry"],
 	"map_path": "_maps/shuttles/shiptest/solgov_paracelsus.dmm",
 	"limit": 1,
 	"job_slots": {

--- a/_maps/configs/srm_glaive.json
+++ b/_maps/configs/srm_glaive.json
@@ -10,6 +10,7 @@
 	"map_path": "_maps/shuttles/shiptest/srm_glaive.dmm",
 	"description": "A standard issue vessel to the highest ranks of the Saint-Roumain Militia. While “standard”, this class of vessel is unique to the Montagne that owns it. Each ship is designed around a central garden consisting of plants, soil, and a tree from the owning Montagnes’ home planet. As a highly religious ascetic order, the SRM supplies each Glaive with supplies to farm, raise animals, and perform medicine in more “natural” ways, using herbs and plants grown in house. Alongside this, the ship has a decent amount of mining equipment, and supplies required to begin the manufacturing of SRM-pattern firearms as is standard for Hunter’s Pride. The ship is captained by a Montagne, who oversees a team of Hunters, and Shadows apprenticing them.",
 	"tags": [
+		"Saint-Roumain Militia",
 		"Mining",
 		"Combat",
 		"Specialist"

--- a/_maps/configs/syndicate_aegis.json
+++ b/_maps/configs/syndicate_aegis.json
@@ -5,6 +5,7 @@
 	"map_path": "_maps/shuttles/shiptest/syndicate_aegis.dmm",
 	"description": "Approximately a third of the way through the ICW, it became apparent that the Syndicate could not muster the sheer throwaway manpower that Nanotrasen could with its swaths of mercenaries and disposable personnel. Instead, the Syndicate began to adopt a much more conservative approach to maintaining personnel, by establishing an initiative to create a host of medical vessels designed to rescue and rehabilitate the fallen. While the Li Tieguai filled the rescue role, the Aegis-Class was to fill the rehabilitation role. Featuring a host of ‘quality of life’ features for long-term patients (a full bar, a hydroponics setup, and so on), an expansive medical bay and an array of comfort fixtures like couches and gardens, the Aegis is perfect for aspiring doctors or wounded patients.",
 	"tags": [
+		"Syndicate (NSV)",
 		"Botany",
 		"Medical",
 		"RP Focus"

--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -9,6 +9,7 @@
 	"map_name": "Kansatsu-Class Scout Courier",
 	"description": "The Kansatsu-class is a Cybersun remodel of the old Type-S SolGov Courier, rebuilt for rapid package ferrying and light surveillance operations in the Frontier. While fairly cramped, it excels at its design goals, with rapid surveys, scouting, and espionage flowing from its presence. Syndicate deployments typically include a deployment of 5, with a recommended max of 7. This is broken down into 1 captain, an intelligence officer for coordinating the field agents, an engineer, and 2 field agents. The simplicity of the hull has led to the ship becoming a widespread indicator of Syndicate interest in locations, and some models have found their way into private purchasers' hands.",
 	"tags": [
+		"Syndicate (Cybersun)",
 		"Specialist"
 	],
 	"map_short_name": "Kansatsu-Class",

--- a/_maps/configs/syndicate_gorlex_hyena.json
+++ b/_maps/configs/syndicate_gorlex_hyena.json
@@ -11,6 +11,7 @@
 	"map_name": "Hyena-class Wrecking Tug",
 	"description": "The Hyena is a common salvage tug, frequently operated by the Gorlex Marauders for “salvage” missions on ICW-era Nanotrasen derelicts (and occasionally occupied outposts and ships). The Hyena features a fairly compact floor plan with a dedicated secure armory space and a fairly large cargo bay for its size, as well as a complement of high-grade hardsuits and mining equipment. The Hyena’s low cost and high demand in its niche has made it a very common sight on the Frontier in the years following the ICW, and despite their tight finances nearly all Gorlex Marauder splinter factions continue to acquire more.",
 	"tags": [
+		"Syndicate (Gorlex)",
 		"Mining",
 		"Combat"
 	],

--- a/_maps/configs/syndicate_gorlex_komodo.json
+++ b/_maps/configs/syndicate_gorlex_komodo.json
@@ -10,6 +10,7 @@
 	"map_short_name": "Komodo-class",
 	"description": "An ICW-era design, the Komodo is a dedicated warship operated by the Gorlex Marauders. Contemporaries of the legendary Starfury-class, Komodos were the backbone of Gorlex and ACLF fleets during the ICW, and saw significant combat service – not always to a tragic end like their Cybersun companions. Contemporary examples often still bear the scars of ICW-period combat, and the dire financial straits of most Gorlex splinter factions means many of those survivors are in a state of poor repair. Despite the stresses of age, they remain capable ships, and often still have the heavier armament associated with their ICW deployments in storage.",
 	"tags": [
+		"Syndicate (Gorlex)",
 		"RP Focus",
 		"Combat",
 		"Engineering"

--- a/_maps/configs/syndicate_lugol.json
+++ b/_maps/configs/syndicate_lugol.json
@@ -4,6 +4,7 @@
 	"map_short_name": "Lugol-class",
 	"description": "The Lugol is effectively an enormous Galactic Engineers Concordat research barge, used as a test bed for refinements to power systems, new technologies, and so on. As it offers freedom from the usual constraints of working aboard vessels belonging to other Syndicate factions, Lugols are especially popular among the GEC’s more radical members. Accordingly, they have a reputation for either accomplishing the impossible or generating the equivalent of a new star when they inevitably melt down. Lugols are generally only found on the Frontier, where the collateral damage from potential accidents can be kept to a minimum and secrecy, when needed, can be better maintained.",
 	"tags": [
+		"Syndicate (GEC)",
 		"Engineering",
 		"Construction"
 	],

--- a/_maps/configs/syndicate_luxembourg.json
+++ b/_maps/configs/syndicate_luxembourg.json
@@ -9,6 +9,7 @@
 	"map_name": "Luxembourg-class Delivery Vessel",
 	"description": "A dual-purpose delivery vessel and mobile storefront, Luxembourgs make up a substantial portion of Donk! Co.’s fleet on the Frontier, where the ever-opportunistic corporation has begun to fill the gaps left behind by the collapse of Nanotrasen’s logistics network. Donk! Co. managers have a great degree of autonomy, and so any given Luxembourg will often bear substantial modifications to the sales floor and on-board cafe, the better to entice new customers in an unstable yet lucrative region of space.",
 	"tags": [
+		"Syndicate (Donk Co.)",
 		"Robotics",
 		"Cargo"
 	],

--- a/_maps/configs/syndicate_twinkleshine.json
+++ b/_maps/configs/syndicate_twinkleshine.json
@@ -9,6 +9,7 @@
 	"map_name": "Twinkleshine-class Battle Cruiser",
 	"description": "After the destruction of the larger Starfury-class Battle Cruisers during the Inter-Corporate War, Cybersun engineered the Twinkleshine as a replacement to fill the now-vacant flagship role. However, the war came to a close before any examples of this class could see combat. Now, they are kept as a valuable symbol of the Syndicate’s might and unity – in theory. As with the Starfury-class, Twinkleshine crews contain a mix of all Syndicate member factions as a matter of political necessity – none would consent to Cybersun operating such powerful ships alone. While Twinkleshine crews are supposedly selected for more diplomatic tendencies than one might expect, the political situation aboard a Twinkleshine is often delicate, particularly as tensions between the Syndicate’s corporate and anti-corporate elements continue to build. Nevertheless, they remain the most potent singular assets in the Syndicate’s combined arsenal, and frequently serve the role of power projection in Frontier space.",
 	"tags": [
+		"Syndicate",
 		"Engineering",
 		"Combat",
 		"Service",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin. I had basically finished it before I was told tags shouldn't be used this way, despite being told some time earlier that I should do it by other staff, so I am PRing it anyways, if it gets closed, it gets closed and I won't bother again.

## Why It's Good For The Game
Seeing the ship's faction is generally a good thing given people shouldn't be playing a ship as a faction it wasn't designed for.
## Changelog

:cl:
add: Each currently added ship has it's intended faction listed in its tags.
/:cl:
