### PR TITLE
Adds a variety maid outfit crate

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1361,8 +1361,8 @@
 
 // because i have no idea where the fuck to put this
 /obj/item/storage/box/maid
-	name = "Maid box"
-	desc = "Contains a maid outfit"
+	name = "Maid outfit"
+	desc = "Contains a normal maid outfit."
 
 /obj/item/storage/box/maid/PopulateContents()
 	var/static/items_inside = list(

--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -231,3 +231,12 @@
 					/obj/item/clothing/under/dress/rilena,
 					/obj/item/gun/energy/buster)
 	crate_name = "collectable merchandise crate"
+
+/datum/supply_pack/costumes_toys/maid_variety
+	name = "Maid Outfit Variety Pack"
+	desc = "Surplus maid outfits from various factions. Supposedly, they're 'tactical,' whatever that means for a maid outfit."
+	cost = 2500 //The tactical maid gloves are insulated, and an insuls crate costs 1500 credits
+	contains = list(/obj/item/storage/box/maid,
+					/obj/item/storage/box/syndimaid,
+					/obj/item/storage/box/inteqmaid)
+	crate_name = "maid outfit crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 2500 credit crate with a normal maid outfit and the syndicate/inteq tactical maid outfits. Also touches up the normal maid outfit box's description/name to be more grammatically correct.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The tactical maid outfits aren't currently obtainable outside of some ruins or adminbus, despite being added in PR #970 (well over a year and a half ago!). They'll still be uncommon with the fairly steep price tag, and there shouldn't be an issue with purchasing them just for insulated gloves, as the crate costs more than the normal insulated gloves crate while containing the same number of gloves. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Adds the variety maid outfit crate!
tweak: Touches up the grammar on the maid outfit box.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
