### PR TITLE
Prismwine's burn resistance is no longer goofy

### DIFF
--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -180,15 +180,13 @@
 /datum/reagent/consumable/ethanol/trickwine/prism_wine/on_mob_metabolize(mob/living/carbon/human/M)
 	..()
 	ADD_TRAIT(M, TRAIT_REFLECTIVE, "trickwine")
-	if(M.physiology.burn_mod <= initial(M.physiology.burn_mod))
-		M.physiology.burn_mod *= 0.5
+	M.physiology.burn_mod *= 0.5
 	M.add_filter("prism-wine", 2, list("type"="outline", "color"="#8FD7DF", "size"=1))
 	M.visible_message("<span class='warning'>[M] seems to shimmer with power!</span>")
 
 /datum/reagent/consumable/ethanol/trickwine/prism_wine/on_mob_end_metabolize(mob/living/carbon/human/M)
 	REMOVE_TRAIT(M, TRAIT_REFLECTIVE, "trickwine")
-	if(M.physiology.burn_mod > initial(M.physiology.burn_mod))
-		M.physiology.burn_mod *= 2
+	M.physiology.burn_mod *= 2
 	M.remove_filter("prism-wine")
 	M.visible_message("<span class='warning'>[M] has returned to normal!</span>")
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

currently it uhhhhhhhhh stacks with itself :3

## Why It's Good For The Game

fix

## Changelog

:cl:
fix: prismwine's burn resistance can no longer end up stacking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
