### PR TITLE
Fix science goggles displaying wrong research value for anomalies

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -50,7 +50,7 @@
 		aSignal = new aSignal(src)
 		aSignal.code = rand(1,100)
 		aSignal.anomaly_type = type
-		aSignal.research = rand(500,4000)
+		aSignal.research = research_value
 
 		var/frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
 		if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Anomalies have a randomized research output, which is visible with science goggles. To harvest this research, you have to signal the anomaly, then put the core into your research console.

The core's research output was actually just randomized as well with the same range as the anomaly, rather than being given its output, meaning the expected output and actual output could be completely different

## Why It's Good For The Game

Science goggles won't lie to you when looking at anomalies

## Changelog

:cl:
fix: science goggles are now more accurate when judging the research value of anomalies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
