### PR TITLE
Tweaks plasmasoul anomalies

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_plasmasoul.dm
+++ b/code/game/objects/effects/anomalies/anomalies_plasmasoul.dm
@@ -15,34 +15,48 @@
 		return
 
 	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
-	for(var/mob/living/mob in range(effectrange,src))
-		if(iscarbon(mob))
-			var/mob/living/carbon/target = mob
-			target.reagents?.add_reagent(/datum/reagent/toxin/plasma, reagent_amount)
-			to_chat(mob, span_warning("Your blood feels thick.."))
-			playsound(mob, 'sound/effects/bubbles.ogg', 50)
+	harm_surrounding_mobs()
 
 /obj/effect/anomaly/plasmasoul/Bumped(atom/movable/AM)
 	var/turf/open/spot = locate(rand(src.x-effectrange, src.x+effectrange), rand(src.y-effectrange, src.y+effectrange), src.z)
-	for(var/mob/living/mob in range(effectrange,src))
-		if(iscarbon(mob))
-			var/mob/living/carbon/target = mob
-			target.reagents?.add_reagent(/datum/reagent/toxin/plasma, reagent_amount)
-			to_chat(mob, span_warning("Your blood feels thick.."))
-			playsound(mob, 'sound/effects/bubbles.ogg', 50)
+	harm_surrounding_mobs()
 	if(istype(spot))
 		spot.atmos_spawn_air("plasma=300;TEMP=200")
 
+/obj/effect/anomaly/plasmasoul/proc/harm_surrounding_mobs()
+	for(var/mob/living/carbon/human/H in range(effectrange, src))
+
+		if(!(H.dna?.species.reagent_tag & PROCESS_ORGANIC))
+			H.adjustFireLoss(20)
+			to_chat(H, span_warning("Something bubbles and hisses under your plating..."))
+			playsound(H, 'sound/items/welder.ogg', 150)
+			continue
+
+		H.reagents?.add_reagent(/datum/reagent/toxin/plasma, reagent_amount)
+		to_chat(H, span_warning("Your blood feels thick..."))
+		playsound(H, 'sound/effects/bubbles.ogg', 50)
+
 /obj/effect/anomaly/plasmasoul/detonate()
-	for(var/mob/living/Mob in range(effectrange*2,src))
-		if(iscarbon(Mob))
-			var/mob/living/carbon/carbon = Mob
-			if(carbon.run_armor_check(attack_flag = "bio") <= 40)
-				carbon.reagents?.add_reagent(/datum/reagent/toxin/plasma, reagent_amount*3)
+	for(var/mob/living/carbon/human/H in range(effectrange*2, src))
+		if(H.run_armor_check(attack_flag = "bio") <= 40)
+			continue
+
+		if(!(H.dna?.species.reagent_tag & PROCESS_ORGANIC))
+			H.adjustFireLoss(60)
+			to_chat(H, span_warning("Plasma flashes and ignites inside of your chassis!"))
+			playsound(H, 'sound/items/welder.ogg', 150)
+			continue
+
+		H.reagents?.add_reagent(/datum/reagent/toxin/plasma, reagent_amount*3)
+		to_chat(H, span_warning("Your blood thickens and bubbles in your veins!"))
+		playsound(H, 'sound/effects/bubbles.ogg', 50)
+
 	var/turf/open/tile = get_turf(src)
+
 	if(istype(tile))
 		tile.atmos_spawn_air("o2=600;plasma=3000;TEMP=2000")
-	. = ..()
+
+	return ..()
 
 /obj/effect/anomaly/plasmasoul/planetary
 	immortal = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Resolves #2763 
Plasmasoul anomalies now check if a mob can process organic chemicals. If they cannot, as is the case with IPCs, instead of adding plasma to your system they burn you. Also cleans up the code a little bit - nothing else player-facing, though.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being forced to make a niche chemical (system cleaner) just to remove otherwise-permanent damage from even going near one of these is not fun, and being revived if you _die_ from it is even more difficult. Plasmasoul anomalies are still quite dangerous to IPCs, just in a more manageable (and fun) way.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Plasmasoul anomalies now burn IPCs instead of applying a toxin
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
