### PR TITLE
Ends the centuries-old war between David the goliath and the Hyena turrets

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_gorlex_hyena.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_hyena.dmm
@@ -3076,7 +3076,7 @@
 	a_intent = "help";
 	desc = "A small goliath pup. Its tendrils have not yet fully grown. Someone, somehow, has managed to fit a large dog collar around its neck.";
 	environment_smash = 0;
-	faction = list("neutral");
+	faction = list("neutral","playerSyndicate");
 	mob_size = 2;
 	move_force = 1000;
 	move_resist = 1000;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the "playerSyndicate" faction to the pet goliath on the hyena, stopping its beef with the turrets

## Why It's Good For The Game

fixes #2520

## Changelog

🆑 
fix: David and the hyena's turrets have come to an understanding and will no longer try to assail eachother
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
