### PR TITLE
Send photos to admin faxes

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -67,8 +67,9 @@
 #define ADMIN_COORDJMP(src) "[src ? "[COORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
 #define ADMIN_VERBOSEJMP(src) "[src ? "[AREACOORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
 #define ADMIN_INDIVIDUALLOG(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];individuallog=[REF(user)]'>LOGS</a>)"
-/// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper). First you need to set the request_state variable to TRUE for the paper.
+/// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper) or atom(photo). First you need to set the request_state variable to TRUE for the paper.
 #define ADMIN_SHOW_PAPER(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
+#define ADMIN_SHOW_PHOTO(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_photo=[REF(atom)]'>PHOTO</a>)"
 
 #define ADMIN_PUNISHMENT_BREAK_BONES "Break all bones"
 #define ADMIN_PUNISHMENT_LIGHTNING "Lightning bolt"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2227,6 +2227,15 @@
 			return
 		paper_to_show.ui_interact(usr)
 
+	else if(href_list["show_photo"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/obj/item/photo/photo_to_show = locate(href_list["show_photo"])
+		if(!istype(photo_to_show))
+			return
+		photo_to_show.show(usr)
+
 /datum/admins/proc/HandleCMode()
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -308,27 +308,34 @@
 				update_icon()
 				return TRUE
 		if("send_special")
-			var/obj/item/paper/fax_paper = loaded_item_ref?.resolve()
-			if(!fax_paper)
+			var/obj/item/loaded = loaded_item_ref?.resolve()
+			var/obj/thing_to_send
+			if(!loaded)
 				return
-			if(!istype(fax_paper))
+			if(istype(loaded, /obj/item/paper))
+				var/obj/item/paper/fax_paper = loaded
+				fax_paper.request_state = TRUE
+				thing_to_send = fax_paper
+			else if(istype(loaded, /obj/item/photo))
+				thing_to_send = loaded
+			else
 				to_chat(usr, icon2html(src.icon, usr) + "<span class='warning'>ERROR: Failed to send fax.</span>")
 				return
 
-			fax_paper.request_state = TRUE
-			fax_paper.loc = null
-
-			INVOKE_ASYNC(src, PROC_REF(animate_object_travel), fax_paper, "fax_receive", find_overlay_state(fax_paper, "send"))
+			if(!thing_to_send)
+				return
+			thing_to_send.loc = null
+			INVOKE_ASYNC(src, PROC_REF(animate_object_travel), thing_to_send, "fax_receive", find_overlay_state(thing_to_send, "send"))
 			history_add("Send", params["name"])
 
-			GLOB.requests.fax_request(usr.client, "sent a fax message from [fax_name]/[fax_id] to [params["name"]]", fax_paper)
-			to_chat(GLOB.admins, "<span class='adminnotice'>[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> <span class='linkify'>sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]</span> [ADMIN_SHOW_PAPER(fax_paper)]")
-			log_fax(fax_paper, params["id"], params["name"])
+			GLOB.requests.fax_request(usr.client, "sent a fax message from [fax_name]/[fax_id] to [params["name"]]", thing_to_send)
+			to_chat(GLOB.admins, "<span class='adminnotice'>[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> <span class='linkify'>sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]</span> [istype(thing_to_send, /obj/item/paper) ? ADMIN_SHOW_PAPER(thing_to_send) : ADMIN_SHOW_PHOTO(thing_to_send)]")
+			log_fax(thing_to_send, params["id"], params["name"])
 			loaded_item_ref = null
 
 			for(var/obj/machinery/fax/fax as anything in GLOB.fax_machines)
 				if(fax.admin_fax_id == params["id"])
-					fax.receive(fax_paper, fax_name)
+					fax.receive(thing_to_send, fax_name)
 					break
 			update_appearance()
 
@@ -360,7 +367,7 @@
  * * loaded - The object to be sent.
  * * id - The network ID of the fax machine you want to send the item to.
  */
-/obj/machinery/fax/proc/send(obj/item/loaded, id)
+/obj/machinery/fax/proc/send(atom/movable/loaded, id)
 	for(var/obj/machinery/fax/fax as anything in GLOB.fax_machines)
 		if(fax.fax_id != id)
 			continue
@@ -385,7 +392,7 @@
  * * loaded - The object to be printed.
  * * sender_name - The sender's name, which will be displayed in the message and recorded in the history of operations.
  */
-/obj/machinery/fax/proc/receive(obj/item/loaded, sender_name, important = FALSE)
+/obj/machinery/fax/proc/receive(atom/movable/loaded, sender_name, important = FALSE)
 	playsound(src, 'sound/items/poster_being_created.ogg', 20, FALSE)
 	INVOKE_ASYNC(src, PROC_REF(animate_object_travel), loaded, "fax_receive", find_overlay_state(loaded, "receive"))
 	say("Received correspondence from [sender_name].")
@@ -442,7 +449,7 @@
  * Arguments:
  * * vend - Item to vend from the fax machine.
  */
-/obj/machinery/fax/proc/vend_item(obj/item/vend)
+/obj/machinery/fax/proc/vend_item(atom/movable/vend)
 	vend.forceMove(drop_location())
 	if(hurl_contents)
 		vend.throw_at(get_edge_target_turf(drop_location(), pick(GLOB.alldirs)), rand(1, 4), EMBED_THROWSPEED_THRESHOLD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![imagen](https://github.com/shiptest-ss13/Shiptest/assets/75212565/5c32c7bb-94f3-4b06-bd32-1deeeeddb4a7)

This pull requests allows you to send photos to admin faxes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can send photos of events happening to your high command, so you don't have to describe everything in text! You can send them cool art you made. Maybe even use it for some strategic plans you drew on a napkin, and you want HighComm to see them.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Long-range bluespace technologies in fax machines now allow the faxing of photos. I am not responsible for any consequences that might result from sending your faction's command personnel a photo of your character's ass.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
