### PR TITLE
Removes reality integrity issues from EXOCOM

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -105,7 +105,7 @@
 	else ..()
 
 /obj/structure/closet/crate/secure/exo
-	desc = "A lock-enabled crate used to carry EXOCON merchandise destined for export to potential buyers."
-	name = "EXOCON storage crate"
+	desc = "A lock-enabled crate used to carry EXOCOM merchandise destined for export to potential buyers."
+	name = "EXOCOM storage crate"
 	icon = 'icons/obj/crates.dmi'
 	icon_state = "exocrate"

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -46,7 +46,7 @@
 	supports_variations = KEPORI_VARIATION
 
 /obj/item/clothing/under/rank/cargo/miner/lavaland
-	desc = "A light uniform for operating in hazardous environments, manufactured en-masse by EXOCON for the profitable frontier prospector market. Adventurous khaki jeans included."
+	desc = "A light uniform for operating in hazardous environments, manufactured en-masse by EXOCOM for the profitable frontier prospector market. Adventurous khaki jeans included."
 	name = "prospector jumpsuit"
 	icon_state = "explorer"
 	item_state = "explorer"

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -1,7 +1,7 @@
 /****************Explorer's Suit and Mask****************/
 /obj/item/clothing/suit/hooded/explorer
 	name = "explorer suit"
-	desc = "A light, armor-plated softsuit, designed for exploration of dangerous planetary enviroments. An NT design by origin, later reappropriated by EXOCON for mass retail production."
+	desc = "A light, armor-plated softsuit, designed for exploration of dangerous planetary enviroments. An NT design by origin, later reappropriated by EXOCOM for mass retail production."
 	icon_state = "explorer"
 	item_state = "explorer"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
@@ -36,7 +36,7 @@
 
 /obj/item/clothing/mask/gas/explorer
 	name = "explorer gas mask"
-	desc = "An advanced atmospheric scrubbing mask with a built-in pressure seal, manufactured by EXOCON. Can be connected to an air supply."
+	desc = "An advanced atmospheric scrubbing mask with a built-in pressure seal, manufactured by EXOCOM. Can be connected to an air supply."
 	icon_state = "gas_mining"
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
 	name = "proto-magnetic crusher"
-	desc = "A multipurpose disembarkation and self-defense tool designed by EXOCON using an incomplete Nanotrasen prototype. \
+	desc = "A multipurpose disembarkation and self-defense tool designed by EXOCOM using an incomplete Nanotrasen prototype. \
 	Found in the grime-stained hands of wannabee explorers across the frontier, it cuts rock and hews flora using magnetic osscilation and a heavy cleaving edge."
 	force = 0 //You can't hit stuff unless wielded
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -79,7 +79,7 @@
 	icon_state = "diamonddrill"
 	item_state = "diamonddrill"
 	toolspeed = 0.2
-	desc = "EXOCON's improvement on the NT autodrill design, featuring a premium diamond cutting head. Yours is the drill that will pierce the heavens!"
+	desc = "EXOCOM's improvement on the NT autodrill design, featuring a premium diamond cutting head. Yours is the drill that will pierce the heavens!"
 	force = 20
 
 /obj/item/pickaxe/drill/cyborg/diamond //This is the BORG version!
@@ -94,7 +94,7 @@
 	toolspeed = 0.1 //the epitome of powertools. extremely fast mining
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
-	desc = "The epitome of conventional rock-smashing technology, invented by NT and cost-optimized by EXOCON. Smashes rocks, objects, and unfortunate wildlife with sonic blasts."
+	desc = "The epitome of conventional rock-smashing technology, invented by NT and cost-optimized by EXOCOM. Smashes rocks, objects, and unfortunate wildlife with sonic blasts."
 	force = 25
 	attack_verb = list("blasted", "smashed", "slammed", "hammered")
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -1,7 +1,7 @@
 /* Mining Points Equipment Vendor */
 /obj/machinery/vending/mining_equipment
 	name = "frontier equipment vendor"
-	desc = "An equipment vendor for miners, prospectors, and all manner of far reach scroungers. Ore Redemption Points can be spent here to purchase rough-and-tumble goods. Sold by EXOCON."
+	desc = "An equipment vendor for miners, prospectors, and all manner of far reach scroungers. Ore Redemption Points can be spent here to purchase rough-and-tumble goods. Sold by EXOCOM."
 	icon_state = "mining"
 	icon_deny = "mining-deny"
 	max_integrity = 500 // A bit more durable than your average snack vendor

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/kinetic_accelerator
 	name = "kinetic accelerator"
-	desc = "A self recharging, ranged self-defense and rock pulverizing tool that does increased damage in low pressure. EXOCON does not condone use of this weapon against other sentient life."
+	desc = "A self recharging, ranged self-defense and rock pulverizing tool that does increased damage in low pressure. EXOCOM does not condone use of this weapon against other sentient life."
 	icon_state = "kineticgun"
 	item_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The EXO Request
A quantum superposition around the name of the EXO mining company has been isolated and destroyed by the shiptest reality force.
From hence on, all shall know only the name **EXOCOM**, rather than also, sometimes, EXOCON. 
**EXOCON is not, and was never real.** 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For EXOCON (Which is not real)
EXOCON is not real. Please report any sightings of EXOCON personnel or equipment for immediate termination. EXOCON is not real.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Nothing Has Changed. Please Remain Calm.

:cl:
fix: weird uncertainty around the name of EXOCOM. EXOCON is not real. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
