### PR TITLE
Stops gas overlays from inheriting turf color

### DIFF
--- a/code/modules/atmospherics/gasmixtures/auxgm.dm
+++ b/code/modules/atmospherics/gasmixtures/auxgm.dm
@@ -138,7 +138,7 @@ GLOBAL_DATUM_INIT(gas_data, /datum/auxgm, new)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE  // should only appear in vis_contents, but to be safe
 	layer = FLY_LAYER
-	appearance_flags = TILE_BOUND
+	appearance_flags = TILE_BOUND | RESET_COLOR
 	vis_flags = NONE
 
 /obj/effect/overlay/gas/New(state)


### PR DESCRIPTION
## About The Pull Request
Adds RESET_COLOR appearance_flag to stop gas overlays from inheriting turf color
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
add: Gas overlays should now look normal on turfs with a color var set.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
