### PR TITLE
Fixes a few missing sprites I caused

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -492,7 +492,7 @@
 	desc = "A wild plant that is found in jungles."
 	icon = 'icons/obj/flora/jungleflora.dmi'
 	icon_state = "busha"
-	base_icon_state = "bush"
+	base_icon_state = "busha"
 
 /obj/structure/flora/junglebush/Initialize()
 	icon_state = "[base_icon_state][rand(1, 3)]"
@@ -500,9 +500,11 @@
 
 /obj/structure/flora/junglebush/b
 	icon_state = "bushb"
+	base_icon_state = "bushb"
 
 /obj/structure/flora/junglebush/c
 	icon_state = "bushc"
+	base_icon_state = "bushc"
 
 /obj/structure/flora/junglebush/large
 	icon_state = "bush"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Junglebushes a b and c use some interesting naming conventions for randomizing sprites which flew under the radar of me fixing them. This was noticed quickly due to the new error fauna sprites, thankfully.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Error rock bushes bad!
![imageArbitraryName](https://media.discordapp.net/attachments/837744059291533395/1149589714161111090/whatthefuckisthis.gif)
(gif courtesy of genericDM)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed the icon states for junglebushes a, b, and c.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
