### PR TITLE
Adds mini-eguns to the cargo market.

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -65,6 +65,14 @@
 					/obj/item/gun/energy/laser)
 	crate_name = "laser crate"
 
+/datum/supply_pack/gun/laser
+	name = "Mini Energy Gun Crate"
+	desc = "Contains two small, versatile energy guns, capable of firing both nonlethal and lethal blasts, but with a limited power cell."
+	cost = 1500
+	contains = list(/obj/item/gun/energy/e_gun/mini,
+					/obj/item/gun/energy/e_gun/mini)
+	crate_name = "laser crate"
+
 /datum/supply_pack/gun/energy
 	name = "Energy Guns Crate"
 	desc = "Contains two versatile energy guns, capable of firing both nonlethal and lethal blasts of light."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the name says.

## Why It's Good For The Game

Energy-based option for a sidearm. 
## Changelog

:cl:
add: Mini Energy Guns can now be bought at the outpost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
