### PR TITLE
Adds the Cobra-20 as a buyable gun in the cargo market. (and fixes the stechkin's description)

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -134,6 +134,13 @@
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/ap,
 					/obj/item/ammo_box/magazine/wt550m9/inc)
 
+/datum/supply_pack/ammo/smgm45ammo
+	name = ".45 Cobra Ammo Crate"
+	desc = "Contains two .45 magazines for the Cobra-20, each containing 24 rounds."
+	cost = 2500
+	contains = list(/obj/item/ammo_box/magazine/smgm45,
+					/obj/item/ammo_box/magazine/smgm45)
+
 /*
 		Rifle ammo
 */

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -137,7 +137,7 @@
 /datum/supply_pack/ammo/smgm45ammo
 	name = ".45 Cobra Ammo Crate"
 	desc = "Contains two .45 magazines for the Cobra-20, each containing 24 rounds."
-	cost = 2500
+	cost = 1500
 	contains = list(/obj/item/ammo_box/magazine/smgm45,
 					/obj/item/ammo_box/magazine/smgm45)
 

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -26,7 +26,7 @@
 
 /datum/supply_pack/gun/makarovs
 	name = "Stechkin pistol crate"
-	desc = "Contains two concealable stechkin pistols, produced by the Gorlex Marauders and chambered in 10mm."
+	desc = "Contains two concealable stechkin pistols, produced by Scaraborough Arms and chambered in 10mm."
 	cost = 2000
 	contains = list(/obj/item/gun/ballistic/automatic/pistol,
 					/obj/item/gun/ballistic/automatic/pistol)

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -119,9 +119,8 @@
 	name = "Cobra-20 SMG Crate"
 	desc = "Contains two .45 submachine guns, manufactured by Scaraborough Arms and chambered in .45"
 	cost = 2500
-	contains = list(/obj/item/gun/ballistic/smg/c20r/cobra,
-					/obj/item/gun/ballistic/smg/c20r/cobra,
-					/obj/item/gun/ballistic/smg/c20r/cobra)
+	contains = list(/obj/item/gun/ballistic/automatic/smg/c20r/cobra,
+					/obj/item/gun/ballistic/automatic/smg/c20r/cobra)
 	crate_name = "SMG crate"
 
 /datum/supply_pack/gun/illestren

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -115,6 +115,15 @@
 					/obj/item/gun/ballistic/shotgun/flamingarrow)
 	crate_name = "rifle crate"
 
+/datum/supply_pack/gun/cobra20
+	name = "Cobra-20 SMG Crate"
+	desc = "Contains two .45 submachine guns, manufactured by Scaraborough Arms and chambered in .45"
+	cost = 1500
+	contains = list(/obj/item/gun/ballistic/smg/c20r/cobra,
+					/obj/item/gun/ballistic/smg/c20r/cobra,
+					/obj/item/gun/ballistic/smg/c20r/cobra)
+	crate_name = "SMG crate"
+
 /datum/supply_pack/gun/illestren
 	name = "Illestren Rifle Crate"
 	desc = "Contains three expertly made bolt action rifles intended for hunting wildlife. Chambered in 8x50mmR rounds."

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -26,7 +26,7 @@
 
 /datum/supply_pack/gun/makarovs
 	name = "Stechkin pistol crate"
-	desc = "Contains two concealable stechkin pistols, produced by Scaraborough Arms and chambered in 10mm."
+	desc = "Contains two concealable stechkin pistols, produced by Scarborough Arms and chambered in 10mm."
 	cost = 2000
 	contains = list(/obj/item/gun/ballistic/automatic/pistol,
 					/obj/item/gun/ballistic/automatic/pistol)

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -118,7 +118,7 @@
 /datum/supply_pack/gun/cobra20
 	name = "Cobra-20 SMG Crate"
 	desc = "Contains two .45 submachine guns, manufactured by Scaraborough Arms and chambered in .45"
-	cost = 1500
+	cost = 2500
 	contains = list(/obj/item/gun/ballistic/smg/c20r/cobra,
 					/obj/item/gun/ballistic/smg/c20r/cobra,
 					/obj/item/gun/ballistic/smg/c20r/cobra)

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -118,7 +118,7 @@
 /datum/supply_pack/gun/cobra20
 	name = "Cobra-20 SMG Crate"
 	desc = "Contains two .45 submachine guns, manufactured by Scaraborough Arms and chambered in .45"
-	cost = 2500
+	cost = 3000
 	contains = list(/obj/item/gun/ballistic/automatic/smg/c20r/cobra,
 					/obj/item/gun/ballistic/automatic/smg/c20r/cobra)
 	crate_name = "SMG crate"


### PR DESCRIPTION
## About The Pull Request

Title says all, i think.
Secretly also fixes the description on the stechkin to say that it's from scaraborough arms and not ''gorlex marauders''
## Why It's Good For The Game
Adds an option for buying an SMG in the market, since there's no SMGs currently available to buy, which felt like a weird skip since there's rifles, PDWs, and pistols. meant to be a sort of inbetween for from pistols and pdws/rifles
## Changelog

:cl:
add: Adds the Cobra-20 as buyable from the outpost alongside it's magazines.
spellcheck: fixes the stechkin being from the gorlex marauders and returns it to it's rightful home of scaraborough arms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->