### PR TITLE
Silicon Emotes Additions

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -269,6 +269,15 @@
 	if(..())
 		playsound(user.loc, 'sound/machines/chime.ogg', 50)
 
+/datum/emote/living/carbon/human/robot_tongue/no
+	key = "no"
+	key_third_person = "no"
+	message = "emits an negative blip."
+
+/datum/emote/living/carbon/human/robot_tongue/no/run_emote(mob/user, params)
+	if(..())
+		playsound(user.loc, 'sound/machines/synth_no.ogg', 50)
+
 /datum/emote/living/carbon/human/robot_tongue/ping
 	key = "ping"
 	key_third_person = "pings"
@@ -279,28 +288,41 @@
 	if(..())
 		playsound(user.loc, 'sound/machines/ping.ogg', 50)
 
-// Clown Robotic Tongue ONLY. Henk.
+/datum/emote/living/carbon/human/robot_tongue/warn
+	key = "warn"
+	key_third_person = "warn"
+	message = "blares an alarm!"
 
-/datum/emote/living/carbon/human/robot_tongue/clown/can_run_emote(mob/user, status_check = TRUE , intentional)
-	if(!..())
-		return FALSE
-	if(user.mind.assigned_role == "Clown")
-		return TRUE
+/datum/emote/living/carbon/human/robot_tongue/warn/run_emote(mob/user, params)
+	if(..())
+		playsound(user.loc, 'sound/machines/warning-buzzer.ogg', 50)
 
-/datum/emote/living/carbon/human/robot_tongue/clown/honk
+/datum/emote/living/carbon/human/robot_tongue/yes
+	key = "yes"
+	key_third_person = "yes"
+	message = "emits an affirmative blip."
+
+/datum/emote/living/carbon/human/robot_tongue/yes/run_emote(mob/user, params)
+	if(..())
+		playsound(user.loc, 'sound/machines/synth_yes.ogg', 50)
+
+// the following emotes were originally clown-locked and synthetic exclusive
+// since clowns have been removed I see no reason to let them collect dust
+
+/datum/emote/living/carbon/human/robot_tongue/honk
 	key = "honk"
 	key_third_person = "honks"
 	message = "honks."
 
-/datum/emote/living/carbon/human/robot_tongue/clown/honk/run_emote(mob/user, params)
+/datum/emote/living/carbon/human/robot_tongue/honk/run_emote(mob/user, params)
 	if(..())
 		playsound(user.loc, 'sound/items/bikehorn.ogg', 50)
 
-/datum/emote/living/carbon/human/robot_tongue/clown/sad
+/datum/emote/living/carbon/human/robot_tongue/sad
 	key = "sad"
 	key_third_person = "plays a sad trombone..."
 	message = "plays a sad trombone..."
 
-/datum/emote/living/carbon/human/robot_tongue/clown/sad/run_emote(mob/user, params)
+/datum/emote/living/carbon/human/robot_tongue/sad/run_emote(mob/user, params)
 	if(..())
 		playsound(user.loc, 'sound/misc/sadtrombone.ogg', 50)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -306,17 +306,8 @@
 	if(..())
 		playsound(user.loc, 'sound/machines/synth_yes.ogg', 50)
 
-// the following emotes were originally clown-locked and synthetic exclusive
-// since clowns have been removed I see no reason to let them collect dust
-
-/datum/emote/living/carbon/human/robot_tongue/honk
-	key = "honk"
-	key_third_person = "honks"
-	message = "honks."
-
-/datum/emote/living/carbon/human/robot_tongue/honk/run_emote(mob/user, params)
-	if(..())
-		playsound(user.loc, 'sound/items/bikehorn.ogg', 50)
+// the following emote were originally clown-locked and synthetic exclusive
+// since clowns have been removed I see no reason to let it collect dust
 
 /datum/emote/living/carbon/human/robot_tongue/sad
 	key = "sad"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -32,6 +32,11 @@
 	vary = TRUE
 	sound = 'sound/items/bikehorn.ogg'
 
+/datum/emote/silicon/no
+	key = "no"
+	message = "emits an negative blip."
+	sound = 'sound/machines/synth_no.ogg'
+
 /datum/emote/silicon/ping
 	key = "ping"
 	key_third_person = "pings"
@@ -48,3 +53,8 @@
 	key = "warn"
 	message = "blares an alarm!"
 	sound = 'sound/machines/warning-buzzer.ogg'
+
+/datum/emote/silicon/yes
+	key = "yes"
+	message = "emits an affirmative blip."
+	sound = 'sound/machines/synth_yes.ogg'

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -25,13 +25,6 @@
 	message = "chimes."
 	sound = 'sound/machines/chime.ogg'
 
-/datum/emote/silicon/honk
-	key = "honk"
-	key_third_person = "honks"
-	message = "honks."
-	vary = TRUE
-	sound = 'sound/items/bikehorn.ogg'
-
 /datum/emote/silicon/no
 	key = "no"
 	message = "emits an negative blip."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new noises to the Silicon Lexicon: *yes and *no as a vague port of https://github.com/PolarisSS13/Polaris/pull/809

Also removes the clown restriction on *sad, and standardizes available emotes between borgs and robotic tongue enjoyers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- There wasn't a real reason for borgs to have exclusive emotes at this point, given they're identical to positronics in-lore
- More noises for silicons allows for more player expression
- Your local IPC being able to play a sad trombone whenever something bad happens will heighten Shiptest comedy by ~62%

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: silicons across the sector have added two new noises to their lexicon, try them out with *yes and *no! 
tweak: silicons across the sector have also overridden their clown inhibitors, allowing them to play a bummer trombone with *sad
tweak: borgs have leaked the secrets of *warn to their integrated positronic counterparts
del: due to wide reaching protest, silicons across the galaxy have decided to give up their ability to *honk in respect for the lives lost during the ICW
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
