### PR TITLE
Slightly buffs bolt-action rifles

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -10,7 +10,7 @@
 /obj/projectile/bullet/a8_50r
 	name = "8x50mmR bullet"
 	speed = 0.3
-	damage = 30
+	damage = 35
 	armour_penetration = 40
 
 // .300 Magnum (Smile Rifle)
@@ -18,7 +18,7 @@
 /obj/projectile/bullet/a300
 	name = ".300 Magnum bullet"
 	speed = 0.3
-	damage = 40
+	damage = 45
 	stamina = 10
 	armour_penetration = 40
 
@@ -63,7 +63,7 @@
 /obj/projectile/bullet/a858
 	name = "8x58mm caseless bullet"
 	speed = 0.3
-	damage = 30
+	damage = 35
 	armour_penetration = 40
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 5 damage to the bolt-action rifle cartridges (8x50mmR, .300 Magnum, and 8x58mm Caseless).

## Why It's Good For The Game

Complaints about the bolt actions feeling weak have been a thing for a while and will probably continue, but at least now they do get slightly higher damage than the existing .30 caliber cartridges such as .308 to account for the fact that they fire heavier projectiles.

No, I won't make any of them break the 50 damage threshold without hollow point- breaking the 2-shots-to-kill threshold is something pretty much no typical ballistic weapon should do without some special considerations (shotguns at point blank, hollow point ammo) or being an event-only weapon (.50 BMG).

## Changelog

:cl:
balance: Slightly increased damage on bolt action rifles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
