### PR TITLE
kills soul departed message on unowned bodies

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,6 +1,7 @@
 /mob/living/carbon/human/examine(mob/user)
 //this is very slightly better than it was because you can use it more places. still can't do \his[src] though.
 	var/t_He = p_they(TRUE)
+	var/t_he = p_they()
 	var/t_His = p_their(TRUE)
 	var/t_his = p_their()
 	var/t_him = p_them()
@@ -126,7 +127,7 @@
 				. += "<span class='warning'>[t_His] soul seems to have been ripped out of [t_his] body. Revival is impossible.</span>"
 			. += ""
 			if(getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE))
-				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
+				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_he] won't be coming back...</span>"
 			else
 				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 


### PR DESCRIPTION
## About The Pull Request

Alternative message for when a body doesn't have a ckey attached to it
![image](https://github.com/shiptest-ss13/Shiptest/assets/98909416/dafbce97-e469-45ce-97bc-448494f6a4de)

## Why It's Good For The Game

1) Removes soul
2) Direct references to souls are generally frowned upon by the Great State of Lorema, Democratic Nation of Shiptest, Setting Building, and Intellectual Discourse
3) Less confusing to new players (soul departed means absolutely nothing to anyone who hasn't played SS13)

## Changelog

:cl:
spellcheck: Bodies that lack ownership are no longer described as "soulless"
/:cl:
