### PR TITLE
Hide invisimin users from HUDs and Ghosts

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -13,6 +13,8 @@
 #define INVISIBILITY_OBSERVER 60
 #define SEE_INVISIBLE_OBSERVER 60
 
+#define INVISIBILITY_INVINISMIN 80 //invisible admins
+
 #define INVISIBILITY_MAXIMUM 100 //the maximum allowed for "real" objects
 
 #define INVISIBILITY_ABSTRACT 101 //only used for abstract objects (e.g. spacevine_controller), things that are not really there.

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -405,9 +405,10 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(holder && mob)
 		if(mob.invisibility == INVISIBILITY_OBSERVER)
 			mob.invisibility = initial(mob.invisibility)
+			mob.remove_from_all_data_huds()
 			to_chat(mob, "<span class='boldannounce'>Invisimin off. Invisibility reset.</span>", confidential = TRUE)
 		else
-			mob.invisibility = INVISIBILITY_OBSERVER
+			mob.add_to_all_human_data_huds()
 			to_chat(mob, "<span class='adminnotice'><b>Invisimin on. You are now as invisible as a ghost.</b></span>", confidential = TRUE)
 
 /client/proc/check_antagonists()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -403,11 +403,12 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	set category = "Admin.Game"
 	set desc = "Toggles ghost-like invisibility (Don't abuse this)"
 	if(holder && mob)
-		if(mob.invisibility == INVISIBILITY_OBSERVER)
+		if(mob.invisibility == INVISIBILITY_INVINISMIN)
 			mob.invisibility = initial(mob.invisibility)
 			mob.remove_from_all_data_huds()
 			to_chat(mob, "<span class='boldannounce'>Invisimin off. Invisibility reset.</span>", confidential = TRUE)
 		else
+			mob.invisibility = INVISIBILITY_INVINISMIN
 			mob.add_to_all_human_data_huds()
 			to_chat(mob, "<span class='adminnotice'><b>Invisimin on. You are now as invisible as a ghost.</b></span>", confidential = TRUE)
 


### PR DESCRIPTION
## About The Pull Request

- Hides invisimin users from HUDs
- Hides invisimin users from ghosts

## Why It's Good For The Game

It makes eventmaking better.

## Changelog

:cl:SuhEugene
admin: made invisimin admins invisible for HUDs and ghosts
/:cl:
