### PR TITLE
Vaporizes squid bloodpacks/random blood bags can no longer spawn with unusuable blood in them

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -38,7 +38,7 @@
 
 /obj/item/reagent_containers/blood/random/Initialize()
 	icon_state = "bloodpack"
-	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-", "L", "S")
+	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-", "L")
 	return ..()
 
 /obj/item/reagent_containers/blood/APlus
@@ -67,9 +67,6 @@
 
 /obj/item/reagent_containers/blood/synthetic
 	blood_type = "Coolant"
-
-/obj/item/reagent_containers/blood/squid
-	blood_type = "S"
 
 /obj/item/reagent_containers/blood/universal
 	blood_type = "U"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Squid blood doesn't exist, so these can randomly give you useless bloodbags

This will need to be mirrored in #2553 since that replaces type L blood with type S blood

## Why It's Good For The Game

I like my blood transfusable

## Changelog

:cl:
bugfix: bloodbags can no longer spawn with untyped (and useless) blood in them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
