### PR TITLE
Passive radiation structures/effects don't trigger if there are no players nearby

### DIFF
--- a/code/game/objects/effects/radiation.dm
+++ b/code/game/objects/effects/radiation.dm
@@ -19,7 +19,7 @@
 		return ..()
 
 	var/player_in_range = FALSE
-	for(var/mob/living/L in range(rad_spread * 2))
+	for(var/mob/living/L in range(rad_spread))
 		if(L.client)
 			player_in_range = TRUE
 			break

--- a/code/game/objects/effects/radiation.dm
+++ b/code/game/objects/effects/radiation.dm
@@ -25,7 +25,7 @@
 			break
 	if(!player_in_range)
 		return ..()
-	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
+	COOLDOWN_START(src, pulse_cooldown, rad_delay)
 	for(var/obj/O in range(rad_spread, src))
 		if(prob(rad_prob))
 			radiation_pulse(O, rad_power, rad_range)

--- a/code/game/objects/effects/radiation.dm
+++ b/code/game/objects/effects/radiation.dm
@@ -6,29 +6,39 @@
 	var/rad_power = 33
 	var/rad_range = 1 // !Range mod = rad dropoff speed
 	var/rad_spread = 6 // Range of nearby atoms to radiate
-	var/rad_delay = 20
 	var/rad_prob = 10
-	var/_pulse = 0 // Holds the world.time interval in process
+	COOLDOWN_DECLARE(pulse_cooldown)
+	var/rad_delay = 2 SECONDS
 
 /obj/effect/radiation/Initialize()
 	START_PROCESSING(SSobj, src)
 	. = ..()
 
 /obj/effect/radiation/process()
-	if(world.time > _pulse)
-		for(var/obj/O in range(rad_spread, src))
-			if(prob(rad_prob))
-				radiation_pulse(O, rad_power, rad_range)
-		_pulse = world.time + rad_delay
+	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
+		return ..()
+
+	var/player_in_range = FALSE
+	for(var/mob/living/L in range(rad_spread * 2))
+		if(L.client)
+			player_in_range = TRUE
+			break
+	if(!player_in_range)
+		return ..()
+	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
+	for(var/obj/O in range(rad_spread, src))
+		if(prob(rad_prob))
+			radiation_pulse(O, rad_power, rad_range)
+
 	..()
 
 /obj/effect/radiation/waste
 	rad_power = 33
-	rad_delay = 40
+	rad_delay = 4 SECONDS
 	rad_prob = 20
 	rad_spread = 3
 
 /obj/effect/radiation/waste/intense //3.6 roetgen. Not bad. Not good.
 	rad_power = 120
-	rad_delay = 80
+	rad_delay = 8 SECONDS
 	rad_prob = 10

--- a/code/game/objects/structures/radioactive.dm
+++ b/code/game/objects/structures/radioactive.dm
@@ -16,7 +16,7 @@
 	. = ..()
 
 /obj/structure/radioactive/process()
-	for(var/mob/living/L in range(5, src)
+	for(var/mob/living/L in range(5, src))
 		if(L.client)
 			Nuke()
 			break
@@ -79,5 +79,4 @@
 	anchored = TRUE
 	rad_power = 1200
 	rad_range = 0.2
-	rad_delay = 20
 	pulse_delay = 0.5 SECONDS

--- a/code/game/objects/structures/radioactive.dm
+++ b/code/game/objects/structures/radioactive.dm
@@ -9,7 +9,7 @@
 	var/rad_power = 100
 	var/rad_range = 1 // !Range mod = rad dropoff speed
 	COOLDOWN_DECLARE(pulse_cooldown)
-	var/pulse_delay = 2 SECONDS
+	var/rad_delay = 2 SECONDS
 
 /obj/structure/radioactive/Initialize()
 	START_PROCESSING(SSobj, src)
@@ -52,7 +52,7 @@
 	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
 		return
 
-	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
+	COOLDOWN_START(src, pulse_cooldown, rad_delay)
 	radiation_pulse(src, rad_power, rad_range)
 
 /obj/structure/radioactive/waste
@@ -62,7 +62,7 @@
 	anchored = TRUE
 	rad_power = 150
 	rad_range = 0.8
-	pulse_delay = 1 SECONDS
+	rad_delay = 1 SECONDS
 
 /obj/structure/radioactive/stack
 	name = "stack of nuclear waste"
@@ -70,7 +70,7 @@
 	icon_state = "barrel_3"
 	anchored = TRUE
 	rad_power = 300
-	pulse_delay = 1 SECONDS
+	rad_delay = 1 SECONDS
 
 /obj/structure/radioactive/supermatter
 	name = "decayed supermatter crystal"
@@ -79,4 +79,4 @@
 	anchored = TRUE
 	rad_power = 1200
 	rad_range = 0.2
-	pulse_delay = 0.5 SECONDS
+	rad_delay = 0.5 SECONDS

--- a/code/game/objects/structures/radioactive.dm
+++ b/code/game/objects/structures/radioactive.dm
@@ -8,19 +8,18 @@
 	density = TRUE
 	var/rad_power = 100
 	var/rad_range = 1 // !Range mod = rad dropoff speed
-	var/rad_delay = 20
-	var/rad_prob = 30
-	var/_pulse = 0 // Holds the world.time interval in process
+	COOLDOWN_DECLARE(pulse_cooldown)
+	var/pulse_delay = 2 SECONDS
 
 /obj/structure/radioactive/Initialize()
 	START_PROCESSING(SSobj, src)
 	. = ..()
 
 /obj/structure/radioactive/process()
-	if(world.time > _pulse)
-		if(prob(rad_prob))
+	for(var/mob/living/L in range(5, src)
+		if(L.client)
 			Nuke()
-		_pulse = world.time + rad_delay
+			break
 	..()
 
 /obj/structure/radioactive/bullet_act(obj/projectile/P)
@@ -50,6 +49,10 @@
 		Nuke()
 
 /obj/structure/radioactive/proc/Nuke(atom/movable/AM)
+	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
+		return
+
+	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
 	radiation_pulse(src, rad_power, rad_range)
 
 /obj/structure/radioactive/waste
@@ -59,7 +62,7 @@
 	anchored = TRUE
 	rad_power = 150
 	rad_range = 0.8
-	rad_prob = 50
+	pulse_delay = 1 SECONDS
 
 /obj/structure/radioactive/stack
 	name = "stack of nuclear waste"
@@ -67,7 +70,7 @@
 	icon_state = "barrel_3"
 	anchored = TRUE
 	rad_power = 300
-	rad_prob = 50
+	pulse_delay = 1 SECONDS
 
 /obj/structure/radioactive/supermatter
 	name = "decayed supermatter crystal"
@@ -77,4 +80,4 @@
 	rad_power = 1200
 	rad_range = 0.2
 	rad_delay = 20
-	rad_prob = 60
+	pulse_delay = 0.5 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Assuming some radiation comes from waste planets generating a bunch of radiation waves, and that there are a lot of radiation generating things players might not even be affected by, radiation/contamination can be reduced by preventing these from activating if they wouldn't affect a player

Also consolidates the random chance for a pulse to trigger into its timer for structures, since there's not much purpose to it

## Why It's Good For The Game

don't need to waste time with replicating radiation somewhere it's not going to end up doing anything

## Changelog

:cl:
tweak: radiation structures/effects only irradiate their surroundings if near a player
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
