### PR TITLE
Buckleable Stools

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -220,7 +220,7 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = FALSE
+	can_buckle = TRUE
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -220,7 +220,6 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = TRUE
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://github.com/shiptest-ss13/Shiptest/assets/86762641/7e625f17-8175-4057-833c-82c3f918f6ae)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Given Shiptest's takeoff/landing gameplay loop, it's important to have buckleable objects on a ship for all of your crew. 

The Aegis has an excess of bar stools and a lack of chairs. Players frequently replace the stools with chairs, or even couches, so the entire crew doesn't fall down whenever the ship moves. This loses quite a bit of flavor, and looks considerably more stupid.

Yes, this is a spite PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak:  you can now buckle to stools, just as the founding members of the SUNS intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
