### PR TITLE
buffs lp engineer radres

### DIFF
--- a/code/game/MapData/shuttles/nanotrasen_ranger.dm
+++ b/code/game/MapData/shuttles/nanotrasen_ranger.dm
@@ -127,7 +127,7 @@
 	item_state = "hardsuit0-ert_security"
 
 /obj/item/clothing/suit/space/hardsuit/ert/lp/engi
-	armor = list("melee" = 30, "bullet" = 15, "laser" = 15, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 100, "acid" = 75)
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 15, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 100, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/lp/engi
 	name = "Loss Prevention Engineering Hardsuit"
 	desc = "The best of the best engineering staff get assigned to the ERT. Second best are given this Hardsuit as a part of the LP Team."
@@ -135,7 +135,7 @@
 	item_state = "ert_engineer"
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/lp/engi
-	armor = list("melee" = 30, "bullet" = 15, "laser" = 15, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 100, "acid" = 75)
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 15, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 100, "acid" = 75)
 	name = "Loss Prevention Engineering Hardsuit Helmet"
 	desc = "The helmet that comes attached to the LP Team Engineering Hardsuit."
 	icon_state = "hardsuit0-ert_engineer"


### PR DESCRIPTION

## About The Pull Request
buffs lp engineer radres
## Why It's Good For The Game
it was less than regular engineer hardsuit before now its normal

## Changelog

:cl:

balance: Slightly improves engineering Loss Prevention hardsuits against radiation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
