### PR TITLE
Granularizes the space suits and armor tab in Outpost cargo, and reduces the cost of specialized space suits

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -8,39 +8,32 @@
 
 /datum/supply_pack/spacesuit_armor/spacesuit
 	name = "Space Suit Crate"
-	desc = "Contains three basic space suits. Although the technology is centuries old, they should protect you from the vacuum of space."
-	cost = 1500
+	desc = "Contains one basic space suit. Although the technology is centuries old, it should protect you from the vacuum of space."
+	cost = 500
 	contains = list(/obj/item/clothing/suit/space,
-					/obj/item/clothing/suit/space,
-					/obj/item/clothing/suit/space,
-					/obj/item/clothing/head/helmet/space,
-					/obj/item/clothing/head/helmet/space,
 					/obj/item/clothing/head/helmet/space)
 	crate_name = "space suit crate"
 
 /datum/supply_pack/spacesuit_armor/pilot_spacesuit
 	name = "Pilot Space Suit Crate"
-	desc = "Two pilot space suits, for improved mobility in mechs and pods."
-	cost = 3500
+	desc = "One pilot space suit, for improved mobility in mechs."
+	cost = 750
 	contains = list(/obj/item/clothing/suit/space/pilot,
-					/obj/item/clothing/suit/space/pilot,
-					/obj/item/clothing/head/helmet/space/pilot/random,
 					/obj/item/clothing/head/helmet/space/pilot/random)
 	crate_name = "pilot space suit crate"
 
 /datum/supply_pack/spacesuit_armor/mining_hardsuits_indie
 	name = "Mining Hardsuit Crate"
-	desc = "Two independent branded mining hardsuits for when explorer suits just dont cut it."
-	cost = 4000
-	contains = list(/obj/item/clothing/suit/space/hardsuit/mining/independent,
-					/obj/item/clothing/suit/space/hardsuit/mining/independent)
+	desc = "One independent branded mining hardsuit for when explorer suits just dont cut it."
+	cost = 1500
+	contains = list(/obj/item/clothing/suit/space/hardsuit/mining/independent)
 	crate_name = "mining hardsuit crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/spacesuit_armor/med_hardsuit
 	name = "Medical Hardsuit Crate"
-	desc = "Two medical hardsuits, resistant to diseases and useful for retrieving patients in space."
-	cost = 5000
+	desc = "One medical hardsuit, resistant to diseases and useful for retrieving patients in space."
+	cost = 1500
 	contains = list(/obj/item/clothing/suit/space/hardsuit/medical,
 					/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"
@@ -49,7 +42,7 @@
 /datum/supply_pack/spacesuit_armor/mining_hardsuit_heavy
 	name = "Heavy Mining Hardsuit Crate"
 	desc = "One deluxe heavy mining hardsuit for dangerous frontier operations. Comes with a pair of EXOCOM jet boots."
-	cost = 6000
+	cost = 3500
 	contains = list(/obj/item/clothing/suit/space/hardsuit/mining/heavy,
 					/obj/item/clothing/shoes/bhop)
 	crate_name = "heavy mining hardsuit crate"
@@ -57,53 +50,43 @@
 
 /datum/supply_pack/spacesuit_armor/sec_hardsuit_bundle
 	name = "Security Hardsuit Crate"
-	desc = "Contains two security hardsuits for light combat duty."
-	cost = 7500
-	contains = list(/obj/item/clothing/suit/space/hardsuit/security/independent,
-					/obj/item/clothing/suit/space/hardsuit/security/independent)
+	desc = "Contains one security hardsuit for light combat duty."
+	cost = 2500
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security/independent)
 	crate_name = "security hardsuit crate"
 	crate_type = /obj/structure/closet/crate/secure/gear
 
 /datum/supply_pack/spacesuit_armor/sci_hardsuit
 	name = "Science Hardsuit Crate"
-	desc = "Contains two science hardsuits, designed to provide safety under advanced experimental conditions."
-	cost = 8500
-	contains = list(/obj/item/clothing/suit/space/hardsuit/rd,
-					/obj/item/clothing/suit/space/hardsuit/rd)
+	desc = "Contains one science hardsuit, designed to provide safety under advanced experimental conditions."
+	cost = 2000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/rd)
 	crate_name = "science hardsuit crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/spacesuit_armor/engi_spacesuit_bundle
 	name = "Engineering Space Suit Crate"
-	desc = "Need to turn your ship into a safety hazard? Not a problem! These three engineering space suits will help get the job done."
-	cost = 9000
+	desc = "Need to turn your ship into a safety hazard? Not a problem! This engineering space suit will help get the job done."
+	cost = 1500
 	contains = list(/obj/item/clothing/suit/space/engineer,
-					/obj/item/clothing/suit/space/engineer,
-					/obj/item/clothing/suit/space/engineer,
-					/obj/item/clothing/head/helmet/space/light/engineer,
-					/obj/item/clothing/head/helmet/space/light/engineer,
 					/obj/item/clothing/head/helmet/space/light/engineer)
 	crate_name = "engineering space suit crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/spacesuit_armor/atmos_hardsuit
 	name = "Atmospherics Hardsuit Crate"
-	desc = "The iconic hardsuit of Nanotrasen's Atmosphere Corps, these two hardsuits are known across space as a symbol of defiance in the face of sudden decompression. Smells faintly of plasma."
-	cost = 12000
-	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos,
-					/obj/item/clothing/suit/space/hardsuit/engine/atmos)
+	desc = "The iconic hardsuit of Nanotrasen's Atmosphere Corps, this hardsuit is known across space as a symbol of defiance in the face of sudden decompression. Smells faintly of plasma."
+	cost = 2500
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos)
 	crate_name = "atmospherics hardsuit crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/spacesuit_armor/swat
 	name = "SWAT Crate"
-	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, and combat belt."
-	cost = 12000
+	desc = "Contains one fullbody set of tough, fireproof, pressurized suit designed in a joint effort by IS-ERI and Nanotrasen. The set contains a suit, helmet, and combat belt."
+	cost = 3500
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
-					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
-					/obj/item/clothing/suit/space/swat,
-					/obj/item/storage/belt/military/assault,
 					/obj/item/storage/belt/military/assault)
 	crate_name = "swat crate"
 	crate_type = /obj/structure/closet/crate/secure/gear

--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -97,42 +97,35 @@
 
 /datum/supply_pack/spacesuit_armor/basic_armor
 	name = "Armor Crate"
-	desc = "Two sets of well-rounded body armor. Each set includes a helmet and vest."
-	cost = 1500
+	desc = "One set of well-rounded body armor. The set includes a helmet and vest."
+	cost = 750
 	contains = list(/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec)
 	crate_name = "armor crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/spacesuit_armor/riot_armor
 	name = "Riot Armor Crate"
-	desc = "Contains two full sets of riot armor. Although heavily padded to deal with close-quarters threats, they perform poorly against most firearms."
-	cost = 3000
+	desc = "Contains one full set of riot armor. Although heavily padded to deal with close-quarters threats, they perform poorly against most firearms."
+	cost = 1500
 	contains = list(/obj/item/clothing/suit/armor/riot,
-					/obj/item/clothing/suit/armor/riot,
-					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
 	crate_name = "riot armor crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/spacesuit_armor/bullet_armor
 	name = "Bulletproof Armor Crate"
-	desc = "Contains two full sets of bulletproof armor, guaranteed to reduce a bullet's stopping power by half but with limited protection against melee weaponry."
-	cost = 3500
+	desc = "Contains one full set of bulletproof armor, guaranteed to reduce a bullet's stopping power by half but with limited protection against melee weaponry."
+	cost = 1750
 	contains = list(/obj/item/clothing/suit/armor/vest/bulletproof,
-					/obj/item/clothing/suit/armor/vest/bulletproof,
-					/obj/item/clothing/head/helmet/bulletproof,
 					/obj/item/clothing/head/helmet/bulletproof)
 	crate_name = "bulletproof armor crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/spacesuit_armor/laser_armor
 	name = "Reflector Vest Crate"
-	desc = "Contains two vests of highly reflective material. Each armor piece diffuses a laser's energy by over half, as well as offering a good chance to reflect the laser entirely."
-	cost = 3000
-	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/laserproof)
+	desc = "Contains one vest made of highly reflective material. The armor piece diffuses a laser's energy by over half, as well as offering a good chance to reflect the laser entirely."
+	cost = 1500
+	contains = list(/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Granularizes the Spacesuits and Armor tab at outpost cargo, and adjusts the descriptions accordingly. Removes a mention of pods in the pilot suit since those don't exist anymore. Reduces the costs of the specialized space suits.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More fine control over the amount of suits or armor you want to buy is probably good. As for the space suit prices, they were incredibly high and prohibitively expensive for what they were to the point you would almost never see any of them bought unless you were just drowning in money.

## Changelog

:cl:
tweak: Granularizes Outpost Spacesuits and Armor
balance: Reduces the cost of specialized space suits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
