### PR TITLE
Removes Solarian invisibility technology

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -510,3 +510,8 @@
 	desc = "You feel ashamed about what you had to do to get this hat"
 	icon_state = "cowboy"
 	item_state = "cowboy"
+
+/obj/item/clothing/head/solgov_surgery
+	name = "SolGov surgery cap"
+	desc = "It's a surgery cap utilized by solarian doctors."
+	icon_state = "solgov_surgery"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -136,13 +136,6 @@
 	soft_type = "paramedic"
 	dog_fashion = null
 
-/obj/item/clothing/head/soft/solgov
-	name = "SolGov surgery cap"
-	desc = "It's a surgery cap utilized by solarian doctors."
-	icon_state = "solgov_surgery"
-	soft_type = "solgov_surgery"
-	dog_fashion = null
-
 /obj/item/clothing/head/soft/cybersun
 	name = "cybersun medic cap"
 	desc = "A turquoise baseball hat emblazoned with a reflective cross. Typical of Cybersun Industries field medics."

--- a/code/modules/clothing/outfits/solgov.dm
+++ b/code/modules/clothing/outfits/solgov.dm
@@ -126,7 +126,7 @@
 	uniform = /obj/item/clothing/under/solgov/formal
 	accessory = /obj/item/clothing/accessory/armband/medblue
 	shoes = /obj/item/clothing/shoes/laceup
-	head = /obj/item/clothing/head/soft/solgov
+	head = /obj/item/clothing/head/solgov_surgery
 	suit =  /obj/item/clothing/suit/solgov/jacket
 	l_hand = /obj/item/storage/firstaid/medical
 


### PR DESCRIPTION
fixes #2269
![hatfix](https://github.com/shiptest-ss13/Shiptest/assets/34109002/4c337d0d-9fd2-4ce7-b24a-e7c09b7b1dbe)
:cl:
fix: The SolGov surgical cap no longer turns invisible when handled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
