### PR TITLE
Tweaks plasma thrusters

### DIFF
--- a/code/game/machinery/shuttle/shuttle_heater.dm
+++ b/code/game/machinery/shuttle/shuttle_heater.dm
@@ -102,7 +102,10 @@
 	var/datum/gas_mixture/air_contents = use_tank ? fuel_tank?.air_contents : airs[1]
 	if(!air_contents)
 		return
-	return air_contents.return_volume()
+	//Using the ideal gas law here - the pressure is 4500 because that's the limit of gas pumps, which most ships use on plasma thrusters
+	//If you refit your fuel system to use a volume pump or cool your plasma, you can have numbers over 100% on the helm as a treat
+	var/mole_capacity = (4500 * air_contents.return_volume()) / (R_IDEAL_GAS_EQUATION * T20C)
+	return mole_capacity
 
 /obj/machinery/atmospherics/components/unary/shuttle/heater/proc/update_gas_stats()
 	var/datum/gas_mixture/air_contents = use_tank ? fuel_tank?.air_contents : airs[1]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes how plasma thrusters calculate the maximum amount of fuel they can store. Instead of using the heater's volume, they now use an amount of moles based on standard conditions for plasma thrusters - if you cool down your plasma or refit your ship to more efficiently fill the thrusters than with a standard gas pump, you can still get numbers over 100% (just like you can with ion engines if you directly connect them to a grid).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Plasma thrusters showing like 180% with a default setup hurts my soul and is also pretty unintuitive. With these changes, you can still tweak your thrusters to be more efficient - for default plasma thrusters though, this makes their display more useful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Plasma thrusters now have a more sensible fuel readout
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
