### PR TITLE
fix for charliestation gravity

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
@@ -310,9 +310,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation)
-"bd" = (
-/turf/template_noop,
-/area/space)
 "be" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
@@ -11479,7 +11476,7 @@ xT
 aa
 aa
 aa
-bd
+aa
 lg
 lH
 lg
@@ -11528,7 +11525,7 @@ xT
 aa
 aa
 aa
-bd
+aa
 lg
 lg
 lg

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -174,6 +174,7 @@
 /area/solar/ancientstation
 	name = "Charlie Station Solar Array"
 	icon_state = "panelsP"
+	has_gravity = STANDARD_GRAVITY
 
 //DERELICT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Charliestation solars didn't get gravity as a solar subtype, they now have it
2 tiles with space area have been fixed to their proper area, probably caused some gravity goofiness too

## Why It's Good For The Game

fixes #769

## Changelog

:cl:
fix: the charliestation ruin on ice planets now obeys local gravity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
