### PR TITLE
Fixes Moth Language Bind

### DIFF
--- a/code/modules/language/mouse.dm
+++ b/code/modules/language/mouse.dm
@@ -4,7 +4,7 @@
 	speech_verb = "squeaks"
 	ask_verb = "squeaks"
 	exclaim_verb = "squeaks"
-	key = "m"
+	key = "l"
 	flags = NO_STUTTER | LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD | LANGUAGE_HIDE_ICON_IF_UNDERSTOOD
 
 /datum/language/mouse/scramble(input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resolves https://github.com/shiptest-ss13/Shiptest/issues/2407 by removing the overlap between mouse and moth language binds.

## Why It's Good For The Game

Squashes bugs (the nasty kind, not the lovable kind).
You can now #%,m once again without destroying your immersion. Rejoice!

## Changelog

:cl:
fix: moth language bind now works as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
