### PR TITLE
AB+ blood fix

### DIFF
--- a/code/datums/blood_type.dm
+++ b/code/datums/blood_type.dm
@@ -28,7 +28,7 @@
 
 /datum/blood_type/ab_plus
 	name = "AB+"
-	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/a_minus, /datum/blood_type/ab_minus, /datum/blood_type/o_minus)
+	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/b_plus, /datum/blood_type/a_minus, /datum/blood_type/a_plus, /datum/blood_type/ab_minus, /datum/blood_type/ab_plus, /datum/blood_type/o_minus, /datum/blood_type/o_plus)
 
 /datum/blood_type/o_minus
 	name = "O-"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds missing compatible bloodtypes to AB+ blood

## Why It's Good For The Game

People with AB+ blood will no longer die when being given any + bloodtype

## Changelog

:cl:
fix: AB+ blood is no longer incompatible with + bloodtypes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
