### PR TITLE
Adds a few items to the ranger.

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -183,12 +183,14 @@
 /obj/item/clothing/suit/armor/vest/security,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/gps,
-/obj/item/gun/ballistic/derringer,
+/obj/item/gun/ballistic/automatic/pistol/commander,
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/item/ammo_box/c38_box,
-/obj/item/ammo_box/c38_box,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
 /turf/open/floor/wood,
 /area/ship/security)
 "bD" = (
@@ -961,12 +963,10 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/starboard)
 "iX" = (
-/obj/machinery/mineral/ore_redemption{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "iZ" = (
@@ -3132,6 +3132,12 @@
 	pixel_x = 7;
 	pixel_y = -20
 	},
+/obj/item/gun/ballistic/automatic/pistol/commander,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm/rubbershot,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "Hd" = (
@@ -4159,10 +4165,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/starboard)
-"TW" = (
-/obj/item/radio/intercom/wideband/directional/north,
-/turf/closed/wall/r_wall,
-/area/ship/bridge)
 "TZ" = (
 /obj/effect/turf_decal/trimline/opaque/orange/arrow_ccw{
 	dir = 4
@@ -4187,12 +4189,15 @@
 	pixel_x = 5
 	},
 /obj/item/pen/fountain{
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 7
 	},
 /obj/machinery/recharger{
-	pixel_x = -5
+	pixel_x = -4
 	},
-/obj/item/stamp/captain,
+/obj/item/stamp/captain{
+	pixel_x = 7
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ur" = (
@@ -4411,10 +4416,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "WF" = (
-/obj/structure/ore_box,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/engine/hull,
-/area/ship/external)
+/obj/item/radio/intercom/wideband,
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "WG" = (
 /obj/machinery/telecomms/server/presets/nanotrasen{
 	autolinkers = list("nanotrasen","hub");
@@ -5527,7 +5531,7 @@ gg
 zW
 zW
 zW
-WF
+QV
 jA
 KQ
 wp
@@ -5951,7 +5955,7 @@ Lk
 mn
 cv
 lW
-TW
+WF
 VQ
 zW
 zW

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -191,6 +191,7 @@
 /obj/item/ammo_box/c9mm,
 /obj/item/ammo_box/magazine/co9mm,
 /obj/item/ammo_box/magazine/co9mm,
+/obj/item/storage/belt/security/webbing,
 /turf/open/floor/wood,
 /area/ship/security)
 "bD" = (

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -3656,6 +3656,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"MD" = (
+/obj/item/disk/design_disk/ammo_c9mm,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "MI" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3993,6 +3997,7 @@
 /obj/effect/turf_decal/industrial/hatch/orange,
 /obj/item/assembly/flash,
 /obj/item/assembly/flash,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Qu" = (
@@ -5172,7 +5177,7 @@ jA
 zW
 Tz
 LQ
-aP
+MD
 aP
 xq
 Wp

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -3985,6 +3985,8 @@
 /obj/item/robot_suit,
 /obj/structure/closet/crate/engineering,
 /obj/effect/turf_decal/industrial/hatch/orange,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Qu" = (
@@ -4157,6 +4159,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/starboard)
+"TW" = (
+/obj/item/radio/intercom/wideband/directional/north,
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "TZ" = (
 /obj/effect/turf_decal/trimline/opaque/orange/arrow_ccw{
 	dir = 4
@@ -4183,6 +4189,10 @@
 /obj/item/pen/fountain{
 	pixel_x = -4
 	},
+/obj/machinery/recharger{
+	pixel_x = -5
+	},
+/obj/item/stamp/captain,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ur" = (
@@ -5941,7 +5951,7 @@ Lk
 mn
 cv
 lW
-Lk
+TW
 VQ
 zW
 zW

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -3995,9 +3995,9 @@
 /obj/item/robot_suit,
 /obj/structure/closet/crate/engineering,
 /obj/effect/turf_decal/industrial/hatch/orange,
-/obj/item/assembly/flash,
-/obj/item/assembly/flash,
 /obj/item/stock_parts/cell/high,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Qu" = (

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -173,4 +173,4 @@ other types of metals and chemistry for reagents).
 
 /obj/item/disk/design_disk/ammo_c9mm/Initialize()
 	. = ..()
-	blueprints[1] = new /datum/design/c9mm()
+	blueprints[1] = new /datum/design/c9mmautolathe()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -171,6 +171,6 @@ other types of metals and chemistry for reagents).
 	name = "Design Disk - 9mm Ammo"
 	desc = "A design disk containing the pattern for a refill box of standard 9mm ammo, used in Commander pistols."
 
-/obj/item/disk/design_disk/ammo_c10mm/Initialize()
+/obj/item/disk/design_disk/ammo_c9mm/Initialize()
 	. = ..()
 	blueprints[1] = new /datum/design/c9mm()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -166,3 +166,11 @@ other types of metals and chemistry for reagents).
 	. = ..()
 	blueprints[1] = new /datum/design/cmm_ripley_upgrade()
 	blueprints[2] = new /datum/design/cmm_durand_upgrade()
+
+/obj/item/disk/design_disk/ammo_c9mm
+	name = "Design Disk - 9mm Ammo"
+	desc = "A design disk containing the pattern for a refill box of standard 9mm ammo, used in Commander pistols."
+
+/obj/item/disk/design_disk/ammo_c10mm/Initialize()
+	. = ..()
+	blueprints[1] = new /datum/design/c9mm()

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -788,10 +788,10 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_BALLISTICS
 
-/datum/design/c9mmm_disk
+/datum/design/c9mmautolathe
 	name = "Ammo Box (9mm)"
-	id = "c9mm_disk"
+	id = "c9mmautolathe"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 15000)
 	build_path = /obj/item/ammo_box/c9mm
-	category = list("Imported")
+	category = list("Ammo")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -794,4 +794,4 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 15000)
 	build_path = /obj/item/ammo_box/c9mm
-	category = list("Ammo")
+	category = list("Imported")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -787,3 +787,11 @@
 	build_path = /obj/item/gun/ballistic/rifle/boltaction
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_BALLISTICS
+
+/datum/design/c9mmm_disk
+	name = "Ammo Box (9mm)"
+	id = "c9mm_disk"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 15000)
+	build_path = /obj/item/ammo_box/c9mm
+	category = list("Imported")


### PR DESCRIPTION
## About The Pull Request
Adds two flashes, a Recharger, a stamp and a wideband to the Ranger bridge. And a commander pistol,mags and ammo to the lieutenant closet and security closet,and adds a 9mm ammo disk for the autolathe. Also removes the ORM due to latency's request.


## Why It's Good For The Game
It lets the captain recharge their e-rifle, complete the cyborg shell, stamp paperwork and actually talk to people for once.
The commanders are to give a bit more firepower,as before the security specialist had only one derringer (!!) and i feel like the lieutenant could do with a bit more firepower,too.
The ORM was removed due to having refineries in outposts.
## Changelog

:cl:
add: Added two flashes, a recharger, a stamp, two commanders, ammo for them and a wideband to the Ranger bridge.
del: The Ranger's ORM.
/:cl:

