### PR TITLE
Removes the singularity, tesla and particle accelerator packs from cargo

### DIFF
--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -298,31 +298,9 @@
 	crate_name = "grounding rod crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/machinery/PA
-	name = "Particle Accelerator Crate"
-	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own particle accelerator! Ages 10 and up."
-	cost = 3000
-	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
-					/obj/machinery/particle_accelerator/control_box,
-					/obj/structure/particle_accelerator/particle_emitter/center,
-					/obj/structure/particle_accelerator/particle_emitter/left,
-					/obj/structure/particle_accelerator/particle_emitter/right,
-					/obj/structure/particle_accelerator/power_box,
-					/obj/structure/particle_accelerator/end_cap)
-	crate_name = "particle accelerator crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
 /*
 		Engine cores
 */
-
-/datum/supply_pack/machinery/sing_gen
-	name = "Singularity Generator Crate"
-	desc = "The key to unlocking the power of Lord Singuloth. Particle accelerator not included."
-	cost = 5000
-	contains = list(/obj/machinery/the_singularitygen)
-	crate_name = "singularity generator crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/machinery/supermatter_shard
 	name = "Supermatter Shard Crate"
@@ -330,13 +308,5 @@
 	cost = 10000
 	contains = list(/obj/machinery/power/supermatter_crystal/shard)
 	crate_name = "supermatter shard crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-
-/datum/supply_pack/machinery/tesla_gen
-	name = "Tesla Generator Crate"
-	desc = "The stabilized heart of a tesla engine. Particle accelerator not included."
-	cost = 6000
-	contains = list(/obj/machinery/the_singularitygen/tesla)
-	crate_name = "tesla generator crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The singularity, tesla, and particle accelerator can no longer be bought since the engines are either unbalanced or impossible to effectively use on most ships

## Why It's Good For The Game

The singularity can't be effectively fitted to any ship without building in hyperspace. Even if it is, it's going to irradiate/EMP everything in a large area, which likely means somewhere important

The tesla is just free infinite power if set up, which is boring. It doesn't have any upkeep and containment is extremely simple

The particle accelerator doesn't do anything except turn on and power those two engines

## Changelog

:cl:
del: The tesla, singularity, and particle generator are no longer purchasable from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
