### PR TITLE
Various Assorted Fixes

### DIFF
--- a/check_regex.yaml
+++ b/check_regex.yaml
@@ -29,7 +29,7 @@ standards:
     - exactly: [1, "/area text paths", '"/area']
     - exactly: [17, "/datum text paths", '"/datum']
     - exactly: [4, "/mob text paths", '"/mob']
-    - exactly: [51, "/obj text paths", '"/obj']
+    - exactly: [49, "/obj text paths", '"/obj']
     - exactly: [0, "/turf text paths", '"/turf']
     - exactly: [117, "text2path uses", "text2path"]
 
@@ -45,7 +45,12 @@ standards:
     - exactly: [0, "incorrect indentations", '^(?:  +)(?!\*)']
     - exactly: [0, "superflous whitespace", '[ \t]+$']
     - exactly: [0, "mixed indentation", '^( +\t+|\t+ +)']
-    - exactly: [21, 'padding inside parentheses', '\(([\t ]+([^)"\n\\]*)|([^("\n]+)[\t ]+)\)']
+    - exactly:
+          [
+              21,
+              "padding inside parentheses",
+              '\(([\t ]+([^)"\n\\]*)|([^("\n]+)[\t ]+)\)',
+          ]
 
     - no_more:
           [

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -592,8 +592,6 @@
 	// this must come before the screen objects only block, dunno why it wasn't before
 	if(over_object == M)
 		user_show_to_mob(M)
-		if(use_sound)
-			playsound(A, use_sound, 50, TRUE, -5)
 	if(!istype(over_object, /atom/movable/screen))
 		INVOKE_ASYNC(src, .proc/dump_content_at, over_object, M)
 		return
@@ -615,6 +613,8 @@
 		to_chat(M, "<span class='warning'>[parent] seems to be [locked_flavor]!</span>")
 		return FALSE
 	if(force || M.CanReach(parent, view_only = TRUE))
+		if(use_sound)
+			playsound(A, use_sound, 50, TRUE, -5)
 		show_to(M)
 
 /datum/component/storage/proc/mousedrop_receive(datum/source, atom/movable/O, mob/M)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -54,7 +54,7 @@
 	return ..()
 
 /obj/machinery/jukebox/update_icon_state()
-	icon_state = "[initial(icon_state)]-[active ? "active" : null]"
+	icon_state = "[initial(icon_state)][active ? "active" : null]"
 	return ..()
 
 /obj/machinery/jukebox/ui_status(mob/user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -495,7 +495,7 @@
 	density = TRUE
 	var/constructionStep = CONSTRUCTION_NOCIRCUIT
 	var/reinforced = 0
-	var/firelock_type
+	var/firelock_type = /obj/machinery/door/firedoor/closed
 
 /obj/structure/firelock_frame/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -251,16 +251,16 @@
 
 ///Returns a valid limb typepath based on the selected option
 /obj/machinery/limbgrower/proc/create_buildpath()
-	var/part_type = being_built.id //their ids match bodypart typepaths
 	var/species = selected_category
 	var/path
 	if(species == SPECIES_HUMAN) //Humans use the parent type.
-		path = "/obj/item/bodypart/[part_type]"
+		path = being_built.build_path
+		return path
 	else if(istype(being_built,/datum/design/digitigrade))
 		path = being_built.build_path
 		return path
 	else
-		path = "/obj/item/bodypart/[part_type]/[species]"
+		path = "[being_built.build_path]/[species]"
 	return text2path(path)
 
 /obj/machinery/limbgrower/RefreshParts()

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -134,7 +134,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/proc/detach(atom/moveto=null)
 	moveto = moveto || get_turf(chassis)
-	if(src.Move(moveto))
+	if(src.forceMove(moveto))
 		chassis.equipment -= src
 		if(chassis.selected == src)
 			chassis.selected = null

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -33,7 +33,7 @@
 	/// What type of reagent this fish needs to be fed.
 	var/food = /datum/reagent/consumable/nutriment
 	/// How often the fish needs to be fed
-	var/feeding_frequency = 5 MINUTES
+	var/feeding_frequency = 20 MINUTES
 	/// Time of last feedeing
 	var/last_feeding
 
@@ -265,10 +265,10 @@
 	var/health_change_per_second = 0
 	if(!proper_environment())
 		health_change_per_second -= 3 //Dying here
-	if(world.time - last_feeding >= feeding_frequency)
-		health_change_per_second -= 0.5 //Starving
-	else
+	if(world.time - last_feeding <= feeding_frequency)
 		health_change_per_second += 0.5 //Slowly healing
+	else
+		return
 	adjust_health(health + health_change_per_second)
 
 /obj/item/fish/proc/adjust_health(amt)
@@ -290,6 +290,8 @@
 	if(!istype(aquarium))
 		return
 	if(length(aquarium.tracked_fish) >= AQUARIUM_MAX_BREEDING_POPULATION) //so aquariums full of fish don't need to do these expensive checks
+		return
+	if(world.time - last_feeding >= feeding_frequency)
 		return
 	var/list/other_fish_of_same_type = list()
 	for(var/obj/item/fish/fish_in_aquarium in aquarium)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -142,7 +142,7 @@
 	update_appearance()
 
 /obj/item/organ/regenerative_core/update_icon_state()
-	icon_state = inert ? "legion_soul_inert" : "legion_soul"
+	icon_state = inert ? "[icon_state]_inert" : "[icon_state]"
 	return ..()
 
 /obj/item/organ/regenerative_core/update_overlays()
@@ -162,6 +162,7 @@
 /obj/item/organ/regenerative_core/legion/crystal
 	name = "crystal heart"
 	desc = "A strange rock in the shape of a heart symbol. Applying will repair your body with crystals, but may have additional side effects. It seems it can't survive for very long outside a host."
+	icon_state = "crystal_heart"
 	crackle_animation = FALSE
 
 /obj/item/organ/regenerative_core/legion/crystal/Initialize()
@@ -191,7 +192,7 @@
 			qdel(src)
 
 /obj/item/organ/regenerative_core/legion/crystal/update_icon_state()
-	icon_state = inert ? "crystal_heart_inert" : "crystal_heart"
+	/*icon_state = inert ? "crystal_heart_inert" : "crystal_heart"*/
 	if(preserved)
 		icon_state = "crystal_heart_preserved"
 	return ..()

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -192,7 +192,6 @@
 			qdel(src)
 
 /obj/item/organ/regenerative_core/legion/crystal/update_icon_state()
-	/*icon_state = inert ? "crystal_heart_inert" : "crystal_heart"*/
 	if(preserved)
 		icon_state = "crystal_heart_preserved"
 	return ..()

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -90,7 +90,7 @@
 
 	if(isfloorturf(T)) //intact floor, pop the tile
 		floorturf = T
-		if(floorturf.floor_tile)
+		if(floorturf.floor_tile && !istype(floorturf, /turf/open/floor/engine))
 			new floorturf.floor_tile(T)
 		floorturf.make_plating()
 

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -7,7 +7,7 @@ const VendingRow = (props, context) => {
   const { act, data } = useBackend(context);
   const { product, productStock, custom } = props;
   const { miningvendor, all_items_free, user } = data;
-  const free = all_items_free || product.price === 0 || !product.premium;
+  const free = all_items_free || product.price === 0;
   const affix = miningvendor ? ' mp' : ' cr';
   return (
     <Table.Row>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the following issues
#2406 
#2405 
#2400 
#2390 
#2255 & #2356 
Plus the unlisted issues of vending machines lying about their stuff being free, jukebox sprites being broken, and mobs being able to play container opening sounds from anywhere so long as the container was on screen.

Also prevents fish from starving to death while in aquariums and instead makes them heal while well fed.

## Why It's Good For The Game

Bug fixes are always good and I've yet to hear anyone have anything but middling hate for the fish starvation mechanics.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: fish should no longer starve to death
fix: the mech equipment panel works again
fix: limbgrower legs should no longer runtime instead of spawning
fix: crystal legion hearts inheriting the wrong sprites
fix: vending machines falsely listing their prices as "free"
fix: normal fulltile firelocks should build properly now
fix: disposal pipes no longer generate metal when ejecting items through reinforced plating
fix: jukebox sprites
fix: players can no longer telepathically fiddle with the zippers of bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
