### PR TITLE
Adds the ability for admins to bar ship docking permission in the event someone knows what they did.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -551,7 +551,9 @@ SUBSYSTEM_DEF(shuttle)
 					message_admins("[key_name_admin(user)] unblocked [port_ship] from [please_leave].")
 					log_admin("[key_name_admin(user)] unblocked [port_ship] from [please_leave].")
 				return TRUE
-			var/reason = input(user, "Provide a reason for blacklisting, which will be displayed on docking attempts", "Bar Them From The Pearly Gates", "Contact local law enforcement for more information.")
+			var/reason = input(user, "Provide a reason for blacklisting, which will be displayed on docking attempts", "Bar Them From The Pearly Gates", "Contact local law enforcement for more information.") as null|text
+			if(!reason)
+				return TRUE
 			if(please_leave in port_ship.blacklisted) //in the event two admins are blacklisting a ship at the same time
 				if(tgui_alert(user, "Ship is already blacklisted, overwrite current reason with your own?", "I call the shots here", list("Yes", "No")) != "Yes")
 					return TRUE

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -536,6 +536,30 @@ SUBSYSTEM_DEF(shuttle)
 				user.client.debug_variables(port.current_ship)
 			return TRUE
 
+		if("blist")
+			var/obj/docking_port/mobile/port = locate(params["id"]) in mobile
+			if(!port || !port.current_ship)
+				return
+			var/datum/overmap/ship/controlled/port_ship = port.current_ship
+			var/temp_loc = input(user, "Select outpost to modify ship blacklist status for", "Get Em Outta Here") as null|anything in SSovermap.outposts
+			if(!temp_loc)
+				return
+			var/datum/overmap/outpost/please_leave = temp_loc
+			if(please_leave in port_ship.blacklisted)
+				if(tgui_alert(user, "Rescind ship blacklist?", "Maybe They Aren't So Bad", list("Yes", "No")) == "Yes")
+					port_ship.blacklisted &= ~please_leave
+					message_admins("[key_name_admin(user)] unblocked [port_ship] from [please_leave].")
+					log_admin("[key_name_admin(user)] unblocked [port_ship] from [please_leave].")
+				return TRUE
+			var/reason = input(user, "Provide a reason for blacklisting, which will be displayed on docking attempts", "Bar Them From The Pearly Gates", "Contact local law enforcement for more information.")
+			if(please_leave in port_ship.blacklisted) //in the event two admins are blacklisting a ship at the same time
+				if(tgui_alert(user, "Ship is already blacklisted, overwrite current reason with your own?", "I call the shots here", list("Yes", "No")) != "Yes")
+					return TRUE
+			port_ship.blacklisted[please_leave] = reason
+			message_admins("[key_name_admin(user)] blacklisted [port_ship] from landing at [please_leave] with reason: [reason]")
+			log_admin("[key_name_admin(user)] blacklisted [port_ship] from landing at [please_leave] with reason: [reason]")
+			return TRUE
+
 		if("fly")
 			for(var/obj/docking_port/mobile/M as anything in mobile)
 				if(REF(M) == params["id"])

--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -211,6 +211,9 @@
 		)
 		return FALSE
 
+	if(src in dock_requester.blacklisted)
+		return new /datum/docking_ticket(_docking_error = "Docking request denied: [dock_requester.blacklisted[src]]")
+
 	adjust_dock_to_shuttle(h_dock, dock_requester.shuttle_port)
 	return new /datum/docking_ticket(h_dock, src, dock_requester)
 

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -63,6 +63,9 @@
 	///Time that next job slot change can occur
 	COOLDOWN_DECLARE(job_slot_adjustment_cooldown)
 
+	///Stations the ship has been blacklisted from landing at, associative station = reason
+	var/list/blacklisted = list()
+
 /datum/overmap/ship/controlled/Rename(new_name, force = FALSE)
 	var/oldname = name
 	if(!..() || (!COOLDOWN_FINISHED(src, rename_cooldown) && !force))
@@ -128,6 +131,7 @@
 		QDEL_NULL(shipkey)
 	QDEL_LIST(manifest)
 	job_slots.Cut()
+	blacklisted.Cut()
 	for(var/a_key in applications)
 		if(isnull(applications[a_key]))
 			continue

--- a/tgui/packages/tgui/interfaces/ShuttleManipulator.js
+++ b/tgui/packages/tgui/interfaces/ShuttleManipulator.js
@@ -92,6 +92,15 @@ export const ShuttleManipulatorStatus = (props, context) => {
                   })
                 }
               />
+              <Button
+                content="BLIST"
+                key={shuttle.id}
+                onClick={() =>
+                  act('blist', {
+                    id: shuttle.id,
+                  })
+                }
+              />
             </Table.Cell>
             <Table.Cell>{shuttle.name}</Table.Cell>
             <Table.Cell>{shuttle.type}</Table.Cell>


### PR DESCRIPTION
## About The Pull Request

Blacklist button in shuttle manipulator. If someone is being naughty  they can be barred access from the station.

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/8ef2ff63-ac8d-4866-8679-44b01d61b19c)

## Why It's Good For The Game


https://github.com/shiptest-ss13/Shiptest/assets/24857008/88d765fc-6d0e-4cdb-935e-dd08646d2058


Judgement.

## Changelog

:cl:
add: admins can now blacklist ships, preventing them from docking at a station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
