### PR TITLE
Nerfs the size of the Etherbor Pistol and Etherbor Rifle

### DIFF
--- a/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
@@ -73,8 +73,7 @@
 	desc = "Etherbor's current and sidearm offering. While intended for marines, it's also available for civillians"
 	icon_state = "kalixpistol"
 	item_state = "kalixpistol"
-	w_class = WEIGHT_CLASS_SMALL
-
+	w_class = WEIGHT_CLASS_NORMAL
 	modifystate = FALSE
 
 	wield_delay = 0.2 SECONDS

--- a/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
@@ -45,6 +45,7 @@
 	desc = "An advanced variant of the BG-12, the BG-16 is the military-grade beam gun designed and manufactured by Etherbor Industries as the standard-issue close-range weapon of the PGF."
 	icon_state = "pgfgun"
 	item_state = "pgfgun"
+	w_class = WEIGHT_CLASS_NORMAL
 
 	cell_type = /obj/item/stock_parts/cell/gun/pgf
 	ammo_type = list(/obj/item/ammo_casing/energy/pgf , /obj/item/ammo_casing/energy/disabler/hitscan)
@@ -72,7 +73,7 @@
 	desc = "Etherbor's current and sidearm offering. While intended for marines, it's also available for civillians"
 	icon_state = "kalixpistol"
 	item_state = "kalixpistol"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 	modifystate = FALSE
 

--- a/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/faction/gezena/energy_gunsword.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/obj/guns/faction/gezena/lefthand.dmi'
 	righthand_file = 'icons/obj/guns/faction/gezena/righthand.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/gezena/belt.dmi'
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 
 	modifystate = TRUE
 
@@ -72,7 +72,7 @@
 	desc = "Etherbor's current and sidearm offering. While intended for marines, it's also available for civillians"
 	icon_state = "kalixpistol"
 	item_state = "kalixpistol"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_NORMAL
 
 	modifystate = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ohhh the lizard

## Why It's Good For The Game

I think they're too strong for their size, with the pistol being more or less equal to a Sharplite laser gun that is normal sized or a pistol that is normal sized, and the Etherbor Rifle being more or less equal to an SMG which is also bulky sized. The BG-16 stays as it was before.

## Changelog

:cl:

balance: The civilian etherbor weapons have been made larger (the SG-8 being normal sized and the BG-12 being bulky sized)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
