### PR TITLE
Glaive patches

### DIFF
--- a/_maps/shuttles/roumain/srm_glaive.dmm
+++ b/_maps/shuttles/roumain/srm_glaive.dmm
@@ -75,7 +75,6 @@
 /obj/item/storage/firstaid,
 /obj/item/healthanalyzer,
 /obj/item/storage/belt/medical,
-/obj/item/lazarus_injector,
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
@@ -95,7 +94,7 @@
 /turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
 "bi" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "bm" = (
@@ -189,27 +188,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"cp" = (
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	id = "port_blasts";
-	name = "Port Blast Door"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "glaive_shields";
-	locked = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"cz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/book/manual/trickwines_4_brewers,
-/turf/open/floor/grass/ship/jungle,
-/area/ship/roumain)
 "cJ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -253,7 +231,6 @@
 "ds" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/item/reagent_containers/food/drinks/breakawayflask,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "dt" = (
@@ -386,8 +363,9 @@
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/caution,
 /obj/structure/cable/orange{
-	icon_state = "1-6"
+	icon_state = "1-2"
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "gd" = (
@@ -744,12 +722,6 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/construction)
-"lb" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/fermenting_barrel,
-/turf/open/floor/grass/ship/jungle,
-/area/ship/roumain)
 "lf" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -773,8 +745,6 @@
 /obj/item/storage/belt/mining,
 /obj/item/reagent_containers/hypospray/medipen/survival,
 /obj/item/flashlight/seclite,
-/obj/item/borg/upgrade/modkit/indoors,
-/obj/item/gun/energy/kinetic_accelerator,
 /obj/item/storage/bag/ore,
 /obj/structure/cable/orange{
 	icon_state = "4-10"
@@ -977,8 +947,6 @@
 /obj/item/storage/belt/mining,
 /obj/item/reagent_containers/hypospray/medipen/survival,
 /obj/item/flashlight/seclite,
-/obj/item/borg/upgrade/modkit/indoors,
-/obj/item/gun/energy/kinetic_accelerator,
 /obj/item/storage/bag/ore,
 /obj/item/gun/ballistic/shotgun/winchester/mk1,
 /obj/item/shovel,
@@ -999,7 +967,6 @@
 /turf/open/floor/wood/yew,
 /area/ship/roumain)
 "nO" = (
-/obj/structure/table/wood,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -1;
 	pixel_y = 4
@@ -1010,6 +977,25 @@
 	},
 /obj/item/weldingtool/largetank,
 /obj/item/clothing/head/welding,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/weldingtool/largetank,
+/obj/item/multitool{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/rods/fifty{
+	pixel_x = -11
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/stack/sheet/metal/fifty{
+	pixel_y = 7;
+	pixel_x = 7
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "nY" = (
@@ -1028,6 +1014,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/railing,
+/obj/structure/fermenting_barrel,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "oC" = (
@@ -1169,11 +1156,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/crew/toilet)
-"sb" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
 "sm" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/railing{
@@ -1444,22 +1426,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/toilet)
 "xe" = (
-/obj/structure/table/wood,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -3;
-	pixel_x = 3
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/multitool{
-	pixel_y = 6;
-	pixel_x = -8
-	},
-/obj/item/weldingtool/largetank,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "xf" = (
@@ -1502,7 +1468,15 @@
 /obj/structure/cable/orange{
 	icon_state = "4-6"
 	},
-/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/autolathe,
+/obj/item/disk/design_disk/ammo_n762{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/disk/design_disk/ammo_1911{
+	pixel_y = 7;
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "yq" = (
@@ -1641,8 +1615,9 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/eva,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "Ac" = (
@@ -1677,7 +1652,6 @@
 /area/ship/medical)
 "At" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
 /turf/open/floor/plating{
 	icon_state = "greenerdirt"
 	},
@@ -1720,9 +1694,12 @@
 /turf/open/floor/plating,
 /area/ship/roumain)
 "AQ" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "glaive_shields";
+	locked = 1
 	},
+/obj/structure/cable/orange,
 /obj/machinery/door/poddoor{
 	id = "port_blasts";
 	name = "Port Blast Door"
@@ -1766,14 +1743,12 @@
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "Bz" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
 /turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "BB" = (
@@ -2080,9 +2055,7 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/roumain)
 "Fr" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/stockparts/basic,
-/obj/item/storage/box/stockparts/basic,
+/obj/structure/fermenting_barrel,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "Fu" = (
@@ -2103,7 +2076,6 @@
 	name = "Body Holofield Switch";
 	id = "glaive_body_holo"
 	},
-/obj/structure/fermenting_barrel,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "FA" = (
@@ -2169,11 +2141,12 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
 /obj/structure/cable/orange{
 	icon_state = "6-9"
 	},
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/eva,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "HA" = (
@@ -2183,6 +2156,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/railing,
+/obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "HB" = (
@@ -2515,6 +2489,22 @@
 /obj/effect/turf_decal/industrial/warning,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/railing,
+/obj/structure/table/wood,
+/obj/item/book/manual/trickwines_4_brewers{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
+	pixel_y = 15;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/breakawayflask{
+	pixel_y = -3;
+	pixel_x = -4
+	},
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "MR" = (
@@ -2543,8 +2533,6 @@
 /obj/item/storage/belt/mining,
 /obj/item/reagent_containers/hypospray/medipen/survival,
 /obj/item/flashlight/seclite,
-/obj/item/borg/upgrade/modkit/indoors,
-/obj/item/gun/energy/kinetic_accelerator,
 /obj/item/storage/bag/ore,
 /obj/item/shovel,
 /obj/item/gps/mining,
@@ -2683,22 +2671,15 @@
 /turf/closed/wall,
 /area/ship/crew/toilet)
 "OF" = (
-/obj/machinery/vending/mining_equipment,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"OR" = (
-/obj/structure/cable/orange{
-	icon_state = "0-9"
-	},
-/obj/machinery/door/poddoor{
-	id = "port_blasts";
-	name = "Port Blast Door"
-	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 8;
 	locked = 1;
 	id = "glaive_shields"
+	},
+/obj/structure/cable/orange,
+/obj/machinery/door/poddoor{
+	id = "port_blasts";
+	name = "Port Blast Door"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
@@ -2829,17 +2810,10 @@
 /turf/open/floor/plating/ship/water,
 /area/ship/roumain)
 "Rn" = (
-/obj/structure/table/wood,
-/obj/item/survey_handheld,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/item/circuitboard/machine/rdserver,
-/obj/item/circuitboard/machine/autolathe,
-/obj/item/disk/design_disk/ammo_n762,
-/obj/item/disk/design_disk/ammo_1911,
-/obj/item/circuitboard/machine/protolathe/department/ballistics,
-/obj/item/circuitboard/computer/rdconsole,
+/obj/structure/fermenting_barrel,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "RF" = (
@@ -2886,12 +2860,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"Sl" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/fermenting_barrel/distiller,
-/turf/open/floor/grass/ship/jungle,
-/area/ship/roumain)
 "Sx" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -2909,7 +2877,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/loom,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
 "SK" = (
@@ -2963,14 +2930,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
 "Tx" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/loom,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "TO" = (
@@ -3105,8 +3068,9 @@
 /area/ship/storage)
 "Wr" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/eva,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "Wy" = (
@@ -3245,6 +3209,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/railing,
+/obj/structure/fermenting_barrel/distiller,
 /turf/open/floor/wood/maple,
 /area/ship/construction)
 "YP" = (
@@ -3935,8 +3900,8 @@ LN
 LN
 LN
 LN
-LN
-FA
+sH
+sH
 "}
 (17,1,1) = {"
 sH
@@ -3948,11 +3913,11 @@ AN
 ZV
 ko
 Lk
-cz
+aM
 YP
 ds
-lb
-Sl
+aM
+aM
 Fu
 wp
 wp
@@ -3972,8 +3937,8 @@ IZ
 MU
 go
 yp
-OF
-cp
+LN
+LN
 FA
 "}
 (18,1,1) = {"
@@ -4239,7 +4204,7 @@ Wr
 jk
 Gi
 gb
-qz
+OF
 FA
 "}
 (25,1,1) = {"
@@ -4276,9 +4241,9 @@ IZ
 fv
 ap
 bi
-sb
-OR
-FA
+LN
+LN
+hu
 "}
 (26,1,1) = {"
 sH
@@ -4315,8 +4280,8 @@ LN
 LN
 LN
 LN
-LN
-hu
+sH
+sH
 "}
 (27,1,1) = {"
 sH

--- a/_maps/shuttles/roumain/srm_glaive.dmm
+++ b/_maps/shuttles/roumain/srm_glaive.dmm
@@ -59,6 +59,7 @@
 /obj/item/clothing/shoes/cowboy/black,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/book/manual/srmlore,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "aM" = (
@@ -87,6 +88,7 @@
 /obj/item/ammo_box/c38_box,
 /obj/item/storage/firstaid/roumain,
 /obj/effect/turf_decal/corner/opaque/blue/diagonal,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "aY" = (
@@ -161,6 +163,7 @@
 /obj/item/clothing/shoes/cowboy/black,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/book/manual/srmlore,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "cg" = (
@@ -345,6 +348,7 @@
 /obj/item/clothing/shoes/cowboy,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/book/manual/srmlore,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/wood/mahogany,
 /area/ship/roumain)
 "fP" = (
@@ -755,6 +759,7 @@
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/pickaxe,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "li" = (
@@ -883,6 +888,7 @@
 /obj/item/clothing/shoes/cowboy,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/book/manual/srmlore,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "mw" = (
@@ -955,6 +961,7 @@
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/pickaxe,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "nt" = (
@@ -1618,6 +1625,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "Ac" = (
@@ -2147,6 +2155,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "HA" = (
@@ -2540,6 +2549,7 @@
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/pickaxe,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "MV" = (
@@ -3071,6 +3081,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "Wy" = (
@@ -3273,6 +3284,7 @@
 /obj/item/clothing/shoes/cowboy,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/book/manual/srmlore,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "ZV" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![2023-11-18 17 55 23](https://github.com/shiptest-ss13/Shiptest/assets/55075747/5c9f5349-90c5-4407-9326-3e1f74d2c727)

- Removes the orm
- Removes the mining vendor
- Removes the ballistics lathe and rnd
- Places production machines and supplies in the former gun room.
- KA's removed
- Mining suits nerfed to eva suits
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Glaive needs a nerf and is pending a total remap.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: tweaked the Glaive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
