### PR TITLE
Fixes the decompressed katana bricking itself

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -763,11 +763,11 @@
 /obj/item/storage/belt/weebstick/afterattack(atom/A, mob/living/user, proximity_flag, params)
 	. = ..()
 	if(primed && length(contents))
+		if(!(A in view(user.client.view, user)))
+			return
 		var/obj/item/I = contents[1]
 		if(!user.put_in_inactive_hand(I))
 			to_chat(user, "<span class='warning'>You need a free hand!</span>")
-			return
-		if(!(A in view(user.client.view, user)))
 			return
 		var/datum/component/storage/CP = GetComponent(/datum/component/storage)
 		CP.locked = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

code pulled the blade out of the sheath before checking if it was viably targetted meaning you could remove the blade without clearing the lock on the sheath

## Why It's Good For The Game

fixes #2501

## Changelog

:cl:
fix: the weebstick is no longer held back from its true purpose if you click on a tile you can't see
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
