### PR TITLE
Players can no longer open additional job slots 

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -303,15 +303,25 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
 
-	if(linked_ship)
-		if(mob_occupant.job in linked_ship.current_ship.job_slots)
-			linked_ship.current_ship.job_slots[mob_occupant.job]++
+	if(linked_ship && mob_occupant.mind.original_ship == WEAKREF(linked_ship.current_ship))
+		var/job_identifier = mob_occupant.job
 
-		if(mob_occupant.mind && mob_occupant.mind.assigned_role)
-			//Handle job slot/tater cleanup.
-			if(LAZYLEN(mob_occupant.mind.objectives))
-				mob_occupant.mind.objectives.Cut()
-				mob_occupant.mind.special_role = null
+		var/datum/job/crew_job
+		for(var/datum/job/job as anything in linked_ship.current_ship.job_slots)
+			if(job.name == job_identifier)
+				crew_job = job
+				break
+
+		if(isnull(crew_job))
+			message_admins(span_warning("Failed to identify the job of [key_name_admin(mob_occupant)] on [linked_ship] at [loc_name(src)]."))
+		else
+			linked_ship.current_ship.job_slots[crew_job]++
+
+	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
+		//Handle job slot/tater cleanup.
+		if(LAZYLEN(mob_occupant.mind.objectives))
+			mob_occupant.mind.objectives.Cut()
+			mob_occupant.mind.special_role = null
 
 	// Delete them from datacore.
 	var/announce_rank = null

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -303,19 +303,22 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
 
-	if(linked_ship && mob_occupant.mind.original_ship == WEAKREF(linked_ship.current_ship))
+	if(!isnull(mob_occupant.mind.original_ship))
+		var/datum/overmap/ship/controlled/original_ship_instance = mob_occupant.mind.original_ship.resolve()
+
 		var/job_identifier = mob_occupant.job
 
 		var/datum/job/crew_job
-		for(var/datum/job/job as anything in linked_ship.current_ship.job_slots)
+		for(var/datum/job/job as anything in original_ship_instance.job_slots)
 			if(job.name == job_identifier)
 				crew_job = job
 				break
 
 		if(isnull(crew_job))
-			message_admins(span_warning("Failed to identify the job of [key_name_admin(mob_occupant)] on [linked_ship] at [loc_name(src)]."))
+			message_admins(span_warning("Failed to identify the job of [key_name_admin(mob_occupant)] belonging to [original_ship_instance.name] at [loc_name(src)]."))
 		else
-			linked_ship.current_ship.job_slots[crew_job]++
+			original_ship_instance.job_slots[crew_job]++
+			original_ship_instance.job_holder_refs[crew_job] -= WEAKREF(mob_occupant)
 
 	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
 		//Handle job slot/tater cleanup.

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -36,8 +36,12 @@
 	var/list/datum/mission/missions
 	/// The maximum number of currently active missions that a ship may take on.
 	var/max_missions = 2
-	/// Manifest list of people on the ship
+
+	/// Manifest list of people on the ship. Indexed by mob REAL NAME. value is JOB INSTANCE
 	var/list/manifest = list()
+
+	/// List of mob refs indexed by their job instance
+	var/list/datum/weakref/job_holder_refs = list()
 
 	var/list/datum/mind/owner_candidates
 
@@ -130,6 +134,7 @@
 	if(!QDELETED(shipkey))
 		QDEL_NULL(shipkey)
 	QDEL_LIST(manifest)
+	job_holder_refs.Cut()
 	job_slots.Cut()
 	blacklisted.Cut()
 	for(var/a_key in applications)
@@ -297,6 +302,10 @@
 	RegisterSignal(H.mind, COMSIG_PARENT_QDELETING, PROC_REF(crew_mind_deleting))
 	if(!owner_mob)
 		set_owner_mob(H)
+
+	if(!(human_job in job_holder_refs))
+		job_holder_refs[human_job] = list()
+	job_holder_refs[human_job] += WEAKREF(H)
 
 /datum/overmap/ship/controlled/proc/set_owner_mob(mob/new_owner)
 	if(owner_mob)

--- a/code/modules/overmap/ships/owner_action.dm
+++ b/code/modules/overmap/ships/owner_action.dm
@@ -70,7 +70,7 @@
 	var/current_slots = parent_ship.job_slots[job_target]
 
 	var/used_slots = 0
-	var/job_holders = job_holder_refs[job_target]
+	var/job_holders = parent_ship.job_holder_refs[job_target]
 
 	for(var/datum/weakref/job_holder_ref as anything in job_holders)
 		var/mob/living/job_holder = job_holder_ref.resolve()
@@ -231,9 +231,9 @@
 				return TRUE
 
 			var/change_amount = params["delta"]
-			if(change_amount > 0)
+			if(change_amount > 0 && !allow_job_slot_increase(target_job))
 				if(!user.client.holder)
-					to_chat(user, span_warning("You cannot increase the number of slots for a job."))
+					to_chat(user, span_warning("You cannot increase the number of slots for this job."))
 					return TRUE
 				message_admins("[key_name_admin(user)] has increased the number of slots for [target_job.name] on [parent_ship.name] by [change_amount].")
 

--- a/tgui/packages/tgui/interfaces/ShipOwner.tsx
+++ b/tgui/packages/tgui/interfaces/ShipOwner.tsx
@@ -9,6 +9,39 @@ import {
 } from '../components';
 import { Window } from '../layouts';
 
+type ShipOwnerData = {
+  crew: [CrewData];
+  jobs: [JobData];
+  memo: string;
+  pending: boolean;
+  joinMode: string;
+  cooldown: number;
+  applications: [ApplicationData];
+  isAdmin: boolean;
+};
+
+type ApplicationData = {
+  ref: string;
+  key: string;
+  name: string;
+  text: string;
+  status: string;
+};
+
+type CrewData = {
+  ref: string;
+  name: string;
+  allowed: boolean;
+};
+
+type JobData = {
+  ref: string;
+  name: string;
+  slots: number;
+  max: number;
+  def: number;
+};
+
 export const ShipOwner = (props, context) => {
   return (
     <Window width={620} height={620} resizable>
@@ -19,8 +52,8 @@ export const ShipOwner = (props, context) => {
   );
 };
 
-const ShipOwnerContent = (props, context) => {
-  const { act, data } = useBackend(context);
+const ShipOwnerContent = (_, context: any) => {
+  const { act, data } = useBackend<ShipOwnerData>(context);
   const [tab, setTab] = useLocalState(context, 'tab', 1);
   const {
     crew = [],
@@ -30,6 +63,7 @@ const ShipOwnerContent = (props, context) => {
     joinMode,
     cooldown = 1,
     applications = [],
+    isAdmin,
   } = data;
   return (
     <Section
@@ -85,7 +119,7 @@ const ShipOwnerContent = (props, context) => {
               <Table.Cell>Message</Table.Cell>
               <Table.Cell>Status</Table.Cell>
             </Table.Row>
-            {applications.map((app) => (
+            {applications.map((app: ApplicationData) => (
               <Table.Row key={app.ref}>
                 <Table.Cell>{app.key}</Table.Cell>
                 <Table.Cell>{app.name}</Table.Cell>
@@ -144,16 +178,16 @@ const ShipOwnerContent = (props, context) => {
             <Table.Cell>Can be owner</Table.Cell>
             <Table.Cell>Transfer Ownership</Table.Cell>
           </Table.Row>
-          {crew.map((mind) => (
-            <Table.Row key={mind.name}>
-              <Table.Cell>{mind.name}</Table.Cell>
+          {crew.map((crew_data: CrewData) => (
+            <Table.Row key={crew_data.name}>
+              <Table.Cell>{crew_data.name}</Table.Cell>
               <Table.Cell>
                 <Button.Checkbox
                   content="Candidate"
-                  checked={mind.allowed}
+                  checked={crew_data.allowed}
                   onClick={() =>
                     act('toggleCandidate', {
-                      ref: mind.ref,
+                      ref: crew_data.ref,
                     })
                   }
                 />
@@ -163,7 +197,7 @@ const ShipOwnerContent = (props, context) => {
                   content="Transfer Owner"
                   onClick={() =>
                     act('transferOwner', {
-                      ref: mind.ref,
+                      ref: crew_data.ref,
                     })
                   }
                 />
@@ -184,13 +218,18 @@ const ShipOwnerContent = (props, context) => {
               <Table.Cell>Job Name</Table.Cell>
               <Table.Cell>Slots</Table.Cell>
             </Table.Row>
-            {jobs.map((job) => (
+            {jobs.map((job: JobData) => (
               <Table.Row key={job.name}>
                 <Table.Cell>{job.name}</Table.Cell>
                 <Table.Cell>
                   <Button
                     content="+"
-                    disabled={cooldown > 0 || job.slots >= job.max}
+                    disabled={!isAdmin || cooldown > 0 || job.slots >= job.max}
+                    tooltip={
+                      !isAdmin
+                        ? 'You must be an admin to increase job slots'
+                        : undefined
+                    }
                     color={job.slots >= job.def ? 'average' : 'default'}
                     onClick={() =>
                       act('adjustJobSlot', {

--- a/tgui/packages/tgui/interfaces/ShipOwner.tsx
+++ b/tgui/packages/tgui/interfaces/ShipOwner.tsx
@@ -12,6 +12,7 @@ import { Window } from '../layouts';
 type ShipOwnerData = {
   crew: [CrewData];
   jobs: [JobData];
+  jobIncreaseAllowed: [string];
   memo: string;
   pending: boolean;
   joinMode: string;
@@ -64,6 +65,7 @@ const ShipOwnerContent = (_, context: any) => {
     cooldown = 1,
     applications = [],
     isAdmin,
+    jobIncreaseAllowed = [],
   } = data;
   return (
     <Section
@@ -224,10 +226,14 @@ const ShipOwnerContent = (_, context: any) => {
                 <Table.Cell>
                   <Button
                     content="+"
-                    disabled={!isAdmin || cooldown > 0 || job.slots >= job.max}
+                    disabled={
+                      !(isAdmin || jobIncreaseAllowed[job.name]) ||
+                      cooldown > 0 ||
+                      job.slots >= job.max
+                    }
                     tooltip={
-                      !isAdmin
-                        ? 'You must be an admin to increase job slots'
+                      !jobIncreaseAllowed[job.name] && !isAdmin
+                        ? 'Cannot increase job slots above maximum.'
                         : undefined
                     }
                     color={job.slots >= job.def ? 'average' : 'default'}


### PR DESCRIPTION
## Changelog

:cl:
balance: Only admins can open job slots
fix: Cryoing correctly opens a job slot
code: Refactored ShipOwner into tsx
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
