### PR TITLE
fixes crusher loot for icemoon ruin dragon not dropping a key

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_drakelair.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_drakelair.dmm
@@ -127,7 +127,8 @@
 "iT" = (
 /obj/structure/stone_tile/slab,
 /mob/living/simple_animal/hostile/megafauna/dragon/icemoon{
-	loot = list(/obj/structure/closet/crate/necropolis/dragon,/obj/item/keycard/gatedrop/drakelair)
+	loot = list(/obj/structure/closet/crate/necropolis/dragon,/obj/item/keycard/gatedrop/drakelair);
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher,/obj/item/keycard/gatedrop/drakelair)
 	},
 /turf/open/indestructible/boss,
 /area/ruin)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds the key to the crusher loot list since the default loot list is overridden by that

## Why It's Good For The Game

Dragon lair could be locked off without admin intervention if the dragon is killed with a crusher

## Changelog

:cl:
fix: you can no longer lock yourself out of the icemoon dragon lair by killing the dragon with a crusher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
