### PR TITLE
Adjusted Pure Soulus Dust

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -315,12 +315,12 @@ WS End */
 	required_reagents = list(/datum/reagent/medicine/lavaland_extract = 1, /datum/reagent/medicine/bonefixingjuice = 1, /datum/reagent/titanium = 5)
 
 /datum/chemical_reaction/pure_soulus_dust_hollow
-	results = list(/datum/reagent/medicine/soulus/pure = 10,)
-	required_reagents = list(/datum/reagent/medicine/soulus = 20, /datum/reagent/medicine/system_cleaner = 1, /datum/reagent/water/hollowwater = 10)
+	results = list(/datum/reagent/medicine/soulus/pure = 20,)
+	required_reagents = list(/datum/reagent/medicine/soulus = 20, /datum/reagent/water/hollowwater = 10)
 
 /datum/chemical_reaction/pure_soulus_dust_holy
-	results = list(/datum/reagent/medicine/soulus/pure = 10,)
-	required_reagents = list(/datum/reagent/medicine/soulus = 20, /datum/reagent/medicine/system_cleaner = 1, /datum/reagent/water/holywater = 10)
+	results = list(/datum/reagent/medicine/soulus/pure = 20,)
+	required_reagents = list(/datum/reagent/medicine/soulus = 20, /datum/reagent/water/holywater = 10)
 
 /datum/chemical_reaction/chartreuse
 	results = list(/datum/reagent/medicine/chartreuse = 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts pure soulus dust to not require system cleaner, and output is 20u. It already requires one of 2 very hard to get reagents on shiptest anyways.

## Why It's Good For The Game

It's a nice chem, but holy/hollow water are super duper rare, on top of needing to collect legion cores. It doesn't need to be this hard. In a hilarious sense...... straight applying legion cores is better pre-PR

## Changelog

:cl:
balance: pure soulus dust now makes 20u per reaction, and system cleaner is not required.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
