### PR TITLE
Tweaks newer rifle projectiles

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -5,7 +5,7 @@
 	damage = 25
 	armour_penetration = 20
 
-// 7.62 (Nagant Rifle)
+// 7.62x54mmR (Illestren Rifle)
 
 /obj/projectile/bullet/a762
 	name = "7.62x54mmR bullet"
@@ -14,8 +14,9 @@
 
 /obj/projectile/bullet/a300
 	name = ".300 Magnum bullet"
-	damage = 60
+	damage = 40
 	stamina = 10
+	armour_penetration = 40
 
 /obj/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62x54mmR bullet"
@@ -34,7 +35,7 @@
 /obj/projectile/bullet/aac_300blk
 	name = ".300 Blackout bullet"
 	damage = 30
-	dismemberment = 20
+	armour_penetration = 20
 
 //7.62x39mm (SVG-67)
 
@@ -50,9 +51,9 @@
 	damage = 30
 	armour_penetration = 40
 
-// 8x58 (SG-whatever)
+// 8x58mm caseless (SG-669)
 
 /obj/projectile/bullet/a858
 	name = "8x58mm caseless bullet"
-	damage = 50
-	armour_penetration = 15
+	damage = 30
+	armour_penetration = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Brings some of the new rifle ammo types since the gun rebalance in line with the edited ones, and finally removes dismemberment from 300 Blackout.

- 8mm caseless is now brought in line with .308 and 7.62x54mmR
- 300 Magnum does less damage but has the same AP as other rifle cartridges
- 300 Blackout loses dismember and gains a little AP (same stats as 7.62x39mm)

300 Magnum is the one I'm least sure about here. It's based on 300 Win-Mag, which is a substantially more powerful cartridge than .308 WIN and similar, so making it just a clone didn't feel right. We might need to nerf the Smile's magazine and/or cycling rate or something to make up for this.

## Why It's Good For The Game

consistency within a weapon class is nice

## Changelog

:cl:
balance: nerfed some outlier rifle cartridges for consistency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
