### PR TITLE
Tweaks glasses colors.

### DIFF
--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -170,10 +170,10 @@
 	colour = "#ffff66"
 
 /datum/client_colour/glass_colour/red
-	colour = "#ffbfbf"
+	colour = "#ffbfcf"
 
 /datum/client_colour/glass_colour/darkred
-	colour = "#eeaaaa"
+	colour = "#e5a5b5"
 
 /datum/client_colour/glass_colour/orange
 	colour = "#ffbb99"

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -170,10 +170,10 @@
 	colour = "#ffff66"
 
 /datum/client_colour/glass_colour/red
-	colour = "#ffbbbb"
+	colour = "#ffbfbf"
 
 /datum/client_colour/glass_colour/darkred
-	colour = "#ee9999"
+	colour = "#eeaaaa"
 
 /datum/client_colour/glass_colour/orange
 	colour = "#ffbb99"

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -170,10 +170,10 @@
 	colour = "#ffff66"
 
 /datum/client_colour/glass_colour/red
-	colour = "#ffaaaa"
+	colour = "#ffbbbb"
 
 /datum/client_colour/glass_colour/darkred
-	colour = "#bb5555"
+	colour = "#ee9999"
 
 /datum/client_colour/glass_colour/orange
 	colour = "#ffbb99"
@@ -182,7 +182,10 @@
 	colour = "#ffddaa"
 
 /datum/client_colour/glass_colour/purple
-	colour = "#ff99ff"
+	colour = "#ffbbff"
+
+/datum/client_colour/glass_colour/darkpurple
+	colour = "#dd99dd"
 
 /datum/client_colour/glass_colour/gray
 	colour = "#cccccc"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -39,6 +39,12 @@
 	. = ..()
 	if(. && user)
 		user.update_sight()
+		if(icon_state == "welding-g")
+			change_glass_color(user, /datum/client_colour/glass_colour/gray)
+		else if(icon_state == "bustin-g")
+			change_glass_color(user, /datum/client_colour/glass_colour/green)
+		else
+			change_glass_color(user, null)
 
 //called when thermal glasses are emped.
 /obj/item/clothing/glasses/proc/thermal_overload()
@@ -238,6 +244,7 @@
 	icon_state = "sunhudbeer"
 	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion."
 	clothing_flags = SCAN_REAGENTS
+	glass_colour_type = /datum/client_colour/glass_colour/orange
 
 /obj/item/clothing/glasses/sunglasses/reagent/equipped(mob/user, slot)
 	. = ..()
@@ -253,6 +260,7 @@
 	icon_state = "sunhudsci"
 	desc = "A pair of tacky purple sunglasses that allow the wearer to recognize various chemical compounds with only a glance."
 	clothing_flags = SCAN_REAGENTS
+	glass_colour_type = /datum/client_colour/glass_colour/darkpurple
 
 /obj/item/clothing/glasses/sunglasses/garb
 	name = "black gar glasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -92,6 +92,7 @@
 	item_state = "glasses"
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1
+	glass_colour_type = /datum/client_colour/glass_colour/orange
 
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"
@@ -260,6 +261,7 @@
 	icon_state = "inteq_goggles"
 	item_state = "inteq_goggles"
 	supports_variations = KEPORI_VARIATION
+	glass_colour_type = /datum/client_colour/glass_colour/orange
 
 /obj/item/clothing/glasses/hud/health/prescription
 	name = "prescription health scanner HUD"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks the colors that show after you alt+click glasses.

To expand more, this PR:
1. Tweaks red, dark red and purple to be easier on the eyes.
2. Makes inteq ballistic HUD orange instead of dark red.
3. Makes beer goggles and science sunglasses have unique colors - they were just regular dark before.
4. Makes diagnostic HUD sunglasses a darker shade of orange than regular HUD.
5. Makes it so that welding goggles that are pushed away don't apply their dark effect.

**Quickly put together images of color tweaks:**
security HUD sunglasses:
![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/b3353b85-d8d9-4b76-8fac-fcbe8423c99a)
security HUD (normal)
![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/49af4b29-943f-4ff1-a6e9-4ae1a316fe6f)
science goggles:
![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/1facce56-f24c-4667-ad88-898431aa580e)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. This hurts to look at.
![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/96813579-b0a4-4724-9e9e-b9ee91e61f3d)
2. Sprite is very much orange, you'd expect them to also be.
3. Inconsistent behaviour + it's cool.
4. Inconsistent behaviour - all the other sunglasses variants are darker.
5. Kinda silly that goggles on your forehead made your vision worse.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: SecHud, SecHud Sunglasses and Science Hud now have less intense colors after alt+clicking.
tweak: Welding goggles that are not in use don't apply their effect on alt+click anymore.
tweak: Inteq Ballistic Hud, Science Sunglasses, Diagnostic Sunglasses and Beer Goggles now get proper colors after alt+clicking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
