### PR TITLE
Tend wounds surgery variants no longer attempt to heal the wrong type of damage

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -65,11 +65,11 @@
 	var/urhealedamt_burn = burnhealing
 	if(missinghpbonus)
 		if(target.stat != DEAD)
-			urhealedamt_brute += round((target.getBruteLoss()/ missinghpbonus),0.1)
-			urhealedamt_burn += round((target.getFireLoss()/ missinghpbonus),0.1)
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ missinghpbonus),0.1) : 0
+			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ missinghpbonus),0.1) : 0
 		else //less healing bonus for the dead since they're expected to have lots of damage to begin with (to make TW into defib not TOO simple)
-			urhealedamt_brute += round((target.getBruteLoss()/ (missinghpbonus*5)),0.1)
-			urhealedamt_burn += round((target.getFireLoss()/ (missinghpbonus*5)),0.1)
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ (missinghpbonus*5)),0.1) : 0
+			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ (missinghpbonus*5)),0.1) : 0
 	if(!get_location_accessible(target, target_zone))
 		urhealedamt_brute *= 0.55
 		urhealedamt_burn *= 0.55


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/2e267cd6-7b43-4900-8a20-09e3b8879d30)

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/75dad61e-84ac-4bd3-b285-a37e43a49d41)


## Why It's Good For The Game

Prevents a tend wounds heal cycle from targeting a limb that won't benefit from its flat healing bonus.

## Changelog

:cl:
tweak: tend brute/burns can no longer attempt to (very ineffectively) heal the other damage type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
