### PR TITLE
Black Market Revamp

### DIFF
--- a/code/__DEFINES/blackmarket.dm
+++ b/code/__DEFINES/blackmarket.dm
@@ -3,6 +3,6 @@
 
 // The BEST way of shipping items: accurate, "undetectable"
 #define SHIPPING_METHOD_LTSRBT "LTSRBT"
-// Throws the item from somewhere at the station.
+// Throws the item from somewhere at the uplink.
 #define SHIPPING_METHOD_LAUNCH "Launch"
 

--- a/code/__DEFINES/blackmarket.dm
+++ b/code/__DEFINES/blackmarket.dm
@@ -3,8 +3,6 @@
 
 // The BEST way of shipping items: accurate, "undetectable"
 #define SHIPPING_METHOD_LTSRBT "LTSRBT"
-// Picks a random area to teleport the item to and gives you a minute to get there before it is sent.
-#define SHIPPING_METHOD_TELEPORT "Teleport"
 // Throws the item from somewhere at the station.
 #define SHIPPING_METHOD_LAUNCH "Launch"
 

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(blackmarket)
 
 	/// Descriptions for each shipping methods.
 	var/shipping_method_descriptions = list(
-		SHIPPING_METHOD_LAUNCH="Launches the item at your coordinates from across deep space, cheap but you might not recieve your item at all. We reccomend being stationary in space away from any large structures for best results.",
+		SHIPPING_METHOD_LAUNCH="Launches the item at your coordinates from across deep space. Cheap, but you might not recieve your item at all. We recommend being stationary in space, away from any large structures, for best results.",
 		SHIPPING_METHOD_LTSRBT="Long-To-Short-Range-Bluespace-Transceiver, a machine that prepares items at a remote storage location and then teleports them to the location of the LTRSBT."
 	)
 

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -89,3 +89,4 @@ SUBSYSTEM_DEF(blackmarket)
 		return FALSE
 	queued_purchases += P
 	return TRUE
+

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -5,8 +5,8 @@ SUBSYSTEM_DEF(blackmarket)
 
 	/// Descriptions for each shipping methods.
 	var/shipping_method_descriptions = list(
-		SHIPPING_METHOD_LAUNCH="Launches the item at your coordinates from across deep space, cheap but you might not recieve your item at all.",
-		SHIPPING_METHOD_LTSRBT="Long-To-Short-Range-Bluespace-Transceiver, a machine that prepares items at a remote storage location and then teleports them to the location of the uplink."
+		SHIPPING_METHOD_LAUNCH="Launches the item at your coordinates from across deep space, cheap but you might not recieve your item at all. We reccomend being stationary in space away from any large structures for best results.",
+		SHIPPING_METHOD_LTSRBT="Long-To-Short-Range-Bluespace-Transceiver, a machine that prepares items at a remote storage location and then teleports them to the location of the LTRSBT."
 	)
 
 	/// List of all existing markets.

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -29,9 +29,8 @@ SUBSYSTEM_DEF(blackmarket)
 			if(!markets[M])
 				stack_trace("SSblackmarket: Item [I] available in market that does not exist.")
 				continue
-			markets[M].add_item(item,FALSE)
-			if(I.pair_item)
-				markets[M].add_item(I.pair_item,TRUE)
+			markets[M].add_item(item, FALSE)
+
 		qdel(I)
 	. = ..()
 

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -47,22 +47,10 @@ SUBSYSTEM_DEF(blackmarket)
 		switch(purchase.method)
 			// Find a ltsrbt pad and make it handle the shipping.
 			if(SHIPPING_METHOD_LTSRBT)
-				if(!telepads.len)
-					continue
-				// Prioritize pads that don't have a cooldown active.
-				var/free_pad_found = FALSE
-				for(var/obj/machinery/ltsrbt/pad in telepads)
-					if(pad.recharge_cooldown)
-						continue
-					pad.add_to_queue(purchase)
-					queued_purchases -= purchase
-					free_pad_found = TRUE
-					break
-
-				if(free_pad_found)
+				if(!purchase.uplink.target)
 					continue
 
-				var/obj/machinery/ltsrbt/pad = pick(telepads)
+				var/obj/machinery/ltsrbt/pad = purchase.uplink.target
 
 				to_chat(recursive_loc_check(purchase.uplink.loc, /mob), "<span class='notice'>[purchase.uplink] flashes a message noting that the order is being processed by [pad].</span>")
 
@@ -76,7 +64,7 @@ SUBSYSTEM_DEF(blackmarket)
 				var/pickedloc = vlevel.get_side_turf(startSide)
 
 				var/atom/movable/item = purchase.entry.spawn_item(pickedloc)
-				item.throw_at(purchase.uplink, 3, 3, spin = FALSE, gentle = TRUE)
+				item.throw_at(purchase.uplink, 3, 3, spin = FALSE)
 
 				to_chat(recursive_loc_check(purchase.uplink.loc, /mob), "<span class='notice'>[purchase.uplink] flashes a message noting the order is being launched at your coordinates from [dir2text(startSide)].</span>")
 
@@ -96,7 +84,7 @@ SUBSYSTEM_DEF(blackmarket)
 
 /// Used to add /datum/blackmarket_purchase to queued_purchases var. Returns TRUE when queued.
 /datum/controller/subsystem/blackmarket/proc/queue_item(datum/blackmarket_purchase/P)
-	if(P.method == SHIPPING_METHOD_LTSRBT && !telepads.len)
+	if(P.method == SHIPPING_METHOD_LTSRBT && !P.uplink.target)
 		return FALSE
 	queued_purchases += P
 	return TRUE

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -89,4 +89,3 @@ SUBSYSTEM_DEF(blackmarket)
 		return FALSE
 	queued_purchases += P
 	return TRUE
-

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(blackmarket)
 				var/pickedloc = vlevel.get_side_turf(startSide)
 
 				var/atom/movable/item = purchase.entry.spawn_item(pickedloc)
-				item.throw_at(purchase.uplink, 3, 3, spin = FALSE)
+				item.throw_at(purchase.uplink, 3, 3, spin = FALSE, gentle = TRUE)
 
 				to_chat(recursive_loc_check(purchase.uplink.loc, /mob), "<span class='notice'>[purchase.uplink] flashes a message noting the order is being launched at your coordinates from [dir2text(startSide)].</span>")
 

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -29,7 +29,9 @@ SUBSYSTEM_DEF(blackmarket)
 			if(!markets[M])
 				stack_trace("SSblackmarket: Item [I] available in market that does not exist.")
 				continue
-			markets[M].add_item(item)
+			markets[M].add_item(item,FALSE)
+			if(I.pair_item)
+				markets[M].add_item(I.pair_item,TRUE)
 		qdel(I)
 	. = ..()
 

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(blackmarket)
 				var/pickedloc = vlevel.get_side_turf(startSide)
 
 				var/atom/movable/item = purchase.entry.spawn_item(pickedloc)
-				item.throw_at(purchase.uplink, 3, 3, spin = FALSE)
+				item.safe_throw_at(purchase.uplink, 3, 3, spin = FALSE)
 
 				to_chat(recursive_loc_check(purchase.uplink.loc, /mob), "<span class='notice'>[purchase.uplink] flashes a message noting the order is being launched at your coordinates from [dir2text(startSide)].</span>")
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -160,6 +160,9 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/twenty
 	amount = 20
 
+/obj/item/stack/sheet/mineral/uranium/ten
+	amount = 10
+
 /obj/item/stack/sheet/mineral/uranium/five
 	amount = 5
 
@@ -209,6 +212,9 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/plasma/twenty
 	amount = 20
+
+/obj/item/stack/sheet/mineral/plasma/ten
+	amount = 10
 
 /obj/item/stack/sheet/mineral/plasma/five
 	amount = 5

--- a/code/modules/cargo/blackmarket/blackmarket_item.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_item.dm
@@ -28,6 +28,8 @@
 	var/availability_prob = 0
 	// Should there be an unlimited stock of an item
 	var/unlimited = FALSE
+	/// Should another item spawn alongside this one in the catalogue?
+	var/datum/blackmarket_item/pair_item
 
 /datum/blackmarket_item/New()
 	if(isnull(price))

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -141,7 +141,7 @@
 	item = /obj/item/clothing/suit/space/hardsuit/combatmedic
 
 	price_min = 1000
-	price_max = 1750
+	price_max = 2500
 	stock_max = 2
 	availability_prob = 40
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -1,15 +1,15 @@
 /datum/blackmarket_item/clothing
 	category = "Clothing"
 
-/datum/blackmarket_item/clothing/ninja_mask
-	name = "Space Ninja Mask"
-	desc = "Apart from being acid, lava, fireproof and being hard to take off someone it does nothing special on it's own."
-	item = /obj/item/clothing/mask/gas/space_ninja
+/datum/blackmarket_item/clothing/cloth
+	name = "Build Your Own Jumpsuit Special"
+	desc = "Ever wanted to learn how to sew? This lovely selection of cloth is perfect to get some practice with."
+	item = /obj/item/stack/sheet/cotton/cloth/ten
 
 	price_min = 200
-	price_max = 500
-	stock_max = 3
-	availability_prob = 40
+	price_max = 400
+	stock_max = 5
+	availability_prob = 80
 
 /datum/blackmarket_item/clothing/durathread_vest
 	name = "Durathread Vest"
@@ -31,15 +31,61 @@
 	stock_max = 4
 	availability_prob = 50
 
+/datum/blackmarket_item/clothing/degraded_armor_set
+	name = "Clearance Bin Armor Set"
+	desc = "Looking to protect yourself, but on a tight budget? These previously used vest and helmets served their former owners well! (May they rest in peace.)"
+	item = /obj/item/storage/box
+
+	price_min = 100
+	price_max = 400
+	stock_max = 3
+	availability_prob = 80
+
+/datum/blackmarket_item/clothing/degraded_armor_set/spawn_item(loc)
+	var/obj/item/storage/box/B = ..()
+	B.name = "Used Armor Set Box"
+	B.desc = "It smells distinctly of iron."
+	new /obj/item/clothing/head/helmet/old(B)
+	new /obj/item/clothing/suit/armor/vest/old(B)
+	return B
+
+/datum/blackmarket_item/clothing/frontiersmen_armor_set
+	name = "X-11 Bulletproof Armor Set"
+	desc = "We got a good deal on some extra bulletproof armor from a Frontiersmen Quartermaster, and we're passing those savings onto you!"
+	item = /obj/item/storage/box
+
+	price_min = 1000
+	price_max = 1750
+	stock_max = 2
+	availability_prob = 50
+
+/datum/blackmarket_item/clothing/frontiersmen_armor_set/spawn_item(loc)
+	var/obj/item/storage/box/B = ..()
+	B.name = "Bulletproof Armor Set Box"
+	B.desc = "A beat up looking box with some armor inside."
+	new /obj/item/clothing/suit/armor/vest/bulletproof/frontier(B)
+	new /obj/item/clothing/head/helmet/bulletproof/x11/frontier(B)
+	return B
+
+/datum/blackmarket_item/clothing/gezena_armor
+	name = "Raksha-plating vest"
+	desc = "Genuine armor vests used by the PGF Marine Corp. This is hot merchandise, so we need to move it fast."
+	item = /obj/item/clothing/suit/armor/gezena/marine
+
+	price_min = 1500
+	price_max = 2000
+	stock_max = 2
+	availability_prob = 20
+
 /datum/blackmarket_item/clothing/full_spacesuit_set
 	name = "\improper Nanotrasen Branded Spacesuit Box"
 	desc = "A few boxes of \"Old Style\" space suits fell off the back of a space truck."
 	item = /obj/item/storage/box
 
-	price_min = 1500
-	price_max = 4000
+	price_min = 250
+	price_max = 750
 	stock_max = 3
-	availability_prob = 30
+	availability_prob = 70
 
 /datum/blackmarket_item/clothing/full_spacesuit_set/spawn_item(loc)
 	var/obj/item/storage/box/B = ..()
@@ -64,7 +110,27 @@
 	desc = "A discarded combat medic hardsuit, found in the ruins of a carpet bombed xeno hive. Definately used, but as sturdy as an anchor."
 	item = /obj/item/clothing/suit/space/hardsuit/combatmedic
 
-	price_min = 5500
-	price_max = 7000
-	stock_max = 1
-	availability_prob = 10
+	price_min = 1000
+	price_max = 1750
+	stock_max = 2
+	availability_prob = 40
+
+/datum/blackmarket_item/clothing/ramzi_suit
+	name = "Rusted Red hardsuit"
+	desc = "A vintage ICW Era Gorlex Maruader hardsuit. The previous owner said we could have it when we pried it off their cold dead hands. Dry cleaning not included."
+	item = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
+
+	price_min = 1250
+	price_max = 2500
+	stock = 1
+	availability_prob = 30
+
+/datum/blackmarket_item/clothing/frontiersmen_hardsuit
+	name = "Frontiersmen hardsuit"
+	desc = "An old, if not durable hardsuit typically used by the Frontiersmen. We accept no liability if you're shot by CLIP while wearing this."
+	item = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
+
+	price_min = 1000
+	price_max = 2000
+	stock_max = 2
+	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -13,7 +13,7 @@
 
 /datum/blackmarket_item/clothing/crown
 	name = "Crown"
-	desc = "A beautiful golden crown, rich with history and pedigree. I'm sure they won't miss it."
+	desc = "A beautiful golden crown, rich with history and pedigree. Better worn than left to collect dust in a museum, right?"
 	item = /obj/item/clothing/head/crown/fancy
 
 	price_min = 1000
@@ -98,14 +98,25 @@
 	return B
 
 /datum/blackmarket_item/clothing/gezena_armor
-	name = "Raksha-plating vest"
-	desc = "Genuine armor vests used by the PGF Marine Corp. This is hot merchandise, so we need to move it fast."
+	name = "Raksha-Plating vest"
+	desc = "Genuine armor vests used by the PGF Marine Corp. If a military guy in a cape comes by, play dumb."
 	item = /obj/item/clothing/suit/armor/gezena/marine
+	pair_item = /datum/blackmarket_item/clothing/gezena_helmet
 
-	price_min = 1500
-	price_max = 2000
-	stock_max = 2
+	price_min = 750
+	price_max = 1500
+	stock_max = 3
 	availability_prob = 20
+
+/datum/blackmarket_item/clothing/gezena_helmet
+	name = "Raksha-Helm"
+	desc = "A helmet used by the PGF Marine Corp. They won't miss it. Not like there's much to protect up there anyways."
+	item = /obj/item/clothing/head/helmet/gezena
+
+	price_min = 500
+	price_max = 600
+	stock_max = 3
+	availability_prob = 0
 
 /datum/blackmarket_item/clothing/full_spacesuit_set
 	name = "\improper Nanotrasen Branded Spacesuit Box"
@@ -136,8 +147,8 @@
 	availability_prob = 70
 
 /datum/blackmarket_item/clothing/combatmedic_suit
-	name = "Combat Medic hardsuit"
-	desc = "A discarded combat medic hardsuit, found in the ruins of a carpet bombed xeno hive. Definately used, but as sturdy as an anchor."
+	name = "Combat Medic Hardsuit"
+	desc = "A discarded combat medic hardsuit, found in the ruins of a carpet bombed xeno hive. Definetely used, but as sturdy as an anchor."
 	item = /obj/item/clothing/suit/space/hardsuit/combatmedic
 
 	price_min = 1000
@@ -146,7 +157,7 @@
 	availability_prob = 40
 
 /datum/blackmarket_item/clothing/ramzi_suit
-	name = "Rusted Red hardsuit"
+	name = "Rusted Red Hardsuit"
 	desc = "A vintage ICW Era Gorlex Maruader hardsuit. The previous owner said we could have it when we pried it off their cold dead hands. Dry cleaning not included."
 	item = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
 
@@ -156,7 +167,7 @@
 	availability_prob = 30
 
 /datum/blackmarket_item/clothing/frontiersmen_hardsuit
-	name = "Frontiersmen hardsuit"
+	name = "Frontiersmen Hardsuit"
 	desc = "An old, if not durable hardsuit typically used by the Frontiersmen. We accept no liability if you're shot by CLIP while wearing this."
 	item = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -149,7 +149,7 @@
 
 /datum/blackmarket_item/clothing/combatmedic_suit
 	name = "Combat Medic Hardsuit"
-	desc = "A discarded combat medic hardsuit, found in the ruins of a carpet bombed xeno hive. Definetely used, but as sturdy as an anchor."
+	desc = "A discarded combat medic hardsuit, found in the ruins of a carpet bombed xeno hive. Definitely used, but as sturdy as an anchor."
 	item = /obj/item/clothing/suit/space/hardsuit/combatmedic
 
 	price_min = 1000

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -68,7 +68,8 @@
 
 	price_min = 100
 	price_max = 400
-	stock_max = 3
+	stock_min = 4
+	stock_max = 6
 	availability_prob = 80
 
 /datum/blackmarket_item/clothing/degraded_armor_set/spawn_item(loc)
@@ -86,7 +87,7 @@
 
 	price_min = 1000
 	price_max = 1750
-	stock_max = 2
+	stock_max = 3
 	availability_prob = 50
 
 /datum/blackmarket_item/clothing/frontiersmen_armor_set/spawn_item(loc)
@@ -153,25 +154,25 @@
 
 	price_min = 1000
 	price_max = 2500
-	stock_max = 2
-	availability_prob = 40
+	stock_max = 3
+	availability_prob = 30
 
 /datum/blackmarket_item/clothing/ramzi_suit
 	name = "Rusted Red Hardsuit"
 	desc = "A vintage ICW Era Gorlex Maruader hardsuit. The previous owner said we could have it when we pried it off their cold dead hands. Dry cleaning not included."
 	item = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
 
-	price_min = 1250
+	price_min = 1500
 	price_max = 2500
 	stock = 1
 	availability_prob = 30
 
 /datum/blackmarket_item/clothing/frontiersmen_hardsuit
 	name = "Frontiersmen Hardsuit"
-	desc = "An old, if not durable hardsuit typically used by the Frontiersmen. We accept no liability if you're shot by CLIP while wearing this."
+	desc = "An old but durable hardsuit typically used by the Frontiersmen. We accept no liability if you're shot by CLIP while wearing this."
 	item = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 
 	price_min = 1000
 	price_max = 2000
-	stock_max = 2
-	availability_prob = 30
+	stock_max = 3
+	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -105,7 +105,7 @@
 	pair_item = /datum/blackmarket_item/clothing/gezena_helmet
 
 	price_min = 750
-	price_max = 1500
+	price_max = 1250
 	stock_max = 3
 	availability_prob = 20
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -11,6 +11,36 @@
 	stock_max = 5
 	availability_prob = 80
 
+/datum/blackmarket_item/clothing/crown
+	name = "Crown"
+	desc = "A beautiful golden crown, rich with history and pedigree. I'm sure they won't miss it."
+	item = /obj/item/clothing/head/crown/fancy
+
+	price_min = 1000
+	price_max = 2000
+	stock_max = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/clothing/galaxy_blue
+	name = "Blue Galaxy Suit"
+	desc = "A handsome silk suit, treated with a finish of bluespace dust for an out of this world sheen."
+	item = /obj/item/clothing/under/rank/civilian/lawyer/galaxy
+
+	price_min = 500
+	price_max = 2000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/clothing/galaxy_red
+	name = "Red Galaxy Suit"
+	desc = "A handsome silk suit, treated with a finish of telecrystal dust. It cuts a menacing figure."
+	item = /obj/item/clothing/under/rank/civilian/lawyer/galaxy/red
+
+	price_min = 500
+	price_max = 2000
+	stock = 1
+	availability_prob = 20
+
 /datum/blackmarket_item/clothing/durathread_vest
 	name = "Durathread Vest"
 	desc = "Don't let them tell you this stuff is \"Like asbestos\" or \"Pulled from the market for safety concerns\". It could be the difference between a robusting and a retaliation."

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -54,12 +54,12 @@
 	availability_prob = 40
 
 /datum/blackmarket_item/consumable/trickwine/spawn_item(loc)
-	var/trickwine = pick(list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
-						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
-						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
-						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
-						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
-						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine))
+	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
+						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
+						/datum/reagent/consumable/ethanol/trickwine/shock_wine,
+						/datum/reagent/consumable/ethanol/trickwine/hearth_wine,
+						/datum/reagent/consumable/ethanol/trickwine/force_wine,
+						/datum/reagent/consumable/ethanol/trickwine/prism_wine))
 	return new trickwine(loc)
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -54,7 +54,7 @@
 
 /datum/blackmarket_item/consumable/morphine
 	name = "Morphine Bottle"
-	desc = "Medicinal? Recreational? You decide!"
+	desc = "Medicinal? Recreational? You can decide with this 30u bottle of morphine!"
 	item = /obj/item/reagent_containers/glass/bottle/morphine
 
 	price_min = 50
@@ -120,7 +120,8 @@
 
 	price_min = 25
 	price_max = 100
-	stock_max = 10
+	stock_min = 10
+	stock_max = 20
 	availability_prob = 40
 
 /datum/blackmarket_item/consumable/berries/spawn_item(loc)
@@ -146,7 +147,7 @@
 	item = /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko
 
 	price_min = 10
-	price_max = 20
+	price_max = 50
 	stock_min = 10
 	stock_max = 20
 	availability_prob = 50

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -19,8 +19,8 @@
 
 	stock_min = 2
 	stock_max = 3
-	price_min = 400
-	price_max = 700
+	price_min = 200
+	price_max = 500
 	availability_prob = 50
 
 /datum/blackmarket_item/consumable/suspicious_pills/spawn_item(loc)
@@ -44,7 +44,7 @@
 
 /datum/blackmarket_item/consumable/pumpup
 	name = "Maintenance Pump-Up"
-	desc = "Resist any Baton stun with this handy device!"
+	desc = "Resist any Baton stun with this handy instant tetanus free injector!."
 	item = /obj/item/reagent_containers/hypospray/medipen/pumpup
 
 	stock_max = 3

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -4,7 +4,7 @@
 /datum/blackmarket_item/consumable/donk_pocket_box
 	name = "Box of Donk Pockets"
 	desc = "A well packaged box containing the favourite snack of every spacefarer."
-	item = /obj/item/storage/box/donkpockets
+	item = /obj/effect/spawner/lootdrop/donkpockets
 
 	stock_min = 2
 	stock_max = 5
@@ -41,6 +41,27 @@
 	price_min = 10
 	price_max = 60
 	availability_prob = 50
+
+/datum/blackmarket_item/consumable/trickwine
+	name = "Trickwine"
+	desc = "The SRM keeps the recipes for their trickwines a closely guarded secret. The Hunters carrying those bottles? Less so."
+	item = /datum/reagent/consumable/ethanol/trickwine/ash_wine
+
+	price_min = 200
+	price_max = 600
+	stock_min = 3
+	stock_max = 7
+	availability_prob = 40
+
+/datum/blackmarket_item/consumable/suspicious_pills/spawn_item(loc)
+	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
+						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
+						/datum/reagent/consumable/ethanol/trickwine/shock_wine,
+						/datum/reagent/consumable/ethanol/trickwine/hearth_wine,
+						/datum/reagent/consumable/ethanol/trickwine/force_wine,
+						/datum/reagent/consumable/ethanol/trickwine/prism_wine))
+	return new trickwine(loc)
+
 
 /datum/blackmarket_item/consumable/pumpup
 	name = "Maintenance Pump-Up"
@@ -135,11 +156,10 @@
 	desc = "PGF military surplus rations. What's in them? Who knows. Surprise is the spice of life after all."
 	item = /obj/effect/spawner/lootdrop/ration
 
-	price_min = 200
+	price_min = 150
 	price_max = 400
-	stock_min = 5
-	stock_max = 15
 	availability_prob = 80
+	unlimited =  TRUE
 
 /datum/blackmarket_item/consumable/thirteenloko
 	name = "Can of Thirteen Loko"

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -54,12 +54,12 @@
 	availability_prob = 40
 
 /datum/blackmarket_item/consumable/trickwine/spawn_item(loc)
-	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
-						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
-						/datum/reagent/consumable/ethanol/trickwine/shock_wine,
-						/datum/reagent/consumable/ethanol/trickwine/hearth_wine,
-						/datum/reagent/consumable/ethanol/trickwine/force_wine,
-						/datum/reagent/consumable/ethanol/trickwine/prism_wine))
+	var/trickwine = pick(list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine))
 	return new trickwine(loc)
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -53,7 +53,7 @@
 	stock_max = 7
 	availability_prob = 40
 
-/datum/blackmarket_item/consumable/suspicious_pills/spawn_item(loc)
+/datum/blackmarket_item/consumable/trickwine/spawn_item(loc)
 	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
 						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
 						/datum/reagent/consumable/ethanol/trickwine/shock_wine,

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -178,7 +178,8 @@
 	item = /obj/item/stack/medical/suture
 
 	price_min = 200
-	price_max = 500
+	price_max = 450
+	stock_min = 2
 	stock_max = 5
 	availability_prob = 40
 
@@ -188,7 +189,8 @@
 	item = /obj/item/stack/medical/mesh
 
 	price_min = 200
-	price_max = 500
+	price_max = 450
+	stock_min = 2
 	stock_max = 5
 	availability_prob = 40
 
@@ -198,7 +200,8 @@
 	item = /obj/item/stack/medical/bruise_pack
 
 	price_min = 300
-	price_max = 600
+	price_max = 500
+	stock_min = 2
 	stock_max = 5
 	availability_prob = 30
 
@@ -208,6 +211,7 @@
 	item = /obj/item/stack/medical/ointment
 
 	price_min = 300
-	price_max = 600
+	price_max = 500
+	stock_min = 2
 	stock_max = 5
 	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -1,16 +1,6 @@
 /datum/blackmarket_item/consumable
 	category = "Consumables"
 
-/datum/blackmarket_item/consumable/clown_tears
-	name = "Bowl of Clown's Tears"
-	desc = "Guaranteed fresh from Weepy Boggins Tragic Kitchen"
-	item = /obj/item/reagent_containers/food/snacks/soup/clownstears
-	stock = 1
-
-	price_min = 520
-	price_max = 600
-	availability_prob = 10
-
 /datum/blackmarket_item/consumable/donk_pocket_box
 	name = "Box of Donk Pockets"
 	desc = "A well packaged box containing the favourite snack of every spacefarer."
@@ -61,3 +51,142 @@
 	price_min = 50
 	price_max = 150
 	availability_prob = 90
+
+/datum/blackmarket_item/consumable/morphine
+	name = "Morphine Bottle"
+	desc = "Medicinal? Recreational? You decide!"
+	item = /obj/item/reagent_containers/glass/bottle/morphine
+
+	price_min = 50
+	price_max = 150
+	stock_max = 4
+	availability_prob = 50
+
+/datum/blackmarket_item/consumable/cyanide
+	name = "Cyanide Bottle"
+	desc = "Cyanide, a tried and true classic for all your poisoning needs."
+	item = /obj/item/reagent_containers/glass/bottle/cyanide
+
+	price_min = 300
+	price_max = 600
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/consumable/sodium_thiopental
+	name = "Sodium Thiopental Bottle"
+	desc = "Sodium Thiopental, a potent and fast acting sedative for any occasion."
+	item = /obj/item/reagent_containers/glass/bottle/sodium_thiopental
+
+	price_min = 300
+	price_max = 600
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/consumable/amanitin
+	name = "Amanitin bottle"
+	desc = "A slow acting, but nearly undetectable poison. For the dignified assassin."
+	item = /obj/item/reagent_containers/glass/bottle/amanitin
+
+	price_min = 300
+	price_max =  600
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/consumable/gumballs
+	name = "Gumball"
+	desc = "Looking for a sweet treat? These gumballs are sure to satisfy."
+	item = /obj/item/reagent_containers/food/snacks/gumball
+
+	price_min = 10
+	price_max = 20
+	stock_min = 10
+	stock_max = 20
+	availability_prob = 80
+
+/datum/blackmarket_item/consumable/xeno_meat
+	name = "Xenomorph steak"
+	desc = "The Frontier's most dangerous game, delivered right to your plate! May constitute a violation of your local BARD laws and regulations."
+	item = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
+
+	price_min = 300
+	price_max = 500
+	stock_max = 5
+	availability_prob = 20
+
+/datum/blackmarket_item/consumable/berries
+	name = "Berries"
+	desc = "Some fresh berries we found growing in the corner of our hangar. We're not 100% sure what species these are."
+	item = /obj/item/reagent_containers/food/snacks/grown/berries
+
+	price_min = 25
+	price_max = 100
+	stock_max = 10
+	availability_prob = 40
+
+/datum/blackmarket_item/consumable/berries/spawn_item(loc)
+	var/berries = pick(list(/obj/item/reagent_containers/food/snacks/grown/berries,
+				/obj/item/reagent_containers/food/snacks/grown/berries/poison/stealth,
+				/obj/item/reagent_containers/food/snacks/grown/berries/death/stealth))
+	return new berries(loc)
+
+/datum/blackmarket_item/consumable/ration
+	name = "Ration Pack"
+	desc = "PGF military surplus rations. What's in them? Who knows. Surprise is the spice of life after all."
+	item = /obj/effect/spawner/lootdrop/ration
+
+	price_min = 200
+	price_max = 400
+	stock_min = 5
+	stock_max = 15
+	availability_prob = 80
+
+/datum/blackmarket_item/consumable/thirteenloko
+	name = "Can of Thirteen Loko"
+	desc = "This product was quietly discontinued after multiple health related incidents. But you aren't a coward, are you?"
+	item = /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko
+
+	price_min = 10
+	price_max = 20
+	stock_min = 10
+	stock_max = 20
+	availability_prob = 50
+
+/datum/blackmarket_item/consumable/sutures
+	name = "Sutures"
+	desc = "A bundle of sutures for stitching up your latest bullet wound."
+	item = /obj/item/stack/medical/suture
+
+	price_min = 200
+	price_max = 500
+	stock_max = 5
+	availability_prob = 40
+
+/datum/blackmarket_item/consumable/regen_mesh
+	name = "Regenerative Mesh"
+	desc = "A smoothing pack of regenerative mesh for your burns."
+	item = /obj/item/stack/medical/mesh
+
+	price_min = 200
+	price_max = 500
+	stock_max = 5
+	availability_prob = 40
+
+/datum/blackmarket_item/consumable/bruise_pack
+	name = "Bruise Packs"
+	desc = "A bundle of old bruise packs, for you guessed it, bruises. Any rumors of these containing hazardous chemicals are just that. Rumors."
+	item = /obj/item/stack/medical/bruise_pack
+
+	price_min = 300
+	price_max = 600
+	stock_max = 5
+	availability_prob = 30
+
+/datum/blackmarket_item/consumable/ointment
+	name = "Burn ointment"
+	desc = "A tube of burn ointment. It's past the expiry date, but those are only suggestions."
+	item = /obj/item/stack/medical/ointment
+
+	price_min = 300
+	price_max = 600
+	stock_max = 5
+	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
@@ -10,3 +10,43 @@
 	price_max = 4000
 	availability_prob = 100
 	unlimited = TRUE
+
+/datum/blackmarket_item/emergency/uranium
+	name = "Uranium"
+	desc = "Fuel? Dirty Bomb? Fancy nightlight? Doesn't matter, we'll supply."
+	item = /obj/item/stack/sheet/mineral/uranium/twenty
+
+	price_min = 2000
+	price_max = 4000
+	availability_prob = 100
+	unlimited = TRUE
+
+/datum/blackmarket_item/emergency/ion_thruster
+	name = "Ion Thruster"
+	desc = "Need a boost? We have a leftover engine board or two from a ship we happened to find. If you're lucky, you won't be the next."
+	item = /obj/item/circuitboard/machine/shuttle/engine/electric
+
+	price_min = 2000
+	price_max = 400
+	stock_max = 5
+	availability_prob = 100
+
+/datum/blackmarket_item/emergency/oyxgen
+	name = "Oxygen Canister"
+	desc = "What keeps us all breathing. It'll keep you breathing too, if you know what's good for you."
+	item = /obj/machinery/portable_atmospherics/canister/oxygen
+
+	price_min = 2000
+	price_max = 4000
+	stock_max = 3
+	availability_prob = 100
+
+/datum/blackmarket_item/emergency/metal_foam
+	name = "Metal Foam Grenade"
+	desc = "Poor piloting blow a hole in the side of your hull? These metal foam grenades should keep everything important in."
+	item = /obj/item/grenade/chem_grenade/metalfoam
+
+	price_min = 300
+	price_max = 750
+	availability_prob = 100
+	unlimited = TRUE

--- a/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
@@ -1,0 +1,12 @@
+/datum/blackmarket_item/emergency
+	category = "Emergency"
+
+/datum/blackmarket_item/emergency/plasma
+	name = "Plasma Fuel"
+	desc = "Low on fuel? We can part with some plasma... for a reasonable price."
+	item = /obj/item/stack/sheet/mineral/plasma/twenty
+
+	price_min = 2000
+	price_max = 4000
+	availability_prob = 100
+	unlimited = TRUE

--- a/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
@@ -2,7 +2,7 @@
 	category = "Emergency"
 
 /datum/blackmarket_item/emergency/plasma
-	name = "Plasma Fuel"
+	name = "Plasma"
 	desc = "Low on fuel? We can part with some plasma... for a reasonable price."
 	item = /obj/item/stack/sheet/mineral/plasma/twenty
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
@@ -27,7 +27,7 @@
 	item = /obj/item/circuitboard/machine/shuttle/engine/electric
 
 	price_min = 2000
-	price_max = 400
+	price_max = 4000
 	stock_max = 5
 	availability_prob = 100
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/emergency.dm
@@ -2,22 +2,22 @@
 	category = "Emergency"
 
 /datum/blackmarket_item/emergency/plasma
-	name = "Plasma"
+	name = "Ten Plasma Sheets"
 	desc = "Low on fuel? We can part with some plasma... for a reasonable price."
-	item = /obj/item/stack/sheet/mineral/plasma/twenty
+	item = /obj/item/stack/sheet/mineral/plasma/ten
 
-	price_min = 2000
-	price_max = 4000
+	price_min = 1750
+	price_max = 2250
 	availability_prob = 100
 	unlimited = TRUE
 
 /datum/blackmarket_item/emergency/uranium
-	name = "Uranium"
+	name = "Ten Uranium Sheets"
 	desc = "Fuel? Dirty Bomb? Fancy nightlight? Doesn't matter, we'll supply."
-	item = /obj/item/stack/sheet/mineral/uranium/twenty
+	item = /obj/item/stack/sheet/mineral/uranium/ten
 
-	price_min = 2000
-	price_max = 4000
+	price_min = 1750
+	price_max = 2250
 	availability_prob = 100
 	unlimited = TRUE
 
@@ -27,7 +27,7 @@
 	item = /obj/item/circuitboard/machine/shuttle/engine/electric
 
 	price_min = 2000
-	price_max = 4000
+	price_max = 3000
 	stock_max = 5
 	availability_prob = 100
 
@@ -37,7 +37,7 @@
 	item = /obj/machinery/portable_atmospherics/canister/oxygen
 
 	price_min = 2000
-	price_max = 4000
+	price_max = 3000
 	stock_max = 3
 	availability_prob = 100
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
@@ -35,7 +35,7 @@
 /datum/blackmarket_item/explosive/c4
 	name = "C4"
 	desc = "Looking to make an explosive entrance? These plastic explosives are perfect for the job."
-	item = obj/item/grenade/c4
+	item = /obj/item/grenade/c4
 
 	price_min = 100
 	price_max = 400
@@ -46,7 +46,7 @@
 /datum/blackmarket_item/explosive/x4
 	name = "X4"
 	desc = "X4 Plastic Explosives! Better than W4, worse than Y4."
-	item = obj/item/grenade/c4/x4
+	item = /obj/item/grenade/c4/x4
 
 	price_min = 400
 	price_max = 700

--- a/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
@@ -1,0 +1,76 @@
+/datum/blackmarket_item/explosive
+	category = "Explosives"
+
+/datum/blackmarket_item/explosive/emp_grenade
+	name = "EMP Grenade"
+	desc = "Use this grenade for SHOCKING results!"
+	item = /obj/item/grenade/empgrenade
+
+	price_min = 100
+	price_max = 400
+	stock_max = 5
+	availability_prob = 50
+
+/datum/blackmarket_item/explosive/h_e
+	name = "HE Grenade"
+	desc = "These high explosive grenades are sure to get some bang for your buck."
+	item = /obj/item/grenade/syndieminibomb/concussion
+
+	price_min = 100
+	price_max = 500
+	stock_max = 5
+	availability_prob = 25
+
+/datum/blackmarket_item/explosive/frag
+	name = "Fragmentation Grenade"
+	desc = "Pull the pin, count to three, and throw for best results."
+	item = /obj/item/grenade/frag
+
+	price_min = 100
+	price_max = 500
+	stock_min = 3
+	stock_max = 5
+	availability_prob = 40
+
+/datum/blackmarket_item/explosive/c4
+	name = "C4"
+	desc = "Looking to make an explosive entrance? These plastic explosives are perfect for the job."
+	item = obj/item/grenade/c4
+
+	price_min = 100
+	price_max = 400
+	stock_min = 5
+	stock_max = 10
+	availability_prob = 50
+
+/datum/blackmarket_item/explosive/x4
+	name = "X4"
+	desc = "X4 Plastic Explosives! Better than W4, worse than Y4."
+	item = obj/item/grenade/c4/x4
+
+	price_min = 400
+	price_max = 700
+	stock_min = 2
+	stock_max = 3
+	availability_prob = 25
+
+/datum/blackmarket_item/explosive/slipocalypse
+	name = "Slipocalyse Cluster Bomb"
+	desc = "Wash away the opposition with sudstastic grenade!"
+	item = /obj/item/grenade/clusterbuster/soap
+
+	price_min = 500
+	price_max = 1500
+	stock = 1
+	availability_prob = 10
+
+/datum/blackmarket_item/explosive/rusted_mine
+	name = "Landmine"
+	desc = "Recovered from a decades old ICW battlefield by our best EOD tech, Nicky Nine Fingers."
+	item = /obj/item/mine/pressure/explosive/rusty
+
+	price_min = 250
+	price_max = 500
+	stock_max = 7
+	availability_prob = 50
+

--- a/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
@@ -79,8 +79,8 @@
 	desc = "Offically, it's an anti-armor RPG launcher. Technically, it's anti-everything. Most things don't enjoy being hit in the face with high explosives."
 	item = /obj/item/gun/ballistic/rocketlauncher
 
-	price_min = 2000
-	price_max = 5000
+	price_min = 3500
+	price_max = 6500
 	stock_min = 2
 	stock_max = 5
 	availability_prob = 20

--- a/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
@@ -18,6 +18,7 @@
 
 	price_min = 100
 	price_max = 500
+	stock_min = 2
 	stock_max = 5
 	availability_prob = 25
 
@@ -51,7 +52,7 @@
 	price_min = 400
 	price_max = 700
 	stock_min = 2
-	stock_max = 3
+	stock_max = 4
 	availability_prob = 25
 
 /datum/blackmarket_item/explosive/slipocalypse

--- a/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/explosives.dm
@@ -74,3 +74,14 @@
 	stock_max = 7
 	availability_prob = 50
 
+/datum/blackmarket_item/explosive/rpg
+	name = "PML-9 RPG"
+	desc = "Offically, it's an anti-armor RPG launcher. Technically, it's anti-everything. Most things don't enjoy being hit in the face with high explosives."
+	item = /obj/item/gun/ballistic/rocketlauncher
+
+	price_min = 2000
+	price_max = 5000
+	stock_min = 2
+	stock_max = 5
+	availability_prob = 20
+

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -95,3 +95,30 @@
 	price_max = 2500
 	stock_max = 3
 	availability_prob = 30
+
+/datum/blackmarket_item/misc/secret_docs
+	name = "Classified Documents"
+	desc = "Good people died to get these. Luckily, we aren't good people."
+	item = /obj/item/documents
+
+	price_min = 2000
+	price_max = 10000
+	stock = 1
+	availability_prob = 40
+
+/datum/blackmarket_item/consumable/secret_docs/spawn_item(loc)
+	var/docs = pick(list(/obj/item/documents/nanotrasen,
+				/obj/item/documents/solgov,
+				/obj/item/documents/terragov,
+				/obj/item/documents/syndicate/red))
+	return new docs(loc)
+
+/datum/blackmarket_item/misc/black_box
+	name = "Blackbox"
+	desc = "Recorded in here is final moments of some poor souls who are no longer with us. We suggest watching it with friends and popcorn."
+	item = /obj/item/blackbox
+
+	price_min = 1000
+	price_max = 10000
+	stock = 1
+	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -21,26 +21,6 @@
 	stock_max = 8
 	availability_prob = 60
 
-/datum/blackmarket_item/misc/trickwine
-	name = "Trickwine"
-	desc = "The SRM keeps the recipes for their trickwines a closely guarded secret. The Hunters carrying those bottles? Less so."
-	item = /datum/reagent/consumable/ethanol/trickwine/ash_wine
-
-	price_min = 200
-	price_max = 600
-	stock_min = 3
-	stock_max = 7
-	availability_prob = 40
-
-/datum/blackmarket_item/consumable/suspicious_pills/spawn_item(loc)
-	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
-						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
-						/datum/reagent/consumable/ethanol/trickwine/shock_wine,
-						/datum/reagent/consumable/ethanol/trickwine/hearth_wine,
-						/datum/reagent/consumable/ethanol/trickwine/force_wine,
-						/datum/reagent/consumable/ethanol/trickwine/prism_wine))
-	return new trickwine(loc)
-
 /datum/blackmarket_item/misc/strange_seed
 	name = "Strange Seeds"
 	desc = "An Exotic Variety of seed that can contain anything from glow to acid."

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -86,12 +86,3 @@
 	stock_max = 3
 	availability_prob = 30
 
-/datum/blackmarket_item/misc/bepis_disk
-	name = "BEPIS Technology Disk"
-	desc = "An ancient technology disk containing some probably useful data. No refunds."
-	item = /obj/item/disk/tech_disk/major
-
-	price_min = 250
-	price_max = 1000
-	stock_max = 10
-	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -56,3 +56,43 @@
 	stock_max = 2
 	availability_prob = 30
 
+/datum/blackmarket_item/misc/organs
+	name = "Organ Freezer"
+	desc = "Need some fresh organs in a jiffy? We got you covered. Make good use of them. Someone died to get these to you."
+	item = /obj/structure/closet/crate/freezer/surplus_limbs/organs
+
+	price_min = 1000
+	price_max = 3000
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/misc/abandoned_crate
+	name = "Abandoned Crate"
+	desc = "Why, it could be \"anything\". Are you feeling lucky?"
+	item = /obj/structure/closet/crate/secure/loot
+
+	price_min = 250
+	price_max = 500
+	stock_min = 5
+	stock_max = 10
+	availability_prob = 50
+
+/datum/blackmarket_item/misc/spygass
+	name = "Spy Glass Kit"
+	desc = "A set of trick glasses and a linked camera. Suit and dashing shades not included."
+	item = /obj/item/storage/box/rxglasses/spyglasskit
+
+	price_min = 250
+	price_max = 1000
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/misc/bepis_disk
+	name = "BEPIS Technology Disk"
+	desc = "An ancient technology disk containing some probably useful data. No refunds."
+	item = /obj/item/disk/tech_disk/major
+
+	price_min = 250
+	price_max = 1000
+	stock_max = 10
+	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -86,3 +86,12 @@
 	stock_max = 3
 	availability_prob = 30
 
+/datum/blackmarket_item/misc/ripley_mk_4
+	name = "Ripley Mk IV Upgrade Kit"
+	desc = "Pimp out your Ripley to the CLIP Mark IV Rogue Model today! Killjoy bureaucrats not included, thank god."
+	item = /obj/item/mecha_parts/mecha_equipment/conversion_kit/ripley/clip
+
+	price_min = 1500
+	price_max = 2500
+	stock_max = 3
+	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -47,7 +47,7 @@
 	item = /obj/structure/closet/crate/freezer/surplus_limbs/organs
 
 	price_min = 1000
-	price_max = 3000
+	price_max = 2500
 	stock_max = 3
 	availability_prob = 30
 
@@ -57,7 +57,7 @@
 	item = /obj/structure/closet/crate/secure/loot
 
 	price_min = 250
-	price_max = 500
+	price_max = 400
 	availability_prob = 100
 	unlimited =  TRUE
 
@@ -86,7 +86,7 @@
 	desc = "Good people died to get these. Luckily, we aren't good people."
 	item = /obj/item/documents
 
-	price_min = 2000
+	price_min = 1000
 	price_max = 10000
 	stock = 1
 	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -58,7 +58,7 @@
 
 /datum/blackmarket_item/misc/organs
 	name = "Organ Freezer"
-	desc = "Need some fresh organs in a jiffy? We got you covered. Make good use of them. Someone died to get these to you."
+	desc = "Need some fresh organs in a jiffy? We got you covered. Make good use of them, someone died to get these to you."
 	item = /obj/structure/closet/crate/freezer/surplus_limbs/organs
 
 	price_min = 1000
@@ -68,14 +68,13 @@
 
 /datum/blackmarket_item/misc/abandoned_crate
 	name = "Abandoned Crate"
-	desc = "Why, it could be \"anything\". Are you feeling lucky?"
+	desc = "Why, it could be anything. Are you feeling lucky?"
 	item = /obj/structure/closet/crate/secure/loot
 
 	price_min = 250
 	price_max = 500
-	stock_min = 5
-	stock_max = 10
-	availability_prob = 50
+	availability_prob = 100
+	unlimited =  TRUE
 
 /datum/blackmarket_item/misc/spygass
 	name = "Spy Glass Kit"
@@ -95,4 +94,4 @@
 	price_min = 250
 	price_max = 1000
 	stock_max = 10
-	availability_prob = 30
+	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -23,7 +23,7 @@
 
 /datum/blackmarket_item/misc/holywater
 	name = "Flask of holy water"
-	desc = "Father Lootius' own brand of ready-made holy water."
+	desc = "Father Fictus' own brand of ready-made holy water."
 	item = /obj/item/reagent_containers/food/drinks/bottle/holywater
 
 	price_min = 400

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -16,7 +16,7 @@
 	desc = "Yeehaw, hardboiled friends! This holster is the first step in your dream of becoming a detective and being allowed to shoot real guns!"
 	item = /obj/item/clothing/accessory/holster
 
-	price_min = 400
+	price_min = 200
 	price_max = 800
 	stock_max = 8
 	availability_prob = 60
@@ -51,7 +51,8 @@
 	desc = "This easily hidden satchel can become a versatile tool to anybody with the desire to keep certain items out of sight and out of mind."
 	item = /obj/item/storage/backpack/satchel/flat/empty
 
-	price_min = 750
+	price_min = 250
 	price_max = 1000
 	stock_max = 2
 	availability_prob = 30
+

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -21,20 +21,25 @@
 	stock_max = 8
 	availability_prob = 60
 
-/datum/blackmarket_item/misc/holywater
-	name = "Flask of holy water"
-	desc = "Father Fictus' own brand of ready-made holy water."
-	item = /obj/item/reagent_containers/food/drinks/bottle/holywater
+/datum/blackmarket_item/misc/trickwine
+	name = "Trickwine"
+	desc = "The SRM keeps the recipes for their trickwines a closely guarded secret. The Hunters carrying those bottles? Less so."
+	item = /datum/reagent/consumable/ethanol/trickwine/ash_wine
 
-	price_min = 400
+	price_min = 200
 	price_max = 600
-	stock_max = 3
+	stock_min = 3
+	stock_max = 7
 	availability_prob = 40
 
-/datum/blackmarket_item/misc/holywater/spawn_item(loc)
-	if (prob(6.66))
-		return new /obj/item/reagent_containers/glass/beaker/unholywater(loc)
-	return ..()
+/datum/blackmarket_item/consumable/suspicious_pills/spawn_item(loc)
+	var/trickwine = pick(list(/datum/reagent/consumable/ethanol/trickwine/ash_wine,
+						/datum/reagent/consumable/ethanol/trickwine/ice_wine,
+						/datum/reagent/consumable/ethanol/trickwine/shock_wine,
+						/datum/reagent/consumable/ethanol/trickwine/hearth_wine,
+						/datum/reagent/consumable/ethanol/trickwine/force_wine,
+						/datum/reagent/consumable/ethanol/trickwine/prism_wine))
+	return new trickwine(loc)
 
 /datum/blackmarket_item/misc/strange_seed
 	name = "Strange Seeds"

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -5,60 +5,60 @@
 	name = "Experimental Wrench"
 	desc = "The extra fast and handy wrench you always wanted!"
 	item = /obj/item/wrench/caravan
-	stock = 1
 
-	price_min = 400
-	price_max = 800
-	availability_prob = 20
+	price_min = 50
+	price_max = 200
+	stock_max = 3
+	availability_prob = 40
 
 /datum/blackmarket_item/tool/caravan_wirecutters
 	name = "Experimental Wirecutters"
 	desc = "The extra fast and handy wirecutters you always wanted!"
 	item = /obj/item/wirecutters/caravan
-	stock = 1
 
-	price_min = 400
-	price_max = 800
-	availability_prob = 20
+	price_min = 50
+	price_max = 200
+	stock_max = 3
+	availability_prob = 40
 
 /datum/blackmarket_item/tool/caravan_screwdriver
 	name = "Experimental Screwdriver"
 	desc = "The extra fast and handy screwdriver you always wanted!"
 	item = /obj/item/screwdriver/caravan
-	stock = 1
 
-	price_min = 400
-	price_max = 800
-	availability_prob = 20
+	price_min = 50
+	price_max = 200
+	stock_max = 3
+	availability_prob = 40
 
 /datum/blackmarket_item/tool/caravan_crowbar
 	name = "Experimental Crowbar"
 	desc = "The extra fast and handy crowbar you always wanted!"
 	item = /obj/item/crowbar/red/caravan
-	stock = 1
 
-	price_min = 400
-	price_max = 800
-	availability_prob = 20
+	price_min = 50
+	price_max = 200
+	stock_max = 3
+	availability_prob = 40
 
 /datum/blackmarket_item/tool/binoculars
 	name = "Binoculars"
 	desc = "Increase your sight by 150% with this handy Tool!"
 	item = /obj/item/binoculars
-	stock = 1
 
-	price_min = 400
-	price_max = 960
-	availability_prob = 30
+	price_min = 50
+	price_max = 300
+	stock_max = 3
+	availability_prob = 40
 
 /datum/blackmarket_item/tool/riot_shield
 	name = "Riot Shield"
 	desc = "Protect yourself from an unexpected Riot at your local Police department!"
 	item = /obj/item/shield/riot
 
-	price_min = 450
-	price_max = 650
-	stock_max = 2
+	price_min = 300
+	price_max = 800
+	stock_max = 3
 	availability_prob = 50
 
 /datum/blackmarket_item/tool/thermite_bottle
@@ -66,9 +66,9 @@
 	desc = "30u of Thermite to assist in creating a quick access point or get away!"
 	item = /obj/item/reagent_containers/glass/bottle/thermite
 
-	price_min = 500
-	price_max = 1500
-	stock_max = 3
+	price_min = 100
+	price_max = 600
+	stock_max = 10
 	availability_prob = 30
 
 /datum/blackmarket_item/tool/science_goggles

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -41,6 +41,16 @@
 	stock_max = 3
 	availability_prob = 40
 
+/datum/blackmarket_item/tools/combat_wrench
+	name = "Combat Wrench"
+	desc = "Under fire while doing repairs? With this dual purpose wrench, never be caught unprepared again!"
+	item = /obj/item/wrench/combat
+
+	price_min = 500
+	price_max = 2500
+	stock = 1
+	availability_prob = 20
+
 /datum/blackmarket_item/tools/syndi_toolbox
 	name = "Syndicate Toolbox"
 	desc = "A set of specialized tools, built to precision perfection and certified by the GEC."

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -41,7 +41,7 @@
 	stock_max = 3
 	availability_prob = 40
 
-/datum/blackmarket_item/tools/combat_wrench
+/datum/blackmarket_item/tool/combat_wrench
 	name = "Combat Wrench"
 	desc = "Under fire while doing repairs? With this dual purpose wrench, never be caught unprepared again!"
 	item = /obj/item/wrench/combat
@@ -91,7 +91,7 @@
 	stock_max = 10
 	availability_prob = 50
 
-/datum/blackmarket_item/tools/thermite_jug
+/datum/blackmarket_item/tool/thermite_jug
 	name = "Thermite Jug"
 	desc = "An extra large 150u jug of thermite. For those hard to reach places."
 	item = /obj/item/reagent_containers/glass/chem_jug/thermite

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -89,7 +89,17 @@
 	price_min = 100
 	price_max = 600
 	stock_max = 10
-	availability_prob = 30
+	availability_prob = 50
+
+/datum/blackmarket_item/tools/thermite_jug
+	name = "Thermite Jug"
+	desc = "An extra large 150u jug of thermite. For those hard to reach places."
+	item = /obj/item/reagent_containers/glass/chem_jug/thermite
+
+	price_min = 400
+	price_max = 2600
+	stock_max = 3
+	availability_prob = 20
 
 /datum/blackmarket_item/tool/science_goggles
 	name = "Science Goggles"
@@ -150,3 +160,13 @@
 	price_max = 3000
 	stock = 1
 	availability_prob = 30
+
+/datum/blackmarket_item/tool/suppressor
+	name = "Suppressor"
+	desc = "A suppressor, for when you to keep your murder on the down low."
+	item = new /obj/item/suppressor
+
+	price_min = 100
+	price_max = 700
+	stock_max = 6
+	availability_prob = 40

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -97,7 +97,7 @@
 	item = /obj/item/reagent_containers/glass/chem_jug/thermite
 
 	price_min = 400
-	price_max = 2600
+	price_max = 1500
 	stock_max = 3
 	availability_prob = 20
 
@@ -128,7 +128,7 @@
 
 	price_min = 100
 	price_max = 1000
-	stock_max = 3
+	stock = 3
 	availability_prob = 30
 
 /datum/blackmarket_item/tool/rocket_gloves
@@ -138,7 +138,7 @@
 
 	price_min = 500
 	price_max = 2000
-	stock_max = 2
+	stock_max = 3
 	availability_prob = 30
 
 /datum/blackmarket_item/tool/chem_master
@@ -168,5 +168,6 @@
 
 	price_min = 100
 	price_max = 700
+	stock_min = 3
 	stock_max = 6
-	availability_prob = 40
+	availability_prob = 60

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -59,7 +59,7 @@
 	price_min = 500
 	price_max = 2000
 	stock = 1
-	availability_prob = 20
+	availability_prob = 30
 
 /datum/blackmarket_item/tool/binoculars
 	name = "Binoculars"
@@ -68,8 +68,9 @@
 
 	price_min = 50
 	price_max = 300
-	stock_max = 3
-	availability_prob = 40
+	stock_min = 2
+	stock_max = 4
+	availability_prob = 70
 
 /datum/blackmarket_item/tool/riot_shield
 	name = "Riot Shield"
@@ -188,7 +189,7 @@
 	item = /obj/item/tank/jetpack/improvised
 
 	price_min = 500
-	price_max = 1250
+	price_max = 1000
 	stock_min = 3
 	stock_max = 6
 	availability_prob = 70

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -51,7 +51,7 @@
 	stock = 1
 	availability_prob = 20
 
-/datum/blackmarket_item/tools/syndi_toolbox
+/datum/blackmarket_item/tool/syndi_toolbox
 	name = "Syndicate Toolbox"
 	desc = "A set of specialized tools, built to precision perfection and certified by the GEC."
 	item = /obj/item/storage/toolbox/syndicate
@@ -101,7 +101,7 @@
 	stock_max = 3
 	availability_prob = 50
 
-/datum/blackmarket_item/tools/thermal_eyepatch
+/datum/blackmarket_item/tool/thermal_eyepatch
 	name = "Thermal Eyepatch"
 	desc = "A thermal eyepatch, capable of tracking the heat signatures of living beings through solid objects."
 	item = /obj/item/clothing/glasses/thermal/eyepatch
@@ -111,7 +111,7 @@
 	stock = 1
 	availability_prob = 20
 
-/datum/blackmarket_item/tools/jumpboots
+/datum/blackmarket_item/tool/jumpboots
 	name = "Jump Boots"
 	desc = "Jump ahead of the competition with these specialized mining boots!"
 	item = /obj/item/clothing/shoes/bhop
@@ -121,7 +121,7 @@
 	stock_max = 3
 	availability_prob = 30
 
-/datum/blackmarket_item/tools/rocket_gloves
+/datum/blackmarket_item/tool/rocket_gloves
 	name = "Rocket Gloves"
 	desc = "The pinacle of tackling technology, no one will be able to resist a tackle from these rocket propelled gloves. Make sure not to miss though, we don't sell wheelchairs."
 	item = /obj/item/clothing/gloves/tackler/rocket
@@ -131,7 +131,7 @@
 	stock_max = 2
 	availability_prob = 30
 
-/datum/blackmarket_item/tools/chem_master
+/datum/blackmarket_item/tool/chem_master
 	name = "Chem Master Board"
 	desc = "A Chem Master board, capable of seperating and packaging reagents. Perfect for any aspiring at home chemist."
 	item = /obj/item/circuitboard/machine/chem_master
@@ -141,7 +141,7 @@
 	stock = 1
 	availability_prob = 30
 
-/datum/blackmarket_item/tools/rcd
+/datum/blackmarket_item/tool/rcd
 	name = "Rapid Construction Device"
 	desc = "Borrowed from a GEC construction site, this handy device will make building a cinch."
 	item = /obj/item/construction/rcd

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -6,7 +6,7 @@
 	desc = "The extra fast and handy wrench you always wanted!"
 	item = /obj/item/wrench/caravan
 
-	price_min = 50
+	price_min = 100
 	price_max = 200
 	stock_max = 3
 	availability_prob = 40
@@ -16,7 +16,7 @@
 	desc = "The extra fast and handy wirecutters you always wanted!"
 	item = /obj/item/wirecutters/caravan
 
-	price_min = 50
+	price_min = 100
 	price_max = 200
 	stock_max = 3
 	availability_prob = 40
@@ -26,7 +26,7 @@
 	desc = "The extra fast and handy screwdriver you always wanted!"
 	item = /obj/item/screwdriver/caravan
 
-	price_min = 50
+	price_min = 100
 	price_max = 200
 	stock_max = 3
 	availability_prob = 40
@@ -36,10 +36,20 @@
 	desc = "The extra fast and handy crowbar you always wanted!"
 	item = /obj/item/crowbar/red/caravan
 
-	price_min = 50
+	price_min = 100
 	price_max = 200
 	stock_max = 3
 	availability_prob = 40
+
+/datum/blackmarket_item/tools/syndi_toolbox
+	name = "Syndicate Toolbox"
+	desc = "A set of specialized tools, built to precision perfection and certified by the GEC."
+	item = /obj/item/storage/toolbox/syndicate
+
+	price_min = 500
+	price_max = 2000
+	stock = 1
+	availability_prob = 20
 
 /datum/blackmarket_item/tool/binoculars
 	name = "Binoculars"
@@ -80,3 +90,53 @@
 	price_max = 200
 	stock_max = 3
 	availability_prob = 50
+
+/datum/blackmarket_item/tools/thermal_eyepatch
+	name = "Thermal Eyepatch"
+	desc = "A thermal eyepatch, capable of tracking the heat signatures of living beings through solid objects."
+	item = /obj/item/clothing/glasses/thermal/eyepatch
+
+	price_min = 1000
+	price_max = 3000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/tools/jumpboots
+	name = "Jump Boots"
+	desc = "Jump ahead of the competition with these specialized mining boots!"
+	item = /obj/item/clothing/shoes/bhop
+
+	price_min = 100
+	price_max = 1000
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/tools/rocket_gloves
+	name = "Rocket Gloves"
+	desc = "The pinacle of tackling technology, no one will be able to resist a tackle from these rocket propelled gloves. Make sure not to miss though, we don't sell wheelchairs."
+	item = /obj/item/clothing/gloves/tackler/rocket
+
+	price_min = 500
+	price_max = 2000
+	stock_max = 2
+	availability_prob = 30
+
+/datum/blackmarket_item/tools/chem_master
+	name = "Chem Master Board"
+	desc = "A Chem Master board, capable of seperating and packaging reagents. Perfect for any aspiring at home chemist."
+	item = /obj/item/circuitboard/machine/chem_master
+
+	price_min = 1000
+	price_max = 3000
+	stock = 1
+	availability_prob = 30
+
+/datum/blackmarket_item/tools/rcd
+	name = "Rapid Construction Device"
+	desc = "Borrowed from a GEC construction site, this handy device will make building a cinch."
+	item = /obj/item/construction/rcd
+
+	price_min = 1000
+	price_max = 3000
+	stock = 1
+	availability_prob = 30

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -164,7 +164,7 @@
 /datum/blackmarket_item/tool/suppressor
 	name = "Suppressor"
 	desc = "A suppressor, for when you to keep your murder on the down low."
-	item = new /obj/item/suppressor
+	item = /obj/item/suppressor
 
 	price_min = 100
 	price_max = 700

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -171,3 +171,44 @@
 	stock_min = 3
 	stock_max = 6
 	availability_prob = 60
+
+/datum/blackmarket_item/tool/blastwave
+	name = "Blastwave Jackhammer"
+	desc = "We found a shipment of brand new hypersonic jackhammers in a cargo freighter. So we don't need these old ones anymore."
+	item = /obj/item/pickaxe/drill/jackhammer/old
+
+	price_min = 750
+	price_max = 1750
+	stock_max = 3
+	availability_prob = 40
+
+/datum/blackmarket_item/tool/impro_jetpack
+	name = "Improvised Jetpack"
+	desc = "A lovingly handcrafted jetpack built by our salvage techs. For the frugal space explorer."
+	item = /obj/item/tank/jetpack/improvised
+
+	price_min = 500
+	price_max = 1250
+	stock_min = 3
+	stock_max = 6
+	availability_prob = 70
+
+/datum/blackmarket_item/tool/jet_harness
+	name = "Jet Harness"
+	desc = "A compact oxygen filled jet harness for tactical EVA insertions and extractions."
+	item = /obj/item/tank/jetpack/oxygen/harness
+
+	price_min = 1250
+	price_max = 3500
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/tool/jetpack_upgrade
+	name = "Hardsuit Jetpack Upgrade"
+	desc = "A modular jetpack compatible with most hardsuits. If the screws feel a bit loose, it's because the last suit it was attached to was beyond recovery."
+	item = /obj/item/tank/jetpack/suit
+
+	price_min = 1750
+	price_max = 3000
+	stock = 1
+	availability_prob = 25

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -156,7 +156,7 @@
 
 /datum/blackmarket_item/weapon/saber_smg
 	name = "Saber 9mm SMG"
-	desc = "A prototype 9mm submachine gun. Most of these never got past the RND phase into distribution. But we happen know a guy."
+	desc = "A prototype 9mm submachine gun. Most of these never got past the RND phase and into distribution. But we happen know a guy."
 	item = /obj/item/gun/ballistic/automatic/smg/proto
 	pair_item = /datum/blackmarket_item/weapon/saber_mag
 
@@ -182,12 +182,12 @@
 
 	price_min = 2500
 	price_max = 5000
-	stock = 1
+	stock = 2
 	availability_prob = 20
 
 /datum/blackmarket_item/weapon/bioterror_foam
 	name = "Bioterror Foam Sprayer"
-	desc = "Banned in at least 17 jurisdictions for being 'cruel', 'inhumane', and 'causing indiscriminate lifelong generational health complications'. Though if you actually cared about those things, you wouldn't be shopping here in the first place."
+	desc = "Banned in at least 17 jurisdictions for being \"cruel\",\"inhumane\", and \"causing indiscriminate lifelong generational health complications\". Though if you actually cared about those things, you wouldn't be shopping here in the first place."
 	item = /obj/item/reagent_containers/spray/chemsprayer/bioterror
 
 	price_min = 3000
@@ -195,16 +195,16 @@
 	stock = 1
 	availability_prob = 20
 
-// /datum/blackmarket_item/weapon/sawn_illestren
-// 	name = "Sawn off Illestren Rifle"
-// 	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."
-// 	item = /obj/item/gun/ballistic/rifle/illestren/sawoff
+/datum/blackmarket_item/weapon/sawn_illestren
+	name = "Sawn off Illestren Rifle"
+	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."
+	item = /obj/item/gun/ballistic/rifle/illestren/sawn
 
-// 	price_min = 600
-// 	price_max = 1250
-// 	stock_min = 2
-// 	stock_max = 5
-// 	availability_prob = 50
+	price_min = 600
+	price_max = 1250
+	stock_min = 2
+	stock_max = 5
+	availability_prob = 50
 
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -154,22 +154,6 @@
 	stock_max = 2
 	availability_prob = 20
 
-// /datum/blackmarket_item/weapon/corrupt_gun_cell
-// 	name = "Damaged Weapon Cell"
-// 	desc = "These got a bit dinged up in their crate after a close shave with GOLD inspectors. The cells are probably still safe to use though."
-// 	item = /obj/item/stock_parts/cell/gun
-
-// 	price_min = 250
-// 	price_max = 500
-// 	stock_min = 4
-// 	stock_max = 10
-// 	availability_prob = 40
-
-// /datum/blackmarket_item/weapon/corrupt_gun_cell/spawn_item(loc)
-// 	var/stock_parts/cell/gun = Cell()
-// 	Cell.corrupt()
-// 	return new berries(loc)
-
 /datum/blackmarket_item/weapon/saber_smg
 	name = "Saber 9mm SMG"
 	desc = "A prototype 9mm submachine gun. Most of these never got past the RND phase into distribution. But we happen know a guy."

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -111,7 +111,7 @@
 	price_min = 250
 	price_max = 750
 	stock = 5
-	availability_prob = 40
+	availability_prob = 60
 
 /datum/blackmarket_item/weapon/e40
 	name = "E-40 Hybrid Assault Rifle"
@@ -126,7 +126,7 @@
 
 /datum/blackmarket_item/weapon/e40_mag
 	name = "Eoehoma .299 Caseless Magazine"
-	desc = "30 round magazines for the E-40 Hybrid Rifle."
+	desc = "A 30 round magazine for the E-40 Hybrid Rifle."
 	item = /obj/item/ammo_box/magazine/e40
 
 	price_min = 750
@@ -194,7 +194,17 @@
 	price_max = 1250
 	stock_min = 2
 	stock_max = 5
-	availability_prob = 50
+	availability_prob = 60
+
+/datum/blackmarket_item/weapon/combat_shotgun
+	name = "Combat Shotgun"
+	desc = "Are your arms tired from pumping Hunter's Pride shotguns? This semi-automatic combat shotgun will make killing a breeze."
+	item = /obj/item/gun/ballistic/shotgun/automatic/combat
+
+	price_min = 2000
+	price_max = 4000
+	stock_max = 3
+	availability_prob = 40
 
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -62,14 +62,25 @@
 	stock_max = 1
 	availability_prob = 10
 
-/datum/blackmarket_item/weapons/himehabu
+/datum/blackmarket_item/weapon/himehabu
 	name = "Himehabu Pistol"
 	desc = "Great things come in small packages. The Himehabu is perfect for all your espionage needs. Chambered in .22lr."
 	item = /obj/item/gun/ballistic/automatic/pistol/himehabu
+	pair_item = /datum/blackmarket_item/weapon/himehabu_mag
 
 	price_min = 100
 	price_max = 600
 	stock_max = 6
-	availability_prob = 50
+	availability_prob = 100
+
+/datum/blackmarket_item/weapon/himehabu_mag
+	name = "Himehabu Magazines"
+	desc = "Compact .22lr magazines for use in the Himehabu pistol."
+	item = /obj/item/ammo_box/magazine/m22lr
+
+	price_min = 100
+	price_max = 200
+	stock_max = 6
+	availability_prob = 0
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -6,9 +6,10 @@
 	desc = "Get the janitor back at his own game with this affordable prank kit."
 	item = /obj/item/restraints/legcuffs/beartrap
 
-	price_min = 300
-	price_max = 550
-	stock_max = 3
+	price_min = 150
+	price_max = 400
+	stock_min = 3
+	stock_max = 7
 	availability_prob = 40
 
 /datum/blackmarket_item/weapon/shotgun_dart
@@ -52,7 +53,7 @@
 	price_min = 1500
 	price_max = 3500
 	stock = 1
-	availability_prob = 20
+	availability_prob = 25
 
 /datum/blackmarket_item/weapon/derringer
 	name = "Derringer"
@@ -81,7 +82,7 @@
 	price_min = 100
 	price_max = 600
 	stock_max = 6
-	availability_prob = 40
+	availability_prob = 50
 
 /datum/blackmarket_item/weapon/himehabu_mag
 	name = "Himehabu Magazines"
@@ -90,6 +91,7 @@
 
 	price_min = 100
 	price_max = 200
+	stock_min = 3
 	stock_max = 6
 	availability_prob = 0
 
@@ -131,7 +133,8 @@
 
 	price_min = 750
 	price_max = 1250
-	stock_max = 3
+	stock_min = 2
+	stock_max = 4
 	availability_prob = 0
 
 /datum/blackmarket_item/weapon/e50
@@ -162,7 +165,7 @@
 
 	price_min = 500
 	price_max = 1000
-	stock_max = 2
+	stock = 2
 	availability_prob = 0
 
 /datum/blackmarket_item/weapon/bg_16
@@ -201,7 +204,7 @@
 	desc = "Ripley with a laser cannon? Odysseus with a missile rack? Sky's the limit with this omni-compatible weapons bay! (Missiles and lasers not included)"
 	item = /obj/item/mecha_parts/concealed_weapon_bay
 
-	price_min = 1250
+	price_min = 1000
 	price_max = 2000
 	stock_max = 3
 	availability_prob = 30
@@ -213,7 +216,7 @@
 	pair_item = /datum/blackmarket_item/weapon/model_h_mag
 
 	price_min = 2000
-	price_max = 4000
+	price_max = 3500
 	stock = 2
 	availability_prob = 35
 
@@ -281,19 +284,20 @@
 	item = /obj/item/gun/ballistic/automatic/powered/gauss
 	pair_item = /datum/blackmarket_item/weapon/proto_gauss_mag
 
-	price_min = 4000
+	price_min = 3500
 	price_max = 6000
-	stock = 1
-	availability_prob = 20
+	stock = 2
+	availability_prob = 25
 
 /datum/blackmarket_item/weapon/proto_gauss_mag
 	name = "Prototype Gauss Rifle Magazine"
 	desc = "A 25 round ferromagnetic pellet magazine for the prototype gauss rifle."
 	item = /obj/item/ammo_box/magazine/gauss
 
-	price_min = 750
-	price_max = 1250
-	stock_max = 2
+	price_min = 600
+	price_max = 1100
+	stock_min = 2
+	stock_max = 4
 	availability_prob = 0
 
 /datum/blackmarket_item/weapon/tec

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -69,7 +69,7 @@
 	item = /obj/item/gun/ballistic/derringer/gold
 	price_min = 1000
 	price_max = 3000
-	stock_max = 1
+	stock = 1
 	availability_prob = 10
 
 /datum/blackmarket_item/weapon/himehabu
@@ -85,7 +85,7 @@
 
 /datum/blackmarket_item/weapon/himehabu_mag
 	name = "Himehabu Magazines"
-	desc = "Compact .22lr magazines for use in the Himehabu pistol."
+	desc = "Compact 10 round .22lr magazines for use in the Himehabu pistol."
 	item = /obj/item/ammo_box/magazine/m22lr
 
 	price_min = 100
@@ -203,7 +203,7 @@
 
 	price_min = 1250
 	price_max = 2000
-	stock_max = 2
+	stock_max = 3
 	availability_prob = 30
 
 /datum/blackmarket_item/weapon/model_h
@@ -244,7 +244,7 @@
 	availability_prob = 20
 
 /datum/blackmarket_item/weapon/sgg_stripper
-	name = "8x58 Stripper Clip"
+	name = "8x58mm Stripper Clip"
 	desc = "A five round 8x58mm stripper clip for use with the SGG-669C."
 	item = /obj/item/ammo_box/a858
 
@@ -288,7 +288,7 @@
 
 /datum/blackmarket_item/weapon/proto_gauss_mag
 	name = "Prototype Gauss Rifle Magazine"
-	desc = "A 30 round ferromagnetic pellet magazine for the prototype gauss rifle."
+	desc = "A 25 round ferromagnetic pellet magazine for the prototype gauss rifle."
 	item = /obj/item/ammo_box/magazine/gauss
 
 	price_min = 750
@@ -302,8 +302,8 @@
 	item = /obj/item/gun/ballistic/automatic/pistol/tec9
 	pair_item = /datum/blackmarket_item/weapon/tec_mag
 
-	price_min = 2000
-	price_max = 3250
+	price_min = 1500
+	price_max = 2750
 	stock_max = 2
 	availability_prob = 35
 
@@ -319,11 +319,11 @@
 
 /datum/blackmarket_item/weapon/scout
 	name = "HP Scout"
-	desc = "A scoped rifle chambered in .300 Magnum. As the name would imply, perfect for scouts. Try not to tunnel vision with the scope like the last guy.."
+	desc = "A scoped rifle chambered in .300 Magnum. As the name would imply, perfect for scouts. Try not to tunnel vision with the scope like the last guy."
 	item = /obj/item/gun/ballistic/rifle/scout
 	pair_item = /datum/blackmarket_item/weapon/scout_stripper
 
-	price_min = 3500
+	price_min = 4000
 	price_max = 6500
 	stock = 1
 	availability_prob = 20

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -239,7 +239,7 @@
 	pair_item = /datum/blackmarket_item/weapon/sgg_stripper
 
 	price_min = 3000
-	price_max = 5000
+	price_max = 6000
 	stock = 1
 	availability_prob = 20
 
@@ -273,6 +273,70 @@
 	price_min = 250
 	price_max = 750
 	stock_max = 2
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/proto_gauss
+	name = "Prototype Gauss Rifle"
+	desc = "A prototype gauss rifle made by Nanotrasen. Perfect for making swiss cheese out of people. Chambered in ferromagnetic pellets."
+	item = /obj/item/gun/ballistic/automatic/powered/gauss
+	pair_item = /datum/blackmarket_item/weapon/proto_gauss_mag
+
+	price_min = 4000
+	price_max = 6000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/proto_gauss_mag
+	name = "Prototype Gauss Rifle Magazine"
+	desc = "A 30 round ferromagnetic pellet magazine for the prototype gauss rifle."
+	item = /obj/item/ammo_box/magazine/gauss
+
+	price_min = 750
+	price_max = 1250
+	stock_max = 2
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/tec
+	name = "TEC-9 Machine Pistol"
+	desc = "Hallelujah! It's raining lead! This 9mm machine pistol is capable of spitting out bullets at rapid pace."
+	item = /obj/item/gun/ballistic/automatic/pistol/tec9
+	pair_item = /datum/blackmarket_item/weapon/tec_mag
+
+	price_min = 2000
+	price_max = 3250
+	stock_max = 2
+	availability_prob = 35
+
+/datum/blackmarket_item/weapon/tec_mag
+	name = "TEC-9 AP Magazine"
+	desc = "A 20 round magazine of AP ammo for the TEC-9 machine pistol."
+	item = /obj/item/ammo_box/magazine/tec9
+
+	price_min = 600
+	price_max = 1000
+	stock_max = 2
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/scout
+	name = "HP Scout"
+	desc = "A scoped rifle chambered in .300 Magnum. As the name would imply, perfect for scouts. Sidenote, scouts are also vulnerable to ambushes."
+	item = /obj/item/gun/ballistic/rifle/scout
+	pair_item = /datum/blackmarket_item/weapon/scout_stripper
+
+	price_min = 3500
+	price_max = 6500
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/scout_stripper
+	name = ".300 Magnum Stripper Clip"
+	desc = "5 round .300 Magnun stripper clips for use with the HP Scout."
+	item = /obj/item/ammo_box/a30
+
+	price_min = 500
+	price_max = 100
+	stock_min = 4
+	stock_max = 6
 	availability_prob = 0
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -319,7 +319,7 @@
 
 /datum/blackmarket_item/weapon/scout
 	name = "HP Scout"
-	desc = "A scoped rifle chambered in .300 Magnum. As the name would imply, perfect for scouts. Sidenote, scouts are also vulnerable to ambushes."
+	desc = "A scoped rifle chambered in .300 Magnum. As the name would imply, perfect for scouts. Try not to tunnel vision with the scope like the last guy.."
 	item = /obj/item/gun/ballistic/rifle/scout
 	pair_item = /datum/blackmarket_item/weapon/scout_stripper
 
@@ -330,7 +330,7 @@
 
 /datum/blackmarket_item/weapon/scout_stripper
 	name = ".300 Magnum Stripper Clip"
-	desc = "5 round .300 Magnun stripper clips for use with the HP Scout."
+	desc = "A 5 round .300 Magnum stripper clips for use with the HP Scout."
 	item = /obj/item/ammo_box/a300
 
 	price_min = 500

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -54,16 +54,6 @@
 	stock = 1
 	availability_prob = 20
 
-/datum/blackmarket_item/weapon/emp_grenade
-	name = "EMP Grenade"
-	desc = "Use this grenade for SHOCKING results!"
-	item = /obj/item/grenade/empgrenade
-
-	price_min = 100
-	price_max = 400
-	stock_max = 2
-	availability_prob = 50
-
 /datum/blackmarket_item/weapon/derringer
 	name = "Derringer"
 	desc = "A concealable handgun small enough to hide nearly anywhere. Uses .38 revolver rounds."
@@ -163,7 +153,7 @@
 	price_min = 2500
 	price_max = 4200
 	stock_max = 2
-	availability_prob = 20
+	availability_prob = 25
 
 /datum/blackmarket_item/weapon/saber_mag
 	name = "Saber 9mm SMG Magazines"

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -154,21 +154,21 @@
 	stock_max = 2
 	availability_prob = 20
 
-/datum/blackmarket_item/weapon/corrupt_gun_cell
-	name = "Damaged Weapon Cell"
-	desc = "These got a bit dinged up in their crate after a close shave with GOLD inspectors. The cells are probably still safe to use though."
-	item = /obj/item/stock_parts/cell/gun
+// /datum/blackmarket_item/weapon/corrupt_gun_cell
+// 	name = "Damaged Weapon Cell"
+// 	desc = "These got a bit dinged up in their crate after a close shave with GOLD inspectors. The cells are probably still safe to use though."
+// 	item = /obj/item/stock_parts/cell/gun
 
-	price_min = 250
-	price_max = 500
-	stock_min = 4
-	stock_max = 10
-	availability_prob = 40
+// 	price_min = 250
+// 	price_max = 500
+// 	stock_min = 4
+// 	stock_max = 10
+// 	availability_prob = 40
 
-/datum/blackmarket_item/weapon/corrupt_gun_cell/spawn_item(loc)
-	var/stock_parts/cell/gun = C()
-	c.corrupt()
-	return new berries(loc)
+// /datum/blackmarket_item/weapon/corrupt_gun_cell/spawn_item(loc)
+// 	var/stock_parts/cell/gun = Cell()
+// 	Cell.corrupt()
+// 	return new berries(loc)
 
 /datum/blackmarket_item/weapon/saber_smg
 	name = "Saber 9mm SMG"

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -206,4 +206,73 @@
 	stock_max = 2
 	availability_prob = 30
 
+/datum/blackmarket_item/weapon/model_h
+	name = "Model H"
+	desc = "A Model H slug pistol. The H stands for Hurt. Chambered in ferromagnetic slugs."
+	item = /obj/item/gun/ballistic/automatic/powered/gauss/modelh
+	pair_item = /obj/item/ammo_box/magazine/modelh
+
+	price_min = 2000
+	price_max = 4000
+	stock = 2
+	availability_prob = 35
+
+/datum/blackmarket_item/consumable/model_h/spawn_item(loc)
+	var/model_h = pick(list(/obj/item/gun/ballistic/automatic/powered/gauss/modelh/suns,
+				/obj/item/gun/ballistic/automatic/powered/gauss/modelh))
+	return new model_h(loc)
+
+/datum/blackmarket_item/weapon/model_h_mag
+	name = "Model H Magazine"
+	desc = "A 10 round magazine for Model H slug pistol."
+	item = /obj/item/ammo_box/magazine/modelh
+
+	price_min = 500
+	price_max = 1000
+	stock_max = 4
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/sgg
+	name = "SSG-669C Rotary Sniper Rifle"
+	desc = "I could tell you it's full name, but we'd be here all day. It's a sniper rifle. It shoots people from far away. Chambered in 8x58mm."
+	item = /obj/item/gun/ballistic/rifle/solgov
+	pair_item = /datum/blackmarket_item/weapon/sgg_stripper
+
+	price_min = 3000
+	price_max = 5000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/sgg_stripper
+	name = "8x58 Stripper Clip"
+	desc = "A five round 8x58mm stripper clip for use with the SGG-669C."
+	item = /obj/item/ammo_box/a858
+
+	price_min = 500
+	price_max = 1000
+	stock_min = 4
+	stock_max = 6
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/pistole_c
+	name = "Pistole C"
+	desc = "Pistole Compact? Pistole Caseless? Pistole Cheese? Fuck if I know. All I know is these little numbers pack a nasty sting. Chambered in 5.56 caseless."
+	item = /obj/item/gun/ballistic/automatic/pistol/solgov/old
+	pair_item =
+
+	price_min = 900
+	price_max = 1250
+	stock_max = 3
+	availability_prob = 30
+
+/datum/blackmarket_item/weapon/pistole_c_mag
+	name = "5.56 Caseless Magazine"
+	desc = "A 12 round magazine for the Pistole Cheese."
+	item = /obj/item/ammo_box/magazine/pistol556mm
+
+	price_min = 250
+	price_max = 750
+	stock_max = 2
+	availability_prob = 0
+
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -48,7 +48,7 @@
 	name = "Derringer"
 	desc = "A concealable handgun small enough to hide nearly anywhere. Uses .38 revolver rounds."
 	item = /obj/item/gun/ballistic/derringer
-	price_min = 400
+	price_min = 100
 	price_max = 600
 	stock_max = 6
 	availability_prob = 50
@@ -60,6 +60,16 @@
 	price_min = 1000
 	price_max = 3000
 	stock_max = 1
-	availability_prob = 5
+	availability_prob = 10
+
+/datum/blackmarket_item/weapons/himehabu
+	name = "Himehabu Pistol"
+	desc = "Great things come in small packages. The Himehabu is perfect for all your espionage needs. Chambered in .22lr."
+	item = /obj/item/gun/ballistic/automatic/pistol/himehabu
+
+	price_min = 100
+	price_max = 600
+	stock_max = 6
+	availability_prob = 50
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -63,7 +63,7 @@
 	stock_max = 6
 	availability_prob = 50
 
-/datum/blackmarket_item/weapon/derringer
+/datum/blackmarket_item/weapon/golden
 	name = "Golden Derringer"
 	desc = "A rare custom-made concealable weapon designed to fire illegal .357 rounds."
 	item = /obj/item/gun/ballistic/derringer/gold

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -196,6 +196,14 @@
 	stock_max = 3
 	availability_prob = 40
 
+/datum/blackmarket_item/weapon/mecha_weapon_bay
+	name = "Concealed Weapons Bay"
+	desc = "Ripley with a laser cannon? Odysseus with a missile rack? Sky's the limit with this omni-compatible weapons bay! (Missiles and lasers not included)"
+	item = /obj/item/mecha_parts/concealed_weapon_bay
 
+	price_min = 1250
+	price_max = 2000
+	stock_max = 2
+	availability_prob = 30
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -61,3 +61,5 @@
 	price_max = 3000
 	stock_max = 1
 	availability_prob = 5
+
+

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -210,7 +210,7 @@
 	name = "Model H"
 	desc = "A Model H slug pistol. The H stands for Hurt. Chambered in ferromagnetic slugs."
 	item = /obj/item/gun/ballistic/automatic/powered/gauss/modelh
-	pair_item = /obj/item/ammo_box/magazine/modelh
+	pair_item = /datum/blackmarket_item/weapon/model_h_mag
 
 	price_min = 2000
 	price_max = 4000

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -258,7 +258,7 @@
 	name = "Pistole C"
 	desc = "Pistole Compact? Pistole Caseless? Pistole Cheese? Fuck if I know. All I know is these little numbers pack a nasty sting. Chambered in 5.56 caseless."
 	item = /obj/item/gun/ballistic/automatic/pistol/solgov/old
-	pair_item =
+	pair_item = /datum/blackmarket_item/weapon/pistole_c_mag
 
 	price_min = 900
 	price_max = 1250

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -175,16 +175,6 @@
 	stock = 2
 	availability_prob = 20
 
-/datum/blackmarket_item/weapon/bioterror_foam
-	name = "Bioterror Foam Sprayer"
-	desc = "Banned in at least 17 jurisdictions for being \"cruel\",\"inhumane\", and \"causing indiscriminate lifelong generational health complications\". Though if you actually cared about those things, you wouldn't be shopping here in the first place."
-	item = /obj/item/reagent_containers/spray/chemsprayer/bioterror
-
-	price_min = 3000
-	price_max = 6000
-	stock = 1
-	availability_prob = 20
-
 /datum/blackmarket_item/weapon/sawn_illestren
 	name = "Sawn off Illestren Rifle"
 	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -217,7 +217,7 @@
 	stock = 2
 	availability_prob = 35
 
-/datum/blackmarket_item/consumable/model_h/spawn_item(loc)
+/datum/blackmarket_item/weapon/model_h/spawn_item(loc)
 	var/model_h = pick(list(/obj/item/gun/ballistic/automatic/powered/gauss/modelh/suns,
 				/obj/item/gun/ballistic/automatic/powered/gauss/modelh))
 	return new model_h(loc)

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -157,13 +157,18 @@
 /datum/blackmarket_item/weapon/corrupt_gun_cell
 	name = "Damaged Weapon Cell"
 	desc = "These got a bit dinged up in their crate after a close shave with GOLD inspectors. The cells are probably still safe to use though."
-	item = /obj/item/stock_parts/cell/gun/corrupt
+	item = /obj/item/stock_parts/cell/gun
 
 	price_min = 250
 	price_max = 500
 	stock_min = 4
 	stock_max = 10
 	availability_prob = 40
+
+/datum/blackmarket_item/weapon/corrupt_gun_cell/spawn_item(loc)
+	var/stock_parts/cell/gun = C()
+	c.corrupt()
+	return new berries(loc)
 
 /datum/blackmarket_item/weapon/saber_smg
 	name = "Saber 9mm SMG"
@@ -206,16 +211,16 @@
 	stock = 1
 	availability_prob = 20
 
-/datum/blackmarket_item/weapon/sawn_illestren
-	name = "Sawn off Illestren Rifle"
-	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."
-	item = /obj/item/gun/ballistic/rifle/illestren/sawoff
+// /datum/blackmarket_item/weapon/sawn_illestren
+// 	name = "Sawn off Illestren Rifle"
+// 	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."
+// 	item = /obj/item/gun/ballistic/rifle/illestren/sawoff
 
-	price_min = 600
-	price_max = 1250
-	stock_min = 2
-	stock_max = 5
-	availability_prob = 50
+// 	price_min = 600
+// 	price_max = 1250
+// 	stock_min = 2
+// 	stock_max = 5
+// 	availability_prob = 50
 
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -34,6 +34,26 @@
 	stock_max = 3
 	availability_prob = 60
 
+/datum/blackmarket_item/weapon/switchblade
+	name = "Switchblade"
+	desc = "Extra shrap switchblades for intimidation AND style. Bandages not included if you cut yourself."
+	item = /obj/item/switchblade
+
+	price_min = 500
+	price_max = 700
+	stock_max = 3
+	availability_prob = 50
+
+/datum/blackmarket_item/weapon/sabre
+	name = "SUNS Dueling Sabre"
+	desc = "A mastercrafted sabre formerly wielded by a SUNS academic. It's very sharp, we had to spend hours stitching our fingers back on after getting it."
+	item = /obj/item/storage/belt/sabre/suns
+
+	price_min = 1500
+	price_max = 3500
+	stock = 1
+	availability_prob = 20
+
 /datum/blackmarket_item/weapon/emp_grenade
 	name = "EMP Grenade"
 	desc = "Use this grenade for SHOCKING results!"
@@ -49,7 +69,7 @@
 	desc = "A concealable handgun small enough to hide nearly anywhere. Uses .38 revolver rounds."
 	item = /obj/item/gun/ballistic/derringer
 	price_min = 100
-	price_max = 600
+	price_max = 500
 	stock_max = 6
 	availability_prob = 50
 
@@ -71,7 +91,7 @@
 	price_min = 100
 	price_max = 600
 	stock_max = 6
-	availability_prob = 100
+	availability_prob = 40
 
 /datum/blackmarket_item/weapon/himehabu_mag
 	name = "Himehabu Magazines"
@@ -82,5 +102,121 @@
 	price_max = 200
 	stock_max = 6
 	availability_prob = 0
+
+/datum/blackmarket_item/weapon/e10
+	name = "E-10 Laser Pistol"
+	desc = "Sharplite letting you down? Try these classic Eoehoma Firearms E-10 Laser Pistols."
+	item = /obj/item/gun/energy/laser/e10
+
+	price_min = 500
+	price_max = 1250
+	stock_max = 5
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/e11
+	name = "E-11 Energy Gun"
+	desc = "Look. I'll be straight with you. These guns are awful. But, they are cheap if you're that desperate."
+	item = /obj/item/gun/energy/e_gun/e11
+
+	price_min = 250
+	price_max = 750
+	stock = 5
+	availability_prob = 40
+
+/datum/blackmarket_item/weapon/e40
+	name = "E-40 Hybrid Assault Rifle"
+	desc = "A dual mode hybrid assault rifle made by the now defunct Eoehoma Firearms. Capable of firing both bullets AND lasers, for the discerning dealer in death. Chambered in Eoehoma .299 Caseless."
+	item = /obj/item/gun/ballistic/automatic/assault/e40
+	pair_item = /datum/blackmarket_item/weapon/e40_mag
+
+	price_min = 7000
+	price_max = 13000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/e40_mag
+	name = "Eoehoma .299 Caseless Magazine"
+	desc = "30 round magazines for the E-40 Hybrid Rifle."
+	item = /obj/item/ammo_box/magazine/e40
+
+	price_min = 750
+	price_max = 1250
+	stock_max = 3
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/e50
+	name = "E-50 Energy Emitter"
+	desc = "An Eoehoma Firearms E-50 Emitter cannon. For when you want a send a message. A really big message."
+	item = /obj/item/gun/energy/laser/e50
+
+	price_min = 4000
+	price_max = 7000
+	stock_max = 2
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/corrupt_gun_cell
+	name = "Damaged Weapon Cell"
+	desc = "These got a bit dinged up in their crate after a close shave with GOLD inspectors. The cells are probably still safe to use though."
+	item = /obj/item/stock_parts/cell/gun/corrupt
+
+	price_min = 250
+	price_max = 500
+	stock_min = 4
+	stock_max = 10
+	availability_prob = 40
+
+/datum/blackmarket_item/weapon/saber_smg
+	name = "Saber 9mm SMG"
+	desc = "A prototype 9mm submachine gun. Most of these never got past the RND phase into distribution. But we happen know a guy."
+	item = /obj/item/gun/ballistic/automatic/smg/proto
+	pair_item = /datum/blackmarket_item/weapon/saber_mag
+
+	price_min = 2500
+	price_max = 4200
+	stock_max = 2
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/saber_mag
+	name = "Saber 9mm SMG Magazines"
+	desc = "Magazines for use in the Saber 9mm SMG. No, they don't work as swords."
+	item = /obj/item/ammo_box/magazine/smgm9mm
+
+	price_min = 500
+	price_max = 1000
+	stock_max = 2
+	availability_prob = 0
+
+/datum/blackmarket_item/weapon/bg_16
+	name = "BG-16 Beam Gun"
+	desc = "Not satisfied by Etherbor's civilian offerings? Try this military grade one we found!"
+	item = /obj/item/gun/energy/kalix/pgf
+
+	price_min = 2500
+	price_max = 5000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/bioterror_foam
+	name = "Bioterror Foam Sprayer"
+	desc = "Banned in at least 17 jurisdictions for being 'cruel', 'inhumane', and 'causing indiscriminate lifelong generational health complications'. Though if you actually cared about those things, you wouldn't be shopping here in the first place."
+	item = /obj/item/reagent_containers/spray/chemsprayer/bioterror
+
+	price_min = 3000
+	price_max = 6000
+	stock = 1
+	availability_prob = 20
+
+/datum/blackmarket_item/weapon/sawn_illestren
+	name = "Sawn off Illestren Rifle"
+	desc = "We had to saw down the barrels on these to fit them in the smuggling compartment. They don't aim too good, but it still packs a good punch."
+	item = /obj/item/gun/ballistic/rifle/illestren/sawoff
+
+	price_min = 600
+	price_max = 1250
+	stock_min = 2
+	stock_max = 5
+	availability_prob = 50
+
+
 
 

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -331,10 +331,10 @@
 /datum/blackmarket_item/weapon/scout_stripper
 	name = ".300 Magnum Stripper Clip"
 	desc = "5 round .300 Magnun stripper clips for use with the HP Scout."
-	item = /obj/item/ammo_box/a30
+	item = /obj/item/ammo_box/a300
 
 	price_min = 500
-	price_max = 100
+	price_max = 1000
 	stock_min = 4
 	stock_max = 6
 	availability_prob = 0

--- a/code/modules/cargo/blackmarket/blackmarket_market.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_market.dm
@@ -13,8 +13,8 @@
 	var/list/categories	= list()
 
 /// Adds item to the available items and add it's category if it is not in categories yet.
-/datum/blackmarket_market/proc/add_item(datum/blackmarket_item/item)
-	if(!prob(initial(item.availability_prob)))
+/datum/blackmarket_market/proc/add_item(datum/blackmarket_item/item, paired)
+	if(!prob(initial(item.availability_prob)) && !paired)
 		return FALSE
 
 	if(ispath(item))

--- a/code/modules/cargo/blackmarket/blackmarket_market.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_market.dm
@@ -49,5 +49,4 @@
 /datum/blackmarket_market/blackmarket
 	name = "Black Market"
 	shipping = list(SHIPPING_METHOD_LTSRBT	=50,
-					SHIPPING_METHOD_LAUNCH	=10,
-					SHIPPING_METHOD_TELEPORT=75)
+					SHIPPING_METHOD_LAUNCH	=10)

--- a/code/modules/cargo/blackmarket/blackmarket_market.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_market.dm
@@ -20,14 +20,15 @@
 	if(ispath(item))
 		item = new item()
 
-	if(item.pair_item)
-		add_item(item.pair_item, TRUE)
-
 	if(!(item.category in categories))
 		categories += item.category
 		available_items[item.category] = list()
 
 	available_items[item.category] += item
+
+	if(item.pair_item)
+		add_item(item.pair_item, TRUE)
+
 	return TRUE
 
 /// Handles buying the item, this is mainly for future use and moving the code away from the uplink.

--- a/code/modules/cargo/blackmarket/blackmarket_market.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_market.dm
@@ -20,6 +20,9 @@
 	if(ispath(item))
 		item = new item()
 
+	if(item.pair_item)
+		add_item(item.pair_item, TRUE)
+
 	if(!(item.category in categories))
 		categories += item.category
 		available_items[item.category] = list()

--- a/code/modules/cargo/blackmarket/blackmarket_telepad.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_telepad.dm
@@ -61,6 +61,16 @@
 	if(!power_efficiency)
 		power_efficiency = 1
 
+/// Stores the LTSRBT Data in the uplink for linking
+/obj/machinery/ltsrbt/attackby(obj/item/O, mob/user, params)
+	if(istype(O, /obj/item/blackmarket_uplink))
+		var/obj/item/blackmarket_uplink/uplink = O
+		uplink.target = src
+		to_chat(user, "<span class='notice'>[src] linked to [O].</span>")
+		return TRUE
+
+	return ..()
+
 /// Adds /datum/blackmarket_purchase to queue unless the machine is free, then it sets the purchase to be instantly recieved
 /obj/machinery/ltsrbt/proc/add_to_queue(datum/blackmarket_purchase/purchase)
 	if(!recharge_cooldown && !recieving && !transmitting)

--- a/code/modules/cargo/blackmarket/blackmarket_telepad.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_telepad.dm
@@ -37,10 +37,8 @@
 
 /obj/machinery/ltsrbt/Initialize()
 	. = ..()
-	SSblackmarket.telepads += src
 
 /obj/machinery/ltsrbt/Destroy()
-	SSblackmarket.telepads -= src
 	// Bye bye orders.
 	if(SSblackmarket.telepads.len)
 		for(var/datum/blackmarket_purchase/P in queue)

--- a/code/modules/cargo/blackmarket/blackmarket_telepad.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_telepad.dm
@@ -27,7 +27,7 @@
 	/// Current recharge progress.
 	var/recharge_cooldown = 0
 	/// Base recharge time which is used to get recharge_time.
-	var/base_recharge_time = 100
+	var/base_recharge_time = 10
 	/// Current /datum/blackmarket_purchase being recieved.
 	var/recieving
 	/// Current /datum/blackmarket_purchase being sent to the target uplink.
@@ -47,9 +47,9 @@
 
 /obj/machinery/ltsrbt/RefreshParts()
 	recharge_time = base_recharge_time
-	// On tier 4 recharge_time should be 20 and by default it is 80 as scanning modules should be tier 1.
+	// On tier 4 recharge_time should be 2 and by default it is 8 as scanning modules should be tier 1.
 	for(var/obj/item/stock_parts/scanning_module/scan in component_parts)
-		recharge_time -= scan.rating * 10
+		recharge_time -= scan.rating
 	recharge_cooldown = recharge_time
 
 	power_efficiency = 0

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -13,6 +13,8 @@
 	var/money = 0
 	/// List of typepaths for "/datum/blackmarket_market"s that this uplink can access.
 	var/list/accessible_markets = list(/datum/blackmarket_market/blackmarket)
+	// Linked LTSRBT for uplink to send to.
+	var/obj/machinery/ltsrbt/target
 
 /obj/item/blackmarket_uplink/Initialize()
 	. = ..()
@@ -52,6 +54,10 @@
 	holochip.name = "washed " + holochip.name
 	user.put_in_hands(holochip)
 	to_chat(user, "<span class='notice'>You withdraw [amount_to_remove] credits into a holochip.</span>")
+
+/obj/item/blackmarket_uplink/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It's LTSRBT link [target ? "contains [target]." : "is empty."]</span>"
 
 /obj/item/blackmarket_uplink/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -2,7 +2,7 @@
 	name = "Black Market Uplink"
 	icon = 'icons/obj/blackmarket.dmi'
 	icon_state = "uplink"
-	desc = "A jury rigged uplink capable of accessing illcit or grey market vendors. There's a port on side for linking it to a LTSRBT for more practical shipping."
+	desc = "A jury rigged uplink capable of accessing illicit or grey market vendors. There's a port on side for linking it to a LTSRBT for more practical shipping."
 
 	// UI variables.
 	var/viewing_category

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -2,6 +2,7 @@
 	name = "Black Market Uplink"
 	icon = 'icons/obj/blackmarket.dmi'
 	icon_state = "uplink"
+	desc = "A jury rigged uplink capable of accessing illcit or grey market vendors. There's a port on side for linking it to a LTSRBT for more practical shipping."
 
 	// UI variables.
 	var/viewing_category

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -155,7 +155,7 @@
 	time = 30
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_MULTITOOL)
 	reqs = list(
-		/obj/item/stock_parts/subspace/amplifier = 1,
+		/obj/item/stock_parts/scanning_module = 1,
 		/obj/item/stack/cable_coil = 15,
 		/obj/item/radio = 1,
 		/obj/item/analyzer = 1

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -58,7 +58,7 @@
 
 /obj/item/blackmarket_uplink/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It's LTSRBT link [target ? "contains [target]." : "is empty."]</span>"
+	. += "<span class='notice'>It's LTSRBT link [target ? "contains a [target]." : "is empty."]</span>"
 
 /obj/item/blackmarket_uplink/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -94,7 +94,7 @@
 /obj/item/blackmarket_uplink/ui_static_data(mob/user)
 	var/list/data = list()
 	data["delivery_method_description"] = SSblackmarket.shipping_method_descriptions
-	data["ltsrbt_built"] = SSblackmarket.telepads.len
+	data["ltsrbt_built"] = target
 	data["markets"] = list()
 	for(var/M in accessible_markets)
 		var/datum/blackmarket_market/BM = SSblackmarket.markets[M]

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -176,7 +176,7 @@
 /datum/supply_pack/machinery/blackmarket_telepad
 	name = "Black Market LTSRBT"
 	desc = "Need a faster and better way of transporting your illegal goods from and to the sector? Fear not, the Long-To-Short-Range-Bluespace-Transceiver (LTSRBT for short) is here to help. Contains a LTSRBT circuit, two bluespace crystals, and one ansible."
-	cost = 5000
+	cost = 1000
 	contains = list(
 		/obj/item/circuitboard/machine/ltsrbt,
 		/obj/item/stack/ore/bluespace_crystal/artificial,

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -419,6 +419,9 @@
 	charge = 0
 	update_appearance()
 
+/obj/item/stock_parts/cell/gun/corrupt()
+	return
+
 /obj/item/stock_parts/cell/gun/update_appearance()
 	cut_overlays()
 	if(grown_battery)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -419,9 +419,6 @@
 	charge = 0
 	update_appearance()
 
-/obj/item/stock_parts/cell/gun/corrupt()
-	return
-
 /obj/item/stock_parts/cell/gun/update_appearance()
 	cut_overlays()
 	if(grown_battery)

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -113,6 +113,12 @@
 		item_state = "illestren_factory_sawn"
 		mob_overlay_state = item_state
 
+/obj/item/gun/ballistic/rifle/illestren/sawn
+	name = "sawn-off Illestren rifle"
+	desc = "An Illestren rifle sawn down to a ridiculously small size. There was probably a reason it wasn't made this short to begin with, but it still packs a punch."
+	item_state = "illestren_sawn"
+	sawn_off = TRUE
+
 /obj/item/gun/ballistic/rifle/solgov
 	name = "SSG-669C"
 	desc = "A bolt-action sniper rifle used by Solarian troops. Beloved for its rotary design and accuracy. Chambered in 8x58mm Caseless."

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -118,6 +118,8 @@
 	desc = "An Illestren rifle sawn down to a ridiculously small size. There was probably a reason it wasn't made this short to begin with, but it still packs a punch."
 	item_state = "illestren_sawn"
 	sawn_off = TRUE
+	weight = WEAPON_MEDIUM
+
 
 /obj/item/gun/ballistic/rifle/solgov
 	name = "SSG-669C"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -118,7 +118,7 @@
 	desc = "An Illestren rifle sawn down to a ridiculously small size. There was probably a reason it wasn't made this short to begin with, but it still packs a punch."
 	item_state = "illestren_sawn"
 	sawn_off = TRUE
-	weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_MEDIUM
 
 
 /obj/item/gun/ballistic/rifle/solgov

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -1877,6 +1877,7 @@
 #include "code\modules\cargo\blackmarket\blackmarket_items\clothing.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\consumables.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\emergency.dm"
+#include "code\modules\cargo\blackmarket\blackmarket_items\explosives.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\misc.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\tools.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\weapons.dm"

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -1876,6 +1876,7 @@
 #include "code\modules\cargo\blackmarket\blackmarket_uplink.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\clothing.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\consumables.dm"
+#include "code\modules\cargo\blackmarket\blackmarket_items\emergency.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\misc.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\tools.dm"
 #include "code\modules\cargo\blackmarket\blackmarket_items\weapons.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

### Mechanical stuff

- Removes Teleportation as a shipping option from the Black Market. The code behind it was removed so it only ate your money.
- Changes how the LTSRBT handles orders. The uplink is now linked to the LTSRBT as it's destination instead of checking for a free telepad across the entire world.
- Adds examines for the Black Market uplink, changes shipping descriptions to be more clear
- Adds the pair_item var for black market items. If the main item spawns, it's paired item is guaranteed to spawn alongside it.
 - The LTSRBT gets orders 10x faster.
-  The Black Market Uplink now uses a microlaser instead of an ansible in it's crafting recipe.
-  A sawn off Illestren typepath
### Catalogue

- Reduces the cost of the LTSRBT at the outpost from 5000 to 1000.
- Adds a whole bunch of new items to the Black Market catalogues, and changes the prices of existing items to be in line with the current economy.
- Removes items and adjusted some descriptions from the Black Market that didn't fit Shiptest's setting.
- Adds two new tabs to the Black Market, Explosives and Emergency.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Honestly, this started as a redo of #2927 to add Eoehoma weapons to the Black Market instead, but the Black Market was kinda shit. The teleport option was broken, the black market uplink could send to any LTSRBT that existed, so someone half the sector away could end up with your orders (if anyone actually bought them that is) and the item selection was pretty poor and still based around a station economy price wise.

Clears up the cruft, and adds a bunch of new items to the Black Market catalogue to hopefully make it an appealing alternative option to buying from the outpost. It's a thematic way to sell items normally wouldn't be seen. Most of the stock is limited as well, which adds a sense of urgency and competition with other ships if there's an item that catches your eye.

Dropped the price of the LTSRBT and changed the uplink recipe to make the Black Market more accessible. You weren't finding an ansible unless you have RND or got lucky. The LTSRBT was also comedically slow to the point where you were left wondering if it worked.

 The sawn off Illestren was so I could directly spawn it for the Black Market. I'd thought it'd be funny.
 
 I'm happy to change any of the items, prices or stocks if needed. 

## Changelog

:cl:
add: A bunch of new items for the Black Market catalogue
add: Two new Black Market Tabs, Explosives and Emergency
add: Sawn off Illestren typepath
del: Black Market Teleportation
del: Space Ninja mask and Clown Tears from Black Market
tweak: Black Market Uplink uses a micro laser instead of an ansible for crafting
tweak: Black Market descriptions and examines
tweak: Black Market Uplinks link directly to a specific LTSRBT
balance: Black Market item price and stock adjusted
balance: LTSRBT is faster
code: pair_item var for Black Market items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
