### PR TITLE
Cybersun cap sprite no longer defaults to black cap.

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -140,7 +140,7 @@
 	name = "cybersun agent cap"
 	desc = "A black baseball hat emblazoned with a reflective Cybersun patch."
 	icon_state = "agentsoft"
-	soft_type = "black"
+	soft_type = "agent"
 	dog_fashion = null
 
 /obj/item/clothing/head/soft/cybersun/medical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Also means it can be flipped without breaking now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oversights bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Cybersun cap no longer defaults to black cap's sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
