### PR TITLE
Better Food Crates

### DIFF
--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -24,7 +24,7 @@
 
 /datum/supply_pack/food/pizza
 	name = "Pizza Crate"
-	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99% anomaly-free!"
+	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99.5% anomaly-free!"
 	cost = 6000 // Best prices this side of the galaxy.
 	contains = list(/obj/item/pizzabox/margherita,
 					/obj/item/pizzabox/mushroom,
@@ -48,38 +48,49 @@
 
 /datum/supply_pack/food/ingredients_basic
 	name = "Basic Ingredients Crate"
-	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, enzyme, sugar, and monkeymeat."
+	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, two slabs of meat, some flour, some rice, a bottle of milk, a bottle of soymilk, and a bag of sugar."
 	cost = 1000
 	contains = list(/obj/item/reagent_containers/food/condiment/flour,
+					/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/rice,
 					/obj/item/reagent_containers/food/condiment/milk,
 					/obj/item/reagent_containers/food/condiment/soymilk,
-					/obj/item/reagent_containers/food/condiment/saltshaker,
-					/obj/item/reagent_containers/food/condiment/peppermill,
-					/obj/item/storage/fancy/egg_box,
-					/obj/item/reagent_containers/food/condiment/enzyme,
 					/obj/item/reagent_containers/food/condiment/sugar,
-					/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
-					/obj/item/reagent_containers/food/snacks/grown/banana,
-					/obj/item/reagent_containers/food/snacks/grown/banana,
-					/obj/item/reagent_containers/food/snacks/grown/banana)
+					/obj/item/storage/fancy/egg_box,
+					/obj/item/reagent_containers/food/snacks/meat/slab,
+					/obj/item/reagent_containers/food/snacks/meat/slab
+	)
 	crate_name = "food crate"
 	crate_type = /obj/structure/closet/crate/freezer
 
+/datum/supply_pack/food/ingredients_specialized
+	name = "Advanced Cooking Crate"
+	desc = "For the discerning chef. Contains a bottle of enzyme, a salt shaker, a pepper mill, a bottle of ketchup, a bottle of hot sauce, and a bottle of cream."
+	cost = 2000
+	contains = list(/obj/item/reagent_containers/food/condiment/enzyme,
+					/obj/item/reagent_containers/food/condiment/saltshaker,
+					/obj/item/reagent_containers/food/condiment/peppermill,
+					/obj/item/reagent_containers/food/condiment/ketchup,
+					/obj/item/reagent_containers/food/condiment/hotsauce,
+					/obj/item/reagent_containers/food/drinks/bottle/cream
+	)
+	crate_name = "condiments crate"
+	crate_type = /obj/structure/closet/crate/freezer
+
 /datum/supply_pack/food/ingredients_randomized
-	name = "Variety Meat Crate"
-	desc = "The best cuts in the whole galaxy."
+	name = "Exotic Meat Crate"
+	desc = "The best cuts in the whole galaxy. Probably."
 	cost = 1000
 	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
 					/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
 					/obj/item/reagent_containers/food/snacks/meat/slab/bear,
 					/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 					/obj/item/reagent_containers/food/snacks/meat/slab/spider,
-					/obj/item/reagent_containers/food/snacks/meat/rawbacon,
 					/obj/item/reagent_containers/food/snacks/meat/slab/penguin,
 					/obj/item/reagent_containers/food/snacks/spiderleg,
 					/obj/item/reagent_containers/food/snacks/fishmeat/carp,
-					/obj/item/reagent_containers/food/snacks/meat/slab/human)
+					/obj/item/reagent_containers/food/snacks/meat/slab/human
+	)
 	crate_name = "meat crate"
 	crate_type = /obj/structure/closet/crate/freezer
 
@@ -87,6 +98,19 @@
 	for(var/i in 1 to 7)
 		var/item = pick(contains)
 		new item(C)
+
+/datum/supply_pack/food/ingredients_randomized/meat
+	name = "Standard Meat Crate"
+	desc = "Less interesting cuts of meat, but filling nonetheless."
+	cost = 1500
+	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab,
+					/obj/item/reagent_containers/food/snacks/meat/slab/chicken,
+					/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+					/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+					/obj/item/reagent_containers/food/snacks/meatball
+	)
+	crate_name = "meat crate"
+	crate_type = /obj/structure/closet/crate/freezer
 
 /datum/supply_pack/food/ingredients_randomized/vegetables
 	name = "Vegetables Crate"
@@ -99,7 +123,8 @@
 					/obj/item/reagent_containers/food/snacks/grown/carrot,
 					/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle,
 					/obj/item/reagent_containers/food/snacks/grown/onion,
-					/obj/item/reagent_containers/food/snacks/grown/pumpkin)
+					/obj/item/reagent_containers/food/snacks/grown/pumpkin
+	)
 	crate_name = "food crate"
 	crate_type = /obj/structure/closet/crate/freezer
 
@@ -109,10 +134,41 @@
 	cost = 1500
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
 					/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+					/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
 					/obj/item/reagent_containers/food/snacks/grown/watermelon,
 					/obj/item/reagent_containers/food/snacks/grown/apple,
 					/obj/item/reagent_containers/food/snacks/grown/berries,
-					/obj/item/reagent_containers/food/snacks/grown/citrus/lemon)
+					/obj/item/reagent_containers/food/snacks/grown/banana
+	)
+	crate_name = "food crate"
+	crate_type = /obj/structure/closet/crate/freezer
+
+/datum/supply_pack/food/ingredients_randomized/grains
+	name = "Grains Crate"
+	desc = "A crate full of various grains. How interesting."
+	cost = 1000
+	contains = list(/obj/item/reagent_containers/food/snacks/grown/wheat,
+					/obj/item/reagent_containers/food/snacks/grown/wheat,
+					/obj/item/reagent_containers/food/snacks/grown/wheat, //Weighted to be more common
+					/obj/item/reagent_containers/food/snacks/grown/oat,
+					/obj/item/reagent_containers/food/snacks/grown/rice,
+					/obj/item/reagent_containers/food/snacks/grown/soybeans
+	)
+	crate_name = "food crate"
+	crate_type = /obj/structure/closet/crate/freezer
+
+/datum/supply_pack/food/ingredients_randomized/bread
+	name = "Bread Crate"
+	desc = "A crate full of various breads. Bready to either be eaten or made into delicious meals."
+	cost = 1000
+	contains = list(/obj/item/reagent_containers/food/snacks/store/bread/plain,
+					/obj/item/reagent_containers/food/snacks/breadslice/plain,
+					/obj/item/reagent_containers/food/snacks/breadslice/plain,
+					/obj/item/reagent_containers/food/snacks/breadslice/plain, //Weighted to be more common
+					/obj/item/reagent_containers/food/snacks/bun,
+					/obj/item/reagent_containers/food/snacks/tortilla,
+					/obj/item/reagent_containers/food/snacks/pizzabread
+	)
 	crate_name = "food crate"
 	crate_type = /obj/structure/closet/crate/freezer
 

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -93,9 +93,10 @@
 	)
 	crate_name = "meat crate"
 	crate_type = /obj/structure/closet/crate/freezer
+	var/items = 7
 
 /datum/supply_pack/food/ingredients_randomized/fill(obj/structure/closet/crate/C)
-	for(var/i in 1 to 7)
+	for(var/i in 1 to items)
 		var/item = pick(contains)
 		new item(C)
 
@@ -156,6 +157,7 @@
 	)
 	crate_name = "food crate"
 	crate_type = /obj/structure/closet/crate/freezer
+	items = 10
 
 /datum/supply_pack/food/ingredients_randomized/bread
 	name = "Bread Crate"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -10,7 +10,6 @@
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit =1,
 		/datum/reagent/consumable/ethanol = 100
 	)
-	blacklist = list(/obj/item/organ/tail/lizard/fake)
 	result = /obj/item/reagent_containers/food/drinks/bottle/lizardwine
 	category = CAT_DRINK
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds more variety to the food crates, allowing enterprising chefs to order ingredients that can actually make a modest amount of food instead of needing to make a full botany setup. It's still a bit sparse, and one day I want to be able to order specific ingredients for a higher price, but for now, this is an improvement I think.

I'm willing to discuss the costs of the crates. Money is still so abstract that I really want input on what this amount of stuff should cost.

## Why It's Good For The Game
Actually allows chefs to cook a reasonable amount of food with ingredients purchased from the outpost, instead of just having to make a full botany setup.

## Changelog

:cl:
tweak: Makes the basics ingredients crate less barren and useless.
add: Advanced cooking crate, for buying the condiments you only need a little bit of.
add: Standard meat crate, when you don't want to buy the weird exotic meat crate.
add: Grains crate, for when you want to make a lot of flour for cooking
add: Bread crate, for when you're lazy and want bread for recipes. Or to eat. I don't care.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
