### PR TITLE
Nerfs the everloving almighty shit out of the jungle demonic office ruin

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
@@ -220,9 +220,27 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "tR" = (
-/obj/structure/closet/gimmick/tacticool,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/structure/closet/syndicate{
+	desc = "It's a basic storage unit.";
+	name = "uniform closet"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/head/helmet/operator,
+/obj/item/clothing/head/helmet/operator,
+/obj/item/clothing/suit/armor/vest/syndie,
+/obj/item/clothing/suit/armor/vest/syndie,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "uj" = (
@@ -494,8 +512,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "PA" = (
-/obj/machinery/suit_storage_unit/syndicate,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/syndi/scarlet,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/oxygen/red,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "QI" = (

--- a/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_demon.dmm
@@ -157,7 +157,7 @@
 /area/ruin/powered)
 "pm" = (
 /obj/structure/table/reinforced,
-/obj/item/upgradescroll,
+/obj/item/paper,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "pE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the ruin by removing most of its gamer gear, and changing the syndicate hardsuit you find into a scarlet hardsuit.


Not to mention the two goddamn deathsquad hardsuits all there, wholesale, for free.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/shiptest-ss13/Shiptest/assets/77556824/a8333190-37ce-441f-a746-bb5f2fc26828)

This shit is not okay jesus fucking christ, two deathsquad hardsuits? Are you insane?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: PositiveEntropy
balance: The Jungle Demonic Office Ruin has now been appropriately balanced, now only having a scarlet hardsuit, decent syndicate armor, and a bulldog with no spare mags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
