### PR TITLE
Ship faction display take 2

### DIFF
--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -34,6 +34,11 @@
 			"description": "The prefix of the ship class, appended to randomly generated names when they're first purchased.",
 			"maxLength": 5
 		},
+		"faction_name": {
+			"title": "Faction Name",
+			"type": [ "null", "string" ],
+			"description": "A custom faction name for the ship class. If exluded or left blank, the ship will use the default faction name for the faction that matches the ship's prefix."
+		},
 		"namelists": {
 			"title": "Namelists",
 			"type": "array",

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -242,6 +242,15 @@ GLOBAL_LIST_INIT(ship_faction_to_prefixes, list(
 		"SEV",
 		"SSV",
 	),
+	"New Gorlex Republic" = list(
+		"NGRV",
+	),
+	"CyberSun" = list(
+		"CSSV",
+	),
+	"Student-Union of Naturalistic Sciences" = list(
+		"SUNS",
+	),
 	"SolGov" = list(
 		"SGSV",
 	),
@@ -252,6 +261,7 @@ GLOBAL_LIST_INIT(ship_faction_to_prefixes, list(
 		"SV",
 		"IMV",
 		"ISV",
+		"XSV",
 	),
 	"Inteq Risk Management Group" = list(
 		"IRMV",
@@ -262,6 +272,12 @@ GLOBAL_LIST_INIT(ship_faction_to_prefixes, list(
 	),
 	"Nanotrasen" = list(
 		"NTSV",
+	),
+	"Frontiersmen Fleet" = list(
+		"FFV",
+	),
+	"Saint-Roumaine Militia" = list(
+		"SRSV",
 	),
 ))
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -193,7 +193,7 @@ SUBSYSTEM_DEF(mapping)
 				S.faction_name = data["faction_name"]
 			else
 				S.faction_name = ship_prefix_to_faction(S.prefix)
-				
+
 		S.category = S.faction_name
 
 		if(islist(data["namelists"]))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -181,20 +181,30 @@ SUBSYSTEM_DEF(mapping)
 		CHECK_LIST_EXISTS("job_slots")
 		var/datum/map_template/shuttle/S = new(data["map_path"], data["map_name"], TRUE)
 		S.file_name = data["map_path"]
-		S.category = "shiptest"
 
 		if(istext(data["map_short_name"]))
 			S.short_name = data["map_short_name"]
 		else
 			S.short_name = copytext(S.name, 1, 20)
+
 		if(istext(data["prefix"]))
 			S.prefix = data["prefix"]
+			if(istext(data["faction_name"]))
+				S.faction_name = data["faction_name"]
+			else
+				S.faction_name = ship_prefix_to_faction(S.prefix)
+				
+		S.category = S.faction_name
+
 		if(islist(data["namelists"]))
 			S.name_categories = data["namelists"]
-		if ( isnum( data[ "unique_ship_access" ] && data["unique_ship_access"] ) )
+
+		if(isnum(data[ "unique_ship_access" ] && data["unique_ship_access"]))
 			S.unique_ship_access = data[ "unique_ship_access" ]
+
 		if(istext(data["description"]))
 			S.description = data["description"]
+
 		if(islist(data["tags"]))
 			S.tags = data["tags"]
 
@@ -225,8 +235,10 @@ SUBSYSTEM_DEF(mapping)
 			S.job_slots[job_slot] = slots
 		if(isnum(data["limit"]))
 			S.limit = data["limit"]
+
 		if(isnum(data["spawn_time_coeff"]))
 			S.spawn_time_coeff = data["spawn_time_coeff"]
+
 		if(isnum(data["officer_time_coeff"]))
 			S.officer_time_coeff = data["officer_time_coeff"]
 
@@ -236,8 +248,10 @@ SUBSYSTEM_DEF(mapping)
 		if(isnum(data["enabled"]) && data["enabled"])
 			S.enabled = TRUE
 			ship_purchase_list[S.name] = S
+
 		if(isnum(data["roundstart"]) && data["roundstart"])
 			maplist[S.name] = S
+
 		if(isnum(data["space_spawn"]) && data["space_spawn"])
 			S.space_spawn = TRUE
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -46,9 +46,6 @@
 		mappath = "_maps/shuttles/[category]/[file_name].dmm"
 	. = ..()
 
-/datum/map_template/shuttle/proc/load_from_json(json)
-	
-
 /datum/map_template/shuttle/preload_size(path, cache)
 	. = ..(path, TRUE) // Done this way because we still want to know if someone actualy wanted to cache the map
 	if(!cached_map)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -17,7 +17,10 @@
 	var/short_name
 	var/list/job_slots = list()
 	var/list/name_categories = list("GENERAL")
+	/// The prefix of the ship's name.
 	var/prefix = "ISV"
+	/// The full name of the ship's faction.
+	var/faction_name = "Independent"
 	var/unique_ship_access = FALSE
 	/// Set by config JSON. If true, the template's ships' "default" spawn location (when bought by a player or loaded at roundstart)
 	/// will be in the middle of space, instead of at an outpost.
@@ -42,6 +45,9 @@
 	else
 		mappath = "_maps/shuttles/[category]/[file_name].dmm"
 	. = ..()
+
+/datum/map_template/shuttle/proc/load_from_json(json)
+	
 
 /datum/map_template/shuttle/preload_size(path, cache)
 	. = ..(path, TRUE) // Done this way because we still want to know if someone actualy wanted to cache the map

--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -146,7 +146,7 @@
 
 		var/list/ship_data = list(
 			"name" = S.name,
-			"faction" = S.faction_name,
+			"faction" = S.source_template.faction_name,
 			"class" = S.source_template.short_name,
 			"desc" = S.source_template.description,
 			"tags" = S.source_template.tags,

--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -146,7 +146,7 @@
 
 		var/list/ship_data = list(
 			"name" = S.name,
-			"faction" = ship_prefix_to_faction(S.source_template.prefix),
+			"faction" = S.faction_name,
 			"class" = S.source_template.short_name,
 			"desc" = S.source_template.description,
 			"tags" = S.source_template.tags,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows specifying a custom faction name in the ship JSON, as well as makes it so the faction name is only inferred from prefix once per round instead of every time the names are moused over.

Also makes ships sort into categories based on faction instead of just being lumped into the shiptest category, so it's a bit easier to find the ship you want to spawn.

## Why It's Good For The Game

Maptainer request

## Changelog

:cl:
admin: Ships should now be categorised by faction in the shuttle manipulator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
