### PR TITLE
Fixes the laser gun being unbuyable from the outpost

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -60,7 +60,7 @@
 	contains = list(/obj/item/gun/energy/laser)
 	crate_name = "laser crate"
 
-/datum/supply_pack/gun/laser
+/datum/supply_pack/gun/mini_energy
 	name = "Mini Energy Gun Crate"
 	desc = "Contains a small, versatile energy gun, capable of firing both nonlethal and lethal blasts, but with a limited power cell."
 	cost = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The laser gun and mini e-gun had the same datum path, so the laser couldn't be bought. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bug fixes good

## Changelog

:cl:
fix: The laser gun can be bought at the outpost again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
