### PR TITLE
Makes the .38 revolver smaller and less expensive.

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -39,7 +39,7 @@
 /datum/supply_pack/gun/detrevolver
 	name = "Hunter's Pride Detective Revolver Crate"
 	desc = "Contains a concealable Solarian revolver, chambered in .38."
-	cost = 1000
+	cost = 600
 	contains = list(/obj/item/gun/ballistic/revolver/detective)
 
 /datum/supply_pack/gun/shadowrevolver

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -472,6 +472,7 @@
 		"The Peacemaker" = "detective_peacemaker",
 		"Black Panther" = "detective_panther"
 		)
+	w_class = WEIGHT_CLASS_SMALL
 	manufacturer = MANUFACTURER_HUNTERSPRIDE
 
 	recoil = 0 //weaker than normal revolver, no recoil


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not much more to say, makes the detective's revolver Small instead of Normal so that it can fit in pockets and whatnot, and changes it's price to 600 (as opposed to 1000 of before or the 750 of the flaming arrow)

## Why It's Good For The Game

The detective revolver as it currently stands is completely outclassed by the Flaming Arrow and other pistols, this gives it a niche as a backup weapon and or the cheapest handgun in the handgun easy to equip to a large crew.
## Changelog

:cl:
balance: The detective's revolver is now priced at 600 credits instead of 1000.
balance: The detective's revolver size is now Small.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
