### PR TITLE
Separates ID cards' update_appearance from update_label, adds id_assignment to job outfits

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -168,6 +168,7 @@
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 	update_label()
+	update_appearance()
 	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
 
 /obj/item/card/id/Destroy()
@@ -421,7 +422,6 @@ update_label()
 /obj/item/card/id/proc/update_label()
 	var/blank = !registered_name
 	name = "[blank ? initial(name) : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
-	update_appearance()
 
 /obj/item/card/id/silver
 	name = "silver identification card"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -206,6 +206,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			id.registered_name = H.real_name
 			id.assignment = "Captain"
 			id.update_label()
+			id.update_appearance()
 
 			if(worn)
 				if(istype(worn, /obj/item/pda))

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -148,8 +148,9 @@
 		card.job_icon = outfit.job_icon
 		card.faction_icon = outfit.faction_icon
 		card.assignment = J.name
+		card.update_appearance()
+		card.assignment = old_assignment
 		card.update_label()
-		card.name = "[!card.registered_name ? initial(card.name) : "[card.registered_name]'s ID Card"][" ([old_assignment])"]" // this is terrible, but whatever
 		H.sec_hud_set_ID()
 
 	qdel(outfit)

--- a/code/modules/clothing/outfits/ert/inteq_ert.dm
+++ b/code/modules/clothing/outfits/ert/inteq_ert.dm
@@ -1,5 +1,6 @@
 /datum/outfit/job/inteq/ert
 	name = "ERT - Inteq Rifleman"
+	id_assignment = "Enforcer"
 	jobtype = /datum/job/officer
 	job_icon = "securityofficer"
 
@@ -22,6 +23,7 @@
 
 /datum/outfit/job/inteq/ert/shotgun
 	name = "ERT - Inteq Shotgunner"
+	id_assignment = "Enforcer"
 
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	belt = /obj/item/storage/belt/security/webbing/inteq/alt
@@ -30,6 +32,7 @@
 
 /datum/outfit/job/inteq/ert/medic
 	name = "ERT - Inteq Corpsman"
+	id_assignment = "Corpsman"
 	jobtype = /datum/job/paramedic
 	job_icon = "paramedic"
 
@@ -43,6 +46,7 @@
 
 /datum/outfit/job/inteq/ert/leader
 	name = "ERT - Inteq Vanguard"
+	id_assignment = "Vanguard"
 	jobtype = /datum/job/hos
 	job_icon = "headofsecurity"
 

--- a/code/modules/clothing/outfits/ert/minutemen_ert.dm
+++ b/code/modules/clothing/outfits/ert/minutemen_ert.dm
@@ -1,5 +1,6 @@
 /datum/outfit/job/clip/minutemen/grunt/dressed/bard
 	name = "ERT - CLIP Minuteman BARD Specialist"
+	id_assignment = "Biohazard Assessment Specialist"
 	job_icon = "clip_cmm2"
 
 	suit = /obj/item/clothing/suit/armor/vest/marine/heavy
@@ -18,6 +19,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/bard/medic
 	name = "ERT - CLIP Minuteman BARD Medical Specialist"
+	id_assignment = "Corpsman"
 
 	suit = /obj/item/clothing/suit/armor/vest/marine
 	suit_store = /obj/item/gun/ballistic/automatic/smg/cm5
@@ -50,6 +52,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/bard/leader
 	name = "ERT - CLIP Minuteman BARD Specialist Sergeant"
+	id_assignment = "Biohazard Assessment Sergeant"
 	job_icon = "clip_cmm3"
 
 	belt = /obj/item/storage/belt/military/clip/e50
@@ -87,6 +90,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/riot/leader
 	name = "ERT - CLIP Minutemen Riot Officer Sergeant"
+	id_assignment = "Security Sergeant"
 	job_icon = "lieutenant"
 
 	ears = /obj/item/radio/headset/clip/alt/captain

--- a/code/modules/clothing/outfits/ert/solgov_ert.dm
+++ b/code/modules/clothing/outfits/ert/solgov_ert.dm
@@ -1,5 +1,6 @@
 /datum/outfit/job/solgov/ert
 	name = "ERT - SolGov Sonnensöldner"
+	id_assignment = "Sonnensöldner"
 	jobtype = /datum/job/officer
 	job_icon = "sonnensoldner"
 
@@ -19,6 +20,7 @@
 
 /datum/outfit/job/solgov/ert/inspector
 	name = "ERT - Inspector (SolGov)"
+	id_assignment = "Inspector"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "solgovrepresentative"
 

--- a/code/modules/clothing/outfits/ert/syndicate_ert.dm
+++ b/code/modules/clothing/outfits/ert/syndicate_ert.dm
@@ -32,7 +32,7 @@
 // gorlex loyalist/2nd battlegroup
 
 /datum/outfit/job/syndicate/ert/gorlex
-	name = "ERT - Syndicate Gorlex Loyalist Trooper"
+	name = "ERT - New Gorlex Republic Trooper"
 
 	head = /obj/item/clothing/head/helmet/swat
 	uniform = /obj/item/clothing/under/syndicate/combat
@@ -42,13 +42,13 @@
 	suit_store = /obj/item/gun/ballistic/automatic/smg/m90
 
 /datum/outfit/job/syndicate/ert/gorlex/pointman
-	name = "ERT - Syndicate Gorlex Loyalist Pointman"
+	name = "ERT - New Gorlex Republic Pointman"
 
 	suit_store = /obj/item/gun/ballistic/shotgun/bulldog
 	belt = /obj/item/storage/belt/security/webbing/bulldog
 
 /datum/outfit/job/syndicate/ert/gorlex/medic
-	name = "ERT - Syndicate Gorlex Loyalist Medic"
+	name = "ERT - New Gorlex Republic Medic"
 	jobtype = /datum/job/paramedic
 	job_icon = "paramedic"
 
@@ -65,7 +65,7 @@
 	backpack_contents = list(/obj/item/ammo_box/magazine/m10mm=2, /obj/item/storage/firstaid/medical=1, /obj/item/defibrillator/compact/combat/loaded=1)
 
 /datum/outfit/job/syndicate/ert/gorlex/sniper
-	name = "ERT - Syndicate Gorlex Loyalist Sniper"
+	name = "ERT - New Gorlex Republic Sniper"
 
 	head = /obj/item/clothing/head/beret/black
 	back = /obj/item/storage/backpack/messenger/sec
@@ -81,7 +81,7 @@
 	backpack_contents = list(/obj/item/ammo_box/magazine/sniper_rounds=2, /obj/item/radio=1)
 
 /datum/outfit/job/syndicate/ert/gorlex/leader
-	name = "ERT - Syndicate Gorlex Loyalist Sergeant"
+	name = "ERT - New Gorlex Republic Sergeant"
 	job_icon = "lieutenant"
 
 	uniform = /obj/item/clothing/under/syndicate/gorlex
@@ -144,6 +144,7 @@
 
 /datum/outfit/job/syndicate/ert/cybersun/medic/leader
 	name = "ERT - Syndicate Cybersun Lead Paramedic"
+	id_assignment = "Lead Paramedic"
 	job_icon = "chiefmedicalofficer"
 
 	head = /obj/item/clothing/head/beret/cmo
@@ -157,6 +158,7 @@
 
 /datum/outfit/job/syndicate/ert/inspector
 	name = "ERT - Inspector (Syndicate)"
+	id_assignment = "Inspector"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "syndicate"
 
@@ -174,11 +176,3 @@
 	suit_store = null
 
 	backpack_contents = list(/obj/item/stamp/syndicate)
-
-/datum/outfit/job/syndicate/ert/inspector/post_equip(mob/living/carbon/human/H, visualsOnly)
-	. = ..()
-	var/obj/item/card/id/W = H.wear_id
-	if(W)
-		W.registered_name = H.real_name
-		W.assignment = "Inspector"
-		W.update_label()

--- a/code/modules/clothing/outfits/factions/frontiersmen.dm
+++ b/code/modules/clothing/outfits/factions/frontiersmen.dm
@@ -25,6 +25,7 @@
 
 /datum/outfit/job/frontiersmen/assistant
 	name = "Frontiersmen - Rookie"
+	id_assignment = "Rookie"
 	job_icon = "assistant"
 	jobtype = /datum/job/assistant
 
@@ -71,6 +72,7 @@
 
 /datum/outfit/job/frontiersmen/captain/admiral
 	name = "Frontiersmen - Admiral"
+	id_assignment = "Admiral"
 
 	uniform = /obj/item/clothing/under/rank/security/officer/frontier/admiral
 	head = /obj/item/clothing/head/caphat/frontier/admiral
@@ -83,7 +85,8 @@
 
 // Chief Engineer
 /datum/outfit/job/frontiersmen/ce
-	name = "Frontiersmen - Senior Sapper"
+	name = "Frontiersmen - Senior Mechanic"
+	id_assignment = "Senior Mechanic"
 	job_icon = "chiefengineer"
 	jobtype = /datum/job/chief_engineer
 
@@ -97,7 +100,8 @@
 
 // Engineer
 /datum/outfit/job/frontiersmen/engineer
-	name = "Frontiersmen - Sapper"
+	name = "Frontiersmen - Mechanic"
+	id_assignment = "Mechanic"
 	job_icon = "stationengineer"
 	jobtype = /datum/job/engineer
 
@@ -115,6 +119,7 @@
 
 /datum/outfit/job/frontiersmen/cook
 	name = "Frontiersmen - Steward"
+	id_assignment = "Steward"
 	job_icon = "cook"
 	jobtype = /datum/job/cook
 
@@ -126,6 +131,7 @@
 
 /datum/outfit/job/frontiersmen/hop
 	name = "Frontiersmen - Helmsman"
+	id_assignment = "Helmsman"
 	job_icon = "headofpersonnel"
 	jobtype = /datum/job/head_of_personnel
 
@@ -138,7 +144,8 @@
 
 // Head of Security
 /datum/outfit/job/frontiersmen/hos
-	name = "Frontiersmen - Shipswain"
+	name = "Frontiersmen - Deck Boss"
+	id_assignment = "Deck Boss"
 	job_icon = "headofsecurity"
 	jobtype = /datum/job/hos
 
@@ -155,6 +162,7 @@
 
 /datum/outfit/job/frontiersmen/security
 	name = "Frontiersmen - Boarder"
+	id_assignment = "Boarder"
 	job_icon = "securityofficer"
 	jobtype = /datum/job/officer
 
@@ -173,7 +181,8 @@
 // Medical Doctor
 
 /datum/outfit/job/frontiersmen/doctor
-	name = "Frontiersmen - Aidman"
+	name = "Frontiersmen - Surgeon"
+	id_assignment = "Surgeon"
 	job_icon = "medicaldoctor"
 	jobtype = /datum/job/doctor
 

--- a/code/modules/clothing/outfits/factions/gezena.dm
+++ b/code/modules/clothing/outfits/factions/gezena.dm
@@ -11,6 +11,7 @@
 //Playable Roles (put in ships):
 /datum/outfit/job/gezena/assistant
 	name = "PGF - Crewman"
+	id_assignment = "Crewman"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 
@@ -20,6 +21,7 @@
 
 /datum/outfit/job/gezena/engineer
 	name = "PGF - Navy Engineer"
+	id_assignment = "Naval Engineer"
 	jobtype = /datum/job/engineer
 	job_icon = "stationengineer"
 
@@ -38,6 +40,7 @@
 
 /datum/outfit/job/gezena/security
 	name = "PGF - Marine"
+	id_assignment = "Marine"
 	jobtype = /datum/job/officer
 	job_icon = "securityofficer"
 
@@ -47,6 +50,7 @@
 
 /datum/outfit/job/gezena/hos
 	name = "PGF - Marine Sergeant"
+	id_assignment = "Sergeant"
 	jobtype = /datum/job/hos
 	job_icon = "headofsecurity"
 

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -20,6 +20,7 @@
 
 /datum/outfit/job/inteq/assistant
 	name = "IRMG - Recruit"
+	id_assignment = "Recruit"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 
@@ -29,6 +30,7 @@
 
 /datum/outfit/job/inteq/captain
 	name = "IRMG - Vanguard (Naked)"
+	id_assignment = "Vanguard"
 	jobtype = /datum/job/captain
 	job_icon = "captain"
 
@@ -55,6 +57,7 @@
 
 /datum/outfit/job/inteq/captain/honorable
 	name = "IRMG - Honorable Vanguard"
+	id_assignment = "Honorable Vanguard"
 
 	head = /obj/item/clothing/head/beret/sec/hos/inteq/honorable
 	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
@@ -65,19 +68,11 @@
 	belt = /obj/item/storage/belt/military/assault
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 
-/datum/outfit/job/inteq/captain/honorable/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	if(visualsOnly)
-		return
-
-	var/obj/item/card/id/W = H.wear_id
-	W.assignment = "Honorable Vanguard"
-	W.update_label()
-
 ///Chief Engineer
 
 /datum/outfit/job/inteq/ce
 	name = "IRMG - Artificer Class II"
+	id_assignment = "Artificer Class II"
 	job_icon = "chiefengineer"
 	jobtype = /datum/job/chief_engineer
 
@@ -101,6 +96,7 @@
 
 /datum/outfit/job/inteq/paramedic
 	name = "IRMG - Corpsman"
+	id_assignment = "Corpsman"
 	job_icon = "paramedic"
 	jobtype = /datum/job/paramedic
 
@@ -115,7 +111,7 @@
 	backpack_contents = list(/obj/item/roller=1)
 
 /datum/outfit/job/inteq/paramedic/empty
-	name = "IRMG Corpsman (Inteq) (Naked)"
+	name = "IRMG - Corpsman (Naked)"
 
 	head = null
 	suit = null
@@ -126,6 +122,7 @@
 
 /datum/outfit/job/inteq/security
 	name = "IRMG - Enforcer"
+	id_assignment = "Enforcer"
 	jobtype = /datum/job/officer
 	job_icon = "securityofficer"
 
@@ -171,6 +168,7 @@
 
 /datum/outfit/job/inteq/engineer
 	name = "IRMG - Artificer"
+	id_assignment = "Artificer"
 	job_icon = "stationengineer"
 	jobtype = /datum/job/engineer
 
@@ -184,6 +182,7 @@
 
 /datum/outfit/job/inteq/warden
 	name = "IRMG - Master At Arms"
+	id_assignment = "Master at Arms"
 	jobtype = /datum/job/warden
 	job_icon = "warden"
 
@@ -205,7 +204,8 @@
 // cmo
 
 /datum/outfit/job/inteq/cmo
-	name = "IRMG Honorable Corpsman (Inteq)"
+	name = "IRMG - Honorable Corpsman"
+	id_assignment = "Honorable Corpsman"
 	jobtype = /datum/job/cmo
 	job_icon = "chiefmedicalofficer"
 

--- a/code/modules/clothing/outfits/factions/minutemen.dm
+++ b/code/modules/clothing/outfits/factions/minutemen.dm
@@ -263,6 +263,7 @@
 
 /datum/outfit/job/clip/minutemen/deckhand
 	name = "CLIP Minutemen - Deckhand"
+	id_assignment = "Deckhand"
 	job_icon = "clip_navy1"
 	jobtype = /datum/job/assistant
 	uniform =  /obj/item/clothing/under/clip
@@ -298,6 +299,7 @@
 
 /datum/outfit/job/clip/minutemen/captain/general
 	name = "CLIP Minutemen - General"
+	id_assignment = "General"
 	job_icon = "clip_cmm6"
 
 	head = /obj/item/clothing/head/clip/slouch/officer
@@ -309,28 +311,13 @@
 	box = /obj/item/storage/box/survival/engineer/radio
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/gun/ballistic/revolver/mateba=1)
 
-/datum/outfit/job/clip/minutemen/captain/general/post_equip(mob/living/carbon/human/H, visualsOnly)
-	. = ..()
-	var/obj/item/card/id/W = H.wear_id
-	if(W)
-		W.registered_name = H.real_name
-		W.assignment = "General"
-		W.update_label()
-
 /datum/outfit/job/clip/minutemen/captain/general/admiral // for flavor, might remove outright
 	name = "CLIP Minutemen - Admiral"
+	id_assignment = "Admiral"
 	job_icon = "clip_navy6"
 
 	head = /obj/item/clothing/head/clip/bicorne
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/clip/admiral
-
-/datum/outfit/job/clip/minutemen/captain/general/admiral/post_equip(mob/living/carbon/human/H, visualsOnly)
-	. = ..()
-	var/obj/item/card/id/W = H.wear_id
-	if(W)
-		W.registered_name = H.real_name
-		W.assignment = "Admiral"
-		W.update_label()
 
 ///chemist
 
@@ -353,6 +340,7 @@
 
 /datum/outfit/job/clip/minutemen/head_of_personnel
 	name = "CLIP Minutemen - Bridge Officer"
+	id_assignment = "Bridge Officer"
 	job_icon = "clip_navy3"
 	jobtype = /datum/job/head_of_personnel
 
@@ -374,6 +362,7 @@
 
 /datum/outfit/job/clip/minutemen/doctor
 	name = "CLIP Minutemen - Corpsman"
+	id_assignment = "Corpsman"
 	job_icon = "clip_navy2"
 	jobtype = /datum/job/doctor
 
@@ -416,6 +405,7 @@
 
 /datum/outfit/job/clip/minutemen/vehicle_crew
 	name = "CLIP Minutemen - Vehicle Crewman"
+	id_assignment = "Vehicle Crewman"
 	job_icon = "clip_mech1"
 	jobtype = /datum/job/roboticist
 
@@ -433,6 +423,7 @@
 
 /datum/outfit/job/clip/minutemen/vehicle_pilot
 	name = "CLIP Minutemen - Vehicle Pilot"
+	id_assignment = "Pilot"
 	job_icon = "clip_mech2"
 	jobtype = /datum/job/mining
 
@@ -447,6 +438,7 @@
 
 /datum/outfit/job/clip/minutemen/vehicle_pilot/commander
 	name = "CLIP Minutemen - Vehicle Commander"
+	id_assignment = "Vehicle Commander"
 	job_icon = "clip_mech3"
 
 	suit = /obj/item/clothing/suit/jacket/miljacket
@@ -454,6 +446,7 @@
 
 /datum/outfit/job/clip/minutemen/vehicle_crew/coordinator
 	name = "CLIP Minutemen - Vehicle Traffic Coordinator"
+	id_assignment = "Traffic Coordinator"
 	job_icon = "clip_mech4"
 	jobtype = /datum/job/roboticist
 
@@ -499,6 +492,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt
 	name = "CLIP Minutemen - Minuteman"
+	id_assignment = "Minuteman"
 	jobtype = /datum/job/officer
 	job_icon = "clip_cmm2"
 	ears = /obj/item/radio/headset/alt
@@ -517,6 +511,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/reserve
 	name = "CLIP Minutemen - Reservist"
+	id_assignment = "Reservist"
 	job_icon = "clip_cmm1"
 	jobtype = /datum/job/assistant
 
@@ -563,6 +558,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/engi
 	name = "CLIP Minutemen - Field Engineer (Dressed)"
+	id_assignment = "Field Engineer"
 	jobtype = /datum/job/engineer
 
 	accessory = /obj/item/clothing/accessory/armband/engine
@@ -576,6 +572,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/med
 	name = "CLIP Minutemen - Field Corpsman (Dressed)"
+	id_assignment = "Field Corpsman"
 	jobtype = /datum/job/doctor
 
 	accessory = /obj/item/clothing/accessory/armband/medblue
@@ -595,6 +592,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/dressed/gunner_armed
 	name = "CLIP Minutemen - Field Gunner (Armed - SKM-24u)" //See above, replace with CLIP LMG when added
+	id_assignment = "Machinegunner"
 
 	accessory = /obj/item/clothing/accessory/armband
 	belt = /obj/item/storage/belt/military/clip/gunner
@@ -606,6 +604,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/lead
 	name = "CLIP Minutemen - Field Sergeant"
+	id_assignment = "Sergeant"
 	job_icon = "clip_cmm3"
 	jobtype = /datum/job/warden
 
@@ -632,6 +631,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/commander
 	name = "CLIP Minutemen - Field Commander"
+	id_assignment = "Commander"
 	job_icon = "clip_cmm4"
 	jobtype = /datum/job/hos
 
@@ -646,6 +646,7 @@
 
 /datum/outfit/job/clip/minutemen/grunt/major
 	name = "CLIP Minutemen - Major"
+	id_assignment = "Major"
 	job_icon = "clip_cmm5"
 	jobtype = /datum/job/captain
 

--- a/code/modules/clothing/outfits/factions/nanotrasen.dm
+++ b/code/modules/clothing/outfits/factions/nanotrasen.dm
@@ -52,6 +52,7 @@
 
 /datum/outfit/job/nanotrasen/captain/lp
 	name = "Nanotrasen - Loss Prevention Lieutenant"
+	id_assignment = "Lieutenant"
 
 	implants = list(/obj/item/implant/mindshield)
 	ears = /obj/item/radio/headset/nanotrasen/alt/captain
@@ -138,6 +139,7 @@
 
 /datum/outfit/job/nanotrasen/roboticist
 	name = "Nanotrasen - Mech Technician"
+	id_assignment = "Mech Technician"
 	job_icon = "roboticist"
 	jobtype = /datum/job/roboticist
 
@@ -152,6 +154,7 @@
 
 /datum/outfit/job/nanotrasen/pilot
 	name = "Nanotrasen - Pilot"
+	id_assignment = "Pilot"
 
 	uniform = /obj/item/clothing/under/rank/security/officer/military
 	suit = /obj/item/clothing/suit/jacket/leather/duster
@@ -177,9 +180,9 @@
 	chameleon_extras = /obj/item/stamp/law
 
 /datum/outfit/job/nanotrasen/lawyer/corporaterepresentative
-	name = "Nanotrasen - Lawyer (Corporate Representative)"
+	name = "Nanotrasen - Corporate Representative"
+	id_assignment = "Corporate Representative"
 	job_icon = "nanotrasen"
-
 
 	uniform = /obj/item/clothing/under/rank/command/head_of_personnel/suit
 	suit = null
@@ -254,6 +257,7 @@
 
 /datum/outfit/job/nanotrasen/security/mech_pilot
 	name = "Nanotrasen - Mech Pilot"
+	id_assignment = "Mech Pilot"
 
 	uniform = /obj/item/clothing/under/rank/security/officer/military/eng
 	head = /obj/item/clothing/head/beret/sec/officer
@@ -262,6 +266,7 @@
 
 /datum/outfit/job/nanotrasen/security/lp
 	name = "Nanotrasen - LP Security Specialist"
+	id_assignment = "Security Specialist"
 
 	implants = list(/obj/item/implant/mindshield)
 	ears = /obj/item/radio/headset/nanotrasen/alt/captain
@@ -396,6 +401,7 @@
 
 /datum/outfit/job/nanotrasen/doctor/lp
 	name = "Nanotrasen - LP Medical Specialist"
+	id_assignment = "Medical Specialist"
 
 	implants = list(/obj/item/implant/mindshield)
 	ears = /obj/item/radio/headset/nanotrasen/alt/captain

--- a/code/modules/clothing/outfits/factions/roumain.dm
+++ b/code/modules/clothing/outfits/factions/roumain.dm
@@ -17,6 +17,7 @@
 
 /datum/outfit/job/roumain/assistant
 	name = "Saint-Roumain Militia - Shadow"
+	id_assignment = "Shadow"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 
@@ -31,6 +32,7 @@
 
 /datum/outfit/job/roumain/captain
 	name = "Saint-Roumain Militia - Hunter Montagne"
+	id_assignment = "Hunter Montagne"
 	job_icon = "captain"
 	jobtype = /datum/job/captain
 
@@ -54,6 +56,7 @@
 
 /datum/outfit/job/roumain/security
 	name = "Saint-Roumain Militia - Hunter"
+	id_assignment = "Hunter"
 	jobtype = /datum/job/officer
 	job_icon = "securityofficer"
 
@@ -75,6 +78,7 @@
 
 /datum/outfit/job/roumain/doctor
 	name = "Saint-Roumain Militia - Hunter Doctor"
+	id_assignment = "Hunter Doctor"
 	job_icon = "medicaldoctor"
 	jobtype = /datum/job/doctor
 

--- a/code/modules/clothing/outfits/factions/solgov.dm
+++ b/code/modules/clothing/outfits/factions/solgov.dm
@@ -11,6 +11,7 @@
 
 /datum/outfit/job/solgov/assistant
 	name = "SolGov - Scribe"
+	id_assignment = "Scribe"
 	jobtype = /datum/job/assistant
 	job_icon = "scribe"
 
@@ -21,6 +22,7 @@
 
 /datum/outfit/job/solgov/bureaucrat
 	name = "SolGov - Bureaucrat"
+	id_assignment = "Bureaucrat"
 	jobtype = /datum/job/curator
 	job_icon = "curator"
 
@@ -61,6 +63,7 @@
 
 /datum/outfit/job/solgov/sonnensoldner
 	name = "SolGov - Sonnensöldner"
+	id_assignment = "Sonnensöldner"
 	jobtype = /datum/job/officer
 	job_icon = "sonnensoldner"
 
@@ -103,6 +106,7 @@
 
 /datum/outfit/job/solgov/overseer
 	name = "SolGov - Overseer"
+	id_assignment = "Overseer"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "headofpersonnel"
 
@@ -140,6 +144,7 @@
 
 /datum/outfit/job/solgov/miner
 	name = "SolGov - Field Engineer"
+	id_assignment = "Field Engineer"
 	jobtype = /datum/job/mining
 	job_icon = "shaftminer"
 
@@ -181,8 +186,9 @@
 
 /datum/outfit/job/solgov/patient
 	name = "SolGov - Attentive Care Patient"
+	id_assignment = "Attentive Care Patient"
 	jobtype = /datum/job/prisoner
-	job_icon = "assistant" // todo: bug rye for patient icon
+	job_icon = "assistant" // todo: bug rye for patient icon // rye. rye. give me 50 gazillion billion dollars paypal
 
 	id = /obj/item/card/id/patient
 	uniform = /obj/item/clothing/under/rank/medical/gown
@@ -191,6 +197,7 @@
 
 /datum/outfit/job/solgov/engineer
 	name = "SolGov - Ship Engineer"
+	id_assignment = "Ship Engineer"
 	jobtype = /datum/job/engineer
 	job_icon = "stationengineer"
 
@@ -213,6 +220,7 @@
 
 /datum/outfit/job/solgov/quartermaster
 	name = "SolGov - Logistics Deck Officer"
+	id_assignment = "Logistics Deck Officer"
 	jobtype = /datum/job/qm
 	job_icon = "quartermaster"
 

--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -31,6 +31,7 @@
 
 /datum/outfit/job/syndicate/assistant
 	name = "Syndicate - Junior Agent"
+	id_assignment = "Junior Agent"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 
@@ -60,6 +61,7 @@
 
 /datum/outfit/job/syndicate/assistant/gec
 	name = "Syndicate - Deckhand (GEC)"
+	id_assignment = "Deckhand"
 
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/toggle/hazard
@@ -76,6 +78,7 @@
 
 /datum/outfit/job/syndicate/assistant/twink
 	name = "Syndicate - Deck Assistant (Twinkleshine)"
+	id_assignment = "Deck Assistant"
 
 	uniform = /obj/item/clothing/under/syndicate
 	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
@@ -101,6 +104,7 @@
 
 /datum/outfit/job/syndicate/assistant/suns
 	name = "Syndicate - Freshman (SUNS)"
+	id_assignment = "Freshman"
 
 	uniform = /obj/item/clothing/under/syndicate/suns
 	alt_uniform = /obj/item/clothing/under/syndicate/suns/alt
@@ -118,12 +122,14 @@
 
 /datum/outfit/job/syndicate/assistant/suns/halfway
 	name = "Syndicate - Junior (SUNS)"
+	id_assignment = "Junior"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/uniform2
 	alt_uniform = /obj/item/clothing/under/syndicate/suns/uniform2/alt
 
 /datum/outfit/job/syndicate/assistant/suns/complete
 	name = "Syndicate - Graduate (SUNS)"
+	id_assignment = "Graduate"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/uniform3
 	alt_uniform = /obj/item/clothing/under/syndicate/suns/uniform3/alt
@@ -226,6 +232,7 @@
 
 /datum/outfit/job/syndicate/botanist/suns
 	name = "Syndicate - Botanist-Chemist (SUNS)"
+	id_assignment = "Botanist-Chemist"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/sciencejumpsuit
 	id = /obj/item/card/id/syndicate_command/crew_id
@@ -269,6 +276,7 @@
 
 /datum/outfit/job/syndicate/captain/twink
 	name = "Flotilla Admiral (Twinkleshine, ACLF)"
+	id_assignment = "Flotilla Admiral"
 
 	uniform = /obj/item/clothing/under/syndicate/ngr/officer
 	head = null
@@ -337,6 +345,7 @@
 
 /datum/outfit/job/syndicate/cargo_tech/donk
 	name = "Syndicate - Customer Associate (Donk)"
+	id_assignment = "Customer Associate"
 
 //chemist
 
@@ -416,6 +425,7 @@
 
 /datum/outfit/job/syndicate/cmo
 	name = "Syndicate - Medical Director (Cybersun)"
+	id_assignment = "Medical Director"
 	jobtype = /datum/job/cmo
 	job_icon = "chiefmedicalofficer"
 
@@ -432,6 +442,7 @@
 
 /datum/outfit/job/syndicate/cmo/suns
 	name = "Syndicate - Medical Instructor (SUNS)"
+	id_assignment = "Medical Instructor"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/doctorscrubs
 	ears = /obj/item/radio/headset/syndicate/alt/captain
@@ -456,6 +467,7 @@
 
 /datum/outfit/job/syndicate/head_of_personnel
 	name = "Syndicate - Bridge Officer"
+	id_assignment = "Bridge Officer"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "headofpersonnel"
 
@@ -472,6 +484,7 @@
 
 /datum/outfit/job/syndicate/head_of_personnel/cybersun
 	name = "Syndicate - Intelligence Officer (Cybersun)"
+	id_assignment = "Intelligence Officer"
 
 	ears = /obj/item/radio/headset/syndicate/alt
 	uniform = /obj/item/clothing/under/syndicate/cybersun/officer
@@ -485,6 +498,7 @@
 
 /datum/outfit/job/syndicate/head_of_personnel/suns
 	name = "Syndicate - Academic Staff (SUNS)"
+	id_assignment = "Academic Staff"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/xo
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof/suns/xo
@@ -522,9 +536,11 @@
 
 /datum/outfit/job/syndicate/hos/gorlex
 	name = "Syndicate - Sergeant (Gorlex)"
+	id_assignment = "Sergeant"
 
 /datum/outfit/job/syndicate/hos/twink
 	name = "Syndicate - Lieutenant (Twinkleshine, NGR)"
+	id_assignment = "Lieutenant"
 	job_icon = "lieutenant"
 
 	uniform = /obj/item/clothing/under/syndicate/ngr/officer
@@ -557,6 +573,8 @@
 
 /datum/outfit/job/syndicate/hos/suns
 	name = "Syndicate - Senior Peacekeeper (SUNS)"
+	id_assignment = "Senior Peacekeeper"
+
 	uniform = /obj/item/clothing/under/syndicate/suns/pkuniform
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof/suns/hos
 	belt = /obj/item/melee/sabre/suns/telescopic
@@ -578,6 +596,7 @@
 
 /datum/outfit/job/syndicate/hos/suns/twink
 	name = "Syndicate - Redshield Officer (Twinkleshine, SUNS)"
+	id_assignment = "Redshield Officer"
 
 	suit = null
 	mask = /obj/item/clothing/mask/gas/syndicate/voicechanger
@@ -665,6 +684,7 @@
 
 /datum/outfit/job/syndicate/paramedic/cybersun
 	name = "Syndicate - Field Medic (Cybersun Industries)"
+	id_assignment = "Field Medic"
 
 	uniform = /obj/item/clothing/under/syndicate/medic
 	head = /obj/item/clothing/head/soft/cybersun/medical
@@ -736,6 +756,7 @@
 
 /datum/outfit/job/syndicate/patient
 	name = "Syndicate - Long Term Patient"
+	id_assignment = "Long Term Patient"
 	jobtype = /datum/job/prisoner
 	job_icon = "assistant"
 
@@ -800,6 +821,7 @@
 
 /datum/outfit/job/syndicate/security
 	name = "Syndicate - Operative"
+	id_assignment = "Operative"
 	jobtype = /datum/job/officer
 	job_icon = "securityofficer"
 
@@ -856,6 +878,8 @@
 
 /datum/outfit/job/syndicate/security/suns
 	name = "Syndicate - Peacekeeper (SUNS)"
+	id_assignment = "Peacekeeper"
+
 	uniform = /obj/item/clothing/under/syndicate/suns/pkuniform
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof/suns
 	alt_suit = /obj/item/clothing/suit/toggle/suns/pkcoat
@@ -891,6 +915,7 @@
 
 /datum/outfit/job/syndicate/miner/gorlex
 	name = "Syndicate - Wrecker (Gorlex Marauders)"
+	id_assignment = "Wrecker"
 
 	uniform = /obj/item/clothing/under/syndicate/gorlex
 	shoes = /obj/item/clothing/shoes/workboots
@@ -923,6 +948,7 @@
 
 /datum/outfit/job/syndicate/miner/cybersun
 	name = "Syndicate - Field Agent (Cybersun)"
+	id_assignment = "Field Agent"
 
 	id = /obj/item/card/id/syndicate_command/crew_id
 	ears = /obj/item/radio/headset
@@ -949,6 +975,7 @@
 
 /datum/outfit/job/syndicate/engineer
 	name = "Syndicate - Ship Technician"
+	id_assignment = "Ship Technician"
 	jobtype = /datum/job/engineer
 	job_icon = "stationengineer"
 
@@ -969,6 +996,7 @@
 
 /datum/outfit/job/syndicate/engineer/gec
 	name = "Syndicate - Ship Engineer (GEC)"
+	id_assignment = "Ship Engineer"
 
 	uniform = /obj/item/clothing/under/syndicate/gec
 	alt_uniform = null
@@ -978,6 +1006,7 @@
 
 /datum/outfit/job/syndicate/engineer/gorlex
 	name = "Syndicate - Mechanic (Gorlex Marauders)"
+	id_assignment = "Mechanic"
 
 	uniform = /obj/item/clothing/under/syndicate/gorlex
 	shoes = /obj/item/clothing/shoes/workboots

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -194,6 +194,8 @@
 	var/job_icon
 	// the background of the job icon
 	var/faction_icon
+	// if there is an id, this will get automatically applied to an id's assignment variable
+	var/id_assignment
 
 	var/alt_uniform
 
@@ -280,6 +282,9 @@
 			C.registered_age = H.age
 		C.job_icon = job_icon
 		C.faction_icon = faction_icon
+		C.update_appearance()
+		if(id_assignment)
+			C.assignment = id_assignment
 		C.update_label()
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -179,6 +179,7 @@
 				return
 			id_card.registered_name = new_name
 			id_card.update_label()
+			id_card.update_appearance()
 			playsound(computer, "terminal_type", 50, FALSE)
 			return TRUE
 		if("PRG_assign")

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -299,12 +299,14 @@
 		id.access = get_all_accesses()+get_all_centcom_access()
 		id.assignment = "Captain"
 		id.update_label()
+		id.update_appearance()
 	else
 		id = new /obj/item/card/id/gold(user.loc)
 		id.registered_name = user.real_name
 		id.access = get_all_accesses()+get_all_centcom_access()
 		id.assignment = "Captain"
 		id.update_label()
+		id.update_appearance()
 		if(worn)
 			if(istype(worn, /obj/item/pda))
 				var/obj/item/pda/PDA = worn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request: 
* Separates the update_appearance proc from update_label. This is because the overlays that an ID card use are tied to the job name listed on the datums, and calling it with a custom assignment name did not give ID cards overlays. update_label now only updates the name of a card.
* Adds id_assignment to datum/outfit/job. This is because mobs spawned using the Select Equipment verb default to their job datum's assignment name instead of their id assignment.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
admin spite PR (i saw someone else spawn in as a sonnensoldner and their id card read security officer)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: ID cards' update_label proc no longer calls update_appearance. Please report any issues that may involve ID cards not updating overlays.
code: Outfits now have an id_assignment field. If a job has an id, and an id_assignment, it will automatically apply.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
