### PR TITLE
MAKES IT SO THE NT PDW-RIFLE HAS A PROPER DESCRIPtION

### DIFF
--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -21,7 +21,7 @@
 
 /obj/item/gun/ballistic/automatic/assualt/ak47/nt
 	name = "\improper NT-SVG"
-	desc = "An even cheaper version of the already-cheap SVG-67, rechambered for the lightweight 4.6x38mm PDW cartridge. The flimsy folding stock and light construction make for a highly portable rifle lacking in accuracy and stopping power."
+	desc = "An even cheaper version of the already-cheap SVG-67, rechambered for the lightweight 4.6x30mm PDW cartridge. The flimsy folding stock and light construction make for a highly portable rifle lacking in accuracy and stopping power."
 	icon = 'icons/obj/guns/48x32guns.dmi'
 	fire_sound = 'sound/weapons/gun/rifle/shot.ogg'
 	icon_state = "ak47_nt"


### PR DESCRIPTION
## About The Pull Request

spellfix moment

## Why It's Good For The Game

clarity in descriptions is good I think :)

## Changelog

:cl:
spellcheck: typo moment in nt-svg rifle ammo type
/:cl:
