### PR TITLE
Adjusted large and plastic beaker costs, increased plastic recipe sheet creation 5x

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -538,7 +538,7 @@
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
+	for(var/i in 1 to created_volume * 5)
 		new /obj/item/stack/sheet/plastic(location)
 
 /datum/chemical_reaction/pax

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -147,7 +147,7 @@
 	desc = "An extra-large beaker. Can hold up to 120 units."
 	icon_state = "beakerwhite"
 	fill_icon_state = "beakerlarge"
-	custom_materials = list(/datum/material/glass=2500, /datum/material/plastic=3000)
+	custom_materials = list(/datum/material/glass=1000, /datum/material/plastic=1000)
 	volume = 120
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,60,120)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -582,7 +582,7 @@
 	name = "Large Beaker"
 	id = "large_beaker"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/glass = 2500)
+	materials = list(/datum/material/glass = 1500)
 	build_path = /obj/item/reagent_containers/glass/beaker/large
 	category = list("initial", "Medical", "Medical Designs")
 


### PR DESCRIPTION
## About The Pull Request

Large and XL beakers are pretty expensive. I've reduced their cost a bit. Because chemistry is more dangerous with more units in a container, you still pay a lot more for the extra space, but they're no longer crazy expensive.

Also, we don't often have a lot of access to plastic here on shiptest, and plastic gates a lot of things. The plastic from the outpost IS WAY MORE than you will EVER need in a typical round (barring something exotic that you are doing), but if no one is willing to do chemistry, it's still a reasonable thing to do.

This just makes it so that doing chemistry for plastic reasonable using the chemistry starter kit, since very few ships have a chem dispenser device.

## Why It's Good For The Game

Plastic making sucks. Now it's okay to consider a small batch. Plus large (100u) and especially XL beakers (120u) were very expensive.

## Changelog

:cl:
balance: costs reduced for large beakers (1500 glass, down from 2500) and XL beakers (1000 glass 1000 plastic, down from 2500 glass and 3000 plastic)
balance: the plastic sheets recipe now outputs 5 sheets instead of 1 sheet per reaction.
/:cl: