### PR TITLE
Paracelsus Tweaks 2

### DIFF
--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -2856,7 +2856,9 @@
 	},
 /obj/structure/closet/wall/red{
 	dir = 1;
-	pixel_y = -28
+	pixel_y = -28;
+	req_one_access_txt = "19";
+	name = "Weapons"
 	},
 /obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/item/gun/ballistic/automatic/pistol/solgov,

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -2585,9 +2585,6 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -2759,6 +2759,10 @@
 "AX" = (
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
+"AZ" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/ebony,
+/area/ship/crew/dorm)
 "Ba" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -6344,7 +6348,7 @@ pK
 NY
 dh
 Wt
-eH
+AZ
 bf
 wI
 "}
@@ -6376,7 +6380,7 @@ rO
 aF
 Bg
 Pk
-eH
+AZ
 bf
 wI
 "}

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -1890,7 +1890,8 @@
 	},
 /obj/structure/closet/secure_closet/wall{
 	pixel_y = 28;
-	name = "navigational supplies"
+	name = "navigational supplies";
+	req_access_txt = "19"
 	},
 /obj/item/gps,
 /obj/item/binoculars,
@@ -2855,18 +2856,19 @@
 /obj/structure/railing/wood{
 	dir = 8
 	},
-/obj/structure/closet/wall/red{
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/structure/closet/secure_closet/wall{
 	dir = 1;
+	icon_state = "sec_wall";
+	name = "firearms locker";
 	pixel_y = -28;
-	req_one_access_txt = "19";
-	name = "firearm locker"
+	req_access_txt = "19"
 	},
-/obj/item/gun/ballistic/automatic/pistol/solgov,
-/obj/item/gun/ballistic/automatic/pistol/solgov,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
 /turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "BU" = (

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -38,10 +38,17 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "aF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
@@ -62,6 +69,7 @@
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 4
 	},
+/obj/machinery/computer/helm/viewscreen/directional/east,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/office)
 "be" = (
@@ -157,6 +165,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
+/obj/machinery/computer/helm/viewscreen/directional/south,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "bD" = (
@@ -194,6 +203,8 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/canteen)
 "co" = (
@@ -295,8 +306,18 @@
 "cN" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "cO" = (
@@ -743,7 +764,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/port)
 "hM" = (
-/obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/neck/stripedsolgovscarf,
 /obj/item/clothing/neck/stripedsolgovscarf,
@@ -764,6 +784,8 @@
 /obj/item/clothing/suit/solgov/suit,
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
+/obj/item/toy/plush/blahaj,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "if" = (
@@ -1278,16 +1300,10 @@
 /turf/open/floor/plating,
 /area/ship/medical/surgery)
 "ns" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "nt" = (
 /obj/effect/turf_decal/borderfloorblack{
@@ -1823,19 +1839,21 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "rT" = (
 /obj/structure/chair/sofa{
 	dir = 1
 	},
+/obj/machinery/computer/helm/viewscreen/directional/south,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/canteen)
 "rY" = (
@@ -2393,7 +2411,6 @@
 /area/ship/crew/canteen)
 "xp" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/wood,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "xw" = (
@@ -2560,10 +2577,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/starboard)
 "yY" = (
-/obj/machinery/door/airlock/solgov/glass{
-	dir = 4;
-	name = "Cafeteria"
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -2584,6 +2597,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/door/airlock/solgov/glass{
+	dir = 4;
+	name = "Cafeteria"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
@@ -3022,11 +3042,10 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "DD" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/kitchen/knife,
 /obj/machinery/light/directional/north,
-/obj/item/kitchen/rollingpin,
+/obj/structure/sink/kitchen{
+	pixel_y = 16
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "DL" = (
@@ -3050,22 +3069,24 @@
 /turf/open/floor/wood/yew,
 /area/ship/crew)
 "Ea" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/railing/wood,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -19;
+	pixel_y = -5
 	},
-/turf/open/floor/wood,
+/obj/machinery/button/door{
+	dir = 4;
+	id = "sg_par_cafeteria";
+	name = "shutter control";
+	pixel_x = -20;
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Eh" = (
 /obj/item/bedsheet/double/solgov{
@@ -3273,13 +3294,8 @@
 "FG" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -17
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -10;
-	pixel_y = 6
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
@@ -3357,15 +3373,15 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical/surgery)
 "Hl" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
@@ -3519,11 +3535,17 @@
 /area/ship/maintenance/starboard)
 "IO" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 5
+/obj/machinery/reagentgrinder{
+	pixel_y = 8;
+	pixel_x = -7
 	},
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 10;
+	pixel_y = 10
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
@@ -3800,6 +3822,15 @@
 /area/ship/hallway/port)
 "Lw" = (
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Lx" = (
@@ -3854,7 +3885,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/office)
 "LK" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
 /obj/machinery/button/door{
 	dir = 4;
@@ -3872,6 +3902,7 @@
 	specialfunctions = 4;
 	normaldoorcontrol = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "LS" = (
@@ -3902,13 +3933,20 @@
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/starboard)
 "Mk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/railing/wood,
+/obj/structure/closet/secure_closet/freezer{
+	anchored = 1;
+	name = "refrigerator"
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Mo" = (
 /obj/structure/chair/office{
@@ -3970,7 +4008,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
 "ML" = (
-/obj/structure/railing/wood,
+/obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -3980,15 +4018,14 @@
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/soymilk,
 /obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/storage/fancy/egg_box,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/structure/closet/secure_closet/freezer{
-	anchored = 1
+	anchored = 1;
+	name = "refrigerator"
 	},
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/snacks/meat/slab,
-/obj/item/reagent_containers/food/snacks/meat/slab,
-/obj/item/storage/box/ingredients/vegetarian,
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "MO" = (
@@ -4092,7 +4129,15 @@
 /area/ship/medical/surgery)
 "NY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = 12;
+	pixel_x = -20
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "Ol" = (
@@ -4132,16 +4177,10 @@
 /turf/open/floor/wood,
 /area/ship/bridge)
 "OO" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "OS" = (
 /obj/structure/sink/kitchen{
@@ -4243,6 +4282,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Pk" = (
@@ -4389,15 +4431,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
@@ -4654,11 +4687,20 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "SG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/canteen)
 "SK" = (
@@ -4681,19 +4723,10 @@
 /area/ship/hallway/starboard)
 "SP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/wood,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -19;
-	pixel_y = -5
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	id = "sg_par_cafeteria";
-	name = "shutter control";
-	pixel_x = -20;
-	pixel_y = 7
-	},
+/obj/structure/table/wood,
+/obj/item/cutting_board,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Tc" = (
@@ -5024,6 +5057,9 @@
 /obj/item/desk_flag/solgov{
 	pixel_y = 3
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/canteen)
 "Wt" = (
@@ -5128,7 +5164,21 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/machinery/autolathe,
+/obj/structure/table,
+/obj/item/cigbutt{
+	pixel_y = 5
+	},
+/obj/item/cigbutt{
+	pixel_y = 15
+	},
+/obj/item/cigbutt{
+	pixel_y = 9;
+	pixel_x = -11
+	},
+/obj/item/clothing/mask/cigarette/robust{
+	pixel_y = 10;
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/port)
 "Xe" = (
@@ -6384,8 +6434,8 @@ qL
 qL
 qL
 Ev
-yY
 vL
+yY
 Ky
 Ky
 Ky

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -3026,6 +3026,7 @@
 /obj/item/cutting_board,
 /obj/item/kitchen/knife,
 /obj/machinery/light/directional/north,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "DL" = (
@@ -3205,6 +3206,9 @@
 /obj/item/reagent_containers/food/drinks/mug/coco{
 	pixel_x = -6;
 	pixel_y = 2
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = 3
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/canteen)
@@ -3966,7 +3970,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
 "ML" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/structure/railing/wood,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -3979,6 +3982,13 @@
 /obj/item/reagent_containers/food/condiment/soymilk,
 /obj/item/storage/fancy/egg_box,
 /obj/item/reagent_containers/food/condiment/enzyme,
+/obj/structure/closet/secure_closet/freezer{
+	anchored = 1
+	},
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/storage/box/ingredients/vegetarian,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "MO" = (
@@ -4434,6 +4444,7 @@
 /obj/item/clothing/suit/solgov/suit,
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
+/obj/item/toy/plush/blahaj,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "QQ" = (

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -1782,8 +1782,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/medical{
 	name = "Chemistry";
-	req_one_access = list(5,45);
+	req_one_access = list(5,10,45);
 	id_tag = "sg_par_chem_bolt"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -1889,7 +1889,8 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/wall{
-	pixel_y = 28
+	pixel_y = 28;
+	name = "navigational supplies"
 	},
 /obj/item/gps,
 /obj/item/binoculars,
@@ -2858,7 +2859,7 @@
 	dir = 1;
 	pixel_y = -28;
 	req_one_access_txt = "19";
-	name = "Weapons"
+	name = "firearm locker"
 	},
 /obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/item/gun/ballistic/automatic/pistol/solgov,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks the layout and supply of the Paracelsus kitchen to be more user-friendly and to better feed a wider range of patients, or just to give the patients more to do by cooking. It now has a rolling pin, sink, extra fridge and some meat and vegetables to cook with. The canteen table now has a deck of cards for recreation.
![image](https://github.com/shiptest-ss13/Shiptest/assets/95449138/de121835-16db-4a90-9f84-e5a02d07c275)

Also adds two extra shark plushies because people requested them and they help with patient recovery speeds (not confirmed).
Adds ship viewscreens to the canteen, cargo bay and scribe waiting area. People want to see where they're going and it gives people more to do.
Adds two bookshelves to the paracelsus dorm room.
Moves the autolathe to the ghettochem area due to overwhelming popular demand. It is necessary for ghetto chemistry and more accessible to people as doctors are more likely to use it than an engineer or the captain.
Fixes the locker full of guns on the bridge being just. Fully unlocked! For some reason! It now can only be accessed by the overseer and captain.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Paracelsus kitchen was a 7 tile nightmare for cooking. Now it is much more user friendly and provides players with more ingredients to make nice food with.
Doctors not having to ask to use the autolathe is also a lot better
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Reworked the paracelsus kitchen layout to be more user friendly and have more ingredients to cook with.
add: Adds two bookcases and two extra shark plushies to the dorms.
add: Adds ship viewscreens to the paracelsus
add: Moves the autolathe on the paracelsus to the ghettochem room
fix: The firearms locker on the paracelsus no longer lacks a lock to prevent patients from accessing the firearms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
