### PR TITLE
Adds Eoehoma laser weapons to the outpost cargo. 

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -161,6 +161,12 @@
 	contains = list(/obj/item/ammo_box/magazine/p16)
 	cost = 1000
 
+/datum/supply_pack/ammo/e40_ammo
+	name = "E-40 Eoehoma .299 Caseless Magazine Crate"
+	desc = "Contains a Eoehoma .299 caseless magazine for the E-40 hybrid rifle, containing thirty rounds."
+	contains = list(/obj/item/ammo_box/magazine/e40)
+	cost = 1000
+
 /datum/supply_pack/ammo/a850r_ammo
 	name = "8x50mmR En Bloc Clip Crate"
 	desc = "Contains a 8x50mmR en bloc clip for rifles like the illestren rifle, containing five rounds."
@@ -273,6 +279,12 @@
 	name = "5.56 Caseless Rubber Ammo Box Crate"
 	desc = "Contains a fifty-round 5.56 caseless box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/ammo_box/c556mmHITP/rubbershot)
+	cost = 250
+
+/datum/supply_pack/ammo/miniguncell
+	name = "Mini Weapon Cell Crate"
+	desc = "Contains a minature weapon cell, compatible with the miniature energy gun."
+	contains = list(/obj/item/stock_parts/cell/gun/mini)
 	cost = 250
 
 /datum/supply_pack/ammo/guncell

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -281,12 +281,6 @@
 	contains = list(/obj/item/ammo_box/c556mmHITP/rubbershot)
 	cost = 250
 
-/datum/supply_pack/ammo/miniguncell
-	name = "Mini Weapon Cell Crate"
-	desc = "Contains a minature weapon cell, compatible with the miniature energy gun."
-	contains = list(/obj/item/stock_parts/cell/gun/mini)
-	cost = 250
-
 /datum/supply_pack/ammo/guncell
 	name = "Weapon Cell Crate"
 	desc = "Contains a weapon cell, compatible with laser guns."

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -186,6 +186,6 @@
 /datum/supply_pack/gun/e40
 	name = "E-40 Hybrid Assault Rifle Crate"
 	desc = "Contains an antiquated dual mode automatic rifle capable of firing both ballistic rounds and lasers. Chambered in .299 Eoehoma caseless."
-	cost = 8000
+	cost = 8500
 	contains = list(/obj/item/gun/ballistic/automatic/assault/e40)
 	crate_name = "hybrid auto rifle crate"

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -60,6 +60,13 @@
 	contains = list(/obj/item/gun/energy/laser)
 	crate_name = "laser crate"
 
+/datum/supply_pack/gun/e10
+	name = "E-10 Laser Pistol Crate"
+	desc = "Contains an antiquated, but still lethal Eoehoma E-10 laser pistol."
+	cost = 750
+	contains = list(/obj/item/gun/energy/laser/e10)
+	crate_name = "laser pistol crate"
+
 /datum/supply_pack/gun/mini_energy
 	name = "Mini Energy Gun Crate"
 	desc = "Contains a small, versatile energy gun, capable of firing both nonlethal and lethal blasts, but with a limited power cell."
@@ -73,6 +80,14 @@
 	cost = 1250
 	contains = list(/obj/item/gun/energy/e_gun)
 	crate_name = "energy gun crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/gun/e11
+	name = "E-11 Clearence Crate"
+	desc = "Contains an antiquated Eoehoma E-11 energy gun, capable of firing both nonlethal and lethal blasts of light. The price has been repeatedly marked down, but it's still likely not worth the cost."
+	cost = 500
+	contains = list(/obj/item/gun/energy/e_gun/e11)
+	crate_name = "E-11 energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/gun/ion
@@ -96,6 +111,13 @@
 	cost = 3000
 	contains = list(/obj/item/gun/energy/kalix)
 	crate_name = "beam rifle crate"
+
+/datum/supply_pack/gun/e50
+	name = "E-50 Energy Emitter Crate"
+	desc = "Contains an Eoehoma E-50 energy emitter gun. Despite it's extreme age, this laser cannon can put out some exceptional hurt."
+	cost = 6000
+	contains = list(/obj/item/gun/energy/laser/e50)
+	crate_name = "E-50 energy emitter crate"
 
 /*
 		Shotguns
@@ -160,3 +182,10 @@
 	cost = 5000
 	contains = list(/obj/item/gun/ballistic/automatic/assault/skm)
 	crate_name = "auto rifle crate"
+
+/datum/supply_pack/gun/e40
+	name = "E-40 Hybrid Assault Rifle Crate"
+	desc = "Contains an antiquated dual mode automatic rifle capable of firing both ballistic rounds and lasers. Chambered in .299 Eoehoma caseless."
+	cost = 8000
+	contains = list(/obj/item/gun/ballistic/automatic/assault/e40)
+	crate_name = "hybrid auto rifle crate"

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -83,7 +83,7 @@
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/gun/e11
-	name = "E-11 Clearence Crate"
+	name = "E-11 Clearance Crate"
 	desc = "Contains an antiquated Eoehoma E-11 energy gun, capable of firing both nonlethal and lethal blasts of light. The price has been repeatedly marked down, but it's still likely not worth the cost."
 	cost = 500
 	contains = list(/obj/item/gun/energy/e_gun/e11)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the E-10, E-11, E-40, E-40 Magazine and E-50 to the outpost cargo catalogue.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More laser variety for crews to play around with is good, and lasers currently lack a heavy firepower option, which the E-40 and E-50 would be able to fill. There's also no way to get Eoehomas in game aside from the E-10s that already spawn on the Mudskipper as far I'm aware. I'm happy to changes the prices if needed.

## Changelog

:cl:
add: E-10 Laser Pistol to cargo for 750 credits
add: E-11 Energy Gun to cargo for 500 credits
add: E-40 Hybrid Rifle to cargo for 8500 credits
add: E-40 Magazine to cargo for 1000 credits
add: E-50 Energy Emitter to cargo for 6000 credits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
