### PR TITLE
You can no longer respawn as a character with a name that matches an already existing character

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -35,6 +35,8 @@ GLOBAL_LIST_EMPTY(aiEyes)
 ///underages who have been reported to security for trying to buy things they shouldn't, so they can't spam
 GLOBAL_LIST_EMPTY(narcd_underages)
 
+GLOBAL_LIST_EMPTY(real_names_joined)
+
 GLOBAL_LIST_EMPTY(language_datum_instances)
 GLOBAL_LIST_EMPTY(all_languages)
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -291,6 +291,12 @@
 	if(auth_check)
 		return
 
+	if(!client.prefs.randomise[RANDOM_NAME]) // do they have random names enabled
+		var/name = client.prefs.real_name
+		if(GLOB.real_names_joined.Find(name)) // is there someone who spawned with the same name
+			to_chat(usr, "<span class='warning'>Someone has spawned with this name already.")
+			return FALSE
+
 	var/error = IsJobUnavailable(job, ship, check_playtime)
 	if(error != JOB_AVAILABLE)
 		alert(src, get_job_unavailable_error_message(error, job))
@@ -398,6 +404,7 @@
 	close_spawn_windows()
 
 	var/mob/living/carbon/human/H = new(loc)
+	GLOB.joined_player_list += ckey
 
 	var/frn = CONFIG_GET(flag/force_random_names)
 	var/admin_anon_names = SSticker.anonymousnames
@@ -418,6 +425,7 @@
 		is_antag = TRUE
 
 	client.prefs.copy_to(H, antagonist = is_antag)
+	update_names_joined_list(H.real_name)
 	H.dna.update_dna_identity()
 	if(mind)
 		if(transfer_after)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1095,6 +1095,14 @@
 		return LAZYLEN(match_list)
 	return FALSE
 
+/mob/proc/update_joined_player_list(newname, oldname)
+	if(newname == oldname)
+		return
+	if(oldname)
+		GLOB.joined_player_list -= oldname
+	if(newname)
+		GLOB.joined_player_list[newname] = TRUE
+
 
 /**
  * Fully update the name of a mob
@@ -1109,6 +1117,9 @@
 		return 0
 
 	log_played_names(ckey,newname)
+
+	if(GLOB.joined_player_list[oldname])
+		update_joined_player_list(newname, oldname)
 
 	real_name = newname
 	name = newname
@@ -1195,6 +1206,11 @@
 	if(client.mouse_override_icon)
 		client.mouse_pointer_icon = client.mouse_override_icon
 
+/mob/proc/update_names_joined_list(new_name, old_name)
+	if(old_name)
+		GLOB.real_names_joined -= old_name
+	if(new_name)
+		GLOB.real_names_joined[new_name] = TRUE
 
 ///This mob is abile to read books
 /mob/proc/is_literate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title. code stolen from https://github.com/tgstation/TerraGov-Marine-Corps/pull/3243

## Why It's Good For The Game

It gets very tiring to moderate new players doing same character respawn. if it's ever needed, admins can just rename a player

## Changelog

:cl:
add: You can no longer late-join as a character with a repeated name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
