### PR TITLE
Adds a few extra engineering crates

### DIFF
--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -264,7 +264,7 @@
 /datum/supply_pack/machinery/teg
 	name = "Thermoelectric Generator Crate"
 	desc = "Turn heat into electricity! Warranty void if sneezed upon."
-	cost = 4000
+	cost = 5000
 	contains = list(/obj/item/circuitboard/machine/generator,
 					/obj/item/circuitboard/machine/circulator,
 					/obj/item/circuitboard/machine/circulator)

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -201,7 +201,7 @@
 	desc = "A crate containing a plasma thruster and its heater's electronics. For when you need a lot of extra thrust."
 	cost = 1500
 	contains = list(/obj/item/circuitboard/machine/shuttle/heater,
-					/obj/item/circuitboard/machine/shuttle/engine/fueled/plasma)
+					/obj/item/circuitboard/machine/shuttle/engine/plasma)
 	crate_name = "plasma thruster crate"
 	crate_type = /obj/structure/closet/crate/engineering
 

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -154,6 +154,15 @@
 	crate_name = "shield generators crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
+/datum/supply_pack/machinery/holofield_generator
+	name = "Holofield Generator Crate"
+	desc = "Contains the electronics you need to set up a new (or replacement) holofield! Buttons not included."
+	cost = 1000
+	contains = list(/obj/item/circuitboard/machine/shieldwallgen/atmos,
+					/obj/item/circuitboard/machine/shieldwallgen/atmos)
+	crate_name = "holofield generator crate"
+	crate_type = /obj/structure/closet/crate/engineering
+
 /datum/supply_pack/machinery/blackmarket_telepad
 	name = "Black Market LTSRBT"
 	desc = "Need a faster and better way of transporting your illegal goods from and to the sector? Fear not, the Long-To-Short-Range-Bluespace-Transceiver (LTSRBT for short) is here to help. Contains a LTSRBT circuit, two bluespace crystals, and one ansible."
@@ -177,6 +186,24 @@
 		/obj/item/shuttle_creator
 	)
 	crate_name = "Shuttle in a Box"
+
+/datum/supply_pack/machinery/ion_thruster
+	name = "Ion Thruster Crate"
+	desc = "A crate containing an ion thruster and its precharger's electronics. For when you need a little extra thrust."
+	cost = 1500
+	contains = list(/obj/item/circuitboard/machine/shuttle/smes,
+					/obj/item/circuitboard/machine/shuttle/engine/electric)
+	crate_name = "ion thruster crate"
+	crate_type = /obj/structure/closet/crate/engineering
+
+/datum/supply_pack/machinery/plasma_thruster
+	name = "Plasma Thruster Crate"
+	desc = "A crate containing a plasma thruster and its heater's electronics. For when you need a lot of extra thrust."
+	cost = 1500
+	contains = list(/obj/item/circuitboard/machine/shuttle/heater,
+					/obj/item/circuitboard/machine/shuttle/engine/fueled/plasma)
+	crate_name = "plasma thruster crate"
+	crate_type = /obj/structure/closet/crate/engineering
 
 /datum/supply_pack/machinery/drill_crate
 	name = "Heavy duty laser mining drill"
@@ -237,11 +264,21 @@
 /datum/supply_pack/machinery/teg
 	name = "Thermoelectric Generator Crate"
 	desc = "Turn heat into electricity! Warranty void if sneezed upon."
-	cost = 5000
+	cost = 4000
 	contains = list(/obj/item/circuitboard/machine/generator,
 					/obj/item/circuitboard/machine/circulator,
 					/obj/item/circuitboard/machine/circulator)
 	crate_name = "thermoelectric generator crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/machinery/turbine
+	name = "Turbine Crate"
+	desc = "Contains the electronics needed for a turbine generator! Plasma gas not included."
+	cost = 4000
+	contains = list(/obj/item/circuitboard/machine/power_turbine,
+					/obj/item/circuitboard/machine/power_compressor,
+					/obj/item/circuitboard/computer/turbine_computer)
+	crate_name = "turbine crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/machinery/collector


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the following crates:
- Turbine Crate: Contains a power turbine, power compressor, and turbine computer board (4000 credits)
- Holofield Generator Crate: Contains two holofield generator boards (1000 credits)
- Ion Thruster Crate: Contains an ion thruster and an engine precharger board (1500 credits)
- Plasma Thruster Crate: Contains a plasma thruster and an engine heater board (1500 credits)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This permits ships without RnD to modify or repair themselves in the wake of RnD being cut from most places - holofield generators and thrusters are on basically every vessel, so it's not as though cutting-edge research is needed to make them. As for the turbine, making it available as a slightly-cheaper alternative to the TEG (especially with its rework which lets it produce thrust as well) for ships which can manage to source the plasma gas to fuel it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added turbine, holofield generator, ion thruster, and plasma thruster crates
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
