### PR TITLE
Changes the Solarian ship prefix from "SGSV" to "SCSV"

### DIFF
--- a/_maps/configs/solgov_chronicle.json
+++ b/_maps/configs/solgov_chronicle.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
 	"map_name": "Chronicle-class Sensor Frigate",
-	"prefix": "SGSV",
+	"prefix": "SCSV",
 	"namelists": [
 		"SOLGOV",
 		"SPACE",

--- a/_maps/configs/solgov_inkwell.json
+++ b/_maps/configs/solgov_inkwell.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
 	"map_name": "Inkwell-class Supply Freighter",
-	"prefix": "SGSV",
+	"prefix": "SCSV",
 	"namelists": [
 		"SOLGOV",
 		"SPACE",

--- a/_maps/configs/solgov_paracelsus.json
+++ b/_maps/configs/solgov_paracelsus.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
 	"map_name": "Paracelsus-class Medical Corvette",
-	"prefix": "SGSV",
+	"prefix": "SCSV",
 	"namelists": [
 		"SOLGOV",
 		"SPACE",

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -252,7 +252,7 @@ GLOBAL_LIST_INIT(ship_faction_to_prefixes, list(
 		"SUNS",
 	),
 	"SolGov" = list(
-		"SGSV",
+		"SCSV",
 	),
 	"Saint-Roumain Militia" = list(
 		"SRSV",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Just a find and replace from "SGSV" to "SCSV"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
"SolGov" isn't an official name for the Most Serene Solar and Intersolar Confederation, so "SolGov Space Vessel" doesn't really make sense. "Solar Confederation Space Vessel" does make sense, though.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Solarian ship prefix is now "SCSV," not "SGSV"
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
