### PR TITLE
QoL advanced build mode 

### DIFF
--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -26,7 +26,7 @@
 	var/atom/movable/screen/buildmode/preview_item/preview
 
 /datum/buildmode/New(client/c)
-	mode = new /datum/buildmode_mode/basic(src)
+	mode = new /datum/buildmode_mode/advanced(src)
 	holder = c
 	buttons = list()
 	li_cb = CALLBACK(src, PROC_REF(post_login))
@@ -36,6 +36,7 @@
 	holder.screen += buttons
 	holder.click_intercept = src
 	mode.enter_mode(src)
+	modebutton.update_appearance()
 
 /datum/buildmode/proc/quit()
 	mode.exit_mode(src)


### PR DESCRIPTION
## About The Pull Request
Hello dear comrades! This pull request is changing QoL for admins who uses build mode. 
I truly believe that nobody is using simple build mode that allows you just to create airlocks, walls and floors while advanced have many more features for admins to use. 

## Why It's Good For The Game

With just a click of a button, administrators can access the most useful tool in build mode without disabling simple build mode every time.

## Changelog

:cl:
admin: faster access to advanced build mode

/:cl:
