### PR TITLE
Adds more ways to ignite e-cigarettes.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -829,7 +829,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 ///////////////
 /obj/item/clothing/mask/vape
 	name = "\improper E-Cigarette"
-	desc = "A classy and highly sophisticated electronic cigarette, for classy and dignified gentlemen. A warning label reads \"Warning: Do not fill with flammable materials.\" Must be lit via interfacing with a PDA."//<<< i'd vape to that.
+	desc = "A classy and highly sophisticated electronic cigarette, for classy and dignified gentlemen. A warning label reads \"Warning: Do not fill with flammable materials.\" Can be lit via interfacing with a PDA, tablet computer, or an APC."//<<< i'd vape to that.
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "red_vapeoff"
 	item_state = "red_vapeoff"
@@ -891,7 +891,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(user, "<span class='warning'>[src] can't be modified!</span>")
 		else
 			..()
-	if(istype(O, /obj/item/pda)) //BeginWS edit - Lightable e-cigarettes
+	if(istype(O, /obj/item/pda) || istype(O, /obj/item/modular_computer/tablet)) //BeginWS edit - Lightable e-cigarettes
 		if(screw)
 			to_chat(user, "<span class='notice'>You need to close the cap first!</span>")
 			return
@@ -920,6 +920,30 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		user.update_inv_wear_mask()
 		user.update_inv_hands() //EndWS edit - Lightable e-cigarettes
 
+/obj/item/clothing/mask/vape/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if((!istype(target, /obj/machinery/power/apc)) || !ishuman(user) || !proximity_flag)
+		return ..()
+	if(screw)
+		to_chat(user, "<span class='notice'>You need to close the cap first!</span>")
+		return
+	on = !on
+	if(on)
+		user.visible_message(
+			"<span class='notice'>[user] turns on [user.p_their()] [src] with a holographic flame from the APC.</span>",
+			"<span class='notice'>You turn on your [src] with a holographic flame from the APC.</span>"
+		)
+		reagents.flags |= NO_REACT
+		icon_state = "[vapecolor]_vape"
+		item_state = "[vapecolor]_vape"
+	else
+		user.visible_message(
+			"<span class='notice'>[user] turns off [user.p_their()] [src] with a holographic gust from the APC.</span>",
+			"<span class='notice'>You turn off your [src] with a holographic gust from the APC.</span>"
+		)
+		reagents.flags &= NO_REACT
+		icon_state = "[vapecolor]_vapeoff"
+		item_state = "[vapecolor]_vapeoff"
+	src.update_icon_state()
 
 /obj/item/clothing/mask/vape/emag_act(mob/user)// I WON'T REGRET WRITTING THIS, SURLY.
 	if(screw)
@@ -1033,7 +1057,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/vape/cigar
 	name = "\improper E-Cigar"
-	desc = "The latest recreational device developed by a small tech startup, Shadow Tech, the E-Cigar has all the uses of a normal E-Cigarette, with the classiness of short fat cigar. Must be lit via interfacing with a PDA."
+	desc = "The latest recreational device developed by a small tech startup, Shadow Tech, the E-Cigar has all the uses of a normal E-Cigarette, with the classiness of short fat cigar. Can be lit via interfacing with a PDA, tablet computer, or an APC."
 	icon_state = "ecigar_vapeoff"
 	item_state = "ecigar_vapeoff"
 	vapecolor = "ecigar"

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -750,7 +750,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	overlay_state = "slime"
 	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/medicine/pyroxadone = 5)
 
-/obj/item/lighter/clockwork //WS edit: Clockwork Zippo, by Tergius. PR #395
+/obj/item/lighter/clockwork
 	name = "bronze zippo"
 	desc = "A zippo plated with brass. I mean bronze. Has a neat red flame!"
 	icon = 'icons/obj/cigarettes.dmi'
@@ -839,19 +839,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/vapetime = 0 //this so it won't puff out clouds every tick
 	var/screw = 0 // kinky
 	var/super = 0 //for the fattest vapes dude.
-	var/vapecolor //What color the vape should be. If this is not filled out it will automatically be set on Initialize() - WS edit - Lightable e-cigarettes
-	var/overlayname = "vape" //Used to decide what overlay sprites to use - WS edit - Lightable e-cigarettes
+	var/vapecolor //What color the vape should be. If this is not filled out it will automatically be set on Initialize()
+	var/overlayname = "vape" //Used to decide what overlay sprites to use
 
 /obj/item/clothing/mask/vape/Initialize(mapload, param_color)
 	. = ..()
 	create_reagents(chem_volume, NO_REACT)
 	reagents.add_reagent(/datum/reagent/drug/nicotine, 50)
-	if(!vapecolor) //BeginWS edit - Lightable e-cigarettes
+	if(!vapecolor)
 		if(!param_color)
 			param_color = pick("red","blue","black","white","green","purple","yellow","orange")
 		vapecolor = param_color
 	icon_state = "[vapecolor]_vapeoff"
-	item_state = "[vapecolor]_vapeoff" //EndWS edit - Lightable e-cigarettes
+	item_state = "[vapecolor]_vapeoff"
 
 /obj/item/clothing/mask/vape/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SCREWDRIVER)
@@ -863,11 +863,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(user, "<span class='notice'>You open the cap on [src].</span>")
 			reagents.flags |= OPENCONTAINER
 			if(obj_flags & EMAGGED)
-				add_overlay("[overlayname]open_high") //WS edit - lightable e-cigarettes
+				add_overlay("[overlayname]open_high")
 			else if(super)
-				add_overlay("[overlayname]open_med") //WS edit - lightable e-cigarettes
+				add_overlay("[overlayname]open_med")
 			else
-				add_overlay("[overlayname]open_low") //WS edit - lightable e-cigarettes
+				add_overlay("[overlayname]open_low")
 		else
 			screw = FALSE
 			to_chat(user, "<span class='notice'>You close the cap on [src].</span>")
@@ -880,18 +880,18 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				cut_overlays()
 				super = 1
 				to_chat(user, "<span class='notice'>You increase the voltage of [src].</span>")
-				add_overlay("[overlayname]open_med") //WS edit - lightable e-cigarettes
+				add_overlay("[overlayname]open_med")
 			else
 				cut_overlays()
 				super = 0
 				to_chat(user, "<span class='notice'>You decrease the voltage of [src].</span>")
-				add_overlay("[overlayname]open_low") //WS edit - lightable e-cigarettes
+				add_overlay("[overlayname]open_low")
 
 		if(screw && (obj_flags & EMAGGED))
 			to_chat(user, "<span class='warning'>[src] can't be modified!</span>")
 		else
 			..()
-	if(istype(O, /obj/item/pda) || istype(O, /obj/item/modular_computer/tablet)) //BeginWS edit - Lightable e-cigarettes
+	if(istype(O, /obj/item/pda) || istype(O, /obj/item/modular_computer/tablet))
 		if(screw)
 			to_chat(user, "<span class='notice'>You need to close the cap first!</span>")
 			return
@@ -918,7 +918,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			STOP_PROCESSING(SSobj, src)
 		src.update_icon_state()
 		user.update_inv_wear_mask()
-		user.update_inv_hands() //EndWS edit - Lightable e-cigarettes
+		user.update_inv_hands()
 
 /obj/item/clothing/mask/vape/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if((!istype(target, /obj/machinery/power/apc)) || !ishuman(user) || !proximity_flag)
@@ -952,7 +952,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			obj_flags |= EMAGGED
 			super = 0
 			to_chat(user, "<span class='warning'>You maximize the voltage of [src].</span>")
-			add_overlay("[overlayname]open_high") //WS edit - lightable e-cigarettes
+			add_overlay("[overlayname]open_high")
 			var/datum/effect_system/spark_spread/sp = new /datum/effect_system/spark_spread //for effect
 			sp.set_up(5, 1, src)
 			sp.start()
@@ -968,7 +968,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/vape/equipped(mob/user, slot)
 	. = ..()
-	if(slot == ITEM_SLOT_MASK) //BeginWS edit - Lightable e-cigarettes
+	if(slot == ITEM_SLOT_MASK)
 		if(on)
 			if(!screw)
 				to_chat(user, "<span class='notice'>You start puffing on \the [src].</span>")
@@ -976,7 +976,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			else //it will not start if the vape is opened.
 				to_chat(user, "<span class='warning'>You need to close the cap first!</span>")
 		else
-			to_chat(user, "<span class='notice'>You need to turn on \the [src] first!")	//EndWS edit - Lightable e-cigarettes
+			to_chat(user, "<span class='notice'>You need to turn on \the [src] first!")
 
 /obj/item/clothing/mask/vape/dropped(mob/user)
 	. = ..()
@@ -1023,7 +1023,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	//open flame removed because vapes are a closed system, they wont light anything on fire
 
 	if(super && vapetime > 3)//Time to start puffing those fat vapes, yo.
-		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new //BeginWS edit - Fix vape clouds
+		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new
 		var/datum/reagents/smokereagents = new
 		reagents.trans_to(smokereagents, reagents.total_volume / 10, 0.65)
 		s.set_up(smokereagents, 1, 24, loc)
@@ -1035,7 +1035,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		var/datum/reagents/smokereagents = new
 		reagents.trans_to(smokereagents, reagents.total_volume / 5, 0.75)
 		s.set_up(smokereagents, 4, 24, loc)
-		s.start() //EndWS edit - Fix vape clouds
+		s.start()
 		vapetime = 0
 		if(prob(5))//small chance for the vape to break and deal damage if it's emagged
 			playsound(get_turf(src), 'sound/effects/pop_expl.ogg', 50, FALSE)
@@ -1051,9 +1051,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(reagents && reagents.total_volume)
 		hand_reagents()
 
-/obj/item/clothing/mask/vape/examine(mob/user) //BeginWS edit - Lightable e-cigarettes
+/obj/item/clothing/mask/vape/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='notice>It is currently [on ? "on" : "off"].</span>") //EndWS edit - Lightable e-cigarettes
+	to_chat(user, "<span class='notice>It is currently [on ? "on" : "off"].</span>")
 
 /obj/item/clothing/mask/vape/cigar
 	name = "\improper E-Cigar"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Do you want your character to vape, but did they not spawn with a PDA? Well, worry not, this PR adds new ways to ignite your e-cigarettes/e-cigars!

First one, is with a tablet. Works essentially the same as with a PDA. There is way more jobs that get a free tablet than those that get a PDA. Plus, you can get those from loadout.

Second one, is with an APC. Smash your vape on the APC and it will get ignited! How does it work? Clearly designers were just very thoughtful and included a vape igniter or whatever you use!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Items being actually usable is nice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: E-cigarettes and e-cigars can now be turned on with tablets and APCs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
