### PR TITLE
Messes with time itself

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -2,7 +2,7 @@
 #define MIDNIGHT_ROLLOVER 864000
 
 ///displays the current time into the round, with a lot of extra code just there for ensuring it looks okay after an entire day passes
-#define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
+#define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[game_timestamp()]" : game_timestamp()]" )
 ///same as above, but based on real time of day
 #define ROUND_REALTIMEOFDAY ( "[REALTIMEOFDAY - SSticker.round_start_timeofday > MIDNIGHT_ROLLOVER ? "[round((REALTIMEOFDAY - SSticker.round_start_timeofday)/MIDNIGHT_ROLLOVER)]:[time2text(world.timeofday - SSticker.round_start_timeofday, "hh:mm:ss", 0)]" : time2text(world.timeofday - SSticker.round_start_timeofday, "hh:mm:ss", 0)]" )
 

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -3,7 +3,8 @@
 
 ///displays the current time into the round, with a lot of extra code just there for ensuring it looks okay after an entire day passes
 #define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
-
+///same as above, but based on real time of day
+#define ROUND_REALTIMEOFDAY ( "[REALTIMEOFDAY - SSticker.round_start_timeofday > MIDNIGHT_ROLLOVER ? "[round((REALTIMEOFDAY - SSticker.round_start_timeofday)/MIDNIGHT_ROLLOVER)]:[time2text(world.timeofday - SSticker.round_start_timeofday, "hh:mm:ss", 0)]" : time2text(world.timeofday - SSticker.round_start_timeofday, "hh:mm:ss", 0)]" )
 
 #define JANUARY 1
 #define FEBRUARY 2

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -71,7 +71,7 @@
 /proc/log_mentor(text)
 	GLOB.mentorlog.Add(text)
 	if (CONFIG_GET(flag/log_admin))
-		WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]MENTOR: [text]")
+		WRITE_FILE(GLOB.world_game_log, "MENTOR: [text]")
 
 /* All other items are public. */
 /proc/log_game(text)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -302,7 +302,7 @@
 		var/statspage = CONFIG_GET(string/roundstatsurl)
 		var/info = statspage ? "<a href='?action=openLink&link=[url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[FOURSPACES]Round ID: <b>[info]</b>"
-	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(ROUND_REALTIMEOFDAY)]</B>"
+	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(REALTIMEOFDAY - SSticker.round_start_timeofday)]</B>"
 	parts += "[FOURSPACES]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -302,7 +302,7 @@
 		var/statspage = CONFIG_GET(string/roundstatsurl)
 		var/info = statspage ? "<a href='?action=openLink&link=[url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[FOURSPACES]Round ID: <b>[info]</b>"
-	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(world.timeofday - SSticker.round_start_timeofday)]</B>"
+	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(ROUND_REALTIMEOFDAY)]</B>"
 	parts += "[FOURSPACES]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)
@@ -379,13 +379,15 @@
 	var/list/parts = list()
 	var/mob/M = C.mob
 	if(M.mind && !isnewplayer(M))
+		var/datum/overmap/ship/controlled/original_ship = M.mind.original_ship?.resolve()
+		var/location = original_ship ? "aboard [original_ship]" : "in [station_name()]"
 		if(M.stat != DEAD && !isbrain(M))
 			parts += "<div class='panel greenborder'>"
-			parts += "<span class='greentext'>You managed to survive the events in [station_name()] as [M.real_name].</span>"
+			parts += "<span class='greentext'>You managed to survive the events [location] as [M.real_name].</span>"
 
 		else
 			parts += "<div class='panel redborder'>"
-			parts += "<span class='redtext'>You did not survive the events in [station_name()]...</span>"
+			parts += "<span class='redtext'>You did not survive the events [location]...</span>"
 
 	else
 		parts += "<div class='panel stationborder'>"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,17 +1,11 @@
-//Returns the world time in english
-/proc/worldtime2text()
-	return gameTimestamp("hh:mm:ss", world.time)
-
 /proc/time_stamp(format = "YYYY-MM-DD hh:mm:ss", show_ds)
 	var/time_string = time2text(world.timeofday, format)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string
 
-/proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
-	if(!wtime)
-		wtime = world.time
+/proc/game_timestamp(format = "hh:mm:ss", wtime = world.time)
 	return time2text(wtime - GLOB.timezoneOffset, format)
 
-/proc/station_time(display_only = FALSE, wtime=world.time)
+/proc/station_time(display_only = FALSE, wtime = world.time)
 	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
 
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -24,14 +24,49 @@
 	else
 		. += " AM"
 
-/proc/sector_year()
-	return GLOB.year_integer - 1519
+/proc/sector_datestamp(realtime = world.realtime, shortened = FALSE)
+	//International Fixed Calendar format (https://en.wikipedia.org/wiki/International_Fixed_Calendar)
+	var/days_since = round(realtime / (24 HOURS))
+	var/year = round(days_since / 365) + 481
+	var/day_of_year = days_since % 365 + 1
+	var/month = round(day_of_year / 28)
+	var/day_of_month = day_of_year % 28 + 1
 
-/proc/sector_datestamp(time_format = "hh:mm:ss", world_time = world.time)
-	return "[sector_year()]FSC-[time2text(world_time, "MMM-DD")] [station_time_timestamp(time_format, world_time)]"
+	if(shortened)
+		return "[year]-[month]-[day_of_month]FSC"
 
-/proc/sector_date(world_time = world.time)
-	return "[time2text(world_time, "MMM DD")], FSC [GLOB.year_integer-1519]"
+	var/monthname
+	switch(month)
+		if(1)
+			monthname = "January"
+		if(2)
+			monthname = "February"
+		if(3)
+			monthname = "March"
+		if(4)
+			monthname = "April"
+		if(5)
+			monthname = "May"
+		if(6)
+			monthname = "June"
+		if(7)
+			monthname = "Sol"
+		if(8)
+			monthname = "July"
+		if(9)
+			monthname = "August"
+		if(10)
+			monthname = "September"
+		if(11)
+			monthname = "October"
+		if(12)
+			monthname = "November"
+		if(13)
+			monthname = "December"
+		if(14)
+			return "Year Day, [year] FSC"
+
+	return "[monthname] [day_of_month], [year] FSC"
 
 //returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format
 /proc/SQLtime(timevar)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -2,7 +2,7 @@
 /proc/worldtime2text()
 	return gameTimestamp("hh:mm:ss", world.time)
 
-/proc/time_stamp(format = "hh:mm:ss", show_ds)
+/proc/time_stamp(format = "YYYY-MM-DD hh:mm:ss", show_ds)
 	var/time_string = time2text(world.timeofday, format)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string
 
@@ -23,6 +23,15 @@
 		. += " PM"
 	else
 		. += " AM"
+
+/proc/sector_year()
+	return GLOB.year_integer - 1519
+
+/proc/sector_datestamp(time_format = "hh:mm:ss", world_time = world.time)
+	return "[sector_year()]FSC-[time2text(wtime, "MMM-DD")] [station_time_timestamp(time_format, world_time)]"
+
+/proc/sector_date(world_time = world.time)
+	return "[time2text(world_time, "MMM DD")], FSC [GLOB.year_integer-1519]"
 
 //returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format
 /proc/SQLtime(timevar)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -24,16 +24,6 @@
 	else
 		. += " AM"
 
-/proc/station_time_debug(force_set)
-	if(isnum(force_set))
-		SSticker.gametime_offset = force_set
-		return
-	SSticker.gametime_offset = rand(0, 864000)		//hours in day * minutes in hour * seconds in minute * deciseconds in second
-	if(prob(50))
-		SSticker.gametime_offset = FLOOR(SSticker.gametime_offset, 3600)
-	else
-		SSticker.gametime_offset = CEILING(SSticker.gametime_offset, 3600)
-
 //returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format
 /proc/SQLtime(timevar)
 	return time2text(timevar || world.timeofday, "YYYY-MM-DD hh:mm:ss")

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -28,7 +28,7 @@
 	return GLOB.year_integer - 1519
 
 /proc/sector_datestamp(time_format = "hh:mm:ss", world_time = world.time)
-	return "[sector_year()]FSC-[time2text(wtime, "MMM-DD")] [station_time_timestamp(time_format, world_time)]"
+	return "[sector_year()]FSC-[time2text(world_time, "MMM-DD")] [station_time_timestamp(time_format, world_time)]"
 
 /proc/sector_date(world_time = world.time)
 	return "[time2text(world_time, "MMM DD")], FSC [GLOB.year_integer-1519]"

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -216,7 +216,7 @@ SUBSYSTEM_DEF(explosions)
 	var/y0 = epicenter.y
 	var/z0 = epicenter.virtual_z()
 	var/area/areatype = get_area(epicenter)
-	SSblackbox.record_feedback("associative", "explosion", 1, list("dev" = devastation_range, "heavy" = heavy_impact_range, "light" = light_impact_range, "flash" = flash_range, "flame" = flame_range, "orig_dev" = orig_dev_range, "orig_heavy" = orig_heavy_range, "orig_light" = orig_light_range, "x" = x0, "y" = y0, "z" = z0, "area" = areatype.type, "time" = time_stamp("YYYY-MM-DD hh:mm:ss", 1)))
+	SSblackbox.record_feedback("associative", "explosion", 1, list("dev" = devastation_range, "heavy" = heavy_impact_range, "light" = light_impact_range, "flash" = flash_range, "flame" = flame_range, "orig_dev" = orig_dev_range, "orig_heavy" = orig_heavy_range, "orig_light" = orig_light_range, "x" = x0, "y" = y0, "z" = z0, "area" = areatype.type, "time" = time_stamp(show_ds = TRUE)))
 
 	// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
 	// Stereo users will also hear the direction of the explosion!

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"\n",
-			"Local Sector Time: [SSticker.round_start_timeofday ? "[station_time_timestamp()] [sector_date()]" : "The round hasn't started yet!"]",
+			"Local Sector Time: [SSticker.round_start_timeofday ? "[station_time_timestamp()] [sector_datestamp()]" : "The round hasn't started yet!"]",
 			"\n",
 			"Internal Round Timer: [SSticker.round_start_timeofday ? ROUND_TIME : "The round hasn't started yet!"]",
 			"Actual Round Timer: [SSticker.round_start_timeofday ? ROUND_REALTIMEOFDAY : "The round hasn't started yet!"]",

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -11,18 +11,17 @@ SUBSYSTEM_DEF(statpanels)
 
 /datum/controller/subsystem/statpanels/fire(resumed = FALSE)
 	if (!resumed)
-		var/actual_round_time = world.timeofday - SSticker.round_start_timeofday
-		var/game_round_time = world.time - SSticker.round_start_time
 		var/list/global_data = list(
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
-			"Local Time: [station_time_timestamp()]",
 			"\n",
-			"Internal Round Timer: [SSticker.round_start_time ? time2text(game_round_time, "hh:mm:ss", 0) : "The round hasn't started yet!"]",
-			"Actual Round Timer: [SSticker.round_start_timeofday ? time2text(actual_round_time, "hh:mm:ss", 0) : "The round hasn't started yet!"]",
+			"Local Sector Time: [SSticker.round_start_timeofday ? station_time_timestamp_fancy("hh:mm:ss") : "The round hasn't started yet!"]",
 			"\n",
-			"Playing/Connected: [get_active_player_count()]/[GLOB.clients.len]"
+			"Internal Round Timer: [SSticker.round_start_timeofday ? ROUND_TIME : "The round hasn't started yet!"]",
+			"Actual Round Timer: [SSticker.round_start_timeofday ? ROUND_REALTIMEOFDAY : "The round hasn't started yet!"]",
+			"\n",
+			"Playing/Connected: [get_active_player_count()]/[length(GLOB.clients)]"
 		)
 
 		if(SSshuttle.jump_mode != BS_JUMP_IDLE)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"\n",
-			"Local Sector Time: [SSticker.round_start_timeofday ? station_time_timestamp_fancy("hh:mm:ss") : "The round hasn't started yet!"]",
+			"Local Sector Time: [SSticker.round_start_timeofday ? "[station_time_timestamp()] [sector_date()]" : "The round hasn't started yet!"]",
 			"\n",
 			"Internal Round Timer: [SSticker.round_start_timeofday ? ROUND_TIME : "The round hasn't started yet!"]",
 			"Actual Round Timer: [SSticker.round_start_timeofday ? ROUND_REALTIMEOFDAY : "The round hasn't started yet!"]",

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -36,10 +36,9 @@ SUBSYSTEM_DEF(ticker)
 	var/selected_tip						// What will be the tip of the day?
 
 	var/timeLeft						//pregame timer
-	//var/start_at		WS Edit - Countdown after init
 
-	var/gametime_offset = 432000		//Deciseconds to add to world.time for station time.
-	var/station_time_rate_multiplier = 12		//factor of station time progressal vs real time.
+	var/gametime_offset = 9 HOURS		//Deciseconds to add to world.time for station time.
+	var/station_time_rate_multiplier = 1		//factor of station time progressal vs real time.
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
@@ -57,11 +56,6 @@ SUBSYSTEM_DEF(ticker)
 	var/list/round_end_events
 	var/mode_result = "undefined"
 	var/end_state = "undefined"
-
-	//Crew Objective stuff
-	var/list/successfulCrew = list()
-	var/list/crewobjlist = list()
-	var/list/crewobjjobs = list()
 
 	/// Why an emergency shuttle was called
 	var/emergency_reason
@@ -136,7 +130,6 @@ SUBSYSTEM_DEF(ticker)
 
 		GLOB.syndicate_code_response_regex = codeword_match
 
-	//start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)		WS Edit - Countdown at init
 	if(CONFIG_GET(flag/randomize_shift_time))
 		gametime_offset = rand(0, 23) HOURS
 	else if(CONFIG_GET(flag/shift_time_realtime))
@@ -280,7 +273,7 @@ SUBSYSTEM_DEF(ticker)
 		cb.InvokeAsync()
 	LAZYCLEARLIST(round_start_events)
 
-	log_world("Game start took [(world.timeofday - init_start)/10]s")
+	log_world("Game start took [(REALTIMEOFDAY - init_start)/10]s")
 	round_start_time = world.time
 	round_start_timeofday = world.timeofday
 	SSdbcore.SetRoundStart()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -37,8 +37,10 @@ SUBSYSTEM_DEF(ticker)
 
 	var/timeLeft						//pregame timer
 
-	var/gametime_offset = 9 HOURS		//Deciseconds to add to world.time for station time.
-	var/station_time_rate_multiplier = 1		//factor of station time progressal vs real time.
+	/// The "start" of the round in station time, for example, 9 HOURS = 9:00 AM
+	var/gametime_offset = 9 HOURS
+	/// Factor of station time progressal vs real time.
+	var/station_time_rate_multiplier = 1
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -159,10 +159,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return
 		if(threatadd > 0)
 			create_threat(threatadd)
-			threat_log += "[worldtime2text()]: [key_name(usr)] increased threat by [threatadd] threat."
+			threat_log += "[game_timestamp()]: [key_name(usr)] increased threat by [threatadd] threat."
 		else
 			spend_threat(-threatadd)
-			threat_log += "[worldtime2text()]: [key_name(usr)] decreased threat by [-threatadd] threat."
+			threat_log += "[game_timestamp()]: [key_name(usr)] decreased threat by [-threatadd] threat."
 	else if (href_list["injectlate"])
 		latejoin_injection_cooldown = 0
 		forced_injection = TRUE
@@ -478,7 +478,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/added_threat = starting_rule.scale_up(extra_rulesets_amount, threat)
 	if(starting_rule.pre_execute())
 		spend_threat(starting_rule.cost + added_threat)
-		threat_log += "[worldtime2text()]: Roundstart [starting_rule.name] spent [starting_rule.cost + added_threat]. [starting_rule.scaling_cost ? "Scaled up[starting_rule.scaled_times]/3 times." : ""]"
+		threat_log += "[game_timestamp()]: Roundstart [starting_rule.name] spent [starting_rule.cost + added_threat]. [starting_rule.scaling_cost ? "Scaled up[starting_rule.scaled_times]/3 times." : ""]"
 		if(starting_rule.flags & HIGHLANDER_RULESET)
 			highlander_executed = TRUE
 		else if(starting_rule.flags & ONLY_RULESET)
@@ -572,7 +572,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		new_rule.trim_candidates()
 		if (new_rule.ready(forced))
 			spend_threat(new_rule.cost)
-			threat_log += "[worldtime2text()]: Forced rule [new_rule.name] spent [new_rule.cost]"
+			threat_log += "[game_timestamp()]: Forced rule [new_rule.name] spent [new_rule.cost]"
 			if (new_rule.execute()) // This should never fail since ready() returned 1
 				if(new_rule.flags & HIGHLANDER_RULESET)
 					highlander_executed = TRUE
@@ -591,7 +591,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
 	var/datum/dynamic_ruleset/rule = sent_rule
 	spend_threat(rule.cost)
-	threat_log += "[worldtime2text()]: [rule.ruletype] [rule.name] spent [rule.cost]"
+	threat_log += "[game_timestamp()]: [rule.ruletype] [rule.name] spent [rule.cost]"
 	rule.pre_execute()
 	if (rule.execute())
 		log_game("DYNAMIC: Injected a [rule.ruletype == "latejoin" ? "latejoin" : "midround"] ruleset [rule.name].")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -166,7 +166,7 @@
 /// This one only handles refunding the threat, override in ruleset to clean up the rest.
 /datum/dynamic_ruleset/proc/clean_up()
 	mode.refund_threat(cost + (scaled_times * scaling_cost))
-	mode.threat_log += "[worldtime2text()]: [ruletype] [name] refunded [cost + (scaled_times * scaling_cost)]. Failed to execute."
+	mode.threat_log += "[game_timestamp()]: [ruletype] [name] refunded [cost + (scaled_times * scaling_cost)]. Failed to execute."
 
 /// Gets weight of the ruleset
 /// Note that this decreases weight if repeatable is TRUE and repeatable_weight_decrease is higher than 0

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -355,7 +355,7 @@
 	message_admins("Starting a round of extended.")
 	log_game("Starting a round of extended.")
 	mode.spend_threat(mode.threat)
-	mode.threat_log += "[worldtime2text()]: Extended ruleset set threat to 0."
+	mode.threat_log += "[game_timestamp()]: Extended ruleset set threat to 0."
 	return TRUE
 
 //////////////////////////////////////////////

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -472,7 +472,7 @@
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, station_time_timestamp(), sector_date(), t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, station_time_timestamp(), sector_datestamp(), t1)
 
 			else if(href_list["del_c"])
 				if((istype(active2, /datum/data/record) && active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -472,7 +472,7 @@
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", authenticated, rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), "504 FS", t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, station_time_timestamp(), sector_date(), t1)
 
 			else if(href_list["del_c"])
 				if((istype(active2, /datum/data/record) && active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -478,7 +478,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), sector_date(), t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), sector_datestamp(shortened = TRUE), t1)
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -478,7 +478,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), "504 FS", t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), sector_date(), t1)
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -339,7 +339,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 		var/list/frozen_details = list()
 		frozen_details["name"] = "[mob_occupant.real_name]"
 		frozen_details["rank"] = announce_rank || "[mob_occupant.job]"
-		frozen_details["time"] = gameTimestamp()
+		frozen_details["time"] = station_time_timestamp()
 
 		control_computer_obj.frozen_crew += list(frozen_details)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -230,7 +230,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 					dat += text("ID: <A href='?src=[REF(src)];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]   <a href='?src=[REF(src)];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</a><br><br>")
 
 				dat += "[station_time_timestamp()]<br>"
-				dat += "[sector_date()]<br>"
+				dat += "[sector_datestamp()]<br>"
 				dat += "<br>"
 				dat += "<h4>General Functions</h4>"
 				dat += "<ul>"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -229,9 +229,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if(id)
 					dat += text("ID: <A href='?src=[REF(src)];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]   <a href='?src=[REF(src)];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</a><br><br>")
 
-				dat += "[worldtime2text()]<br>" //:[world.time / 100 % 6][world.time / 100 % 10]"
-				dat += "[time2text(world.realtime, "MMM DD")] 504 FS"
-				dat += "<br><br>"
+				dat += "[station_time_timestamp()]<br>"
+				dat += "[sector_date()]<br>"
+				dat += "<br>"
 				dat += "<h4>General Functions</h4>"
 				dat += "<ul>"
 				dat += "<li><a href='byond://?src=[REF(src)];choice=1'>[PDAIMG(notes)] Notekeeper</a></li>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -494,9 +494,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	dat += "</b>[FOURSPACES][ticket_href("Refresh", ref_src)][FOURSPACES][ticket_href("Re-Title", ref_src, "retitle")]"
 	if(state != AHELP_ACTIVE)
 		dat += "[FOURSPACES][ticket_href("Reopen", ref_src, "reopen")]"
-	dat += "<br><br>Opened at: [gameTimestamp(wtime = opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	dat += "<br><br>Opened at: [game_timestamp(wtime = opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
 	if(closed_at)
-		dat += "<br>Closed at: [gameTimestamp(wtime = closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
+		dat += "<br>Closed at: [game_timestamp(wtime = closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
 	dat += "<br><br>"
 	if(initiator)
 		dat += "<b>Actions:</b><br>[full_monty(ref_src)]<br>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -541,7 +541,7 @@
 				var/counter = 1
 				while(R.fields[text("com_[]", counter)])
 					counter++
-				R.fields[text("com_[]", counter)] = text("Made by [] on [], []<BR>[]", allowed_access, station_time_timestamp(), sector_date(), t1)
+				R.fields[text("com_[]", counter)] = text("Made by [] on [], []<BR>[]", allowed_access, station_time_timestamp(), sector_datestamp(shortened = TRUE), t1)
 				to_chat(usr, "<span class='notice'>Successfully added comment.</span>")
 				return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -541,7 +541,7 @@
 				var/counter = 1
 				while(R.fields[text("com_[]", counter)])
 					counter++
-				R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), "504 FS", t1)
+				R.fields[text("com_[]", counter)] = text("Made by [] on [], []<BR>[]", allowed_access, station_time_timestamp(), sector_date(), t1)
 				to_chat(usr, "<span class='notice'>Successfully added comment.</span>")
 				return
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -52,7 +52,7 @@
 	unset_machine()
 	timeofdeath = world.time
 	if(ckey)
-		GLOB.respawn_timers[client?.ckey] = world.timeofday
+		GLOB.respawn_timers[client?.ckey] = REALTIMEOFDAY
 	tod = station_time_timestamp()
 	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -705,7 +705,7 @@
 		log_game("[key_name(usr)] AM failed due to disconnect.")
 
 	if(GLOB.respawn_timers[usrkey] && !admin_bypass)
-		var/time_left = GLOB.respawn_timers[usrkey] + respawn_timer - world.timeofday
+		var/time_left = GLOB.respawn_timers[usrkey] + respawn_timer - REALTIMEOFDAY
 		if(time_left > 0)
 			to_chat(usr, "<span class='boldnotice'>You still have [DisplayTimeText(time_left)] left before you can respawn.</span>")
 			return

--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -90,7 +90,7 @@
 	if(planet_name)
 		for(var/mob/Mob as anything in GLOB.player_list)
 			if(dock_requester.shuttle_port.is_in_shuttle_bounds(Mob))
-				Mob.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[planet_name]</u></span><br>[station_time_timestamp_fancy("hh:mm")]")
+				Mob.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[planet_name]</u></span><br>[station_time_timestamp("hh:mm")]")
 				playsound(Mob, landing_sound, 50)
 
 

--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -217,7 +217,7 @@
 /datum/overmap/outpost/post_docked(datum/overmap/ship/controlled/dock_requester)
 	for(var/mob/M as anything in GLOB.player_list)
 		if(dock_requester.shuttle_port.is_in_shuttle_bounds(M))
-			M.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[name]</u></span><br>[station_time_timestamp_fancy("hh:mm")]")
+			M.play_screen_text("<span class='maptext' style=font-size:24pt;text-align:center valign='top'><u>[name]</u></span><br>[station_time_timestamp("hh:mm")]")
 
 	// Instance the virtual speaker for use in radio messages. It needs an atom to trace things back to; we use the token.
 	// You might think "but wait, can't we just keep one speaker around instead of instancing it for each fucking radio message?"

--- a/code/modules/paperwork/fax_manager.dm
+++ b/code/modules/paperwork/fax_manager.dm
@@ -121,7 +121,7 @@ GLOBAL_DATUM_INIT(fax_manager, /datum/fax_manager, new)
 	var/list/request = list()
 	var/obj/item/paper/request/message = new()
 	request["id_message"] = requests.len
-	request["time"] = gameTimestamp()
+	request["time"] = game_timestamp()
 	request["sender"] = sender
 	request["sender_fax_id"] = sender_fax.fax_id
 	request["sender_fax_name"] = sender_fax.fax_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few outstanding bugs where time displays would show the incorrect round length or similar due to use of timeofday instead of REALTIMEOFDAY

## Why It's Good For The Game
Less funkiness, and a better way to coordinate things in-character, hopefully.

## Changelog

:cl:
tweak: "Local Sector Time" now runs at 1x speed and starts at 9:00AM (unless config is changed)
tweak: Round end now shows the ship you spawned on when possible instead of just the sector name
tweak: Slightly moves around the statpanel info to emphasise LST
fix: Round time should no longer act strange when midnight passes
fix: Respawns should no longer be delayed 24h when done over midnight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
