### PR TITLE
Radio OpSec

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -251,7 +251,7 @@
  * * sat_shift - A value between 0 and 1 that will be multiplied against the saturation
  * * lum_shift - A value between 0 and 1 that will be multiplied against the luminescence
  */
-/datum/chatmessage/proc/colorize_string(name, sat_shift = 1, lum_shift = 1)
+/proc/colorize_string(name, sat_shift = 1, lum_shift = 1)
 	// seed to help randomness
 	var/static/rseed = rand(1,26)
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -251,15 +251,15 @@
  * * sat_shift - A value between 0 and 1 that will be multiplied against the saturation
  * * lum_shift - A value between 0 and 1 that will be multiplied against the luminescence
  */
-/proc/colorize_string(name, sat_shift = 1, lum_shift = 1)
+/proc/colorize_string(name, sat_shift = 1, lum_shift = 1, sat_min = CM_COLOR_SAT_MIN, sat_max = CM_COLOR_SAT_MAX, lum_min = CM_COLOR_LUM_MIN, lum_max = CM_COLOR_LUM_MAX)
 	// seed to help randomness
 	var/static/rseed = rand(1,26)
 
 	// get hsl using the selected 6 characters of the md5 hash
-	var/hash = copytext(md5(name + GLOB.round_id), rseed, rseed + 6)
+	var/hash = copytext(md5(name + "1852"), rseed, rseed + 6)
 	var/h = hex2num(copytext(hash, 1, 3)) * (360 / 255)
-	var/s = (hex2num(copytext(hash, 3, 5)) >> 2) * ((CM_COLOR_SAT_MAX - CM_COLOR_SAT_MIN) / 63) + CM_COLOR_SAT_MIN
-	var/l = (hex2num(copytext(hash, 5, 7)) >> 2) * ((CM_COLOR_LUM_MAX - CM_COLOR_LUM_MIN) / 63) + CM_COLOR_LUM_MIN
+	var/s = (hex2num(copytext(hash, 3, 5)) >> 2) * ((sat_max - sat_min) / 63) + sat_min
+	var/l = (hex2num(copytext(hash, 5, 7)) >> 2) * ((lum_max - lum_min) / 63) + lum_min
 
 	// adjust for shifts
 	s *= clamp(sat_shift, 0, 1)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -256,7 +256,7 @@
 	var/static/rseed = rand(1,26)
 
 	// get hsl using the selected 6 characters of the md5 hash
-	var/hash = copytext(md5(name + "1852"), rseed, rseed + 6)
+	var/hash = copytext(md5(name + GLOB.round_id), rseed, rseed + 6)
 	var/h = hex2num(copytext(hash, 1, 3)) * (360 / 255)
 	var/s = (hex2num(copytext(hash, 3, 5)) >> 2) * ((sat_max - sat_min) / 63) + sat_min
 	var/l = (hex2num(copytext(hash, 5, 7)) >> 2) * ((lum_max - lum_min) / 63) + lum_min

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -18,6 +18,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	"[FREQ_CTF_BLUE]" = "blueteamradio"
 	))
 
+GLOBAL_LIST_INIT(freqcolor, list())
+
 /atom/movable/proc/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!can_speak())
 		return
@@ -43,7 +45,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.
 	//Basic span
-	var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
+	//var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
+	var/spanpart1 = "<span [get_radio_span(radio_freq)]>"
 	//Start name span.
 	var/spanpart2 = "<span class='name'>"
 	//Radio freq/name display
@@ -134,10 +137,21 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "makes a strange sound."
 
 /proc/get_radio_span(freq)
+	if(!freq)
+		return "class='game say'"
 	var/returntext = GLOB.freqtospan["[freq]"]
 	if(returntext)
-		return returntext
-	return "radio"
+		return "class='[returntext]'"
+	else if(freq != FREQ_COMMON)
+		var/returncolor = GLOB.freqcolor["[freq]"]
+		if(returncolor)
+			return "style='color:#[returncolor]' class='radio'"
+		else
+			returncolor = random_color()
+			GLOB.freqcolor["[freq]"] = returncolor
+			return "style='color:#[returncolor]' class='radio'"
+	else
+		return "class='radio'"
 
 /proc/get_radio_name(freq)
 	var/returntext = GLOB.reverseradiochannels["[freq]"]

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -45,7 +45,6 @@ GLOBAL_LIST_INIT(freqcolor, list())
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.
 	//Basic span
-	//var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
 	var/spanpart1 = "<span [get_radio_span(radio_freq)]>"
 	//Start name span.
 	var/spanpart2 = "<span class='name'>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(freqcolor, list())
 		if(returncolor) // If we've already picked a color for this channel, don't do it again.
 			return "style='color:[returncolor]' class='radio'"
 		else // If we haven't picked a color for this channel, pick one now.
-			returncolor = pick("#E91E63", "#C2185B", "#9C27B0", "#5727B0", "#272AB0")
+			returncolor = colorize_string("[freq]", 1, 0.55)
 			GLOB.freqcolor["[freq]"] = returncolor
 			return "style='color:[returncolor]' class='radio'"
 	else // This should only handle Common

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -136,20 +136,20 @@ GLOBAL_LIST_INIT(freqcolor, list())
 		return "makes a strange sound."
 
 /proc/get_radio_span(freq)
-	if(!freq)
+	if(!freq) // If there's no freq attached to the message, then it's not for a radio.
 		return "class='game say'"
 	var/returntext = GLOB.freqtospan["[freq]"]
-	if(returntext)
+	if(returntext) // If we find a pre-defined span for the freq, use that instead.
 		return "class='[returntext]'"
-	else if(freq != FREQ_COMMON)
+	else if(freq != FREQ_COMMON) // We don't want to change the color of Common.
 		var/returncolor = GLOB.freqcolor["[freq]"]
-		if(returncolor)
-			return "style='color:#[returncolor]' class='radio'"
-		else
-			returncolor = random_color()
+		if(returncolor) // If we've already picked a color for this channel, don't do it again.
+			return "style='color:[returncolor]' class='radio'"
+		else // If we haven't picked a color for this channel, pick one now.
+			returncolor = pick("#E91E63", "#C2185B", "#9C27B0", "#5727B0", "#272AB0")
 			GLOB.freqcolor["[freq]"] = returncolor
-			return "style='color:#[returncolor]' class='radio'"
-	else
+			return "style='color:[returncolor]' class='radio'"
+	else // This should only handle Common
 		return "class='radio'"
 
 /proc/get_radio_name(freq)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(freqcolor, list())
 			returncolor = colorize_string("[freq]", 1, 0.55)
 			GLOB.freqcolor["[freq]"] = returncolor
 			return "style='color:[returncolor]' class='radio'"
-	else // This should only handle Common
+	else // This should only handle Common.
 		return "class='radio'"
 
 /proc/get_radio_name(freq)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(freqcolor, list())
 		if(returncolor) // If we've already picked a color for this channel, don't do it again.
 			return "style='color:[returncolor]' class='radio'"
 		else // If we haven't picked a color for this channel, pick one now.
-			returncolor = colorize_string("[freq]", 1, 0.55)
+			returncolor = colorize_string("[freq]", 1, 0.85)
 			GLOB.freqcolor["[freq]"] = returncolor
 			return "style='color:[returncolor]' class='radio'"
 	else // This should only handle Common.

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/returntext = GLOB.reverseradiochannels["[freq]"]
 	if(returntext)
 		return returntext
-	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
+	return "Custom"
 
 /proc/attach_spans(input, list/spans)
 	return "[message_spans_start(spans)][input]</span>"


### PR DESCRIPTION
This simply adjusts radio channel text in chat like so:
Before:
`[146.7] Blorbo blorbs, "We are going to beat you to death."`
After:
`[Custom] Blorbo blorbs, "We are going to beat you to death."`
Additionally, each custom channel will have a random color assigned to it.
![image](https://github.com/shiptest-ss13/Shiptest/assets/34109002/3f002946-1118-4990-9e7a-128378dcebc4)



Todo
- [x] Make it work
- [x] Sanitize color output to be within a high enough contrast

:cl:
tweak: Custom radio channels no longer leak themselves
tweak: Custom radio channels are assigned a random color.
/:cl: