### PR TITLE
Nerfs kissing

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -455,7 +455,7 @@
  * This fake hit only happens if we can deal damage and if we hit a living thing. Otherwise, we just do normal on hit effects.
  */
 /obj/projectile/kiss/proc/harmless_on_hit(mob/living/living_target)
-	playsound(get_turf(living_target), hitsound, 100, TRUE)
+	playsound(get_turf(living_target), hitsound, 50, TRUE, -12, ignore_walls = FALSE)
 	if(!suppressed)  // direct
 		living_target.visible_message(span_danger("[living_target] is hit by \a [src]."), span_userdanger("You're hit by \a [src]!"), vision_distance=COMBAT_MESSAGE_RANGE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the sound played upon kiss by halving the volume and reducing the range so you can only hear it if you are around 5 tiles to whoever was kissed, while fully blocking it behind walls.

https://github.com/shiptest-ss13/Shiptest/assets/66234359/5c41058c-8ec9-4838-a076-65a15148094a


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Kissing is currently way too loud that it can be heard from nearly anywhere in most of the ships, this PR tries to fix it so it has a more reasonable range while blocking walls.

Additionally I've seen and heard a few players get uncomfortable over being able to hear some of the crewmembers get a bit kissy towards each other even when they tried to move far away from it.

I figured that 5 tiles may be a reasonable range considering that most of the rooms are around that size but I'm still open to changing it.

## Changelog

:cl: Hardly
tweak: Kissing volume and range has been reduced. Kissing cannot be heard beyond 5 ranges or behind walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
