### PR TITLE
Add default return for robotic emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -239,7 +239,8 @@
 	message_param = "beeps at %t."
 
 /datum/emote/living/carbon/human/robot_tongue/beep/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/twobeep.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/buzz
@@ -249,7 +250,8 @@
 	message_param = "buzzes at %t."
 
 /datum/emote/living/carbon/human/robot_tongue/buzz/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/buzz-sigh.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/buzz2
@@ -257,7 +259,8 @@
 	message = "buzzes twice."
 
 /datum/emote/living/carbon/human/robot_tongue/buzz2/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/buzz-two.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/chime
@@ -266,7 +269,8 @@
 	message = "chimes."
 
 /datum/emote/living/carbon/human/robot_tongue/chime/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/chime.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/no
@@ -275,7 +279,8 @@
 	message = "emits an negative blip."
 
 /datum/emote/living/carbon/human/robot_tongue/no/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/synth_no.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/ping
@@ -285,7 +290,8 @@
 	message_param = "pings at %t."
 
 /datum/emote/living/carbon/human/robot_tongue/ping/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/ping.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/warn
@@ -294,7 +300,8 @@
 	message = "blares an alarm!"
 
 /datum/emote/living/carbon/human/robot_tongue/warn/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/warning-buzzer.ogg', 50)
 
 /datum/emote/living/carbon/human/robot_tongue/yes
@@ -303,7 +310,8 @@
 	message = "emits an affirmative blip."
 
 /datum/emote/living/carbon/human/robot_tongue/yes/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/machines/synth_yes.ogg', 50)
 
 // the following emote were originally clown-locked and synthetic exclusive
@@ -315,7 +323,8 @@
 	message = "plays a sad trombone..."
 
 /datum/emote/living/carbon/human/robot_tongue/sad/run_emote(mob/user, params)
-	if(..())
+	. = ..()
+	if(.)
 		playsound(user.loc, 'sound/misc/sadtrombone.ogg', 50)
 
 //kepi (plus one vox i guess)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PR fixes this bug

![image](https://github.com/shiptest-ss13/Shiptest/assets/32931701/1e7a4f99-e2d6-49a3-bdbc-2953d90a892e)


## Why It's Good For The Game

Bugfixes are good

## Changelog

🆑SuhEugene
fix: Fixed a bug when robotic emote would say that emote is unusable even if it has been successfully used.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
