### PR TITLE
Updates syndicate ship prefixes

### DIFF
--- a/_maps/configs/syndicate_aegis.json
+++ b/_maps/configs/syndicate_aegis.json
@@ -1,5 +1,5 @@
 {
-	"prefix": "SSV",
+	"prefix": "SUNS",
 	"map_name": "Aegis-class Long Term Care Ship",
 	"map_short_name": "Aegis-class",
 	"map_path": "_maps/shuttles/syndicate/syndicate_aegis.dmm",

--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
-	"prefix": "SSV",
+	"prefix": "CSSV",
 	"namelists": [
 		"CYBERSUN",
 		"SPACE",

--- a/_maps/configs/syndicate_gorlex_hyena.json
+++ b/_maps/configs/syndicate_gorlex_hyena.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
-	"prefix": "SSV",
+	"prefix": "NGRV",
 	"namelists": [
 		"GORLEX",
 		"NATURAL_AGGRESSIVE",

--- a/_maps/configs/syndicate_gorlex_komodo.json
+++ b/_maps/configs/syndicate_gorlex_komodo.json
@@ -1,5 +1,5 @@
 {
-	"prefix": "SSV",
+	"prefix": "ISV",
 	"namelists": [
 		"GORLEX",
 		"NATURAL_AGGRESSIVE",

--- a/_maps/configs/syndicate_litieguai.json
+++ b/_maps/configs/syndicate_litieguai.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
 	"map_name": "Li Tieguai-class Rescue Ship",
-	"prefix": "SSV",
+	"prefix": "CSSV",
 	"map_short_name": "Li Tieguai-class",
 	"description": "A small, nimble, and exceptionally well-built medical response vessel, the Li Tieguai is a recent addition to Cybersun’s fleet, forming a critical component of their Frontier stabilization program. Li Tieguais come equipped with high-end medical equipment, including a selection of Cybersun augments and prosthetics, as well as weaponry and armor sufficient to protect its personnel in the often-dangerous Frontier sectors, so that they can offer premium healthcare (at premium prices) in even the most dangerous of scenarios.",
 	"tags": [

--- a/_maps/configs/syndicate_lugol.json
+++ b/_maps/configs/syndicate_lugol.json
@@ -1,6 +1,6 @@
 {
 	"map_name": "Lugol-class GEC Engineering Project",
-	"prefix": "SEV",
+	"prefix": "XSV",
 	"map_short_name": "Lugol-class",
 	"description": "The Lugol is effectively an enormous Galactic Engineers Concordat research barge, used as a test bed for refinements to power systems, new technologies, and so on. As it offers freedom from the usual constraints of working aboard vessels belonging to other Syndicate factions, Lugols are especially popular among the GEC’s more radical members. Accordingly, they have a reputation for either accomplishing the impossible or generating the equivalent of a new star when they inevitably melt down. Lugols are generally only found on the Frontier, where the collateral damage from potential accidents can be kept to a minimum and secrecy, when needed, can be better maintained.",
 	"tags": [
@@ -14,7 +14,7 @@
 	],
 	"map_path": "_maps/shuttles/syndicate/syndicate_gec_lugol.dmm",
 	"map_id": "gec_lugol",
-	"limit": 2,
+	"limit": 1,
 	"job_slots": {
 		"Project Overseer": {
 			"outfit": "/datum/outfit/job/syndicate/ce/gec",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the prefixes on Syndicate ships to reflect subfaction more strongly.

- 2nd Battlegroup uses NGRV (New Gorlex Republic Vessel)
- Hardliners use ISV (They don't have a unique registration because they aren't an organized group and aren't officially part of Cybersun. this puts them in a similar position to non-Frontiersman pirates, using ISV while not being normal independents.)
- Cybersun uses CSSV (CyberSun Space Vessel)
- SUNS uses SUNS (SUNS, lol)
- ACLF still uses SSV
- The Lugol, as GEC's only ship and an adminspawn ship, uses XSV (Experimental Space Vessel)

## Why It's Good For The Game

the syndicate kind of Isn't anymore and pushing faction distinctions is good, especially between the gorlex splinters

## Changelog

:cl:
tweak: Changed prefixes on Syndicate ships to reflect subfaction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
