### PR TITLE
Heating rations now provides their bonus vitamin/nutriment reagents

### DIFF
--- a/code/modules/food_and_drinks/food/ration.dm
+++ b/code/modules/food_and_drinks/food/ration.dm
@@ -59,10 +59,10 @@
 		var/cooking_efficiency = 1
 		if(istype(Heater))
 			cooking_efficiency = Heater.efficiency
-		if(bonus_reagents && bonus_reagents.len)
+		if(length(bonus_reagents))
 			for(var/r_id in bonus_reagents)
 				var/amount = bonus_reagents[r_id] * cooking_efficiency
-				if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
+				if(ispath(r_id, /datum/reagent/consumable/nutriment))
 					reagents.add_reagent(r_id, amount, tastes)
 				else
 					reagents.add_reagent(r_id, amount)

--- a/code/modules/food_and_drinks/food/ration.dm
+++ b/code/modules/food_and_drinks/food/ration.dm
@@ -3,6 +3,7 @@
 	desc = "standard issue ration"
 	filling_color = "#664330"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 2)
 	icon = 'icons/obj/food/ration.dmi'
 	icon_state = "ration_side"
 	in_container = TRUE
@@ -55,7 +56,16 @@
 		..()
 	else
 		name = "warm [initial(name)]"
-		bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 2)
+		var/cooking_efficiency = 1
+		if(istype(Heater))
+			cooking_efficiency = Heater.efficiency
+		if(bonus_reagents && bonus_reagents.len)
+			for(var/r_id in bonus_reagents)
+				var/amount = bonus_reagents[r_id] * cooking_efficiency
+				if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
+					reagents.add_reagent(r_id, amount, tastes)
+				else
+					reagents.add_reagent(r_id, amount)
 		cooked = TRUE
 
 /obj/item/reagent_containers/food/snacks/ration/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request

Ration packs now use bonus_reagents properly, prior they would set the list when being heated and not use it

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/1bf14f40-5140-410f-a228-e07599ae83ac)

## Why It's Good For The Game

Cooking rations now makes them better

## Changelog

:cl:
fix: heating rations increases their nutritional value as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
