### PR TITLE
Put the right magazines in the Comms Outpost ruin. 

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_comm_outpost.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_comm_outpost.dmm
@@ -202,9 +202,9 @@
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/combat,
 /obj/item/gun/ballistic/automatic/pistol,
-/obj/item/ammo_box/magazine/pistolm9mm,
-/obj/item/ammo_box/magazine/pistolm9mm,
-/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/syndicate_outpost)
 "To" = (


### PR DESCRIPTION
## About The Pull Request
switched 9mm to 10mm, the magazines actually used by the gun that spawns there.

## Why It's Good For The Game
No more useless mags. 
## Changelog

:cl:
tweak: changed the 3 9mm magazines in the lavaland comms outpost ruin to 10mm
:cl:
