### PR TITLE
Make IPC able to recharge at borg stations

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -73,7 +73,7 @@
 			mutantbrain = /obj/item/organ/brain/mmi_holder
 		else
 			mutantbrain = /obj/item/organ/brain/mmi_holder/posibrain
-		C.RegisterSignal(C, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, /mob/living/carbon/proc/charge)
+		C.RegisterSignal(C, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, TYPE_PROC_REF(/mob/living/carbon, charge))
 	return ..()
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/C)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -73,12 +73,14 @@
 			mutantbrain = /obj/item/organ/brain/mmi_holder
 		else
 			mutantbrain = /obj/item/organ/brain/mmi_holder/posibrain
+		C.RegisterSignal(C, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, /mob/living/carbon/proc/charge)
 	return ..()
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	if(change_screen)
 		change_screen.Remove(C)
+	C.UnregisterSignal(C, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
 
 /datum/species/ipc/spec_death(gibbed, mob/living/carbon/C)
 	saved_screen = C.dna.features["ipc_screen"]
@@ -239,3 +241,9 @@
 			BP.limb_id = chassis_of_choice.limbs_id
 			BP.name = "\improper[chassis_of_choice.name] [parse_zone(BP.body_zone)]"
 			BP.update_limb()
+
+/mob/living/carbon/proc/charge(datum/source, amount, repairs)
+	if(nutrition < NUTRITION_LEVEL_WELL_FED)
+		adjust_nutrition(amount / 10) // The original amount is capacitor_rating*100
+	if(repairs)
+		heal_bodypart_damage(repairs, repairs - 1)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -245,5 +245,3 @@
 /mob/living/carbon/proc/charge(datum/source, amount, repairs)
 	if(nutrition < NUTRITION_LEVEL_WELL_FED)
 		adjust_nutrition(amount / 10) // The original amount is capacitor_rating*100
-	if(repairs)
-		heal_bodypart_damage(repairs, repairs - 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IPC will now recharge/repair like borg when they get into a borg recharger.

## Why It's Good For The Game

Robort <3

## Changelog

:cl:
add: IPC can now recharge/repair at borg recharge station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
