### PR TITLE
Autowiki Reagents Table

### DIFF
--- a/code/modules/autowiki/pages/reactions.dm
+++ b/code/modules/autowiki/pages/reactions.dm
@@ -1,0 +1,65 @@
+/*
+Templates:
+
+Autowiki/Reaction
+{{{chems|ERROR}}} {{#if: {{{temperature|}}} | <br />Temperature {{{temperature}}} | }} {{#if: {{{container|}}} | <br />Needs container "{{{container}}}" | }} <br/>Makes {{{volume|1}}}u
+
+Autowiki/Reagent
+{{#if: {{{tooltip|}}} | {{Tooltip|{{{volume}}} part [[#{{{name}}}|{{{name}}}]]|{{{tooltip}}}|FEF6E7}} | {{{volume}}} part {{{name}}} }}
+
+*/
+
+/datum/autowiki/reactions
+	page = "Template:Autowiki/Content/Reactions"
+
+/datum/autowiki/reactions/generate()
+	var/list/output = list()
+
+	var/list/mixable_reagents = list()
+	var/list/all_reactions = list()
+	for(var/type in subtypesof(/datum/chemical_reaction))
+		var/datum/chemical_reaction/reaction = new type
+		all_reactions += reaction
+		mixable_reagents |= reaction.results
+
+	for(var/datum/chemical_reaction/reaction as anything in all_reactions)
+		var/required_chems = ""
+		for(var/datum/reagent/required_chem_type as anything in reaction.required_reagents)
+			var/has_tooltip = (required_chem_type in mixable_reagents) && !(required_chem_type in reaction.results) && !(required_chem_type in GLOB.base_reagents)
+			required_chems += format_required_reagent(required_chem_type, reaction.required_reagents[required_chem_type], has_tooltip)
+
+		for(var/datum/reagent/required_catalyst_type as anything in reaction.required_catalysts)
+			var/has_tooltip = (required_catalyst_type in mixable_reagents) && !(required_catalyst_type in reaction.results) && !(required_catalyst_type in GLOB.base_reagents)
+			required_chems += format_required_reagent(required_catalyst_type, reaction.required_catalysts[required_catalyst_type], has_tooltip, "Catalyst")
+
+		for(var/datum/reagent/result_chem_type as anything in reaction.results)
+			var/result_name = escape_value(initial(result_chem_type.name))
+			var/list/details = list("volume" = reaction.results[result_chem_type], "chems" = required_chems, "name" = result_name)
+
+			if(reaction.required_temp > 0)
+				details["temperature"] = "[reaction.is_cold_recipe ? "below" : "above"] [reaction.required_temp]K"
+
+			if(reaction.required_container)
+				details["container"] = "[escape_value(initial(reaction.required_container.name))]"
+
+			var/description = include_template("Autowiki/Reaction", details)
+			if(result_name in output)
+				output[result_name] += "<br />OR<br />[description]"
+			else
+				output[result_name] = description
+
+	return output
+
+/datum/autowiki/reactions/proc/format_required_reagent(datum/reagent/required_reagent_type, volume, has_tooltip = FALSE, type)
+	var/list/details = list(
+		"volume" = volume,
+		"name" = escape_value(initial(required_reagent_type.name))
+	)
+
+	if(has_tooltip)
+		details["tooltip"] = include_template("Autowiki/Content/Reactions/[initial(required_reagent_type.name)]")
+
+	if(type)
+		details["type"] = type
+
+	return include_template("Autowiki/Reagent", details)

--- a/code/modules/autowiki/pages/reagents.dm
+++ b/code/modules/autowiki/pages/reagents.dm
@@ -1,65 +1,52 @@
-/*
-Templates:
-
-Autowiki/Reaction
-{{{chems|ERROR}}} {{#if: {{{temperature|}}} | <br />Temperature {{{temperature}}} | }} {{#if: {{{container|}}} | <br />Needs container "{{{container}}}" | }} <br/>Makes {{{volume|1}}}u
-
-Autowiki/Reagent
-{{#if: {{{tooltip|}}} | {{Tooltip|{{{volume}}} part [[#{{{name}}}|{{{name}}}]]|{{{tooltip}}}|FEF6E7}} | {{{volume}}} part {{{name}}} }}
-
-*/
-
 /datum/autowiki/reagents
-	page = "Template:Autowiki/Content/Reactions"
+	page = "Template:Autowiki/Content/Reagents"
 
 /datum/autowiki/reagents/generate()
-	var/list/output = list()
+	var/output = ""
 
 	var/list/mixable_reagents = list()
-	var/list/all_reactions = list()
 	for(var/type in subtypesof(/datum/chemical_reaction))
 		var/datum/chemical_reaction/reaction = new type
-		all_reactions += reaction
 		mixable_reagents |= reaction.results
+		qdel(reaction)
 
-	for(var/datum/chemical_reaction/reaction as anything in all_reactions)
-		var/required_chems = ""
-		for(var/datum/reagent/required_chem_type as anything in reaction.required_reagents)
-			var/has_tooltip = (required_chem_type in mixable_reagents) && !(required_chem_type in reaction.results) && !(required_chem_type in GLOB.base_reagents)
-			required_chems += format_required_reagent(required_chem_type, reaction.required_reagents[required_chem_type], has_tooltip)
+	var/list/categories = list()
 
-		for(var/datum/reagent/required_catalyst_type as anything in reaction.required_catalysts)
-			var/has_tooltip = (required_catalyst_type in mixable_reagents) && !(required_catalyst_type in reaction.results) && !(required_catalyst_type in GLOB.base_reagents)
-			required_chems += format_required_reagent(required_catalyst_type, reaction.required_catalysts[required_catalyst_type], has_tooltip, "Catalyst")
+	for(var/reagent in mixable_reagents)
+		var/datum/reagent/chem = new reagent
 
-		for(var/datum/reagent/result_chem_type as anything in reaction.results)
-			var/result_name = escape_value(initial(result_chem_type.name))
-			var/list/details = list("volume" = reaction.results[result_chem_type], "chems" = required_chems, "name" = result_name)
+		LAZYINITLIST(categories[chem.category])
+		categories[chem.category] += list(chem)
 
-			if(reaction.required_temp > 0)
-				details["temperature"] = "[reaction.is_cold_recipe ? "below" : "above"] [reaction.required_temp]K"
-
-			if(reaction.required_container)
-				details["container"] = "[escape_value(initial(reaction.required_container.name))]"
-
-			var/description = include_template("Autowiki/Reaction", details)
-			if(result_name in output)
-				output[result_name] += "<br />OR<br />[description]"
-			else
-				output[result_name] = description
+	for(var/category in sortList(categories))
+		output += generate_category(category, categories[category])
+		output += "\n"
 
 	return output
 
-/datum/autowiki/reagents/proc/format_required_reagent(datum/reagent/required_reagent_type, volume, has_tooltip = FALSE, type)
-	var/list/details = list(
-		"volume" = volume,
-		"name" = escape_value(initial(required_reagent_type.name))
-	)
+/datum/autowiki/reagents/proc/generate_category(name, list/datum/reagent/reagents)
+	var/output = "== [escape_value(name)] ==\n"
 
-	if(has_tooltip)
-		details["tooltip"] = include_template("Autowiki/Content/Reactions/[initial(required_reagent_type.name)]")
+	output += "{| class='wikitable sortable' style=width:100%; text-align:left; border: 3px solid #FFDD66; cellspacing=0; cellpadding=2; background-color:white;'\n"
+	output += "! scope='col' style='width:150px; background-color:#FFDD66;' |Name\n"
+	output += "! class='unsortable' scope='col' style='width:150px; background-color:#FFDD66;' |Recipe\n"
+	output += "! class='unsortable' scope='col' style='background-color:#FFDD66;' |Description\n"
+	output += "! scope='col' style='background-color: #FFEE88;' | Metabolization Rate\n"
+	output += "! scope='col' style='background-color: #FFEE88;' | Overdose Threshold\n"
+	output += "! scope='col' style='background-color: #FFEE88;' | Addiction Threshold\n"
+	output += "|-\n"
 
-	if(type)
-		details["type"] = type
+	reagents = sortList(reagents, /proc/cmp_typepaths_asc)
 
-	return include_template("Autowiki/Reagent", details)
+	for(var/datum/reagent/reagent as anything in reagents)
+		output += "! style='background-color: #FFEE88;' | [include_template("anchor", list("1" = escape_value(reagent.name)))][escape_value(reagent.name)] <span style='color:[escape_value(reagent.color)];background-color:[escape_value(reagent.color)]'>_</span>\n"
+		output += "|[include_template("Autowiki/Content/Reactions/[escape_value(reagent.name)]")]\n"
+		output += "|[escape_value(reagent.description)]\n"
+		output += "|data-sort-value=[reagent.metabolization_rate]|[reagent.metabolization_rate] units per tick\n"
+		output += "|[reagent.overdose_threshold || "data-sort-value=0|N/A"]\n"
+		output += "|[reagent.addiction_threshold || "data-sort-value=0|N/A"]\n"
+		output += "|-\n"
+
+	output += "|}\n"
+
+	return output

--- a/code/modules/autowiki/pages/reagents.dm
+++ b/code/modules/autowiki/pages/reagents.dm
@@ -31,9 +31,9 @@
 	output += "! scope='col' style='width:150px; background-color:#FFDD66;' |Name\n"
 	output += "! class='unsortable' scope='col' style='width:150px; background-color:#FFDD66;' |Recipe\n"
 	output += "! class='unsortable' scope='col' style='background-color:#FFDD66;' |Description\n"
-	output += "! scope='col' style='background-color: #FFEE88;' | Metabolization Rate\n"
-	output += "! scope='col' style='background-color: #FFEE88;' | Overdose Threshold\n"
-	output += "! scope='col' style='background-color: #FFEE88;' | Addiction Threshold\n"
+	output += "! scope='col' | Metabolization Rate\n"
+	output += "! scope='col' | Overdose Threshold\n"
+	output += "! scope='col' | Addiction Threshold\n"
 	output += "|-\n"
 
 	reagents = sortList(reagents, /proc/cmp_typepaths_asc)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -77,6 +77,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	///How good of an accelerant is this reagent
 	var/accelerant_quality = 0
 
+	///The section of the autowiki chem table this reagent will be under
+	var/category = "Misc"
+
 /datum/reagent/New()
 	. = ..()
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -2,6 +2,7 @@
 	name = "Drug"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
+	category = "Drug"
 	var/trippy = TRUE //Does this drug make you trip?
 
 /datum/reagent/drug/on_mob_end_metabolize(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -11,6 +11,7 @@
 	name = "Consumable"
 	taste_description = "generic food"
 	taste_mult = 4
+	category = "Food and Drink"
 	var/nutriment_factor = 1 * REAGENTS_METABOLISM
 	var/quality = 0	//affects mood, typically higher for mixed drinks with more complex recipes
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -9,6 +9,7 @@
 /datum/reagent/medicine
 	name = "Medicine"
 	taste_description = "bitterness"
+	category = "Medicine"
 
 /datum/reagent/medicine/on_mob_life(mob/living/carbon/M)
 	current_cycle++

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -2,6 +2,7 @@
 /datum/reagent/thermite
 	name = "Thermite"
 	description = "Thermite produces an aluminothermic reaction known as a thermite reaction. Can be used to melt walls."
+	category = "Pyrotechnics"
 	reagent_state = SOLID
 	color = "#550000"
 	taste_description = "sweet tasting metal"
@@ -19,6 +20,7 @@
 /datum/reagent/nitroglycerin
 	name = "Nitroglycerin"
 	description = "Nitroglycerin is a heavy, colorless, oily, explosive liquid obtained by nitrating glycerol."
+	category = "Pyrotechnics"
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "oil"
 
@@ -37,6 +39,7 @@
 /datum/reagent/clf3
 	name = "Chlorine Trifluoride"
 	description = "Makes a temporary 3x3 fireball when it comes into existence, so be careful when mixing. ClF3 applied to a surface burns things that wouldn't otherwise burn, including typically-robust flooring, potentially exposing it to the vacuum of space."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#FFC8C8"
 	metabolization_rate = 4
@@ -82,6 +85,7 @@
 /datum/reagent/sorium
 	name = "Sorium"
 	description = "Sends everything flying from the detonation point."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#5A64C8"
 	taste_description = "air and bitterness"
@@ -89,6 +93,7 @@
 /datum/reagent/liquid_dark_matter
 	name = "Liquid Dark Matter"
 	description = "Sucks everything into the detonation point."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#210021"
 	taste_description = "compressed bitterness"
@@ -96,6 +101,7 @@
 /datum/reagent/gunpowder
 	name = "Gunpowder"
 	description = "Explodes. Violently."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#000000"
 	metabolization_rate = 0.05
@@ -120,6 +126,7 @@
 /datum/reagent/rdx
 	name = "RDX"
 	description = "Military grade explosive"
+	category = "Pyrotechnics"
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	taste_description = "salt"
@@ -127,6 +134,7 @@
 /datum/reagent/tatp
 	name = "TaTP"
 	description = "Suicide grade explosive"
+	category = "Pyrotechnics"
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	taste_description = "death"
@@ -134,6 +142,7 @@
 /datum/reagent/flash_powder
 	name = "Flash Powder"
 	description = "Makes a very bright flash."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#C8C8C8"
 	taste_description = "salt"
@@ -141,6 +150,7 @@
 /datum/reagent/smoke_powder
 	name = "Smoke Powder"
 	description = "Makes a large cloud of smoke that can carry reagents."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#C8C8C8"
 	taste_description = "smoke"
@@ -148,6 +158,7 @@
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"
 	description = "Makes a deafening noise."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#C8C8C8"
 	taste_description = "loud noises"
@@ -155,6 +166,7 @@
 /datum/reagent/phlogiston
 	name = "Phlogiston"
 	description = "Catches you on fire and makes you ignite."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#FA00AF"
 	taste_description = "burning"
@@ -179,6 +191,7 @@
 /datum/reagent/napalm
 	name = "Napalm"
 	description = "Very flammable."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#FA00AF"
 	taste_description = "burning"
@@ -206,6 +219,7 @@
 /datum/reagent/cryostylane
 	name = "Cryostylane"
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Cryostylane slowly cools all other reagents in the container 0K."
+	category = "Pyrotechnics"
 	color = "#0000DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
@@ -227,6 +241,7 @@
 /datum/reagent/pyrosium
 	name = "Pyrosium"
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Pyrosium slowly heats all other reagents in the container."
+	category = "Pyrotechnics"
 	color = "#64FAC8"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
@@ -242,6 +257,7 @@
 /datum/reagent/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
 	name = "Teslium"
 	description = "An unstable, electrically-charged metallic slurry. Periodically electrocutes its victim, and makes electrocutions against them more deadly. Excessively heating teslium results in dangerous destabilization. Do not allow to come into contact with water."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#20324D" //RGB: 32, 50, 77
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -273,6 +289,7 @@
 /datum/reagent/teslium/energized_jelly
 	name = "Energized Jelly"
 	description = "Electrically-charged jelly. Boosts jellypeople's nervous system, but only shocks other lifeforms."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#CAFF43"
 	taste_description = "jelly"
@@ -291,6 +308,7 @@
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"
 	description = "A historical fire suppressant. Originally believed to simply displace oxygen to starve fires, it actually interferes with the combustion reaction itself. Vastly superior to the cheap water-based extinguishers found on NT vessels."
+	category = "Pyrotechnics"
 	reagent_state = LIQUID
 	color = "#A6FAFF55"
 	taste_description = "the inside of a fire extinguisher"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -7,6 +7,7 @@
 	color = "#CF3600" // rgb: 207, 54, 0
 	taste_description = "bitterness"
 	taste_mult = 1.2
+	category = "Toxin"
 	var/toxpwr = 1.5
 	var/silent_toxin = FALSE //won't produce a pain message when processed by liver/life() if there isn't another non-silent toxin present.
 

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -1813,6 +1813,7 @@
 #include "code\modules\atmospherics\machinery\portable\scrubber.dm"
 #include "code\modules\autowiki\autowiki.dm"
 #include "code\modules\autowiki\pages\base.dm"
+#include "code\modules\autowiki\pages\reactions.dm"
 #include "code\modules\autowiki\pages\reagents.dm"
 #include "code\modules\autowiki\pages\ships.dm"
 #include "code\modules\autowiki\pages\techweb.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I said I would do this long ago, then I failed because I made it too complex. This is a far simpler solution that mostly uses what we already have.

An example is [here](https://shiptest.net/wiki/User:Mark/autochem-test)

but the final result will be [here](https://shiptest.net/wiki/Template:Autowiki/Content/Reagents)

no I'm not off of my hiatus I just got hit with inspiration and coded this

## Why It's Good For The Game

Automatically updating and always complete reagents wiki with all the bells and whistles of recursive chems and additional info

## Changelog

:cl:
add: Autowiki generated reagents list page
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
