### PR TITLE
cocoon spinning no longer spends nutriment if you don't do anything with it

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -185,7 +185,6 @@ GLOBAL_LIST_INIT(spider_last, world.file2list("strings/names/spider_last.txt"))
 	if (H.nutrition >= nutrition_threshold)
 		to_chat(H, "<span class='warning'>You pull out a strand from your spinneret, ready to wrap a target. <BR> \
 		(Press ALT+CLICK or MMB on the target to start wrapping.)</span>")
-		H.adjust_nutrition(E.spinner_rate * -0.5)
 		addtimer(VARSET_CALLBACK(E, web_ready, TRUE), E.web_cooldown)
 		RegisterSignal(H, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(cocoonAtom))
 		return

--- a/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -216,7 +216,7 @@ GLOBAL_LIST_INIT(spider_last, world.file2list("strings/names/spider_last.txt"))
 		if(!do_after(H, 10 SECONDS, 1, A))
 			to_chat(H, "<span class='warning'>Your web spinning was interrupted!</span>")
 			return
-		H.adjust_nutrition(E.spinner_rate * -3)
+		H.adjust_nutrition(E.spinner_rate * -3.5)
 		var/obj/structure/spider_player/cocoon/C = new(A.loc)
 		if(isliving(A))
 			C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Activating the cocoon ability costs nutriment, regardless of if it is used or interrupted. This removes that bit so you don't waste nutrition for your silly spider abilities.

## Why It's Good For The Game

Feels unintuitive, other ability doesn't do this

## Changelog

:cl:
tweak: rachnid cocoon spinning no longer spends nutrition when activated, only on successful cocooning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
