### PR TITLE
Removes armor from hats

### DIFF
--- a/code/modules/clothing/head/berets.dm
+++ b/code/modules/clothing/head/berets.dm
@@ -32,9 +32,9 @@
 
 /obj/item/clothing/head/beret/durathread
 	name = "durathread beret"
-	desc =  "A beret made from durathread, its resilient fibres provide some protection to the wearer."
+	desc =  "A beret made from durathread, its resilient fibres provide a modicum of fire protection to the wearer."
 	icon_state = "beretdurathread"
-	armor = list("melee" = 15, "bullet" = 5, "laser" = 15, "energy" = 25, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 5)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 5, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 5)
 
 //Civilian
 /obj/item/clothing/head/beret/grey
@@ -56,7 +56,6 @@
 	name = "quartermaster beret"
 	desc =  "A cargo beret with a faded medal haphazardly stitched into it. Worn by a true cargonian, it commands respect from everyone."
 	icon_state = "beret_qm"
-	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5)
 
 /obj/item/clothing/head/beret/cargo
 	name = "cargo beret"
@@ -65,30 +64,25 @@
 
 /obj/item/clothing/head/beret/mining
 	name = "mining beret"
-	desc =  "A grey beret with a pickaxe insignia sewn into it. Seems to be padded and fireproofed to offer the wearer some protection."
+	desc =  "A grey beret with a pickaxe insignia sewn into it."
 	icon_state = "beret_mining"
-	armor = list("melee" = 25, "bullet" = 10, "laser" = 10, "energy" = 15, "bomb" = 30, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 
 //Sec
 /obj/item/clothing/head/beret/sec
 	name = "security beret"
-	desc = "A robust beret with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection."
+	desc = "A robust beret with the security insignia emblazoned on it."
 	icon_state = "beret_sec"
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 60
 	dog_fashion = null
 
 /obj/item/clothing/head/beret/sec/hos
 	name = "head of security's black beret"
 	desc = "A black beret with the Head of Security's insignia emblazoned on it. A symbol of excellence, a badge of courage, a mark of distinction."
 	icon_state = "beret_hos"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 60)
 
 /obj/item/clothing/head/beret/sec/warden
 	name = "warden's beret"
 	desc = "A beret made with black reinforced fabric with the Warden's insignia emblazoned on it. For wardens with class."
 	icon_state = "beret_warden"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 
 /obj/item/clothing/head/beret/sec/officer
 	desc = "A beret made out of black reinforced fabric with the security insignia emblazoned on it. For officers with class."
@@ -103,7 +97,7 @@
 	name = "engineering beret"
 	desc = "A beret with the engineering insignia emblazoned on it. For engineers that are more inclined towards style than safety."
 	icon_state = "beret_engineering"
-	armor = list("rad" = 10, "fire" = 10)
+	armor = list("rad" = 5, "fire" = 10)
 
 /obj/item/clothing/head/beret/eng/hazard
 	name = "engineering hazardberet"
@@ -114,13 +108,13 @@
 	name = "atmospherics beret"
 	desc = "A beret for those who have shown immaculate proficienty in piping. Or plumbing. Mostly piping."
 	icon_state = "beret_atmospherics"
-	armor = list("rad" = 10, "fire" = 10)
+	armor = list("rad" = 5, "fire" = 10)
 
 /obj/item/clothing/head/beret/ce
 	name = "chief engineer beret"
 	desc = "A white beret with the engineering insignia emblazoned on it. Its owner knows what they're doing. Probably."
 	icon_state = "beret_ce"
-	armor = list("rad" = 20, "fire" = 30)
+	armor = list("rad" = 10, "fire" = 30)
 
 //Science
 /obj/item/clothing/head/beret/sci
@@ -170,22 +164,16 @@
 	name = "captain beret"
 	desc = "A lovely blue Captain beret with a gold and white insignia. Truly fit for only the finest officers."
 	icon_state = "beret_captain"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 90
 
 /obj/item/clothing/head/beret/hop
 	name = "head of personnel beret"
 	desc = "A lovely blue Head of Personnel's beret with a silver and white insignia. It smells faintly of paper and dogs."
 	icon_state = "beret_hop"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 90
 
 /obj/item/clothing/head/beret/command
 	name = "command beret"
 	desc = "A modest blue command beret with a silver rank insignia. Smells of power and the sweat of assistants."
 	icon_state = "beret_com"
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 10, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 25)
-	strip_delay = 90
 
 // SolGov
 
@@ -193,7 +181,6 @@
 	name = "\improper SolGov beret"
 	desc = "A beret with SolGov's emblem emblazoned on it. Colored in SolGov blue."
 	icon_state = "beret_solgov"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 
 /obj/item/clothing/head/beret/solgov/plain
 	name = "\improper SolGov beret"
@@ -226,7 +213,6 @@
 	name = "honorable vanguard beret"
 	desc = "A snow white beret with an air of distinction around it, emblazoned with the golden shield of the IRMG as the badge."
 	icon_state = "inteq_honorable_beret"
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 90)
 
 // Frontier
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -21,8 +21,6 @@
 	icon_state = "captain"
 	item_state = "that"
 	flags_inv = 0
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/captain
 
 //Captain: This is no longer space-worthy
@@ -57,7 +55,6 @@
 	name = "head of personnel's cap"
 	icon_state = "hopcap"
 	desc = "The symbol of true bureaucratic micromanagement."
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	dog_fashion = /datum/dog_fashion/head/head_of_personnel
 
 /obj/item/clothing/head/hopcap/nt
@@ -92,7 +89,6 @@
 /obj/item/clothing/head/fedora/det_hat
 	name = "detective's fedora"
 	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat."
-	armor = list("melee" = 25, "bullet" = 5, "laser" = 25, "energy" = 35, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 50)
 	icon_state = "detective"
 	var/candy_cooldown = 0
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/fedora/detective
@@ -132,8 +128,6 @@
 	name = "head of security cap"
 	desc = "The robust standard-issue cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 60)
-	strip_delay = 80
 
 /obj/item/clothing/head/HoS/cowboy
 	name = "sheriff's hat"
@@ -144,10 +138,8 @@
 
 /obj/item/clothing/head/cowboy/sec
 	name = "deputy hat"
-	desc = "A robust stetson adorned with a deputy's badge. It has a reinforced lining under the imitation leather."
+	desc = "A robust stetson adorned with a deputy's badge. Its imitation leather is thick and worn."
 	icon_state = "cowboysec"
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 60
 
 /obj/item/clothing/head/cowboy/sec/roumain
 	name = "hunter's hat"
@@ -181,41 +173,37 @@
 
 /obj/item/clothing/head/HoS/beret/syndicate
 	name = "syndicate beret"
-	desc = "A black beret with thick armor padding inside. Stylish and robust."
+	desc = "A nondescript black beret. Stylish and robust."
 	icon_state = "beret_officer"
 	item_state = "beret_officer"
 
 /obj/item/clothing/head/warden
 	name = "warden's police hat"
-	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."
+	desc = "It's a special hat issued to the Warden of a security force. A classic symbol of middling authority."
 	icon_state = "policehelm"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
-	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/warden
 
 /obj/item/clothing/head/warden/red
 	name = "warden's red hat"
 	desc = "A warden's red hat. Looking at it gives you the feeling of wanting to keep people in cells for as long as possible."
 	icon_state = "wardenhat"
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
-	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/warden_red
 
 /obj/item/clothing/head/warden/cowboy
 	name = "jailor's hat"
-	desc = "A menacing black stetson adorned with a jailor's badge. It has a heavily reinforced lining under the imitation leather."
+	desc = "A menacing black stetson adorned with a jailor's badge. Made of thick imitation leather."
 	icon_state = "cowboywarden"
 
 	dog_fashion = /datum/dog_fashion/head/cowboy
 
 /obj/item/clothing/head/warden/inteq
 	name = "master at arms' campaign hat"
-	desc = "A special armored campaign hat with the IRMG insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection."
+	desc = "A special brown campaign hat with the IRMG insignia emblazoned on it. For yelling at clueless recruits in style."
 	icon_state = "maahat"
 
 /obj/item/clothing/head/warden/drill
 	name = "warden's campaign hat"
-	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection."
+	desc = "A special campaign hat with the security insignia emblazoned on it."
 	icon_state = "wardendrill"
 	item_state = "wardendrill"
 	dog_fashion = null

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -266,7 +266,6 @@
 /obj/item/clothing/head/hunter
 	name = "bounty hunting hat"
 	desc = "Ain't nobody gonna cheat the hangman in my town."
-	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 15, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/head/cone
@@ -321,7 +320,6 @@
 	name = "crown"
 	desc = "A crown fit for a king, a petty king maybe."
 	icon_state = "crown"
-	armor = list("melee" = 15, "bullet" = 0, "laser" = 0,"energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/head/crown/fancy
@@ -454,8 +452,6 @@
 	icon_state = "ngrcap"
 	item_state = "ngrcap"
 	flags_inv = 0
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 60
 
 /obj/item/clothing/head/maidheadband/syndicate
 	name = "tactical maid headband"
@@ -475,8 +471,6 @@
 	icon_state = "inteq_peaked"
 	item_state = "inteq_peaked"
 	flags_inv = 0
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 60)
-	strip_delay = 60
 
 /obj/item/clothing/head/maidheadband
 	name = "maid headband"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -121,8 +121,6 @@
 	desc = "It's a robust baseball hat in tasteful red colour."
 	icon_state = "secsoft"
 	soft_type = "sec"
-	armor = list("melee" = 30, "bullet" = 25, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 50)
-	strip_delay = 60
 	dog_fashion = null
 
 /obj/item/clothing/head/soft/sec/brig_phys
@@ -155,7 +153,6 @@
 	desc = "A rich brown utility cover with the golden shield of the IRMG on it."
 	icon_state = "inteqsoft"
 	soft_type = "inteq"
-	armor = list("melee" = 30, "bullet" = 25, "laser" = 25, "energy" = 35, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 50)
 	dog_fashion = null
 
 /obj/item/clothing/head/soft/inteq/corpsman


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes armor from soft caps, peaked caps, berets, and so on.

## Why It's Good For The Game

Berets providing equivalent or superior protection to helmets is just plain ridiculous. Fashion is a choice, but there are still tradeoffs. If you're going into a fight, you should look the part.

Also functionally makes it so way fewer ships basically have free helmets everywhere. Inteq crews in particular are going to be much less protected from head injuries. Wear your helmet.

## Changelog

:cl:
balance: Removed armor from berets, peaked caps, and soft caps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
