### PR TITLE
Removes roundstart maid outfits

### DIFF
--- a/_maps/shuttles/independent/independent_beluga.dmm
+++ b/_maps/shuttles/independent/independent_beluga.dmm
@@ -3342,7 +3342,6 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
-/obj/item/clothing/gloves/combat/maid/inteq,
 /obj/item/clothing/under/suit/charcoal,
 /obj/item/clothing/glasses/monocle,
 /obj/item/clothing/shoes/laceup{
@@ -3453,10 +3452,6 @@
 /obj/item/storage/box/mousetraps{
 	pixel_y = -3;
 	pixel_x = -9
-	},
-/obj/item/storage/box/maid{
-	pixel_x = -9;
-	pixel_y = 8
 	},
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/crew/dorm)

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -1205,7 +1205,6 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/bin,
-/obj/item/storage/box/inteqmaid,
 /obj/item/trash/chips,
 /obj/item/trash/energybar,
 /obj/item/trash/cheesie,

--- a/_maps/shuttles/nanotrasen/nanotrasen_skipper.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_skipper.dmm
@@ -3710,7 +3710,6 @@
 /obj/structure/closet/cardboard{
 	name = "pranking materials"
 	},
-/obj/item/storage/box/maid,
 /obj/item/toy/katana,
 /obj/item/bikehorn,
 /obj/item/grown/bananapeel,

--- a/_maps/shuttles/syndicate/syndicate_aegis.dmm
+++ b/_maps/shuttles/syndicate/syndicate_aegis.dmm
@@ -2047,18 +2047,11 @@
 /area/ship/engineering)
 "rf" = (
 /obj/structure/table,
-/obj/item/storage/box/maid{
-	pixel_x = -5;
-	pixel_y = 7
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/bedsheetbin,
-/obj/item/storage/box/maid{
-	pixel_x = 6
-	},
 /obj/machinery/light_switch{
 	pixel_y = 22
 	},

--- a/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
@@ -992,10 +992,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/item/clothing/under/syndicate/skirt/maid,
-/obj/item/clothing/gloves/combat/maid,
-/obj/item/clothing/head/maidheadband/syndicate,
-/obj/item/clothing/accessory/maidapron/syndicate,
 /obj/structure/closet/crate/secure/loot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -67,10 +67,6 @@
 	description = "Only the truly insane would wear this around their neck."
 	path = /obj/item/clothing/neck/petcollar
 
-/datum/gear/accessory/maidneckpiece
-	display_name = "maid neckpiece"
-	path = /obj/item/clothing/neck/maid
-
 /datum/gear/accessory/gloves/black
 	display_name = "black gloves"
 	description = "Standard hand coverings for everyday use."
@@ -85,11 +81,6 @@
 	display_name = "evening gloves"
 	description = "Excessively fancy elbow-length gloves."
 	path = /obj/item/clothing/gloves/color/evening
-	slot = ITEM_SLOT_GLOVES
-
-/datum/gear/accessory/gloves/maid
-	display_name = "maid arm covers"
-	path = /obj/item/clothing/gloves/maid
 	slot = ITEM_SLOT_GLOVES
 
 /datum/gear/accessory/tiki

--- a/code/modules/client/loadout/loadout_hat.dm
+++ b/code/modules/client/loadout/loadout_hat.dm
@@ -80,10 +80,6 @@
 	display_name = "top hat"
 	path = /obj/item/clothing/head/that
 
-/datum/gear/hat/maidheadband
-	display_name = "maid headband"
-	path = /obj/item/clothing/head/maidheadband
-
 /datum/gear/hat/fedora
 	display_name = "fedora"
 	path = /obj/item/clothing/head/fedora

--- a/code/modules/client/loadout/loadout_uniform.dm
+++ b/code/modules/client/loadout/loadout_uniform.dm
@@ -241,7 +241,3 @@
 /datum/gear/uniform/tacticool
 	display_name = "tacticool turtleneck"
 	path = /obj/item/clothing/under/syndicate/tacticool
-
-/datum/gear/uniform/maid
-	display_name = "maid dress"
-	path = 	/obj/item/clothing/under/costume/maid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes maid outfits from loadouts, as well as from a variety of faction maps. The remaining ones are only on RP-focused independent ships and event ships.

## Why It's Good For The Game

Lorema + admin request. Please be at least a little normal.

## Changelog

:cl:
del: Removed maid outfits from loadouts and faction ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
