### PR TITLE
Removes every last visible mention of Lizard Wine

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -365,8 +365,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	shot_glass_icon_state = "shotglassred"
 
 /datum/reagent/consumable/ethanol/lizardwine
-	name = "lizard wine"
-	description = "An alcoholic beverage from Space China, made by infusing lizard tails in ethanol."
+	name = "sarathi wine"
+	description = "A relatively popular Kalixcane beverage, made by infusing cacti in ethanol."
 	color = "#7E4043" // rgb: 126, 64, 67
 	boozepwr = 45
 	quality = DRINK_FANTASTIC

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -365,7 +365,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	shot_glass_icon_state = "shotglassred"
 
 /datum/reagent/consumable/ethanol/lizardwine
-	name = "sarathi wine"
+	name = "Kalixcis Wine"
 	description = "A relatively popular Kalixcane beverage, made by infusing cacti in ethanol."
 	color = "#7E4043" // rgb: 126, 64, 67
 	boozepwr = 45

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -116,7 +116,7 @@
 	build_path = /obj/item/organ/tongue
 	category = list("initial",SPECIES_HUMAN)
 
-// Grows a fake lizard tail - not usable in lizard wine and other similar recipes.
+// Grows a fake lizard tail
 /datum/design/lizard_tail
 	name = "Lizard Tail"
 	id = "liztail"

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -83,7 +83,7 @@
 
 /obj/item/organ/tail/lizard/fake
 	name = "fabricated lizard tail"
-	desc = "A fabricated severed lizard tail. This one's made of synthflesh. Probably not usable for lizard wine."
+	desc = "A fabricated severed lizard tail. This one's made of synthflesh."
 
 /obj/item/organ/tail/elzu
 	name = "\improper Elzuose tail"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It is now Kalixcian wine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Screw this stupid racist LARP shit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: PositiveEntropy
fix: All visible mentions of lizard wine now refer to Kalixcian Wine, a beverage made from cactus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
