### PR TITLE
Adds the Candor to Cargo.

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -30,6 +30,12 @@
 	contains = list(/obj/item/gun/ballistic/automatic/pistol,
 					/obj/item/gun/ballistic/automatic/pistol)
 
+/datum/supply_pack/gun/candors
+	name = "Candor Pistol Crate"
+	desc = "Contains a Candor pistol, the trusty sidearm of any spacer, produced by Hunter's Pride and chambered in .45 ACP."
+	cost = 1000
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/candor)
+
 /datum/supply_pack/gun/revolver
 	name = "Scarborough Revolver Crate"
 	desc = "Contains a concealable Scarborough revolver, chambered in .357."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As it says, the mags and ammo were already buyable before so not much fancy here!!
## Why It's Good For The Game

The candor oughta be viable!! it's the hot new thing!! everyone's rockin it!! it's the trusty sidearm of every spacer!! 
Also requested by Apogee and Ryerice.

## Changelog

:cl:
add: The Candor may now be bought from the outpost. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
