### PR TITLE
Adds a voice log to the wideband

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -181,6 +181,7 @@
 			radio.last_chatter_time = world.time
 	//WS edit end
 
+//for all the widebands that heard the message, log it in their voice log
 	for(var/obj/item/radio/wideband in radios)
 		if(wideband.frequency == FREQ_WIDEBAND)
 			var/name = data["name"]

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -188,7 +188,7 @@
 			log_details["name"] = "[name]▸"
 			log_details["message"] = "\"[html_decode(message)]\""
 			log_details["time"] = station_time_timestamp()
-			wideband.loglist += list(log_details)
+			wideband.loglist.Insert(1, list(log_details))
 			wideband.log_trim()
 
 	// From the list of radios, find all mobs who can hear those.

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -179,18 +179,14 @@
 		if(radio.last_chatter_time + 1 SECONDS < world.time && source != radio)
 			playsound(radio, "sound/effects/radio_chatter.ogg", 20, FALSE)
 			radio.last_chatter_time = world.time
-	//WS edit end
-
-//for all the widebands that heard the message, log it in their voice log
-	for(var/obj/item/radio/wideband in radios)
-		if(wideband.frequency == FREQ_WIDEBAND)
+		if(radio.log)
 			var/name = data["name"]
 			var/list/log_details = list()
 			log_details["name"] = "[name]▸"
 			log_details["message"] = "\"[html_decode(message)]\""
 			log_details["time"] = station_time_timestamp()
-			wideband.loglist.Insert(1, list(log_details))
-			wideband.log_trim()
+			radio.loglist.Insert(1, list(log_details))
+			radio.log_trim()
 
 	// From the list of radios, find all mobs who can hear those.
 	var/list/receive = get_mobs_in_radio_ranges(radios)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -181,6 +181,16 @@
 			radio.last_chatter_time = world.time
 	//WS edit end
 
+	for(var/obj/item/radio/wideband in radios)
+		if(wideband.frequency == FREQ_WIDEBAND)
+			var/name = data["name"]
+			var/list/log_details = list()
+			log_details["name"] = "[name]▸"
+			log_details["message"] = "\"[html_decode(message)]\""
+			log_details["time"] = station_time_timestamp()
+			wideband.loglist += list(log_details)
+			wideband.log_trim()
+
 	// From the list of radios, find all mobs who can hear those.
 	var/list/receive = get_mobs_in_radio_ranges(radios)
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -167,6 +167,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 31)
 	frequency = FREQ_WIDEBAND
 	freqlock = TRUE
 	freerange = TRUE
+	log = TRUE
 	wallframe = /obj/item/wallframe/intercom/wideband
 
 /obj/item/radio/intercom/wideband/Initialize(mapload, ndir, building)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -34,6 +34,8 @@
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
+	var/log = FALSE // If true, the UI will display the voice log for the frequency
+	var/list/loglist = list() //the voice log
 
 	// Encryption key handling
 	var/obj/item/encryptionkey/keyslot
@@ -140,6 +142,8 @@
 	data["useCommand"] = use_command
 	data["subspace"] = subspace_transmission
 	data["subspaceSwitchable"] = subspace_switchable
+	data["chatlog"] = log
+	data["chatloglist"] = loglist
 	data["headset"] = FALSE
 
 	return data
@@ -371,6 +375,11 @@
 	emped = FALSE
 	on = TRUE
 	return TRUE
+
+/obj/item/radio/proc/log_trim()
+	if(loglist.len <= 50)
+		return
+	loglist = loglist.Copy(loglist.len-50 ,0)
 
 ///////////////////////////////
 //////////Borg Radios//////////

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -379,7 +379,7 @@
 /obj/item/radio/proc/log_trim()
 	if(loglist.len <= 50)
 		return
-	loglist = loglist.Copy(loglist.len-50 ,0)
+	loglist.Cut(51)
 
 ///////////////////////////////
 //////////Borg Radios//////////

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -1,7 +1,7 @@
 import { map } from 'common/collections';
 import { toFixed } from 'common/math';
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, NumberInput, Section } from '../components';
+import { Box, Button, LabeledList, NumberInput, Section, Divider, Table } from '../components';
 import { RADIO_CHANNELS } from '../constants';
 import { Window } from '../layouts';
 
@@ -18,6 +18,8 @@ export const Radio = (props, context) => {
     useCommand,
     subspace,
     subspaceSwitchable,
+    chatlog,
+    chatloglist = [],
   } = data;
   const tunedChannel = RADIO_CHANNELS.find(
     (channel) => channel.freq === frequency
@@ -28,15 +30,19 @@ export const Radio = (props, context) => {
   }))(data.channels);
   // Calculate window height
   let height = 106;
+  let width = 360;
   if (subspace) {
     if (channels.length > 0) {
       height += channels.length * 21 + 6;
     } else {
       height += 24;
     }
+  } else if (chatlog) {
+    height += 400;
+    width += 110;
   }
   return (
-    <Window width={360} height={height}>
+    <Window width={width} height={height}>
       <Window.Content>
         <Section>
           <LabeledList>
@@ -127,6 +133,24 @@ export const Radio = (props, context) => {
             )}
           </LabeledList>
         </Section>
+        {!!chatlog && (
+          <Section title="Voice Log" height="350px" width="460px" overflowY="scroll" >
+            <Table >
+              <Table.Row header>
+                <Table.Cell>Timestamp</Table.Cell>
+                <Table.Cell>Transcript</Table.Cell>
+                <Divider />
+              </Table.Row>
+              {chatloglist.map((log) => (
+                <Table.Row key={log.message} className="candystripe">
+                  <Table.Cell>{log.time}</Table.Cell>
+                  <Table bold color="blue">{log.name}</Table>
+                  <Table >{log.message}</Table>
+                </Table.Row>
+              ))}
+            </Table>
+          </Section>
+        )}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -144,7 +144,7 @@ export const Radio = (props, context) => {
         {!!chatlog && (
           <Section
             title="Voice Log"
-            height="350px"
+            height="400px"
             width="460px"
             overflowY="scroll"
           >

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -1,7 +1,15 @@
 import { map } from 'common/collections';
 import { toFixed } from 'common/math';
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, NumberInput, Section, Divider, Table } from '../components';
+import {
+  Box,
+  Button,
+  LabeledList,
+  NumberInput,
+  Section,
+  Divider,
+  Table,
+} from '../components';
 import { RADIO_CHANNELS } from '../constants';
 import { Window } from '../layouts';
 
@@ -134,8 +142,13 @@ export const Radio = (props, context) => {
           </LabeledList>
         </Section>
         {!!chatlog && (
-          <Section title="Voice Log" height="350px" width="460px" overflowY="scroll" >
-            <Table >
+          <Section
+            title="Voice Log"
+            height="350px"
+            width="460px"
+            overflowY="scroll"
+          >
+            <Table>
               <Table.Row header>
                 <Table.Cell>Timestamp</Table.Cell>
                 <Table.Cell>Transcript</Table.Cell>
@@ -144,8 +157,10 @@ export const Radio = (props, context) => {
               {chatloglist.map((log) => (
                 <Table.Row key={log.message} className="candystripe">
                   <Table.Cell>{log.time}</Table.Cell>
-                  <Table bold color="blue">{log.name}</Table>
-                  <Table >{log.message}</Table>
+                  <Table bold color="blue">
+                    {log.name}
+                  </Table>
+                  <Table>{log.message}</Table>
                 </Table.Row>
               ))}
             </Table>


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a voice log to the wideband that stores the last 50 messages spoken along with their timestamps to make the wideband more usable without having to be glued to it
![image](https://github.com/shiptest-ss13/Shiptest/assets/105491762/e2897056-4cb2-4530-b6ed-464b7f48157c)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it's sure to make ships interact more with each other by taking on a role similar to a chatroom 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added a voice log for the wideband
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
