### PR TITLE
Crashes the Stock Parts Market

### DIFF
--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -18,8 +18,8 @@
 
 /datum/supply_pack/machinery/t1
 	name = "T1 parts crate"
-	desc = "A bundle of basic machine parts, containing 3 of each common part type."
-	cost = 1500
+	desc = "A bundle of basic machine parts, containing 3 of each common part type for when you're too lazy to print them yourself."
+	cost = 500
 	contains = list(/obj/item/storage/box/stockparts/basic)
 	crate_name = "\improper T2 parts crate"
 	crate_type = /obj/structure/closet/crate
@@ -27,7 +27,7 @@
 /datum/supply_pack/machinery/t2
 	name = "T2 parts crate"
 	desc = "A bundle of advanced machine parts, containing 2 of each common part type."
-	cost = 5000
+	cost = 1500
 	contains = list(/obj/item/storage/box/stockparts/t2)
 	crate_name = "\improper T2 parts crate"
 	crate_type = /obj/structure/closet/crate/science
@@ -35,17 +35,19 @@
 /datum/supply_pack/machinery/t3
 	name = "T3 parts crate"
 	desc = "A bundle of high-tech machine parts, containing 2 of each common part type."
-	cost = 13000
+	cost = 3000
 	contains = list(/obj/item/storage/box/stockparts/t3)
 	crate_name = "\improper T3 parts crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/machinery/power
 	name = "Power Cell Crate"
-	desc = "Looking for power overwhelming? Look no further. Contains three high-voltage power cells."
+	desc = "Looking for power overwhelming? Look no further. Contains five high-voltage power cells."
 	cost = 1000
 	contains = list(/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high,
+					/obj/item/stock_parts/cell/high
+					/obj/item/stock_parts/cell/high
 					/obj/item/stock_parts/cell/high)
 	crate_name = "power cell crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -21,7 +21,7 @@
 	desc = "A bundle of basic machine parts, containing 3 of each common part type for when you're too lazy to print them yourself."
 	cost = 500
 	contains = list(/obj/item/storage/box/stockparts/basic)
-	crate_name = "\improper T2 parts crate"
+	crate_name = "\improper stock parts crate"
 	crate_type = /obj/structure/closet/crate
 
 /datum/supply_pack/machinery/t2
@@ -29,7 +29,7 @@
 	desc = "A bundle of advanced machine parts, containing 2 of each common part type."
 	cost = 1500
 	contains = list(/obj/item/storage/box/stockparts/t2)
-	crate_name = "\improper T2 parts crate"
+	crate_name = "\improper stock parts crate"
 	crate_type = /obj/structure/closet/crate/science
 
 /datum/supply_pack/machinery/t3
@@ -37,7 +37,7 @@
 	desc = "A bundle of high-tech machine parts, containing 2 of each common part type."
 	cost = 3000
 	contains = list(/obj/item/storage/box/stockparts/t3)
-	crate_name = "\improper T3 parts crate"
+	crate_name = "\improper stock parts crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/machinery/power
@@ -46,8 +46,8 @@
 	cost = 1000
 	contains = list(/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high
-					/obj/item/stock_parts/cell/high
+					/obj/item/stock_parts/cell/high,
+					/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high)
 	crate_name = "power cell crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical


### PR DESCRIPTION
## About The Pull Request

Greatly lowers the prices of the stock parts crates and increases the amount of power cells in the power cell crate.

## Why It's Good For The Game

"Hmm today I will purchase two each of T3 stock parts not including cells for the very reasonable price of 13,000 credits. Then I will order a crate of T2 stock parts for a thrifty 5,000 credits."
 ~ Nobody Ever

## Changelog

:cl:
balance: lowered stock parts prices and raised power cell count in the outpost communications console
:cl:
