### PR TITLE
Play local sound volume

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -45,9 +45,10 @@
 	if(!check_rights(R_SOUND))
 		return
 
+	var/vol = input("Select a volume for the sound", "Volume") as null|anything in list(100, 75, 50, 25, 5)
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]")
-	playsound(get_turf(src.mob), S, 50, FALSE, FALSE)
+	playsound(get_turf(src.mob), S, vol, FALSE, FALSE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/play_direct_mob_sound(S as sound, mob/M)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -45,7 +45,7 @@
 	if(!check_rights(R_SOUND))
 		return
 
-	var/vol = input("Select a volume for the sound", "Volume") as null|anything in list(100, 75, 50, 25, 5)
+	var/vol = input("Select a volume for the sound", "Play Local Sound", 50) as num
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]")
 	playsound(get_turf(src.mob), S, vol, FALSE, FALSE)


### PR DESCRIPTION
## About The Pull Request

Adds volume settings for Fun>Play local music
![image](https://github.com/MysticalFaceLesS/Shiptest/assets/105150564/e2b931fd-82cf-47ff-8b62-fbbd44d6a477)

## Why It's Good For The Game

Just imagine how good this is to not change volume of each track by yourself in some adobe audition.

## Changelog

:cl:
add: volume setting for play local sound
/:cl: