### PR TITLE
Adds co-op cigarette lighting

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -396,7 +396,7 @@
 		var/obj/item/clothing/mask/cigarette/ourcig = M.wear_mask
 		if(istype(ourcig) && istype(theircig))
 			if(ourcig.lit && !theircig.lit)
-				theircig.light(span_notice("[M] leans towards [src], lighting [p_their()] [theircig.name] with [M.p_their()] [ourcig.name]."))
+				theircig.light(span_notice("[M] leans towards [src], lighting [p_their()] [theircig.name] with [M.p_their()] own."))
 				return
 
 	if(body_position == LYING_DOWN)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -391,6 +391,14 @@
 	if(M == src && check_self_for_injuries())
 		return
 
+	if(M.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+		var/obj/item/clothing/mask/cigarette/theircig = wear_mask
+		var/obj/item/clothing/mask/cigarette/ourcig = M.wear_mask
+		if(istype(ourcig) && istype(theircig))
+			if(ourcig.lit && !theircig.lit)
+				theircig.light(span_notice("[M] leans towards [src], lighting [p_their()] [theircig.name] with [M.p_their()] [ourcig.name]."))
+				return
+
 	if(body_position == LYING_DOWN)
 		if(buckled)
 			to_chat(M, "<span class='warning'>You need to unbuckle [src] first to do that!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you have a cigarette equipped, and someone else has an un-lit cigarette equipped, you can light theirs via help intent+target mouth

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/c1a352a4-5ae5-41e3-91c7-37780cbb8535)

## Why It's Good For The Game

New co-op interaction

## Changelog

:cl:
add: If you are smoking a cigarette, you can light someone else's cigarette via help intent while targeting the mouth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
