### PR TITLE
Fixes Month Display

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -23,7 +23,7 @@
 	var/days_since = round(realtime / (24 HOURS))
 	var/year = round(days_since / 365) + 481
 	var/day_of_year = days_since % 365 + 1
-	var/month = round(day_of_year / 28) + 1
+	var/month = round(day_of_year / 28)
 	var/day_of_month = day_of_year % 28 + 1
 
 	if(shortened)
@@ -31,33 +31,33 @@
 
 	var/monthname
 	switch(month)
-		if(1)
+		if(0)
 			monthname = "January"
-		if(2)
+		if(1)
 			monthname = "February"
-		if(3)
+		if(2)
 			monthname = "March"
-		if(4)
+		if(3)
 			monthname = "April"
-		if(5)
+		if(4)
 			monthname = "May"
-		if(6)
+		if(5)
 			monthname = "June"
-		if(7)
+		if(6)
 			monthname = "Sol"
-		if(8)
+		if(7)
 			monthname = "July"
-		if(9)
+		if(8)
 			monthname = "August"
-		if(10)
+		if(9)
 			monthname = "September"
-		if(11)
+		if(10)
 			monthname = "October"
-		if(12)
+		if(11)
 			monthname = "November"
-		if(13)
+		if(12)
 			monthname = "December"
-		if(14)
+		if(13)
 			return "Year Day, [year] FSC"
 
 	return "[monthname] [day_of_month], [year] FSC"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -23,7 +23,7 @@
 	var/days_since = round(realtime / (24 HOURS))
 	var/year = round(days_since / 365) + 481
 	var/day_of_year = days_since % 365 + 1
-	var/month = round(day_of_year / 28)
+	var/month = round(day_of_year / 28) + 1
 	var/day_of_month = day_of_year % 28 + 1
 
 	if(shortened)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, the month display for IC/sector time was a month earlier than it should have been. This also resulted in nothing displaying for January because there is no month 0.

## Why It's Good For The Game
Time consistency and actually displaying the IC month

## Changelog

:cl:
fix: Sector time now actually shows the month of January.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
