### PR TITLE
De-armors solgov hats

### DIFF
--- a/code/modules/clothing/factions/clip.dm
+++ b/code/modules/clothing/factions/clip.dm
@@ -217,7 +217,6 @@
 //	righthand_file = 'icons/mob/inhands/faction/clip/gezena_righthand.dmi'
 	icon_state = "clip_cap"
 	item_state = "bluecloth"
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/head/clip/corpsman
 	name = "\improper CLIP Minutemen corpsman cap"
@@ -234,8 +233,6 @@
 	name = "CLIP Minutemen officer's slouch hat"
 	desc = "A commanding slouch hat adorned with a officer's badge, used by the CLIP Minutemen."
 	icon_state = "clip_officer_hat"
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	strip_delay = 60
 
 /obj/item/clothing/head/clip/boonie
 	name = "CLIP Minutemen boonie hat"
@@ -246,7 +243,6 @@
 	name = "general's bicorne"
 	desc = "A fancy bicorne used by generals of the CLIP Minutemen."
 	icon_state = "clip_general_hat"
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/head/helmet/bulletproof/x11/clip
 	name = "\improper Minutemen X11 Helmet"
@@ -292,8 +288,6 @@
 
 	icon_state = "clip_fedora"
 	item_state = "detective"
-
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //dets hat is armored for some reaon
 
 /obj/item/clothing/head/flatcap/clip
 	name = "GOLD flatcap"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -508,7 +508,6 @@
 /obj/item/clothing/head/solgov
 	name = "\improper SolGov officer's cap"
 	desc = "A blue cap worn by high-ranking officers of SolGov."
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 	icon_state = "cap_solgov"
 	item_state = "cap_solgov"
 	strip_delay = 80
@@ -516,7 +515,6 @@
 /obj/item/clothing/head/solgov/terragov
 	name = "\improper TerraGov officer's cap"
 	desc = "A cap worn by high-ranking officers of SolGov. This one is still in original TerraGov green."
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 	icon_state = "cap_terragov"
 	item_state = "cap_terragov"
 
@@ -527,7 +525,6 @@
 	item_state = "sonnensoldner_hat"
 	worn_y_offset = 4
 	dog_fashion = null
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 
 /obj/item/clothing/head/solgov/captain
 	name = "\improper SolGov bicorne hat"
@@ -536,7 +533,6 @@
 	item_state = "solgov_bicorne"
 	worn_y_offset = 2
 	dog_fashion = null
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 
 /obj/item/clothing/head/helmet/space/plasmaman/solgov
 	name = "\improper SolGov envirosuit helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes armor from Solgov hats, which were missed in the last hat PR.

## Why It's Good For The Game

You don't get a free pass just because you're Swiss.

## Changelog

:cl:
balance: removed armor value from Solgov hats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
