### PR TITLE
Compactification of survivor loot

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/survivors.dm
+++ b/code/modules/mob/living/simple_animal/hostile/survivors.dm
@@ -44,11 +44,15 @@
 /mob/living/simple_animal/hostile/asteroid/whitesands/survivor
 	name = "Hermit Wanderer"
 	desc =" A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body, twisted by the heavy metals and high background radiation of the sandworlds."
+	loot = list(
+		/obj/effect/mob_spawn/human/corpse/damaged/whitesands/survivor
+	)
 
 /mob/living/simple_animal/hostile/asteroid/whitesands/survivor/random/Initialize()
 	. = ..()
 	if(prob(35))
 		new /mob/living/simple_animal/hostile/asteroid/whitesands/ranged/hunter(loc)
+		return INITIALIZE_HINT_QDEL
 	if(prob(10))
 		new /mob/living/simple_animal/hostile/asteroid/whitesands/ranged/gunslinger(loc)
 		return INITIALIZE_HINT_QDEL
@@ -88,6 +92,12 @@
 //survivor corpses
 
 /obj/effect/mob_spawn/human/corpse/damaged/whitesands
+	uniform = /obj/item/clothing/under/color/random
+	belt = /obj/item/storage/belt/fannypack
+	shoes = /obj/item/clothing/shoes/workboots/mining
+	suit = /obj/item/clothing/suit/hooded/survivor
+	l_pocket = /obj/item/radio
+	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	var/survivor_type //room for alternatives inside the fuckoff grade init.
 
 /obj/effect/mob_spawn/human/corpse/damaged/whitesands/Initialize() //everything here should equal out to 100 for the sake of my sanity.
@@ -102,88 +112,6 @@
 			)
 		)
 	//to-do: learn how to make mobsprites for other survivors
-		//uniforms are random to show varied backgrounds, but similar goal
-	if(survivor_type == "survivor")
-		uniform = pickweight(list(
-			/obj/item/clothing/under/color/random = 65,
-			/obj/item/clothing/under/rank/cargo/miner/lavaland = 10,
-			/obj/item/clothing/under/rank/prisoner = 10,
-			/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 5,
-			/obj/item/clothing/under/color/khaki/buster = 5,
-			/obj/item/clothing/under/rank/cargo/miner = 5
-			)
-		)
-	else if (survivor_type == "hunter")
-		uniform = pickweight(list(
-			/obj/item/clothing/under/color/random = 50,
-			/obj/item/clothing/under/rank/cargo/miner/lavaland = 25,
-			/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 15,
-			/obj/item/clothing/under/rank/security/officer/camo = 5,
-			/obj/item/clothing/under/utility = 5
-			)
-		)
-	else if (survivor_type == "gunslinger")
-		uniform = pickweight(list(
-			/obj/item/clothing/under/rank/cargo/miner/lavaland = 35,
-			/obj/item/clothing/under/color/random = 25,
-			/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 15,
-			/obj/item/clothing/under/rank/security/officer/camo = 10,
-			/obj/item/clothing/under/syndicate/camo = 10,
-			/obj/item/clothing/under/syndicate/combat = 5
-			)
-		)
-	else
-		uniform = /obj/item/clothing/under/color/random
-
-	//storage is semi-randomized, giving some variety
-	if(survivor_type == "survivor")
-		belt = 	pickweight(list(
-			/obj/item/storage/belt/fannypack = 40,
-			/obj/item/storage/belt/mining = 20,
-			/obj/item/storage/belt/mining/alt = 15,
-			/obj/item/storage/belt/utility = 10,
-			/obj/item/storage/belt/bandolier = 9,
-			/obj/item/storage/belt/utility/full = 5,
-			/obj/item/storage/belt/chameleon= 1,
-			)
-		)
-	else if(survivor_type == "hunter")
-		belt = 	pickweight(list(
-			/obj/item/storage/belt/mining = 30,
-			/obj/item/storage/belt/fannypack = 20,
-			/obj/item/storage/belt/mining/alt = 15,
-			/obj/item/storage/belt/mining/primitive = 15,
-			/obj/item/storage/belt/bandolier = 10,
-			/obj/item/storage/belt/military = 7,
-			/obj/item/storage/belt/mining/vendor = 3,
-			)
-		)
-	else if(survivor_type == "gunslinger")
-		belt = pickweight(list(
-			/obj/item/storage/belt/mining = 30,
-			/obj/item/storage/belt/bandolier = 30,
-			/obj/item/storage/belt/military = 20,
-			/obj/item/storage/belt/fannypack = 15,
-			/obj/item/storage/belt/mining/alt = 5,
-			/obj/item/storage/belt/mining/primitive = 5
-			)
-		)
-	else
-		belt = /obj/item/storage/belt/fannypack
-
-	//everyone wears the same suit
-	suit = /obj/item/clothing/suit/hooded/survivor
-
-	if (survivor_type == "gunslinger")
-		if(prob(30))
-			shoes = /obj/item/clothing/shoes/combat //but sometimes there are nicer shoes
-		else
-			shoes = /obj/item/clothing/shoes/workboots/mining
-	else
-		shoes = /obj/item/clothing/shoes/workboots/mining
-
-
-
 
 	//gloves are a tossup
 	gloves = pickweight(list(
@@ -260,35 +188,6 @@
 	if(prob(30)) //some pens maybe?
 		backpack_contents += /obj/item/reagent_containers/hypospray/medipen/survival
 
-	//pockets
-	if(survivor_type == "survivor") //could also use fleshing out
-		if(prob(30))
-			l_pocket = /obj/item/reagent_containers/food/snacks/meat/steak/goliath
-		else
-			l_pocket = /obj/item/tank/internals/emergency_oxygen/engi
-		if (prob(20))
-			r_pocket = /obj/item/spacecash/bundle/mediumrand
-		else
-			r_pocket = null
-
-	if(survivor_type == "hunter")
-		l_pocket = /obj/item/tank/internals/emergency_oxygen/engi
-		if (prob(20))
-			r_pocket = /obj/item/reagent_containers/food/snacks/meat/steak/goliath
-		else if (prob(60))
-			r_pocket = /obj/item/ammo_box/aac_300blk_stripper
-		else
-			r_pocket = null
-
-	if(survivor_type == "gunslinger")
-		if(prob(50))
-			l_pocket = /obj/item/ammo_box/magazine/skm_545_39
-		r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
-
-	else
-		r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
-		l_pocket = /obj/item/radio
-
 	//masks
 	mask = pickweight(list(
 		/obj/item/clothing/mask/gas = 40,
@@ -298,7 +197,7 @@
 		)
 	)
 
-	//the eyes are the window into the soul. I don't think these things have souls but whatever.
+	//the eyes are the window into the soul.
 	if(prob(70))
 		glasses = pickweight(list(
 			/obj/item/clothing/glasses/heat = 20,
@@ -307,8 +206,6 @@
 			/obj/item/clothing/glasses = 20
 			)
 		)
-	else
-		glasses = null
 
 	//and of course, ears.
 	if(prob(1)) //oh my god they can't hear the sandstorm coming they've got airpods in
@@ -319,21 +216,91 @@
 			/obj/item/radio/headset/alt = 50
 			)
 		)
+	//now for the fun stuff
+	switch(survivor_type)
+		if("survivor")
+			//uniforms are random to show varied backgrounds, but similar goal
+			uniform = pickweight(list(
+				/obj/item/clothing/under/color/random = 65,
+				/obj/item/clothing/under/rank/cargo/miner/lavaland = 10,
+				/obj/item/clothing/under/rank/prisoner = 10,
+				/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 5,
+				/obj/item/clothing/under/color/khaki/buster = 5,
+				/obj/item/clothing/under/rank/cargo/miner = 5
+				)
+			)
+			//storage is semi-randomized, giving some variety
+			belt = 	pickweight(list(
+				/obj/item/storage/belt/fannypack = 40,
+				/obj/item/storage/belt/mining = 20,
+				/obj/item/storage/belt/mining/alt = 15,
+				/obj/item/storage/belt/utility = 10,
+				/obj/item/storage/belt/bandolier = 9,
+				/obj/item/storage/belt/utility/full = 5,
+				/obj/item/storage/belt/chameleon= 1,
+				)
+			)
+			if(prob(30))
+				l_pocket = /obj/item/reagent_containers/food/snacks/meat/steak/goliath
+			if(prob(20))
+				r_pocket = /obj/item/spacecash/bundle/smallrand
 
-	//exosuit bits
-	suit_store = null
-	if (survivor_type == "hunter")
-		if(prob(20))
-			new /obj/item/gun/ballistic/rifle/polymer(loc)
-		else
-			visible_message("<span class='userwarning'>The hunter's weapon shatters as they impact the ground!</span>")
-			suit_store = null
-	if(survivor_type == "gunslinger")
-		if(prob(20))
-			new /obj/item/gun/ballistic/automatic/smg/skm_carbine(loc)
-		else
-			visible_message("<span class='userwarning'>The gunslinger's weapon shatters as they impact the ground!</span>")
-			suit_store = null
+		if("hunter")
+			uniform = pickweight(list(
+				/obj/item/clothing/under/color/random = 50,
+				/obj/item/clothing/under/rank/cargo/miner/lavaland = 25,
+				/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 15,
+				/obj/item/clothing/under/rank/security/officer/camo = 5,
+				/obj/item/clothing/under/utility = 5
+				)
+			)
+			belt = 	pickweight(list(
+				/obj/item/storage/belt/mining = 30,
+				/obj/item/storage/belt/fannypack = 20,
+				/obj/item/storage/belt/mining/alt = 15,
+				/obj/item/storage/belt/mining/primitive = 15,
+				/obj/item/storage/belt/bandolier = 10,
+				/obj/item/storage/belt/military = 7,
+				/obj/item/storage/belt/mining/vendor = 3,
+				)
+			)
+			if(prob(20))
+				l_pocket = /obj/item/reagent_containers/food/snacks/meat/steak/goliath
+			else if(prob(60))
+				l_pocket = /obj/item/ammo_box/aac_300blk_stripper
+			if(prob(20))
+				new /obj/item/gun/ballistic/rifle/polymer(loc)
+			else
+				visible_message(span_warning("The hunter's weapon shatters as they impact the ground!"))
+
+		if("gunslinger")
+			uniform = pickweight(list(
+				/obj/item/clothing/under/rank/cargo/miner/lavaland = 35,
+				/obj/item/clothing/under/color/random = 25,
+				/obj/item/clothing/under/rank/cargo/miner/lavaland/old = 15,
+				/obj/item/clothing/under/rank/security/officer/camo = 10,
+				/obj/item/clothing/under/syndicate/camo = 10,
+				/obj/item/clothing/under/syndicate/combat = 5
+				)
+			)
+			belt = pickweight(list(
+				/obj/item/storage/belt/mining = 30,
+				/obj/item/storage/belt/bandolier = 30,
+				/obj/item/storage/belt/military = 20,
+				/obj/item/storage/belt/fannypack = 15,
+				/obj/item/storage/belt/mining/alt = 5,
+				/obj/item/storage/belt/mining/primitive = 5
+				)
+			)
+			if(prob(30))
+				shoes = /obj/item/clothing/shoes/combat //sometimes there are nicer shoes
+			if(prob(50))
+				l_pocket = /obj/item/ammo_box/magazine/skm_545_39
+			if(prob(20))
+				new /obj/item/gun/ballistic/automatic/smg/skm_carbine(loc)
+			else
+				visible_message(span_warning("The gunslinger's weapon shatters as they impact the ground!"))
+
 	. = ..()
 
 


### PR DESCRIPTION
## About The Pull Request

default whitesands hermits now pull from the "survivor" loot variant rather than no loot variant
hunters spawning now actually delete the old hermit mob, rather than committing mitosis
hermit loot has been compactified, defaults are now declared in the object rather than initialize, and variant-specific loot now uses a switch statement
fixes a bug where non-gunslinger hermits had their pockets overwritten with default equipment, they will now sometimes have goliath steaks, cash (for melee hermits) or .300 BLK strippers (hunters) in their pockets
reduces the cash bundle melee hermits can drop from a medium random (500-3000) to small random (100-500) bundle since they are quite common. This can be reduced further if deemed necessary.

## Why It's Good For The Game

babe it's 3:00 PM time for your code scrunching

## Changelog

:cl:
fix: melee hermits now pull from the "survivor" loot variant rather than no loot variant
fix: hermits can no longer commit mitosis
tweak: hermit loot has been compactified, defaults are now declared in the object rather than initialize, and variant-specific loot now uses a switch statement
fix: all hermits now have pocket loot randomized as intended
tweak: reduces the cash bundle melee hermits can drop from a medium random (500-3000) to small random (100-500) bundle since they are quite common
/:cl:
