### PR TITLE
Limits Riggs-class ships to one

### DIFF
--- a/_maps/configs/independent_rigger.json
+++ b/_maps/configs/independent_rigger.json
@@ -18,7 +18,7 @@
 	],
 	"map_path": "_maps/shuttles/independent/independent_rigger.dmm",
 	"roundstart": true,
-	"limit": 2,
+	"limit": 1,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/captain/western",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ship is decently sized and supports a decently sized crew. Having multiple diminishes that by spreading out players if multiple are spawned around the same time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
tweak: Multiple Riggs-classes cannot be spawned by players anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
