### PR TITLE
Ports Yogstation's Version of Disarm Rework (nerfs disarms)

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -109,7 +109,7 @@
 #define SHOVE_SLOWDOWN_STRENGTH 0.85 //multiplier
 //Shove disarming item list
 GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
-	/obj/item/gun, /obj/item/kitchen/knife)))
+	/obj/item/gun)))
 
 //Combat object defines
 //Embedded objects

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -109,7 +109,7 @@
 #define SHOVE_SLOWDOWN_STRENGTH 0.85 //multiplier
 //Shove disarming item list
 GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
-	/obj/item/gun)))
+	/obj/item/gun, /obj/item/kitchen/knife)))
 
 //Combat object defines
 //Embedded objects

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -102,16 +102,15 @@
 #define DEFAULT_MESSAGE_RANGE 7
 
 //Shove knockdown lengths (deciseconds)
-#define SHOVE_KNOCKDOWN_SOLID 30
-#define SHOVE_KNOCKDOWN_HUMAN 30
-#define SHOVE_KNOCKDOWN_TABLE 30
-#define SHOVE_KNOCKDOWN_COLLATERAL 10
-#define SHOVE_CHAIN_PARALYZE 40
+#define SHOVE_KNOCKDOWN_HUMAN 10
+#define SHOVE_CHAIN_PARALYZE 30
 //Shove slowdown
 #define SHOVE_SLOWDOWN_LENGTH 30
 #define SHOVE_SLOWDOWN_STRENGTH 0.85 //multiplier
 //Shove disarming item list
-GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(/obj/item/gun)))
+GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
+	/obj/item/gun)))
+
 //Combat object defines
 //Embedded objects
 #define EMBEDDED_PAIN_CHANCE 15	//Chance for embedded objects to cause pain (damage user)

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -11,6 +11,8 @@
 #define MOVESPEED_ID_MOB_GRAB_STATE "mob_grab_state"
 #define MOVESPEED_ID_MOB_WALK_RUN "mob_walk_run"
 
+#define MOVESPEED_ID_SHOVE "SHOVE"
+
 //necrovirus
 #define MOVESPEED_ID_NECRO_VIRUS_SLOWDOWN "NECRO_VIRUS"
 

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -11,8 +11,6 @@
 #define MOVESPEED_ID_MOB_GRAB_STATE "mob_grab_state"
 #define MOVESPEED_ID_MOB_WALK_RUN "mob_walk_run"
 
-#define MOVESPEED_ID_SHOVE "SHOVE"
-
 //necrovirus
 #define MOVESPEED_ID_NECRO_VIRUS_SLOWDOWN "NECRO_VIRUS"
 

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -51,6 +51,7 @@
 #define ANTI_TINFOIL_MANEUVER (1<<12) //Hats with negative effects when worn (i.e the tinfoil hat).
 #define DANGEROUS_OBJECT (1<<13) //Clothes that cause a larger notification when placed on a person.
 #define FAST_EMBARK (1<<14) //Clothes that speed up mech and pod boarding.
+
 /// Flags for the organ_flags var on /obj/item/organ
 
 #define ORGAN_SYNTHETIC (1<<0)	//Synthetic organs, or cybernetic organs. Reacts to EMPs and don't deteriorate or heal

--- a/code/modules/unit_tests/combat.dm
+++ b/code/modules/unit_tests/combat.dm
@@ -94,5 +94,4 @@
 	victim.attack_hand(attacker)
 
 	TEST_ASSERT_EQUAL(victim.loc.x, run_loc_bottom_left.x + 2, "Victim was moved after being pushed against a wall")
-	TEST_ASSERT(victim.has_status_effect(STATUS_EFFECT_KNOCKDOWN), "Victim was not knocked down after being pushed against a wall")
 	TEST_ASSERT_EQUAL(victim.get_active_held_item(), null, "Victim didn't drop toolbox after being pushed against a wall")


### PR DESCRIPTION
## About The Pull Request

Alters the disarm behavior already pulled from TG to match the balance changes made by Yogstation 13 coders when they merged TG's disarm rework four-ish years ago. See https://github.com/yogstation13/Yogstation/pull/9284

The following changes have been made:

1. Disarm interactions with tables and disposal bins have been removed
2. Shoving someone who is standing and wearing riot armor does nothing except move them back. No slow is applied, nor can a gun in their active hand be loosened and then dropped with two consecutive shoves. They still retain the inability to collide with mobs or have a mob colliding against them knock them down.
3. Shoving someone into a wall no longer knocks them down. Instead, their active hand item is dropped. Individuals wearing riot armor are unaffected.
4. Shoving someone who is prone stuns them for a reduced duration if they have melee armor located on their chest. The higher the armor, the more the three-second stun is reduced.
5. The knockdown for being shoved into someone has been reduced to a one-second knockdown on both parties, instead of three seconds for the shoved and one second for the person behind them.

Tested on a local server and the behavior seems to be working as intended.

## Why It's Good For The Game

1. Consistency with wall behavior and disarms being less "powerful". Considering some disposal bins go into space if I remember correctly, this is not good.
2. Makes riot armor appropriately potent at dealing with unarmed assailants.
3. Knockdowns are incredibly powerful, especially considering the follow-up disarm stun which guarantees an aggro grab. Unarmed individuals should not be able to so easily put someone at their mercy barring shoving into someone else or potentially slipping someone.
4. Makes it so melee armor helps against a melee-based attack. Makes sense.
5. Not sure why these were different values. There should certainly be a punishment for positioning in such a way that you line up for a knockdown, but the knockdown itself takes long enough to get up from that you can easily be kicked over and thoroughly savaged by an attacker.

While PvP is not the main focus of this server, stun combat is generally bad, nor should an unarmed, unprepared combatant be able to so easily overpower with better gear. The goal of the PR is to retain some of the behavior and strategy that could be utilized with disarm shoves while significantly reducing their power.

## Changelog

:cl:
balance: Disarms no longer knockdown individuals shoved into a wall. Instead, their active hand is disarmed.
balance: Riot armor now prevents ALL disarm intent disarms or slows; you can only be kicked over if already prone
balance: Armor reduces the duration of the paralyze if you're shoved while prone
/:cl:
