### PR TITLE
Doubles time limits for all missions (except fishing ones)

### DIFF
--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -72,7 +72,7 @@
 	name = "Diamond needed (urgent!!)"
 	weight = 3
 	value = 700
-	duration = 20 MINUTES
+	duration = 40 MINUTES
 	dur_mod_range = 0.2
 	container_type = /obj/item/storage/box/true_love
 	objective_type = /obj/item/stack/sheet/mineral/diamond
@@ -115,7 +115,7 @@ Acquire: Anomaly
 	name = "Anomaly core requested"
 	weight = 8
 	value = 3000
-	duration = 40 MINUTES
+	duration = 80 MINUTES
 	dur_mod_range = 0.2
 	container_type = /obj/item/storage/box/anomaly
 	objective_type = /obj/item/assembly/signaler/anomaly
@@ -149,7 +149,7 @@ Acquire: Anomaly
 	desc = "I require a live goliath for research purposes. Trap one within the given \
 			Lifeform Containment Unit and return it to me and you will be paid handsomely."
 	value = 1500
-	duration = 30 MINUTES
+	duration = 60 MINUTES
 	weight = 6
 	container_type = /obj/structure/closet/mob_capture
 	objective_type = /mob/living/simple_animal/hostile/asteroid/goliath

--- a/code/modules/overmap/missions/research_mission.dm
+++ b/code/modules/overmap/missions/research_mission.dm
@@ -4,7 +4,7 @@
 			Please anchor the attached sensor array to your ship and fly it through the storms.\
 			It must be powered to collect the data. "
 	value = 3000 // base value, before adding bonus for number of things to fly through
-	duration = 30 MINUTES
+	duration = 60 MINUTES
 	weight = 8
 
 	var/datum/overmap/objective_type = /datum/overmap/event/electric


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Current missions aren't built to be rushed, they're built surrounding planetary/space exploration and short time limits detract from that by forcing everyone to rush or lose the mission. 30 minutes plus or minus a bit isn't enough to reliably explore/interact/etc and get back to the station.

Also makes urgent delivery missions reasonably possible without pre-collecting the stuff they need.

## Why It's Good For The Game

Let me explore damnit

## Changelog

:cl:
tweak: missions outside of the fishing missions have had their time limits doubled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
