### PR TITLE
Massive Ruin Fixes + Removals PR

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -82,7 +82,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/corner/opaque/grey,
-/obj/machinery/rnd/production/protolathe,
+/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav)
 "cW" = (
@@ -1924,7 +1924,7 @@
 /obj/effect/turf_decal/trimline/opaque/purple/line{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav)
 "XX" = (
 /obj/structure/window/reinforced{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR is made so I can stop getting angry at the ruins beyond saving that are still ingame. My criteria for a ruin being removed is if another ruin already does its niche better, if the ruin is outdated and/or the ruin is excessively small or unbalanced. For ruins that dont meet this criteria but are still outdated, they will be getting balance fixes and touch ups or a total remap.

This PR is a draft for now because I will need to update the PR changelog and description as I make changes and communicate with the maptainers on what stays and what goes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Normally I'm all for remapping instead of removing ruins, but some ruins are very much beyond saving. Clearing out space for better ruins to take the spotlight is always nice. Some older ruins are fine but are missing certain things or have loot that worked fine in the past, but doesn't reflect the balance we want for ruins in the present.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: dangerous_research.dmm now no longer has a space tile under a door and a medical lathe instead of an omnilathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
