### PR TITLE
Removes the fake wall on the Independent Seccie Outpost, Adds an Outpost Fax Recipient, ERT Tweaks

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -5173,6 +5173,9 @@
 "Gv" = (
 /obj/structure/table,
 /obj/effect/turf_decal/floordetail/tiled,
+/obj/machinery/fax/admin/outpost{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/outpost/security)
 "GB" = (

--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -7013,10 +7013,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/outpost/hallway/central)
-"Rx" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating,
-/area/outpost/vacant_rooms)
 "RA" = (
 /obj/structure/railing/wood{
 	dir = 10;
@@ -18222,7 +18218,7 @@ MI
 eE
 hX
 lb
-Rx
+wL
 lY
 uJ
 Lh

--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -5821,12 +5821,6 @@
 /obj/effect/turf_decal/corner/opaque/neutral,
 /turf/open/floor/plasteel,
 /area/outpost/hallway/central)
-"Ki" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	dir = 4
-	},
-/turf/closed/indestructible/rock,
-/area/outpost/external)
 "Kl" = (
 /obj/effect/turf_decal/corner/opaque/grey/full,
 /obj/structure/cable/yellow{
@@ -19338,7 +19332,7 @@ mC
 mC
 HD
 HD
-Ki
+HD
 HD
 mC
 mC

--- a/_maps/outpost/nanotrasen_asteroid.dmm
+++ b/_maps/outpost/nanotrasen_asteroid.dmm
@@ -13493,12 +13493,10 @@
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
 "UX" = (
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/indestructible/fakeglass,
 /area/outpost/engineering/atmospherics)
 "UY" = (
 /obj/structure/table/wood,
@@ -13600,9 +13598,7 @@
 /turf/open/floor/plasteel/rockvault,
 /area/outpost/operations)
 "Vm" = (
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/closed/indestructible/fakeglass,
 /area/outpost/engineering/atmospherics)
 "Vn" = (
 /obj/effect/turf_decal/siding/wood{
@@ -13811,6 +13807,13 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/outpost/hallway/central)
+"We" = (
+/obj/structure/table/glass,
+/obj/machinery/fax/admin/outpost{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/operations)
 "Wi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -26246,7 +26249,7 @@ EN
 wS
 wS
 aG
-iv
+We
 Ke
 wS
 cH

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -174,6 +174,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "bj" = (
@@ -1662,6 +1663,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "mm" = (
@@ -2277,6 +2279,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "pv" = (
@@ -3818,6 +3821,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "zw" = (
@@ -5903,6 +5907,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "OR" = (
@@ -6664,6 +6669,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "Ti" = (
@@ -7463,8 +7469,10 @@
 /area/outpost/security/armory)
 "XG" = (
 /obj/structure/table/reinforced,
-/obj/machinery/fax/ruin,
 /obj/machinery/light/directional/south,
+/obj/machinery/fax/admin/outpost{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/outpost/security)
 "XI" = (

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -65,7 +65,7 @@
 		return
 
 	if (!sender)
-		sender = input("Who is the message from?", "Sender") as null|anything in list(RADIO_CHANNEL_CENTCOM, RADIO_CHANNEL_SYNDICATE, RADIO_CHANNEL_SOLGOV, RADIO_CHANNEL_INTEQ, RADIO_CHANNEL_MINUTEMEN)		//WS Edit - SolGov Rep
+		sender = input("Who is the message from?", "Sender") as null|anything in list(RADIO_CHANNEL_CENTCOM, RADIO_CHANNEL_SYNDICATE, RADIO_CHANNEL_SOLGOV, RADIO_CHANNEL_INTEQ, RADIO_CHANNEL_MINUTEMEN, "Outpost")		//WS Edit - SolGov Rep
 		if(!sender)
 			return
 		switch(sender)
@@ -75,6 +75,8 @@
 				sender = input("From what division?", "Minutemen") as null|anything in list("Colonial Minutemen Headquarters", "The Galactic Optium Labor Divison", "The Biohazard Assesment and Removal Division")
 			if (RADIO_CHANNEL_INTEQ)
 				sender = "Inteq Risk Management"
+			if ("Outpost")
+				sender = "Outpost Authority"
 		if(!sender)
 			return
 	message_admins("[key_name_admin(src)] has started answering [key_name_admin(H)]'s [sender] request.")

--- a/code/modules/clothing/outfits/ert/indie_ert.dm
+++ b/code/modules/clothing/outfits/ert/indie_ert.dm
@@ -14,6 +14,15 @@
 	belt = /obj/item/storage/belt/security/full
 	id = /obj/item/card/id
 
+/datum/outfit/job/independent/ert/post_equip(mob/living/carbon/human/H, visualsOnly, client/preference_source)
+	. = ..()
+	if(visualsOnly)
+		return
+
+	var/I = H.wear_id
+	if(I)
+		I.access += ACCESS_CENT_GENERAL
+
 /datum/outfit/job/independent/ert/emt
 	name = "ERT - Independent Paramedic"
 	jobtype = /datum/job/paramedic

--- a/code/modules/clothing/outfits/ert/indie_ert.dm
+++ b/code/modules/clothing/outfits/ert/indie_ert.dm
@@ -19,9 +19,8 @@
 	if(visualsOnly)
 		return
 
-	var/I = H.wear_id
-	if(I)
-		I.access += ACCESS_CENT_GENERAL
+	var/obj/item/card/id/W = H.wear_id
+	W.access += list(ACCESS_CENT_GENERAL)
 
 /datum/outfit/job/independent/ert/emt
 	name = "ERT - Independent Paramedic"

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -66,13 +66,13 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 
 /datum/outfit/job/inteq/captain/honorable/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
 	if(visualsOnly)
 		return
 
 	var/obj/item/card/id/W = H.wear_id
 	W.assignment = "Honorable Vanguard"
 	W.update_label()
-	..()
 
 ///Chief Engineer
 

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -59,7 +59,7 @@
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
 		list(fax_name = "Nanotrasen Central Command", fax_id = "nanotrasen", color = "green", emag_needed = FALSE),
-		list(fax_name = "Outpost Authority", fax_id = "outpost", color = "orange", emag_needed = FALSE)
+		list(fax_name = "Outpost Authority", fax_id = "outpost", color = "orange", emag_needed = FALSE),
 		list(fax_name = "IRMG Mothership", fax_id = "inteq", color = "yellow", emag_needed = FALSE),
 		list(fax_name = "Solarian Confederation Frontier Affairs", fax_id = "solgov", color = "teal", emag_needed = FALSE),
 		list(fax_name = "Roumain Council of Huntsmen", fax_id = "roumain", color = "brown", emag_needed = FALSE),
@@ -506,6 +506,11 @@
 	radio_channel = RADIO_CHANNEL_CENTCOM
 	visible_to_network = FALSE
 	admin_fax_id = "nanotrasen"
+
+/obj/machinery/fax/admin/outpost
+	name = "Outpost Fax Machine"
+	fax_name = "Outpost Authority"
+	admin_fax_id = "outpost"
 
 /obj/machinery/fax/admin/solgov
 	name = "SolGov Frontier Affairs Fax Machine"

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -59,6 +59,7 @@
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
 		list(fax_name = "Nanotrasen Central Command", fax_id = "nanotrasen", color = "green", emag_needed = FALSE),
+		list(fax_name = "Outpost Authority", fax_id = "outpost", color = "orange", emag_needed = FALSE)
 		list(fax_name = "IRMG Mothership", fax_id = "inteq", color = "yellow", emag_needed = FALSE),
 		list(fax_name = "Solarian Confederation Frontier Affairs", fax_id = "solgov", color = "teal", emag_needed = FALSE),
 		list(fax_name = "Roumain Council of Huntsmen", fax_id = "roumain", color = "brown", emag_needed = FALSE),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title. Fixes #2707 
![imagen](https://github.com/shiptest-ss13/Shiptest/assets/75212565/8ddf14d5-a002-4deb-9bba-0f60e0cb9b0c)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I appreciate how mobile the place allows one to be, but being able to barge into what is normally behind admin-only shutters is a bad idea. 

Fixes good. Outpost officers should be able to access their own outpost.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Outpost Authority fax
add: ERT Spawns at NT Outpost
tweak: Indie ERTs should now spawn with outpost access
fix: The fake door leading to the indie outpost security's area has been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
