### PR TITLE
Kills combat knife crate and replaces it with survival knives

### DIFF
--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -66,7 +66,7 @@
 /datum/supply_pack/sec_supply/combatknives
 	name = "Combat Knives Crate"
 	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
-	cost = 2500
+	cost = 1000
 	contains = list(/obj/item/kitchen/knife/combat,
 					/obj/item/kitchen/knife/combat,
 					/obj/item/kitchen/knife/combat)

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -67,9 +67,9 @@
 	name = "Combat Knives Crate"
 	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
 	cost = 1000
-	contains = list(/obj/item/kitchen/knife/combat,
-					/obj/item/kitchen/knife/combat,
-					/obj/item/kitchen/knife/combat)
+	contains = list(/obj/item/kitchen/knife/combat/survival,
+					/obj/item/kitchen/knife/combat/survival,
+					/obj/item/kitchen/knife/combat/survival)
 	crate_name = "combat knife crate"
 
 /datum/supply_pack/sec_supply/fire

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -66,7 +66,7 @@
 /datum/supply_pack/sec_supply/combatknives
 	name = "Combat Knives Crate"
 	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
-	cost = 1000
+	cost = 500
 	contains = list(/obj/item/kitchen/knife/combat/survival,
 					/obj/item/kitchen/knife/combat/survival,
 					/obj/item/kitchen/knife/combat/survival)

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -63,9 +63,9 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
-/datum/supply_pack/sec_supply/combatknives
-	name = "Combat Knives Crate"
-	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
+/datum/supply_pack/sec_supply/survknives
+	name = "Survival Knives Crate"
+	desc = "Contains three sharpened survival knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
 	cost = 500
 	contains = list(/obj/item/kitchen/knife/combat/survival,
 					/obj/item/kitchen/knife/combat/survival,


### PR DESCRIPTION
## About The Pull Request
As the name says!!!!!
## Why It's Good For The Game
Holdover from TG, massively overpriced for today's shiptest and combat knives are being kept as a higher-tier loot item.
## Changelog

:cl:

balance: Changes combat knives in cargo to survival knives and cheapens their crate.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
