### PR TITLE
Syndicate engineers now have GEC suits set as their alternate jumpsuit.

### DIFF
--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -954,6 +954,7 @@
 
 	id = /obj/item/card/id/syndicate_command/crew_id
 	uniform = /obj/item/clothing/under/syndicate/ngr
+	alt_uniform = /obj/item/clothing/under/syndicate/gec
 	accessory = /obj/item/clothing/accessory/armband/engine
 	glasses = /obj/item/clothing/glasses/sunglasses
 	shoes = /obj/item/clothing/shoes/jackboots
@@ -970,6 +971,7 @@
 	name = "Syndicate - Ship Engineer (GEC)"
 
 	uniform = /obj/item/clothing/under/syndicate/gec
+	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/hazard
 	head = /obj/item/clothing/head/hardhat
 	id = /obj/item/card/id/syndicate_command/crew_id
@@ -979,13 +981,13 @@
 
 	uniform = /obj/item/clothing/under/syndicate/gorlex
 	shoes = /obj/item/clothing/shoes/workboots
-	alt_uniform = null
 	glasses = null
 
 /datum/outfit/job/syndicate/engineer/twink
 	name = "Syndicate - Ship Engineer (Twinkleshine, GEC)"
 
 	uniform = /obj/item/clothing/under/syndicate/gec
+	alt_uniform = null
 	id = /obj/item/card/id/syndicate_command/crew_id/engi
 	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
 	ears = null

--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -1022,6 +1022,7 @@
 	name = "Syndicate - Ship Engineer (SUNS)"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/workerjumpsuit
+	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/suns/workervest
 	gloves = /obj/item/clothing/gloves/suns/yellow
 	shoes = /obj/item/clothing/shoes/jackboots/suns

--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -1022,7 +1022,6 @@
 	name = "Syndicate - Ship Engineer (SUNS)"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/workerjumpsuit
-	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/suns/workervest
 	gloves = /obj/item/clothing/gloves/suns/yellow
 	shoes = /obj/item/clothing/shoes/jackboots/suns


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cybersun (Kansatu), SUNS (Aegis) and NGR (Hyena) engineers/mechanics now start with GEC jumpsuits, **if** you have the "alternate jumpsuit" option selected in the loadout.
![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/2feb8053-bf94-4720-a76a-ddca3166341c) ![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/71051874-7733-4846-b7da-71b2c3aceb3d) ![obraz](https://github.com/shiptest-ss13/Shiptest/assets/108196626/301a2327-a291-4c6d-8843-1e290a3fcf38)

Also, this change does not apply to the Hardliners, as I'm not sure if they would hire GEC engis. Correct me on that if I'm wrong.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is said in lore that those factions tend to hire GEC workers, but there wasn't really anything to back it up in game.
It's also a treat for all the GEC characters. The ability to show their true colors on board of other faction's ships.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Alternate jumpsuits for Cybersun, SUNS and NGR engineers/mechanics are now GEC uniforms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
