### PR TITLE
Removes elzu multitool and emag interaction

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -46,6 +46,7 @@
 
 	var/current_color
 	var/EMPeffect = FALSE
+	var/emag_effect = FALSE
 	var/static/unhealthy_color = rgb(237, 164, 149)
 	loreblurb = "Elzuosa are an uncommon and unusual species best described as crystalline, electrically-powered plantpeople. They hail from the warm planet Kalixcis, where they evolved alongside the Sarathi. Kalixcian culture places no importance on blood-bonds, and those from it tend to consider their family anyone they are sufficiently close to, and choose their own names."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
@@ -63,6 +64,7 @@
 		return
 	var/mob/living/carbon/human/ethereal = _carbon
 	default_color = "#[ethereal.dna.features["ethcolor"]]"
+	RegisterSignal(ethereal, COMSIG_ATOM_EMAG_ACT, PROC_REF(on_emag_act))
 	RegisterSignal(ethereal, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
@@ -78,6 +80,7 @@
 			BP.update_limb(is_creating = TRUE)
 
 /datum/species/elzuose/on_species_loss(mob/living/carbon/human/_carbon, datum/species/new_species, pref_load)
+	UnregisterSignal(_carbon, COMSIG_ATOM_EMAG_ACT)
 	UnregisterSignal(_carbon, COMSIG_ATOM_EMP_ACT)
 	UnregisterSignal(_carbon, COMSIG_DIGOUT)
 	UnregisterSignal(_carbon, COMSIG_MOVABLE_MOVED)
@@ -177,7 +180,8 @@
 		return
 
 	if(_human.stat != DEAD && !EMPeffect)
-		current_color = health_adjusted_color(_human, default_color)
+		if(!emag_effect)
+			current_color = health_adjusted_color(_human, default_color)
 		set_ethereal_light(_human, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
@@ -231,6 +235,16 @@
 		if(EMP_HEAVY)
 			addtimer(CALLBACK(src, PROC_REF(stop_emp), _human), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 20 seconds
 
+/datum/species/elzuose/proc/on_emag_act(mob/living/carbon/human/_human, mob/user)
+	if(emag_effect)
+		return
+	emag_effect = TRUE
+	if(user)
+		to_chat(user, span_notice("You tap [_human] on the back with your card."))
+	_human.visible_message(span_danger("[_human] starts flickering in an array of colors!"))
+	handle_emag(_human)
+	addtimer(CALLBACK(src, PROC_REF(stop_emag), _human), 30 SECONDS) //Disco mode for 30 seconds! This doesn't affect the ethereal at all besides either annoying some players, or making someone look badass.
+
 /datum/species/elzuose/spec_life(mob/living/carbon/human/_human)
 	.=..()
 	handle_charge(_human)
@@ -239,6 +253,18 @@
 	EMPeffect = FALSE
 	spec_updatehealth(_human)
 	to_chat(_human, span_notice("You feel more energized as your shine comes back."))
+
+/datum/species/elzuose/proc/handle_emag(mob/living/carbon/human/_human)
+	if(!emag_effect)
+		return
+	current_color = pick(ELZUOSE_EMAG_COLORS)
+	spec_updatehealth(_human)
+	addtimer(CALLBACK(src, PROC_REF(handle_emag), _human), 5) //Call ourselves every 0.5 seconds to change color
+
+/datum/species/elzuose/proc/stop_emag(mob/living/carbon/human/_human)
+	emag_effect = FALSE
+	spec_updatehealth(_human)
+	_human.visible_message(span_danger("[_human] stops flickering and goes back to their normal state!"))
 
 /datum/species/elzuose/proc/handle_charge(mob/living/carbon/human/_human)
 	brutemod = 1.25
@@ -294,3 +320,34 @@
 	if(istype(stomach))
 		return stomach.crystal_charge
 	return ELZUOSE_CHARGE_NONE
+
+/datum/species/elzuose/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, intent, mob/living/carbon/human/_human)
+	if(istype(I, /obj/item/multitool))
+		if(user.a_intent == INTENT_HARM)
+			. = ..() // multitool beatdown
+			return
+
+		if (emag_effect == TRUE)
+			to_chat(user, span_warning("The multitool can't get a lock on [_human]'s EM frequency!"))
+			return
+
+		if(user != _human)
+			// random color change
+			default_color = "#" + GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
+			current_color = health_adjusted_color(_human, default_color)
+			spec_updatehealth(_human)
+			_human.visible_message(span_danger("[_human]'s EM frequency is scrambled to a random color."))
+		else
+			// select new color
+			var/new_etherealcolor = input(user, "Choose your Elzuose color:", "Character Preference",default_color) as color|null
+			if(new_etherealcolor)
+				var/temp_hsv = RGBtoHSV(new_etherealcolor)
+				if(ReadHSV(temp_hsv)[3] >= ReadHSV("#505050")[3]) // elzu colors should be bright ok??
+					default_color = sanitize_hexcolor(new_etherealcolor, 6, TRUE)
+					current_color = health_adjusted_color(_human, default_color)
+					spec_updatehealth(_human)
+					_human.visible_message(span_notice("[_human] modulates [_human.p_their()] EM frequency to [new_etherealcolor]"))
+				else
+					to_chat(user, span_danger("Invalid color. Your color is not bright enough."))
+	else
+		. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -46,7 +46,6 @@
 
 	var/current_color
 	var/EMPeffect = FALSE
-	var/emag_effect = FALSE
 	var/static/unhealthy_color = rgb(237, 164, 149)
 	loreblurb = "Elzuosa are an uncommon and unusual species best described as crystalline, electrically-powered plantpeople. They hail from the warm planet Kalixcis, where they evolved alongside the Sarathi. Kalixcian culture places no importance on blood-bonds, and those from it tend to consider their family anyone they are sufficiently close to, and choose their own names."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
@@ -64,7 +63,6 @@
 		return
 	var/mob/living/carbon/human/ethereal = _carbon
 	default_color = "#[ethereal.dna.features["ethcolor"]]"
-	RegisterSignal(ethereal, COMSIG_ATOM_EMAG_ACT, PROC_REF(on_emag_act))
 	RegisterSignal(ethereal, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
@@ -80,7 +78,6 @@
 			BP.update_limb(is_creating = TRUE)
 
 /datum/species/elzuose/on_species_loss(mob/living/carbon/human/_carbon, datum/species/new_species, pref_load)
-	UnregisterSignal(_carbon, COMSIG_ATOM_EMAG_ACT)
 	UnregisterSignal(_carbon, COMSIG_ATOM_EMP_ACT)
 	UnregisterSignal(_carbon, COMSIG_DIGOUT)
 	UnregisterSignal(_carbon, COMSIG_MOVABLE_MOVED)
@@ -180,8 +177,7 @@
 		return
 
 	if(_human.stat != DEAD && !EMPeffect)
-		if(!emag_effect)
-			current_color = health_adjusted_color(_human, default_color)
+		current_color = health_adjusted_color(_human, default_color)
 		set_ethereal_light(_human, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
@@ -235,16 +231,6 @@
 		if(EMP_HEAVY)
 			addtimer(CALLBACK(src, PROC_REF(stop_emp), _human), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 20 seconds
 
-/datum/species/elzuose/proc/on_emag_act(mob/living/carbon/human/_human, mob/user)
-	if(emag_effect)
-		return
-	emag_effect = TRUE
-	if(user)
-		to_chat(user, span_notice("You tap [_human] on the back with your card."))
-	_human.visible_message(span_danger("[_human] starts flickering in an array of colors!"))
-	handle_emag(_human)
-	addtimer(CALLBACK(src, PROC_REF(stop_emag), _human), 30 SECONDS) //Disco mode for 30 seconds! This doesn't affect the ethereal at all besides either annoying some players, or making someone look badass.
-
 /datum/species/elzuose/spec_life(mob/living/carbon/human/_human)
 	.=..()
 	handle_charge(_human)
@@ -253,18 +239,6 @@
 	EMPeffect = FALSE
 	spec_updatehealth(_human)
 	to_chat(_human, span_notice("You feel more energized as your shine comes back."))
-
-/datum/species/elzuose/proc/handle_emag(mob/living/carbon/human/_human)
-	if(!emag_effect)
-		return
-	current_color = pick(ELZUOSE_EMAG_COLORS)
-	spec_updatehealth(_human)
-	addtimer(CALLBACK(src, PROC_REF(handle_emag), _human), 5) //Call ourselves every 0.5 seconds to change color
-
-/datum/species/elzuose/proc/stop_emag(mob/living/carbon/human/_human)
-	emag_effect = FALSE
-	spec_updatehealth(_human)
-	_human.visible_message(span_danger("[_human] stops flickering and goes back to their normal state!"))
 
 /datum/species/elzuose/proc/handle_charge(mob/living/carbon/human/_human)
 	brutemod = 1.25
@@ -320,34 +294,3 @@
 	if(istype(stomach))
 		return stomach.crystal_charge
 	return ELZUOSE_CHARGE_NONE
-
-/datum/species/elzuose/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, intent, mob/living/carbon/human/_human)
-	if(istype(I, /obj/item/multitool))
-		if(user.a_intent == INTENT_HARM)
-			. = ..() // multitool beatdown
-			return
-
-		if (emag_effect == TRUE)
-			to_chat(user, span_warning("The multitool can't get a lock on [_human]'s EM frequency!"))
-			return
-
-		if(user != _human)
-			// random color change
-			default_color = "#" + GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
-			current_color = health_adjusted_color(_human, default_color)
-			spec_updatehealth(_human)
-			_human.visible_message(span_danger("[_human]'s EM frequency is scrambled to a random color."))
-		else
-			// select new color
-			var/new_etherealcolor = input(user, "Choose your Elzuose color:", "Character Preference",default_color) as color|null
-			if(new_etherealcolor)
-				var/temp_hsv = RGBtoHSV(new_etherealcolor)
-				if(ReadHSV(temp_hsv)[3] >= ReadHSV("#505050")[3]) // elzu colors should be bright ok??
-					default_color = sanitize_hexcolor(new_etherealcolor, 6, TRUE)
-					current_color = health_adjusted_color(_human, default_color)
-					spec_updatehealth(_human)
-					_human.visible_message(span_notice("[_human] modulates [_human.p_their()] EM frequency to [new_etherealcolor]"))
-				else
-					to_chat(user, span_danger("Invalid color. Your color is not bright enough."))
-	else
-		. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the color changing interaction elzu have with multitools and emags.

## Why It's Good For The Game

![image](https://github.com/shiptest-ss13/Shiptest/assets/56049844/b81646c9-1490-46ad-88ea-ec5b08b0d6ad)

Thgvr asked me too

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Elzu can no longer change their color with the multitool or emag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
