### PR TITLE
Static anomalies now require one of their safe approach methods rather than ALL OF THEM

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_static.dm
+++ b/code/game/objects/effects/anomalies/anomalies_static.dm
@@ -39,19 +39,19 @@
 		playsound(src, 'sound/effects/walkietalkie.ogg', 75)
 		if(stored_mob && looking.stat != DEAD && prob(25))
 			say_fucky_things()
-		if (!HAS_TRAIT(looking, TRAIT_MINDSHIELD) && looking.stat != DEAD || !looking.research_scanner && looking.stat != DEAD || !HAS_TRAIT(looking, TRAIT_DEAF))
-			looking.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 200)
-			playsound(src, 'sound/effects/stall.ogg', 50)
-			if(looking.getOrganLoss(ORGAN_SLOT_BRAIN) >= 150 && looking.stat != DEAD)
-				if(prob(20))
-					var/mob/living/carbon/victim = looking
-					var/obj/effect/anomaly/tvstatic/planetary/expansion
-					expansion = new(get_turf(victim))
-					visible_message(span_warning("The static overtakes [victim], taking their place!"))
-					victim.death()
-					expansion.stored_mob = victim
-					victim.forceMove(expansion)
-	return
+		if(HAS_TRAIT(looking, TRAIT_MINDSHIELD) || looking.stat == DEAD || looking.research_scanner || HAS_TRAIT(looking, TRAIT_DEAF))
+			continue
+		looking.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 200)
+		playsound(src, 'sound/effects/stall.ogg', 50)
+		if(looking.getOrganLoss(ORGAN_SLOT_BRAIN) >= 150 && looking.stat != DEAD)
+			if(prob(20))
+				var/mob/living/carbon/victim = looking
+				var/obj/effect/anomaly/tvstatic/planetary/expansion
+				expansion = new(get_turf(victim))
+				visible_message("<span class='warning'> The static overtakes [victim], [expansion] taking their place!</span>")
+				victim.death()
+				expansion.stored_mob = victim
+				victim.forceMove(expansion)
 
 
 /obj/effect/anomaly/tvstatic/Bumped(atom/movable/AM)

--- a/code/game/objects/effects/anomalies/anomalies_static.dm
+++ b/code/game/objects/effects/anomalies/anomalies_static.dm
@@ -48,7 +48,7 @@
 				var/mob/living/carbon/victim = looking
 				var/obj/effect/anomaly/tvstatic/planetary/expansion
 				expansion = new(get_turf(victim))
-				visible_message(span_warning(The static overtakes [victim], [expansion] taking their place!"))
+				visible_message(span_warning("The static overtakes [victim], [expansion] taking their place!"))
 				victim.death()
 				expansion.stored_mob = victim
 				victim.forceMove(expansion)

--- a/code/game/objects/effects/anomalies/anomalies_static.dm
+++ b/code/game/objects/effects/anomalies/anomalies_static.dm
@@ -48,7 +48,7 @@
 				var/mob/living/carbon/victim = looking
 				var/obj/effect/anomaly/tvstatic/planetary/expansion
 				expansion = new(get_turf(victim))
-				visible_message("<span class='warning'> The static overtakes [victim], [expansion] taking their place!</span>")
+				visible_message(span_warning(The static overtakes [victim], [expansion] taking their place!"))
 				victim.death()
 				expansion.stored_mob = victim
 				victim.forceMove(expansion)


### PR DESCRIPTION
## About The Pull Request

To safely approach a static anomaly currently you need to be
mindshielded
wearing a research scanner
deaf
OR dead and deaf

## Why It's Good For The Game

brain damage divine death blast

## Changelog

:cl:
fix: static anomalies can now be safely approached if mindshielded, wearing a research scanner, or deaf, not all three at the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
