### PR TITLE
Temporarily Comments out Fishing Quests

### DIFF
--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -212,8 +212,7 @@ Acquire: Anomaly
 	objective_type = /mob/living/simple_animal/bot/firebot/rockplanet
 
 /*
-		Acquire: Fishing
-*/
+		Acquire: Fishing //Fishing currently doesn't work at all so commenting these out until it's fixed so they don't clog the mission console.
 
 /datum/mission/acquire/aquarium
 	name = "Fish needed for my aquarium"
@@ -288,6 +287,7 @@ Acquire: Anomaly
 	var/mob/creature = target
 	if(creature.stat == DEAD)
 		return 0
+*/
 
 /*
 		Acquiry mission containers


### PR DESCRIPTION
## About The Pull Request

Comments out fishing quests from the outpost communications console. The code is still there it's just not active.

## Why It's Good For The Game

Fishing in general doesn't work on live despite working perfectly well on private servers. As far as I know nobody knows why.

Currently the missions tab in the outpost communications console is clogged with fish retrieval missions you can't complete. Players who don't know this only take the missions to buy fishing supplies and fly to planets only to realize fishing doesn't work. Players who do know this accept the missions and immediately give them up to clear up the list in hopes of getting missions that are actually possible to complete.

## Changelog

:cl:
code: comments out fishing missions
:cl: