### PR TITLE
Increases the Damage of the Illestren Rifle

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -10,7 +10,7 @@
 /obj/projectile/bullet/a762_54
 	name = "7.62x54mmR bullet"
 	speed = 0.3
-	damage = 30
+	damage = 50
 	armour_penetration = 40
 
 // .300 Magnum (Smile Rifle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the damage of the Illestren rifle from 30 to 50 per shot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Illestren Rifle is very underwhelming. The slow firing speed of a bolt action, small clip size of 5 rounds, unprintable ammunition you have to purchase from cargo, and bulky size would balance out a higher damage value but it does very low damage making it one of the worse guns in the game. Considering how it was adapted from the Mosin Nagant rifle which originally did much more damage this seems to be unintentional.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Increased the damage of the 7.62x54mmR bullet (Illestren Rifle Ammunition) from 30 to 50.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
