### PR TITLE
Removes a flora with an error texture on Jungle_Paradise

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -3331,10 +3331,6 @@
 	pixel_x = 21
 	},
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "rock3";
-	pixel_y = 9
-	},
 /turf/open/floor/plating/dirt/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
 "uk" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a flora with an invalid varedited texture on Jungle_Paradise. 
Please don't varedit flora textures. Use the correct type or subtype it and . ..() if one doesn't exist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missing textures on maps is bad and not good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Removed a flora with a varedited error texture on jungle_paradise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
