### PR TITLE
Fix half of verbs not showing up

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1087,7 +1087,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return
 	var/list/verblist = list()
 	var/list/verbstoprocess = verbs.Copy()
-	if(mob?.client?.prefs.broadcast_login_logout)
+	if(mob)
 		verbstoprocess += mob.verbs
 		for(var/atom/movable/thing as anything in mob.contents)
 			verbstoprocess += thing.verbs


### PR DESCRIPTION
## About The Pull Request

Hello comrades. This PR fixes a mistake, because of which none of `/mob` verbs was sent to the TGUI panel on client connection for clients having "Broadcast Log in/out" disabled.

## Why It's Good For The Game

Half of verbs wasn't showing up because of strange check condition completely unrelated to what's really needed to be checked.

## Changelog

🆑SuhEugene
fix: fixed incomplete TGUI Panel verb list
/🆑
