### PR TITLE
Murders The Devil from The Bible in the form of a bee

### DIFF
--- a/code/datums/mapgen/planetary/BeachGenerator.dm
+++ b/code/datums/mapgen/planetary/BeachGenerator.dm
@@ -119,7 +119,7 @@
 
 		/mob/living/simple_animal/butterfly = 4,
 		/mob/living/simple_animal/hostile/retaliate/poison/snake = 5,
-		/mob/living/simple_animal/hostile/poison/bees/toxin = 3,
+		/mob/living/simple_animal/hostile/poison/bees = 3,
 	)
 	mob_spawn_chance = 2
 	feature_spawn_chance = 0.1

--- a/code/datums/mapgen/planetary/JungleGenerator.dm
+++ b/code/datums/mapgen/planetary/JungleGenerator.dm
@@ -228,7 +228,7 @@
 	)
 	mob_spawn_chance = 1
 	mob_spawn_list = list(
-		/mob/living/simple_animal/hostile/poison/bees/toxin = 1,
+		/mob/living/simple_animal/hostile/poison/bees = 1,
 		/mob/living/simple_animal/hostile/mushroom = 1,
 		/mob/living/simple_animal/pet/dog/corgi/capybara = 1
 	)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,29)
+	var/loot = rand(1,30)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -84,13 +84,15 @@
 			new /obj/item/clothing/suit/armor/ascetic(src)
 		if(29)
 			new /obj/item/kitchen/knife/envy(src)
+		if(30)
+			new /mob/living/simple_animal/hostile/poison/bees(src)
 
 /obj/structure/closet/crate/necropolis/tendril/greater
 	desc = "It's watching you wearily. It seems terribly bloated."
 
 /obj/structure/closet/crate/necropolis/tendril/greater/PopulateContents()
 	for(var/i in 1 to 3)
-		var/loot = rand(1,29)
+		var/loot = rand(1,30)
 		switch(loot)
 			if(1)
 				new /obj/item/shared_storage/red(src)
@@ -161,6 +163,9 @@
 				new /obj/item/clothing/suit/armor/ascetic(src)
 			if(29)
 				new /obj/item/kitchen/knife/envy(src)
+			if(30)
+				new /mob/living/simple_animal/hostile/poison/bees/toxin(src)
+			// :3c
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -161,6 +161,7 @@
 				new /obj/item/clothing/suit/armor/ascetic(src)
 			if(29)
 				new /obj/item/kitchen/knife/envy(src)
+
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc
 	name = "KA Mod Disk"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,30)
+	var/loot = rand(1,29)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -84,15 +84,13 @@
 			new /obj/item/clothing/suit/armor/ascetic(src)
 		if(29)
 			new /obj/item/kitchen/knife/envy(src)
-		if(30)
-			new /mob/living/simple_animal/hostile/poison/bees(src)
 
 /obj/structure/closet/crate/necropolis/tendril/greater
 	desc = "It's watching you wearily. It seems terribly bloated."
 
 /obj/structure/closet/crate/necropolis/tendril/greater/PopulateContents()
 	for(var/i in 1 to 3)
-		var/loot = rand(1,30)
+		var/loot = rand(1,29)
 		switch(loot)
 			if(1)
 				new /obj/item/shared_storage/red(src)
@@ -163,10 +161,6 @@
 				new /obj/item/clothing/suit/armor/ascetic(src)
 			if(29)
 				new /obj/item/kitchen/knife/envy(src)
-			if(30)
-				new /mob/living/simple_animal/hostile/poison/bees/toxin(src)
-			// :3c
-
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc
 	name = "KA Mod Disk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
 
## About The Pull Request
Removes chem bees from the jungle and beach spawn pools, replacing them with normal bees.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Walking off of a ship onto one of the relatively "peaceful" planets, only to be loaded up with admin chemicals was a pretty awful experience. 

We inherited these little guys from Voidcrew, honestly that should be enough reason to remove them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: planetary chem bees have been replaced with the garden variety
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
