### PR TITLE
2 short ammo changes.

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -77,15 +77,15 @@
 	name = "Buckshot Crate"
 	desc = "Contains two boxes of buckshot for use in lethal persuasion."
 	cost = 2000
-	contains = list(/obj/item/storage/box/lethalshot,
-					/obj/item/storage/box/lethalshot)
+	contains = list(/obj/item/ammo_box/a12g,
+					/obj/item/ammo_box/a12g)
 
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains two boxes of slug shells for use in lethal persuasion."
 	cost = 2000
-	contains = list(/obj/item/storage/box/slugshot,
-					/obj/item/storage/box/slugshot)
+	contains = list(/obj/item/ammo_box/a12g/slug,
+					/obj/item/ammo_box/a12g/slug,)
 
 /*
 		.38 ammo
@@ -188,3 +188,16 @@
 					/obj/item/ammo_box/a762,
 					/obj/item/ammo_box/a762)
 	cost = 1000
+
+/*
+		.45???
+*/
+
+/datum/supply_pack/ammo/c45_bulk
+	name = ".45 ACP Bulk Crate"
+	desc = "Contains 2 boxes of .45 ACP, each containing 50 rounds."
+	contains = list(
+		/obj/item/ammo_box/c45
+		/obj/item/ammo_box/c45
+	)
+	cost = 2500

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -197,7 +197,7 @@
 	name = ".45 ACP Bulk Crate"
 	desc = "Contains 2 boxes of .45 ACP, each containing 50 rounds."
 	contains = list(
-		/obj/item/ammo_box/c45
-		/obj/item/ammo_box/c45
+		/obj/item/ammo_box/c45,
+		/obj/item/ammo_box/c45,
 	)
 	cost = 2500

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -76,14 +76,14 @@
 /datum/supply_pack/ammo/buckshot
 	name = "Buckshot Crate"
 	desc = "Contains two boxes of buckshot for use in lethal persuasion."
-	cost = 2000
+	cost = 500
 	contains = list(/obj/item/ammo_box/a12g,
 					/obj/item/ammo_box/a12g)
 
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains two boxes of slug shells for use in lethal persuasion."
-	cost = 2000
+	cost = 500
 	contains = list(/obj/item/ammo_box/a12g/slug,
 					/obj/item/ammo_box/a12g/slug,)
 
@@ -200,4 +200,4 @@
 		/obj/item/ammo_box/c45,
 		/obj/item/ammo_box/c45,
 	)
-	cost = 2500
+	cost = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
.45 can be bought in bulk (c-20 fans rejoice) also shotgun ammo isn't stupidly expensive
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
walance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: you can now buy .45 ammo in bulk
balance: shotgun ammo via cargo isn't comically expensive anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
