### PR TITLE
Crashed Pubby Tweaks

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
@@ -1,21 +1,216 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"as" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = 6;
-	pixel_y = 14
+"ab" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-141"
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"as" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash/split)
 "aR" = (
-/obj/structure/sign/number/one,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ba" = (
+/obj/structure/salvageable/computer,
+/obj/item/stack/ore/salvage/scrapgold,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash)
+"by" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/salvageable/computer,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash)
+"bS" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"bW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/light/directional/east,
+/obj/effect/gibspawner,
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"bZ" = (
+/turf/open/floor/plating/asteroid/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"ch" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ck" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/button/door{
+	id = "pubbywspodsw";
+	name = "Pod Door Control";
+	pixel_x = -25;
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/engine,
 /area/ruin/whitesands/pubbycrash)
-"ba" = (
+"co" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"cp" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ct" = (
+/obj/structure/bed/dogbed{
+	anchored = 1;
+	name = "citrus's bed"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 9
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/pod,
+/area/ruin/whitesands/pubbycrash)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"cN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"di" = (
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash)
+"dm" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/button/door{
+	id = "pubbywspodsw";
+	name = "Pod Door Control";
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/structure/salvageable/server,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"dW" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/number/nine{
+	dir = 4
+	},
+/obj/item/stock_parts/cell/hyper,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ek" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"eq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash/split)
+"ff" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"fk" = (
+/obj/structure/closet/wall/blue{
+	dir = 1;
+	name = "Captain's locker";
+	pixel_y = -28
+	},
+/obj/item/clothing/suit/space/hardsuit/mining/heavy,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"fr" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -23,28 +218,830 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"by" = (
+"fA" = (
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance/five,
+/obj/effect/spawner/lootdrop/maintenance/five,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash)
+"fO" = (
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_y = -9;
+	pixel_x = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fR" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"fX" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/salvageable/machine,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ge" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_y = -3;
+	pixel_x = -6
+	},
+/obj/item/gun/energy/laser/hitscanpistol,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"gg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/effect/mob_spawn/human/corpse/nanotrasenassaultsoldier,
+/obj/effect/gibspawner,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash)
+"gs" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"gx" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-5"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gy" = (
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"gG" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/number/seven{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"gL" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"hh" = (
+/turf/closed/mineral/random/whitesands,
+/area/ruin/whitesands/pubbycrash)
+"ho" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"hz" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/salvageable/safe_server,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"hA" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/cave/explored)
+"ih" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"iw" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/noticeboard{
+	pixel_y = 31
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"iW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "engine fuel pump"
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"jt" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
+	},
+/obj/structure/salvageable/server,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"jA" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"jF" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash/split)
+"jG" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"kp" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kA" = (
+/obj/structure/railing/corner,
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-23"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"kM" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"kP" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/ore/salvage/scrapgold,
+/obj/item/stack/ore/salvage/scrapgold,
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"kU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"ln" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset/wall{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ly" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/gibspawner,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"lA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"lB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "engine fuel pump"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"lI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"lK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"lR" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-46"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mp" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"mH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"mU" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands/survivor,
+/turf/open/floor/plastic,
+/area/ruin/whitesands/pubbycrash/split)
+"mW" = (
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_y = -12;
+	pixel_x = 5
+	},
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"no" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"nq" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-55"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/wrapping,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"nP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"nQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"oj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_y = -2;
+	pixel_x = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"oo" = (
+/obj/structure/closet/wall/white{
+	dir = 1;
+	name = "Medicine storage";
+	pixel_y = -30
+	},
+/obj/item/storage/firstaid/ancient{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/storage/firstaid/medical,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/pod,
+/area/ruin/whitesands/pubbycrash)
+"oq" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"oO" = (
+/obj/structure/table/reinforced,
+/obj/item/laser_pointer,
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"oS" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-55"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"pe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"pu" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-139"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"pE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash)
+"pG" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/structure/salvageable/server,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"pR" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"pT" = (
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/machinery/button/door{
+	id = "whiteshipubbyEngines";
+	name = "Engine Lockdown Control";
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/structure/salvageable/circuit_imprinter,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"qz" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"qN" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-74"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"re" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"rT" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/split)
+"rW" = (
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/ore/salvage/scrapgold,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"rZ" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/whitesands/pubbycrash)
+"sd" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-2"
+	},
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 1;
+	faction = list("adobe");
+	desc = " A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body, twisted by the heavy metals and high background radiation of the sandworlds. Their helmet also seems to be filled with vomit"
+	},
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"so" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ss" = (
+/obj/machinery/door/airlock/glass,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/pod,
+/turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"bS" = (
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/kinetic_crusher,
-/obj/structure/rack,
-/obj/item/pickaxe/mini,
-/obj/item/pickaxe/mini,
+"sA" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"sC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"sD" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/structure/closet/wall{
+	icon_door = "orange_wall";
+	name = "Mining equipment";
+	pixel_y = 28
+	},
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west{
+	start_charge = 0
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/split)
+"sV" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/shuttle/engine/plasma,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"tB" = (
+/obj/structure/sign/number/one,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"uh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash)
+"ul" = (
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash)
+"up" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"uB" = (
 /obj/effect/turf_decal/siding/brown,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 5
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/split)
+"vc" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"vw" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"vL" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"vO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/split)
+"vX" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/whitesands/pubbycrash)
-"bW" = (
+"wn" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"wL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"wV" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash)
+"xa" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/gibspawner,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"xc" = (
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"xz" = (
 /obj/effect/turf_decal/box,
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -67,65 +1064,594 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/whitesands/pubbycrash)
-"bZ" = (
-/turf/open/floor/plating/asteroid/whitesands,
-/area/overmap_encounter/planetoid/sand)
-"ck" = (
+"xA" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash)
+"xH" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"xX" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"yj" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"ym" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"yt" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-141"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yx" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"yK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"yU" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-46"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"zi" = (
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/multitool,
+/obj/structure/railing,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash)
+"zP" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/ntspaceworks_small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"zX" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/directional/west,
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 1;
+	faction = list("saloon")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Ai" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ak" = (
+/obj/item/reagent_containers/food/drinks/britcup{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/obj/item/trash/pistachios{
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"AA" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash/split)
+"AD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/ruin/whitesands/pubbycrash)
+"AH" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/ore/salvage/scrapgold,
+/obj/item/stack/ore/salvage/scrapgold,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"AJ" = (
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"AO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Bd" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"Bi" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_x = 30
+	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"co" = (
+"Bw" = (
+/turf/closed/mineral/random/whitesands,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Bz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"BD" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"BH" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Cg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Cs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/ntspaceworks_small/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/obj/item/storage/box/stockparts/basic{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ct" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Cw" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Dg" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/salvageable/computer,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Di" = (
+/obj/structure/sign/number/one,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"Dn" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/salvageable/machine,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Dx" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-141"
+	},
+/turf/open/floor/plating/asteroid/whitesands,
+/area/overmap_encounter/planetoid/cave/explored)
+"DB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"DQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"DY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/shuttle/heater,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ea" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"Eb" = (
+/obj/item/trash/cheesie{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"Eh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/lighter,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Em" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/turf/open/floor/plastic,
+/area/ruin/whitesands/pubbycrash/split)
+"Et" = (
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_x = -3;
+	pixel_y = -10
+	},
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-21"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ew" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"EG" = (
+/obj/machinery/door/airlock/hatch{
+	welded = 1
+	},
+/turf/template_noop,
+/area/ruin/whitesands/pubbycrash/split)
+"ET" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/number/four{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Fc" = (
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_x = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fn" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"Fo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash{
+	pixel_y = -3;
+	pixel_x = -6
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"Fq" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/salvageable/server,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"FP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/railing{
+	dir = 10;
+	layer = 4.1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/item/stack/ore/salvage/scrapgold,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash)
+"FY" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Ga" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"cp" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"ct" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"Gi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"cx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
-/obj/item/stack/ore/salvage/scrapmetal,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"cN" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+"Gl" = (
+/turf/template_noop,
+/area/template_noop)
+"Gp" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"di" = (
+"GA" = (
+/obj/structure/railing,
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
+/obj/item/stack/ore/salvage/scrapgold,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash)
+"GF" = (
+/obj/machinery/newscaster/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"GK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plastic,
+/area/ruin/whitesands/pubbycrash/split)
+"Ha" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Hb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/gibspawner,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ho" = (
+/obj/effect/turf_decal/box/corners,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"Hq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"HQ" = (
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_y = -12;
+	pixel_x = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"If" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Ig" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 12
@@ -135,57 +1661,8 @@
 /obj/item/stack/sheet/cotton/cloth,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
-"dm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "engine fuel pump"
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"dW" = (
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/stack/ore/salvage/scrapgold,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"ek" = (
-/obj/effect/turf_decal/industrial/stand_clear,
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/button/door{
-	id = "pubbywspodsw";
-	name = "Pod Door Control";
-	pixel_x = -25;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/ore/salvage/scrapmetal,
-/obj/structure/salvageable/server,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"eq" = (
-/obj/structure/sign/number/one,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"ff" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/ruin/whitesands/pubbycrash)
-"fk" = (
+/area/ruin/whitesands/pubbycrash/split)
+"Ik" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box{
 	pixel_y = 2
@@ -202,120 +1679,39 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"fA" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+"In" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash)
+"IC" = (
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"fO" = (
-/obj/machinery/power/terminal{
-	dir = 8
+"IR" = (
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"fR" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/item/stack/ore/salvage/scraptitanium,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"fX" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"gg" = (
-/obj/structure/reagent_dispensers/servingdish,
-/obj/structure/table/reinforced,
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = 6
-	},
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = -1
-	},
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = 13
-	},
-/turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
-"gs" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-8"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"gu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plasteel/grimy,
 /area/ruin/whitesands/pubbycrash)
-"gx" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-5"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"gy" = (
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/structure/railing,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"gG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"gL" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"hh" = (
+"IU" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -323,32 +1719,278 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Ji" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"Jz" = (
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/salvageable/protolathe,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Kt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	faction = list("saloon")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Ky" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/whitesands/pubbycrash/split)
+"KB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/pubbycrash)
+"KI" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"ho" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+"KO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/ntspaceworks_small/left{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"hz" = (
-/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 4;
+	faction = list("saloon")
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"KS" = (
+/obj/effect/turf_decal/industrial/caution,
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/sign/poster/retro/nanotrasen_logo_70s{
+	pixel_x = -32
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"KT" = (
+/obj/structure/railing,
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-12"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Li" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall/red{
+	dir = 8;
+	name = "Firearm Locker";
+	pixel_x = 29;
+	welded = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/item/gun/ballistic/automatic/pistol/commander,
+/obj/item/gun/ballistic/automatic/pistol/commander,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Lj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/pod,
+/area/ruin/whitesands/pubbycrash)
+"Lm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/item/stock_parts/cell/hyper{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_x = -9
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ls" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash)
+"LM" = (
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"LU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/whitesands/pubbycrash)
-"hA" = (
+"LW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Mi" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Ml" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "ws_atmos"
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"Mr" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/pistachios{
+	pixel_y = 5
+	},
+/obj/item/trash/energybar,
+/obj/item/trash/cheesie,
+/obj/item/trash/can/food,
+/obj/item/trash/sosjerky{
+	pixel_x = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"NI" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/stairs{
+	dir = 1
+	},
+/area/ruin/whitesands/pubbycrash)
+"Og" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 1;
+	faction = list("saloon")
+	},
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Oz" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/salvageable/machine,
+/turf/open/floor/plastic,
+/area/ruin/whitesands/pubbycrash/split)
+"ON" = (
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
+	dir = 4;
+	faction = list("adobe");
+	desc = " A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body, twisted by the heavy metals and high background radiation of the sandworlds. Their helmet also seems to be filled with vomit"
+	},
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash/split)
+"Pr" = (
 /obj/structure/closet/wall/red{
 	dir = 4;
 	name = "Pilots locker";
@@ -372,8 +2014,289 @@
 /obj/item/clothing/under/rank/security/officer/nt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
+/area/ruin/whitesands/pubbycrash/split)
+"Pu" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"PA" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"PI" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/circuitboard/machine/shuttle/smes,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"PK" = (
+/obj/effect/turf_decal/box,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/salvageable/autolathe,
+/turf/open/floor/plasteel,
 /area/ruin/whitesands/pubbycrash)
-"iw" = (
+"PY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"PZ" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-21"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Qb" = (
+/obj/effect/gibspawner,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Qo" = (
+/mob/living/simple_animal/hostile/asteroid/whitesands/ranged,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Qu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/shuttle/heater,
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/ore/salvage/scrapplasma/five,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Qw" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"QD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"QI" = (
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"QR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"RC" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"RL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"RT" = (
+/turf/closed/mineral/random/whitesands,
+/area/overmap_encounter/planetoid/cave/explored)
+"Sy" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ruin/whitesands/pubbycrash/engine_room)
+"SO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"SU" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Tg" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/red,
+/obj/item/circuitboard/machine/shuttle/smes,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"TB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesands/pubbycrash)
+"TF" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ruin/whitesands/pubbycrash/split)
+"Uo" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Us" = (
+/obj/machinery/door/airlock/hatch{
+	welded = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/pod,
+/area/ruin/whitesands/pubbycrash)
+"Uy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Vj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Vt" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VG" = (
+/obj/structure/sign/number/two,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/effect/gibspawner,
+/turf/open/floor/engine,
+/area/ruin/whitesands/pubbycrash)
+"VK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"VP" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -382,71 +2305,136 @@
 	id = "whiteship_windows"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"iW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/area/ruin/whitesands/pubbycrash/split)
+"Wg" = (
+/obj/structure/sign/number/two,
+/obj/item/stack/ore/salvage/scrapmetal,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"jt" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/engine,
 /area/ruin/whitesands/pubbycrash)
-"jA" = (
-/obj/item/trash/cheesie{
-	pixel_x = 5;
-	pixel_y = 6
+"Wo" = (
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"jF" = (
+"WD" = (
 /obj/item/stack/ore/salvage/scraptitanium,
 /turf/open/floor/plating,
 /area/ruin/whitesands/pubbycrash)
-"jG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/ntspaceworks_small/left{
+"Xi" = (
+/obj/item/radio/intercom/directional/west,
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 4;
-	faction = list("saloon")
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"kp" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"kA" = (
-/obj/item/reagent_containers/food/drinks/britcup{
-	pixel_x = 9;
-	pixel_y = -3
-	},
-/obj/item/trash/pistachios{
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/whitesands/pubbycrash)
-"kM" = (
+"Xm" = (
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/kinetic_crusher,
+/obj/structure/rack,
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini,
+/obj/effect/turf_decal/siding/brown,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/whitesands/pubbycrash/split)
+"Xn" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/whitesands/pubbycrash)
+"XA" = (
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"XK" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"Yt" = (
+/obj/structure/reagent_dispensers/servingdish,
+/obj/structure/table/reinforced,
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 6
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = -1
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 13
+	},
+/turf/open/floor/plastic,
+/area/ruin/whitesands/pubbycrash/split)
+"Yu" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"YC" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/servingdish,
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = -1
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 13
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesands/pubbycrash)
+"YL" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/pubbycrash/engine_room)
+"Zg" = (
+/turf/open/floor/engine/hull,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zj" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-3"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zk" = (
+/obj/effect/gibspawner,
+/turf/open/floor/plating,
+/area/ruin/whitesands/pubbycrash)
+"Zp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
@@ -469,363 +2457,10 @@
 	pixel_x = 7;
 	pixel_y = 12
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plasteel/tech,
 /area/ruin/whitesands/pubbycrash)
-"kP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"kU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 8
-	},
-/area/ruin/whitesands/pubbycrash)
-"ln" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"ly" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/whitesands/pubbycrash)
-"lA" = (
-/obj/structure/table/reinforced,
-/obj/item/laser_pointer,
-/obj/item/radio/off{
-	pixel_x = 6;
-	pixel_y = 14
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"lB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"lK" = (
-/obj/effect/turf_decal/box,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/salvageable/autolathe,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"lR" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-46"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"mp" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-3"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"mH" = (
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"mU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_y = -3;
-	pixel_x = -6
-	},
-/obj/item/gun/energy/laser/hitscanpistol,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"mW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesands/pubbycrash)
-"nq" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-55"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"nG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"nP" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"nQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesands/pubbycrash)
-"oo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset/wall{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesands/pubbycrash)
-"oq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"oO" = (
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"oS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"pe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/obj/item/stock_parts/cell/hyper{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/stack/ore/salvage/scrapmetal/five{
-	pixel_x = -9
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"pu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/ntspaceworks_small/right{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
-/obj/item/storage/box/stockparts/basic{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"pE" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"pG" = (
-/obj/machinery/firealarm/directional/west,
-/turf/closed/mineral/random/whitesands,
-/area/overmap_encounter/planetoid/cave/explored)
-"pR" = (
-/obj/effect/turf_decal/industrial/stand_clear,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/obj/structure/salvageable/server,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"pT" = (
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance/five,
-/obj/effect/spawner/lootdrop/maintenance/five,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"qz" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/circuitboard/machine/shuttle/smes,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"qN" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-74"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"re" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"rT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"rW" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"rZ" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"sd" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-2"
-	},
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 1;
-	faction = list("adobe");
-	desc = " A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body, twisted by the heavy metals and high background radiation of the sandworlds. Their helmet also seems to be filled with vomit"
-	},
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"so" = (
-/obj/effect/turf_decal/industrial/caution,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/sign/poster/retro/nanotrasen_logo_70s{
-	pixel_x = -32
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"ss" = (
+"Zu" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -861,1491 +2496,17 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/whitesands/pubbycrash)
-"sA" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/whitesands/pubbycrash)
-"sC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"sD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/ash{
-	pixel_y = -3;
-	pixel_x = -6
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"sV" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"uh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"ul" = (
-/mob/living/simple_animal/hostile/asteroid/whitesands/ranged,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"up" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/item/stack/ore/salvage/scrapmetal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"uB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/ash{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"vc" = (
-/obj/effect/turf_decal/box/corners,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"vw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/effect/gibspawner,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"vL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"vO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"vX" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"wn" = (
-/obj/effect/turf_decal/siding/brown,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 5
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"wL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall/red{
-	dir = 8;
-	name = "Firearm Locker";
-	pixel_x = 29;
-	welded = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/item/gun/ballistic/automatic/pistol/commander,
-/obj/item/gun/ballistic/automatic/pistol/commander,
-/obj/item/ammo_box/magazine/co9mm,
-/obj/item/ammo_box/magazine/co9mm,
-/obj/item/ammo_box/magazine/co9mm,
-/obj/item/ammo_box/magazine/co9mm,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"wV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"xa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"xc" = (
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"xy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"xA" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/structure/salvageable/computer,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"yj" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/noticeboard{
-	pixel_y = 31
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"ym" = (
-/obj/effect/gibspawner,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"yt" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-141"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"yx" = (
-/obj/structure/railing/corner,
-/obj/effect/decal/cleanable/dirt,
+"Zx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 4;
-	faction = list("adobe");
-	desc = " A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body, twisted by the heavy metals and high background radiation of the sandworlds. Their helmet also seems to be filled with vomit"
-	},
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"yK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/grunge{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"yU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/gibspawner,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"zi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"zP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"zX" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/reagent_dispensers/servingdish,
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = -1
-	},
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = 13
-	},
-/obj/item/kitchen/spoon/plastic{
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Ak" = (
-/obj/structure/closet/crate/bin,
-/obj/item/trash/pistachios{
-	pixel_y = 5
-	},
-/obj/item/trash/energybar,
-/obj/item/trash/cheesie,
-/obj/item/trash/can/food,
-/obj/item/trash/sosjerky{
-	pixel_x = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"AH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"AJ" = (
-/turf/closed/wall/mineral/titanium,
-/area/ruin/whitesands/pubbycrash)
-"AO" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Bd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Bz" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"BD" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"BH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Cg" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil,
-/obj/structure/sign/poster/contraband/red_rum{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Cs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"Ct" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	faction = list("saloon")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Cw" = (
-/obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"Dg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"Di" = (
-/obj/structure/railing/corner,
-/turf/closed/mineral/random/whitesands,
-/area/overmap_encounter/planetoid/cave/explored)
-"Dn" = (
-/obj/structure/railing,
-/obj/structure/salvageable/computer{
-	dir = 8
-	},
-/obj/item/stack/ore/salvage/scrapgold,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Dx" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_windows"
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"DB" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/salvageable/machine,
-/turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
-"DQ" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/item/stack/ore/salvage/scraptitanium,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"DY" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Ea" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesands/pubbycrash)
-"Eb" = (
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/shuttle/engine/plasma,
-/obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Eh" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"Em" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/lighter/enigma,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Et" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/ntspaceworks_small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Ew" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"EG" = (
-/obj/machinery/door/airlock/hatch{
-	welded = 1
-	},
-/turf/template_noop,
-/area/ruin/whitesands/pubbycrash)
-"ET" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/west,
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 1;
-	faction = list("saloon")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Fc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/shuttle/heater,
-/obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Fn" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
-/area/ruin/whitesands/pubbycrash)
-"Fq" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"FP" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"FY" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Ga" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Gi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Gl" = (
-/turf/template_noop,
-/area/template_noop)
-"GA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/whitesands/pubbycrash)
-"GF" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/shuttle/heater,
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/stack/ore/salvage/scrapplasma/five,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"GK" = (
-/obj/structure/closet/wall/blue{
-	dir = 1;
-	name = "Captain's locker";
-	pixel_y = -28
-	},
-/obj/item/clothing/suit/space/hardsuit/mining/heavy,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Ha" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Hb" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Ho" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/light/directional/east,
-/obj/effect/gibspawner,
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"Hq" = (
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/stack/ore/salvage/scrapgold,
-/obj/item/stack/ore/salvage/scrapgold,
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"HQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"If" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Ig" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/salvageable/machine,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Ik" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
-"In" = (
-/obj/structure/railing,
-/turf/closed/mineral/random/whitesands,
-/area/overmap_encounter/planetoid/cave/explored)
-"IC" = (
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"IQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Ji" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/whitesands/pubbycrash)
-"Jz" = (
-/obj/item/stack/ore/salvage/scrapmetal/five,
-/obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"JI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Kt" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Ky" = (
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesands/pubbycrash)
-"KB" = (
-/obj/structure/salvageable/computer,
-/obj/item/stack/ore/salvage/scrapgold,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"KI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/plasma,
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"KO" = (
-/obj/machinery/power/apc/auto_name/directional/east{
-	start_charge = 10
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"KS" = (
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/multitool,
-/obj/structure/railing,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"KT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"Lj" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Lm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesands/pubbycrash)
-"Ls" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/turf_decal/siding/brown,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"LM" = (
-/turf/closed/mineral/random/whitesands,
-/area/ruin/whitesands/pubbycrash)
-"LU" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/number/nine{
-	dir = 4
-	},
-/obj/item/stock_parts/cell/hyper,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"LW" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	dir = 4;
-	id = "whiteship_windows"
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Mi" = (
-/obj/structure/sign/number/two,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/ore/salvage/scraptitanium,
-/obj/effect/gibspawner,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"Ml" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/circuitboard/machine/shuttle/smes,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Mr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/salvageable/computer{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"NI" = (
-/obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"Og" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/railing{
-	dir = 10;
-	layer = 4.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/item/stack/ore/salvage/scrapgold,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Oz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_y = -2;
-	pixel_x = 5
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Pr" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/warning/corner,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Pu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"PA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesands/pubbycrash)
-"PI" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
-/area/ruin/whitesands/pubbycrash)
-"PK" = (
-/obj/effect/gibspawner,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"PY" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"PZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "engine fuel pump"
-	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Qb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/item/stack/ore/salvage/scrapmetal,
-/obj/effect/mob_spawn/human/corpse/nanotrasenassaultsoldier,
-/obj/effect/gibspawner,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Qo" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-9"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"Qu" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
-/area/ruin/whitesands/pubbycrash)
-"Qw" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/number/seven{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"QD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesands/pubbycrash)
-"QI" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"QR" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/whitesands/pubbycrash)
-"RC" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"RL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/wrapping,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"RT" = (
-/turf/closed/mineral/random/whitesands,
-/area/overmap_encounter/planetoid/cave/explored)
-"Sy" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/stack/ore/salvage/scraptitanium,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"SO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/gibspawner,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesands/pubbycrash)
-"SU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"Tg" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/mob_spawn/human/corpse/damaged/whitesands/survivor,
-/turf/open/floor/plastic,
-/area/ruin/whitesands/pubbycrash)
-"TB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"TF" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Uo" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Us" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/mob/living/simple_animal/hostile/asteroid/whitesands/survivor{
-	dir = 1;
-	faction = list("saloon")
-	},
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Uy" = (
-/obj/machinery/door/airlock/hatch{
-	welded = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/pod,
-/area/ruin/whitesands/pubbycrash)
-"Vj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
-/turf/open/floor/engine/hull,
-/area/ruin/whitesands/pubbycrash)
-"Vt" = (
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"VG" = (
-/obj/structure/sign/number/two,
-/obj/item/stack/ore/salvage/scrapmetal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"VK" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"VP" = (
-/obj/effect/decal/fakelattice{
-	icon_state = "lattice-2"
-	},
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/sand)
-"Wg" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/stack/ore/salvage/scrapgold,
-/obj/item/stack/ore/salvage/scrapgold,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Wo" = (
-/obj/structure/bed/dogbed{
-	anchored = 1;
-	name = "citrus's bed"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 9
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/pod,
-/area/ruin/whitesands/pubbycrash)
-"WD" = (
-/obj/effect/turf_decal/industrial/stand_clear,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/ruin/whitesands/pubbycrash)
-"Xm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Xn" = (
-/obj/effect/turf_decal/industrial/caution,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/machinery/button/door{
-	id = "whiteshipubbyEngines";
-	name = "Engine Lockdown Control";
-	pixel_x = -25;
-	dir = 4
-	},
-/obj/structure/salvageable/destructive_analyzer,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"XA" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/whitesands/pubbycrash)
-"XK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/whitesands/pubbycrash)
-"Yt" = (
-/obj/machinery/newscaster/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating{
-	icon_state = "panelscorched";
-	initial_gas_mix = "ws_atmos"
-	},
-/area/ruin/whitesands/pubbycrash)
-"Yu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/number/four{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/whitesands/pubbycrash)
-"YC" = (
-/obj/structure/closet/wall/white{
-	dir = 1;
-	name = "Medicine storage";
-	pixel_y = -30
-	},
-/obj/item/storage/firstaid/ancient{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/item/storage/firstaid/medical,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/pod,
-/area/ruin/whitesands/pubbycrash)
-"YL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"Zg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/obj/structure/salvageable/protolathe,
-/turf/open/floor/plating,
-/area/ruin/whitesands/pubbycrash)
-"Zj" = (
-/turf/open/floor/engine/hull,
-/area/ruin/whitesands/pubbycrash)
-"Zk" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/structure/closet/wall{
-	icon_door = "orange_wall";
-	name = "Mining equipment";
-	pixel_y = 28
-	},
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
-"Zp" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/whitesands/pubbycrash)
+/area/ruin/whitesands/pubbycrash/engine_room)
 
 (1,1,1) = {"
 Gl
@@ -2354,15 +2515,15 @@ Gl
 Gl
 Gl
 Gl
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 Gl
@@ -2378,22 +2539,22 @@ Gl
 Gl
 Gl
 RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 Gl
@@ -2403,25 +2564,25 @@ Gl
 "}
 (3,1,1) = {"
 Gl
+Gl
 RT
 RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
-RT
+Vt
+Vt
+Vt
+Gl
+Gl
+Gl
+Vt
+Vt
+Gl
+Vt
+Vt
+Gl
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 Gl
@@ -2433,24 +2594,24 @@ Gl
 RT
 RT
 RT
-RT
-cN
-dW
-Eb
-LM
-cN
-Ky
-cN
-cN
-Hq
-Wg
-cN
-RT
-RT
-RT
-RT
-RT
 Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+RT
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 Gl
@@ -2459,135 +2620,135 @@ Gl
 Gl
 RT
 RT
-RT
-RT
-cN
-qz
-GF
-cN
-cN
-SO
-oo
-cN
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
+Vt
 Fc
-Ml
-cN
-RT
-RT
-RT
-RT
-RT
 Vt
 Vt
+Vt
+RT
+RT
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 "}
 (6,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-cN
+Vt
+hA
+hA
 QI
-dm
-cN
-cN
+AJ
+AJ
+bS
 mW
-cN
-Ji
+Vt
+sA
 PZ
 fO
-cN
-RT
-RT
-RT
-RT
+SU
 Vt
-Vt
-Vt
+RT
+RT
+RT
+Gl
+Gl
+Gl
 Gl
 Gl
 "}
 (7,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-cN
+RT
+AJ
+AJ
 SU
 HQ
-cN
-xA
+sA
+oS
 pu
 Et
-jG
+AJ
 yU
 oS
 Dx
+AJ
 RT
 RT
 RT
-RT
-Vt
-Vt
-Vt
+Gl
+Gl
+Gl
 Gl
 Gl
 "}
 (8,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-cN
+RT
+AJ
+xX
 rW
 sV
-cN
-Pr
+Bw
+xX
 Qw
-LU
+xX
 Yu
 kP
 AH
-Dx
+xX
+AJ
 RT
 RT
 RT
 RT
 Vt
-Vt
-Vt
-Vt
+Gl
+Gl
 Gl
 "}
 (9,1,1) = {"
 Gl
-Gl
 RT
 RT
 RT
-cN
-cN
+RT
+xX
+Tg
 Qu
-cN
-Ha
+xX
+xX
 Hb
 ln
-cN
+xX
 DY
 PI
-cN
-RT
+xX
+AJ
+AJ
 RT
 RT
 RT
 Vt
 Vt
-Vt
-Vt
+Gl
 Gl
 "}
 (10,1,1) = {"
@@ -2595,27 +2756,27 @@ Gl
 RT
 RT
 RT
-Vj
-GA
+RT
+xX
 YL
 iW
-Xn
-Zg
+xX
+xX
 pe
-wV
+xX
 so
 lB
 re
-cN
-Zj
+xX
+RT
+AJ
 RT
 RT
 Vt
 Vt
 Vt
-Vt
-Vt
-Vt
+Gl
+Gl
 "}
 (11,1,1) = {"
 RT
@@ -2623,17 +2784,45 @@ RT
 RT
 RT
 AJ
-cN
+xX
 VK
 ho
-Ho
+xX
 Dg
 Cs
 zP
 KO
 xa
 Ew
-cN
+SO
+RT
+AJ
+RT
+RT
+Vt
+Vt
+Vt
+Gl
+Gl
+"}
+(12,1,1) = {"
+RT
+RT
+RT
+AJ
+AJ
+xX
+aR
+yj
+xX
+xH
+gG
+dW
+ET
+Pu
+LW
+SO
+AJ
 AJ
 RT
 RT
@@ -2641,53 +2830,26 @@ Vt
 Vt
 Vt
 Vt
-Vt
-Vt
-"}
-(12,1,1) = {"
-RT
-RT
-RT
-RT
-sA
-cN
-LW
-LW
-cN
-cN
-gG
-cN
-cN
-LW
-LW
-cN
-sA
-RT
-RT
-Vt
-Vt
-Vt
-Vt
-Vt
-Vt
+Gl
 "}
 (13,1,1) = {"
+Gl
 RT
 RT
 RT
-RT
-RT
-RT
-aR
+AJ
+xX
+xX
 Sy
-ET
+xX
 cp
 PA
 fR
-AO
+xX
 jt
 Mi
-ek
+xX
+AJ
 RT
 RT
 RT
@@ -2695,17 +2857,16 @@ Vt
 Vt
 Vt
 Vt
-Vt
-Vt
+Gl
 "}
 (14,1,1) = {"
+Gl
 RT
 RT
 RT
-RT
-RT
-RT
-RT
+jG
+Ha
+QR
 Bz
 pT
 JI
@@ -2713,9 +2874,9 @@ Lm
 BH
 KS
 up
-RT
-RT
-RT
+qz
+xX
+Zg
 RT
 RT
 Vt
@@ -2726,14 +2887,14 @@ Vt
 Vt
 "}
 (15,1,1) = {"
-Gl
 RT
 RT
 RT
-RT
-RT
+AJ
+ch
+xX
 gL
-vc
+Zx
 bW
 DQ
 gu
@@ -2741,52 +2902,52 @@ Ct
 gy
 fX
 vc
+xX
+ch
 RT
 RT
-RT
-RT
-bZ
 Vt
 Vt
 Vt
 Vt
-Gl
+Vt
+Vt
 "}
 (16,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-pR
-eq
+AJ
+Ai
+xX
 vL
-FP
-KI
+vL
+xX
+xX
 QD
-vw
-lK
-RT
-VG
-WD
-RT
-RT
-RT
-bZ
+xX
+xX
+vL
+vL
+xX
+Ai
+AJ
+AJ
 Vt
 Vt
 Vt
 Vt
-Gl
+Vt
+Vt
 "}
 (17,1,1) = {"
-Gl
-Gl
 RT
 RT
+AJ
+AJ
 sA
-cN
-cN
+Zj
+tB
 RC
 zX
 Uo
@@ -2794,26 +2955,26 @@ nQ
 XK
 FY
 nP
-cN
-cN
-sA
+VG
+dm
+AJ
+AJ
 RT
 RT
-bZ
 Vt
 Vt
 Vt
 Vt
-Gl
+Vt
 "}
 (18,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-ck
-Kt
+AJ
+AJ
+RT
+RT
 Bd
 fA
 IQ
@@ -2823,49 +2984,49 @@ zi
 oq
 hh
 ck
-ba
-Cw
+AJ
+RT
+RT
+RT
 Vt
 Vt
 Vt
 Vt
 Vt
-Gl
-Gl
 "}
 (19,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
-cN
-cN
-cN
-cN
-cN
+RT
+AJ
+RT
+vw
+Ho
+xz
+ih
 yK
-cN
-cN
-cN
-cN
-cN
-cN
+Kt
+di
+mp
+Ho
+hh
+AJ
+AJ
+RT
+AJ
 Vt
-Cw
 Vt
 Vt
 Vt
-Vt
-Gl
 Gl
 "}
 (20,1,1) = {"
-Gl
-Gl
 RT
 RT
 RT
+RT
+AJ
 pG
 Di
 ff
@@ -2874,44 +3035,44 @@ Uy
 co
 ly
 PK
-jF
-mH
+hh
+Wg
+hh
+RT
+AJ
 Vt
-IC
+bZ
 Vt
 Vt
-Cw
-VP
-gx
 Vt
-Gl
+Vt
 Gl
 "}
 (21,1,1) = {"
 Gl
-Gl
 RT
 RT
 RT
-RT
-In
+Xn
+vX
+vX
 Wo
 YC
-cN
+Gp
 RL
-cN
+Vj
 Fq
 If
-Vt
-Vt
-kp
-Cw
-Vt
-VP
-nq
-yt
+vX
+vX
+Xn
 RT
-Gl
+Vt
+bZ
+Vt
+Vt
+Vt
+Vt
 Gl
 "}
 (22,1,1) = {"
@@ -2919,25 +3080,25 @@ Gl
 RT
 RT
 RT
-cN
-cN
-cN
-cN
-cN
-cN
+AJ
+KI
+IU
+AO
+wn
+lK
 TB
-cN
+Li
 mH
-IC
-RT
+PY
+pR
+KI
+fr
+Cw
 Vt
 Vt
 Vt
-cN
-cN
-cN
-cN
-RT
+Vt
+Vt
 Gl
 Gl
 "}
@@ -2946,247 +3107,355 @@ Gl
 RT
 RT
 RT
-iw
+AJ
 vX
-rZ
-QR
-cN
-Ak
+vX
+vX
+vX
+vX
 xy
-Pu
+vX
+vX
+vX
+vX
+vX
+vX
+Vt
 Cw
 Vt
-RT
-VP
-gx
-xc
-cN
-Zk
-Ls
-cN
-RT
-RT
+Vt
+Vt
+Vt
+Gl
 Gl
 "}
 (24,1,1) = {"
-Gl
-Gl
 RT
 RT
-iw
+RT
+RT
+AJ
 jA
 kA
 NI
 Lj
 Us
 sC
-cN
+rZ
+Zk
+WD
+ul
+AJ
+IC
 Vt
+Vt
+Cw
+VP
+gx
+Vt
+Gl
+Gl
+"}
+(25,1,1) = {"
+RT
+RT
+RT
+RT
+RT
+AJ
+KT
+ct
+oo
+vX
+nG
+vX
+Ls
+xA
+AJ
+Vt
+kp
+Cw
+Vt
+VP
+nq
+yt
+RT
+Gl
+Gl
+"}
+(26,1,1) = {"
+Gl
+RT
+RT
+RT
+vX
+vX
+vX
+vX
+vX
+vX
+Ga
+vX
+ul
+XA
+RT
+Vt
+Vt
+Vt
+AA
+AA
+AA
+AA
+RT
+Gl
+Gl
+"}
+(27,1,1) = {"
+Gl
+RT
+RT
+RT
+wV
+Xi
+Fn
+IR
+vX
+Mr
+Gi
+In
+ym
+AJ
+RT
+VP
+gx
+xc
+AA
+sD
+rT
+AA
+RT
+RT
+Gl
+"}
+(28,1,1) = {"
+Gl
+RT
+RT
+RT
+wV
+Eb
+Ak
+kM
+ss
+Og
+kU
+vX
+AJ
 RT
 RT
 IC
 lR
 nq
-cN
-Zp
-bS
-cN
-RT
-RT
-Gl
-"}
-(25,1,1) = {"
-Gl
-Gl
-RT
-RT
-iw
-PY
-KT
-ct
-cN
-Ig
-nG
-cN
-Vt
-RT
-Vt
-Vt
-cN
-cN
-cN
-Fn
-wn
-cN
-RT
-RT
-Gl
-"}
-(26,1,1) = {"
-Gl
-Gl
-RT
-RT
-cN
-yj
-Cg
-fk
-cN
-BD
-Ga
-cN
-ul
-Cw
-Cw
-sd
-Eh
-hA
-yx
-pE
-XA
-cN
-RT
-RT
-RT
-"}
-(27,1,1) = {"
-Gl
-Gl
-RT
-RT
-cN
-cN
-cN
-cN
-cN
-cN
-Gi
-cN
-Jz
-kp
-Vt
-Vt
-cN
-gg
-Tg
-sD
-rT
-iw
-RT
-RT
-RT
-"}
-(28,1,1) = {"
-Gl
-Gl
-RT
-RT
-RT
-RT
-cN
-kM
-ss
-Og
-kU
-If
-yt
-Vt
-IC
-Vt
-cN
-as
-Ik
+AA
 vO
 Xm
-iw
+AA
 RT
 RT
-RT
+Gl
 "}
 (29,1,1) = {"
 Gl
-Gl
-Gl
 RT
 RT
 RT
-cN
+wV
+Ji
+Hq
 KB
-Qb
+vX
 hz
 cx
-uh
-oO
-mp
-gx
+vX
+AJ
+RT
 Vt
-cN
-DB
-di
+Vt
+AA
+AA
+AA
 TF
 uB
-iw
+AA
 RT
 RT
-RT
+Gl
 "}
 (30,1,1) = {"
 Gl
-Gl
-Gl
 RT
 RT
 RT
-RT
-RT
-Mr
+vX
+iw
+Bi
+Ik
+vX
 Dn
 lA
-If
+vX
 Qo
 ym
-gs
 Cw
-cN
-cN
-cN
-cN
-cN
-cN
+sd
+as
+Pr
+ON
+jF
+eq
+AA
 RT
 RT
 RT
 "}
 (31,1,1) = {"
 Gl
-Gl
-Gl
 RT
 RT
 RT
-RT
-RT
-RT
-RT
-RT
-cN
-IC
+vX
+vX
+vX
+vX
+vX
+vX
+Cg
+vX
+LM
+kp
 Vt
 Vt
-Vt
-cN
+AA
 Yt
 mU
+Fo
+no
+VZ
+RT
+RT
+RT
+"}
+(32,1,1) = {"
+Gl
+RT
+RT
+RT
+RT
+RT
+vX
+Zp
+Zu
+FP
+AD
+xA
+ab
+Vt
+IC
+Vt
+AA
+Em
+GK
 cN
-cN
-AJ
+lI
+VZ
+RT
+RT
+RT
+"}
+(33,1,1) = {"
+Gl
+Gl
+RT
+RT
+RT
+RT
+vX
+ba
+gg
+pE
+ek
+uh
+yx
+Zj
+gx
+Vt
+AA
+Oz
+Ig
+Ml
+DB
+VZ
+RT
+RT
+RT
+"}
+(34,1,1) = {"
+Gl
+Gl
+RT
+RT
+RT
+RT
+RT
+RT
+LU
+GA
+oO
+xA
+BD
+Qb
+gs
+Cw
+AA
+AA
+AA
+AA
+AA
+AA
+RT
+RT
+RT
+"}
+(35,1,1) = {"
+Gl
+RT
+RT
+RT
+RT
+RT
+RT
+RT
+RT
+RT
+RT
+vX
+XA
+Vt
+Vt
+Vt
+AA
+GF
+ge
+AA
+AA
+Ky
 RT
 RT
 Gl
 "}
-(32,1,1) = {"
+(36,1,1) = {"
 Gl
-Gl
+RT
 RT
 RT
 RT
@@ -3202,16 +3471,16 @@ Cw
 VP
 nq
 EG
-Em
-GK
-cN
-AJ
+Eh
+fk
+AA
+Ky
 RT
 RT
 RT
 Gl
 "}
-(33,1,1) = {"
+(37,1,1) = {"
 Gl
 Gl
 RT
@@ -3228,17 +3497,17 @@ kp
 IC
 Vt
 qN
-cN
-Oz
-cN
-AJ
+AA
+oj
+AA
+Ky
 RT
 RT
 RT
 RT
 Gl
 "}
-(34,1,1) = {"
+(38,1,1) = {"
 Gl
 Gl
 Gl
@@ -3265,7 +3534,7 @@ Gl
 Gl
 Gl
 "}
-(35,1,1) = {"
+(39,1,1) = {"
 Gl
 Gl
 Gl
@@ -3292,7 +3561,7 @@ Gl
 Gl
 Gl
 "}
-(36,1,1) = {"
+(40,1,1) = {"
 Gl
 Gl
 Gl

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
@@ -379,9 +379,6 @@
 /obj/structure/salvageable/safe_server,
 /turf/open/floor/plasteel/dark,
 /area/ruin/whitesands/pubbycrash)
-"hA" = (
-/turf/open/floor/plating/asteroid/whitesands/lit,
-/area/overmap_encounter/planetoid/cave/explored)
 "ih" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/item/stack/ore/salvage/scraptitanium,
@@ -2648,8 +2645,8 @@ RT
 RT
 RT
 Vt
-hA
-hA
+Vt
+Vt
 QI
 AJ
 AJ

--- a/_maps/map_catalogue.txt
+++ b/_maps/map_catalogue.txt
@@ -337,8 +337,8 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 		Tags = "No Combat", "Minor Loot", "Inhospitable"
 
 		File Name = "_maps\RandomRuins\Ruins\whitesands_surface_pubbyslopcrash.dmm"
-		Size = (x = 35)(y = 25)(z = 1)
-		Tags = "Minor Combat Challange", "Medium Loot", "Shelter"
+		Size = (x = 40)(y = 25)(z = 1)
+		Tags = "Minor Combat Challenge", "Medium Loot", "Shelter"
 
 
 

--- a/code/game/area/areas/ruins/sandplanet.dm
+++ b/code/game/area/areas/ruins/sandplanet.dm
@@ -7,5 +7,13 @@
 	icon_state = "green"
 
 /area/ruin/whitesands/pubbycrash
-	name = "Pubby Crash"
-	icon_state = "blue"
+	name = "Pubby-Class Wreckage"
+	icon_state = "bluenew"
+
+/area/ruin/whitesands/pubbycrash/engine_room
+	name = "Pubby-Class Engine Room"
+	icon_state = "green"
+
+/area/ruin/whitesands/pubbycrash/split
+	name = "Pubby-Class Chunk"
+	icon_state = "red"


### PR DESCRIPTION
## About The Pull Request
As per the request of @Latentish 

This PR tweaks the recently merged (#2363) Crashed Pubby Ruin. The shape of the crash area should now be more realistic. Several issues have been fixed, as well.

![image](https://github.com/shiptest-ss13/Shiptest/assets/118859017/4dc076fe-8dce-4ab5-a37e-c201ee5e77d2)
![9cbdcebcc92d3e5d3a96e44677e129bf](https://github.com/shiptest-ss13/Shiptest/assets/118859017/9b6d7ad7-bf15-44a1-9008-4ce6ce08a3bc)
![image](https://github.com/shiptest-ss13/Shiptest/assets/118859017/d5732f90-f242-41f4-b5e7-e58b10dc5e08)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

🆑
tweak: The Crashed Pubby Ruin has been tweaked slightly.
fix: Fixed a floating wallmount in the Crashed Pubby Ruin.
/🆑