### PR TITLE
Removes telekinetic beaker cap manipulation

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -140,6 +140,7 @@
 /obj/item/reagent_containers/AltClick(mob/user)
 	if(!can_interact(user))
 		return
+	. = ..()
 	if(can_have_cap)
 		if(cap_lost)
 			to_chat(user, "<span class='warning'>The cap seems to be missing! Where did it go?</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -138,7 +138,8 @@
 		reagents.remove_reagent(reag.type, reag.volume * frac)
 
 /obj/item/reagent_containers/AltClick(mob/user)
-	. = ..()
+	if(!can_interact(user))
+		return
 	if(can_have_cap)
 		if(cap_lost)
 			to_chat(user, "<span class='warning'>The cap seems to be missing! Where did it go?</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

AltClick() does not by default check for range (and probably other stuff), adds a can_interact() check

## Why It's Good For The Game

fixes #1498

## Changelog

🆑 
fix: Players are no longer bottlecap-omancers, and can no longer magically manipulate bottle caps at range
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
