### PR TITLE
Un-Aspawns the Crying Sun

### DIFF
--- a/_maps/configs/pgf_crying_sun.json
+++ b/_maps/configs/pgf_crying_sun.json
@@ -46,5 +46,5 @@
 			"slots": 3
 		}
 	},
-	"enabled":false
+	"enabled":true
 }


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
hey. i think we can trust people with this ship. let it roam free.

## Changelog

🆑
tweak: The Crying Sun is no longed aspawned.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
