### PR TITLE
Adds Etherbor civilian weapons to cargo

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -281,6 +281,12 @@
 	contains = list(/obj/item/stock_parts/cell/gun)
 	cost = 500
 
+/datum/supply_pack/ammo/guncell/kalix
+	name = "Etherbor Cell Crate"
+	desc = "Contains an Etherbor weapon cell, compatible with Etherbor armaments with a slightly higher capacity."
+	contains = list(/obj/item/stock_parts/cell/gun/kalix)
+	cost = 600
+
 /datum/supply_pack/ammo/c46x30mm_boxcrate
 	name = "4.6x30mm Ammo Box Crate"
 	desc = "Contains a fifty-round 4.6x30mm box for PDWs such as the WT-550."

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -83,6 +83,20 @@
 	crate_name = "ion rifle crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
+/datum/supply_pack/gun/laser/kalix/pistol
+	name = "Etherbor SG-8 Beam Pistol Crate"
+	desc = "Contains a single SG-8 Beam Pistol, a civilian-grade sidearm developed in the PGF, manufactured by Etherbor Industries."
+	cost = 1000
+	contains = list(/obj/item/gun/energy/kalix/pistol)
+	crate_name = "beam pistol crate"
+
+/datum/supply_pack/gun/laser/kalix
+	name = "Etherbor BG-12 Beam Rifle Crate"
+	desc = "Contains a single BG-12 Beam Rifle, a civilian-grade semi-automatic developed in the PGF, manufactured by Etherbor Industries."
+	cost = 3000
+	contains = list(/obj/item/gun/energy/kalix)
+	crate_name = "beam rifle crate"
+
 /*
 		Shotguns
 */


### PR DESCRIPTION
## About The Pull Request

Adds the civilian Etherbor weapons (SG-8 pistol and BG-12 semi-automatic rifle) to the cargo console.

## Why It's Good For The Game

Etherbor supposedly sells these weapons on the civilian market but they don't. Even not considering that, there doesn't seem to be any non-NT energy weapon at all on the cargo console and I want to give independents or crews that don't like NT some options. Open to changing the price on the crates but I think its more or less pretty fair to how the weapons perform.

## Changelog

:cl:
add: Etherbor SG-8 Beam Pistol to cargo for 1000 credits
add: Etherbor BG-12 Beam Rifle to cargo for 3000 credits
add: Etherbor civilian weapon cells for 600 credits, slightly higher capacity than the generic cells
/:cl:
