### PR TITLE
stops outposts placing on top of space

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost_types.dm
+++ b/code/modules/overmap/objects/outpost/outpost_types.dm
@@ -2,6 +2,13 @@
 	Map templates
 */
 
+/datum/map_template/outpost
+	// Necessary to stop planetary outposts from having space underneath all their turfs.
+	// They were being "placed on top", so instead of their baseturf, there was just space underneath.
+	// (Interestingly, this is much less of a problem for ruins: PlaceOnTop ignores the top closed turf in the baseturfs stack
+	// of the new tile, meaning that placing plating on top of a wall doesn't result in a wall underneath the plating.)
+	should_place_on_top = FALSE
+
 /datum/map_template/outpost/New()
 	. = ..(path = "_maps/outpost/[name].dmm")
 


### PR DESCRIPTION
## About The Pull Request

planetary outposts currently have /turf/open/space/basic underneath all their turfs even if the baseturf ztrait is set correctly. this fixes that, by making outpost map templates (elevator / hangar templates included, though that shouldn't make a difference due to the way they're used) no longer spawn "on top of" turfs: now they replace them instead

## Why It's Good For The Game

randomly spaced turfs are bad

## Changelog

:cl:
fix: fixes planetary outposts from having space underneath all the turfs
/:cl: