### PR TITLE
The bulletproof armor crate no longer falsely advertises carrying three suits instead of two

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -136,7 +136,7 @@
 
 /datum/supply_pack/spacesuit_armor/bullet_armor
 	name = "Bulletproof Armor Crate"
-	desc = "Contains three full sets of bulletproof armor, guaranteed to reduce a bullet's stopping power by half but with limited protection against melee weaponry."
+	desc = "Contains two full sets of bulletproof armor, guaranteed to reduce a bullet's stopping power by half but with limited protection against melee weaponry."
 	cost = 3500
 	contains = list(/obj/item/clothing/suit/armor/vest/bulletproof,
 					/obj/item/clothing/suit/armor/vest/bulletproof,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Description doesn't match contents, looked like 2 suits per crate was the baseline so I changed that instead of the number of suits

## Why It's Good For The Game

I can't wait for my THREE bulletproof armor sets!

## Changelog

:cl:
fix: bulletproof armor crates are no longer stated to carry one more armor set than they actually do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
