### PR TITLE
Granularizes riot shields similarly to armor and guns.

### DIFF
--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -56,11 +56,9 @@
 
 /datum/supply_pack/sec_supply/riotshields
 	name = "Riot Shields Crate"
-	desc = "For when the greytide gets really uppity. Contains three riot shields."
-	cost = 2000
-	contains = list(/obj/item/shield/riot,
-					/obj/item/shield/riot,
-					/obj/item/shield/riot)
+	desc = "Contains a riot shield, effective at holding back hostile fauna, xenofauna, or large crowds."
+	cost = 600
+	contains = list(/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
 /datum/supply_pack/sec_supply/survknives


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as it says! 600 credits for one riot shield

## Why It's Good For The Game

good for similar reasons the other ones were you dont get more riot shields than you ened and people might use them more this way :)
## Changelog

:cl:

tweak: Riot shield crates now contain only one shield but are priced at 600 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
