### PR TITLE
suns armor oversight fixes

### DIFF
--- a/code/modules/clothing/factions/suns.dm
+++ b/code/modules/clothing/factions/suns.dm
@@ -171,6 +171,9 @@
 	mob_overlay_icon = 'icons/mob/clothing/faction/suns/suits.dmi'
 	lefthand_file = 'icons/mob/inhands/faction/suns/suns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/faction/suns/suns_righthand.dmi'
+	body_parts_covered = CHEST|GROIN|ARMS|LEGS
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	heat_protection = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/suit/armor/vest/bulletproof/suns/hos
 	name = "gilded peacekeeper plating"
@@ -192,6 +195,9 @@
 	armor = list("melee" = 15, "bullet" = 30, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 25)
 	lefthand_file = 'icons/mob/inhands/faction/suns/suns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/faction/suns/suns_righthand.dmi'
+	body_parts_covered = CHEST|GROIN|ARMS|LEGS
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	heat_protection = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/suit/armor/vest/bulletproof/suns/captain
 	name = "decorated academic coat"

--- a/code/modules/clothing/factions/suns.dm
+++ b/code/modules/clothing/factions/suns.dm
@@ -337,6 +337,7 @@
 	icon_state = "sunsvisor"
 	item_state = "suns_pkhelmet"
 	tint = 0
+	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) // identical stats to bulletproof helmet, as chest matches bulletproof vest
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS //Why? Because I'm not giving PK's sec masks nor hud sunglasses.
 	icon = 'icons/obj/clothing/faction/suns/head.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/suns/head.dmi'


### PR DESCRIPTION
## About The Pull Request

One line change to make the Peacekeeper Visor and the Gilded one have bulletproof helmet stats, as their armor inherits bulletproof vest

Also all SUNS armor now covers arms and legs too (because they're all coats)

## Why It's Good For The Game

Less inconsistencies between intended design of item and actual function.

Also I'm still malding.

## Changelog

:cl:
balance: Peacekeeper visors have real armor now (especially against bullet)
balance: SUNS armored coats now cover all body parts instead of just chest
/:cl:

