### PR TITLE
Fixes 2647

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -253,7 +253,7 @@
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.use_materials(alloy.materials, amount)
 
-	generate_mineral(alloy.build_path)
+	generate_mineral(alloy.build_path, amount)
 
 /obj/machinery/mineral/processing_unit/proc/can_smelt(datum/design/D)
 	if(D.make_reagents.len)
@@ -271,8 +271,8 @@
 
 	return build_amount
 
-/obj/machinery/mineral/processing_unit/proc/generate_mineral(P)
-	var/O = new P(src)
+/obj/machinery/mineral/processing_unit/proc/generate_mineral(P, amount)
+	var/O = new P(src, amount)
 	unload_mineral(O)
 
 /obj/machinery/mineral/processing_unit/on_deconstruction()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Arcane machine tried to smelt up to 10 sheets of material but the alloy smelting proc didn't get a smelting number passed so it just spawned 1 sheet and called it a day.

## Why It's Good For The Game

fixes #2647

## Changelog

:cl:
fix: ore smelter no longer obliterates materials when smelting alloys
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->