### PR TITLE
Make body bag printable in the autolathe

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/bodybag.dmi'
 	icon_state = "bodybag_folded"
 	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/plastic = 4000)
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1175,6 +1175,14 @@
 	build_path = /obj/item/storage/bag/trash
 	category = list("initial","Tools","Tool Designs","Misc")
 
+/datum/design/bodybag
+	name="Body Bag"
+	id="bodybag"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/plastic = 4000)
+	build_path = /obj/item/bodybag
+	category = list("initial","Medical","Misc")
+
 /datum/design/fishing_rod_basic
 	name = "Fishing Rod"
 	id = "fishing rod"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Body bags are printable for a price of 2 plastic sheet in every autolathe/protolathe.

## Why It's Good For The Game

Honestly they are just handy and the design feel basic enough to be available everywere.

## Changelog

:cl:
add: Body bags in the autolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
