### PR TITLE
Sets Lugol to admin spawn

### DIFF
--- a/_maps/configs/syndicate_lugol.json
+++ b/_maps/configs/syndicate_lugol.json
@@ -42,5 +42,5 @@
 			"slots": 2
 		}
 	},
-"enabled": true
+"enabled": false
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/shiptest-ss13/Shiptest/assets/81882910/c330921b-8c0b-4b1f-9553-932c681de70a)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Lugol is now admin spawn only
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
