### PR TITLE
Asteroid ore veins

### DIFF
--- a/code/datums/mapgen/planetary/AsteroidGenerator.dm
+++ b/code/datums/mapgen/planetary/AsteroidGenerator.dm
@@ -160,11 +160,11 @@
 	)
 
 	feature_spawn_list = list(
-		/obj/structure/geyser/random = 10,
+		/obj/structure/geyser/random = 5,
 		/obj/structure/spawner/mining/carp = 5,
 		/obj/structure/vein/asteroid = 10,
-		/obj/structure/vein/classtwo/asteroid = 20,
-		/obj/structure/vein/classthree/asteroid = 15
+		/obj/structure/vein/classtwo/asteroid = 15,
+		/obj/structure/vein/classthree/asteroid = 12
 	)
 
 	mob_spawn_list = list(

--- a/code/datums/mapgen/planetary/AsteroidGenerator.dm
+++ b/code/datums/mapgen/planetary/AsteroidGenerator.dm
@@ -114,7 +114,10 @@
 		/obj/structure/geyser/random = 1,
 		/obj/structure/spawner/mining/goliath = 1,
 		/obj/structure/spawner/mining = 1,
-		/obj/structure/spawner/mining/hivelord = 1
+		/obj/structure/spawner/mining/hivelord = 1,
+		/obj/structure/vein/asteroid = 5,
+		/obj/structure/vein/classtwo/asteroid = 10,
+		/obj/structure/vein/classthree/asteroid = 5
 	)
 
 	mob_spawn_list = list(
@@ -157,8 +160,11 @@
 	)
 
 	feature_spawn_list = list(
-		/obj/structure/geyser/random = 1,
-		/obj/structure/spawner/mining/carp = 1
+		/obj/structure/geyser/random = 10,
+		/obj/structure/spawner/mining/carp = 5,
+		/obj/structure/vein/asteroid = 10,
+		/obj/structure/vein/classtwo/asteroid = 20,
+		/obj/structure/vein/classthree/asteroid = 15
 	)
 
 	mob_spawn_list = list(

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -209,3 +209,36 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		)
 	max_mobs = 6
 	spawn_time = 80
+
+// Asteroid veins are the same as the base planetary ones yield wise, but with the asteroid mobs.
+
+/obj/structure/vein/asteroid
+	mob_types = list(
+		/mob/living/simple_animal/hostile/asteroid/goliath = 60,
+		/mob/living/simple_animal/hostile/asteroid/basilisk = 30,
+		/mob/living/simple_animal/hostile/asteroid/hivelord = 30,
+		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
+		/mob/living/simple_animal/hostile/carp = 20,
+		)
+
+/obj/structure/vein/classtwo/asteroid
+	mob_types = list(
+		/mob/living/simple_animal/hostile/asteroid/goliath = 60,
+		/mob/living/simple_animal/hostile/asteroid/basilisk = 30,
+		/mob/living/simple_animal/hostile/asteroid/hivelord = 30,
+		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
+		/mob/living/simple_animal/hostile/carp = 20,
+		/mob/living/simple_animal/hostile/carp/megacarp = 10,
+		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 5
+		)
+
+/obj/structure/vein/classthree/asteroid
+	mob_types = list(
+		/mob/living/simple_animal/hostile/asteroid/goliath = 60,
+		/mob/living/simple_animal/hostile/asteroid/basilisk = 30,
+		/mob/living/simple_animal/hostile/asteroid/hivelord = 30,
+		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
+		/mob/living/simple_animal/hostile/carp/megacarp = 20,
+		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 10
+		)
+

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/asteroid/hivelord = 30,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
 		/mob/living/simple_animal/hostile/carp = 20,
-		/mob/living/simple_animal/hostile/carp/megacarp = 10,
+		/mob/living/simple_animal/hostile/carp/megacarp = 15,
 		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 5
 		)
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -175,8 +175,8 @@
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
 	health_doll_icon = "megacarp"
-	maxHealth = 75
-	health = 75
+	maxHealth = 60
+	health = 60
 	pixel_x = -16
 	base_pixel_x = -16
 	mob_size = MOB_SIZE_LARGE

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -175,8 +175,8 @@
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
 	health_doll_icon = "megacarp"
-	maxHealth = 20
-	health = 20
+	maxHealth = 75
+	health = 75
 	pixel_x = -16
 	base_pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
@@ -186,8 +186,8 @@
 	bonus_tame_chance = 0
 
 	obj_damage = 80
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	melee_damage_lower = 25
+	melee_damage_upper = 25
 
 	var/regen_cooldown = 0
 	var/rideable = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -175,8 +175,8 @@
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
 	health_doll_icon = "megacarp"
-	maxHealth = 60
-	health = 60
+	maxHealth = 20
+	health = 20
 	pixel_x = -16
 	base_pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
@@ -186,8 +186,8 @@
 	bonus_tame_chance = 0
 
 	obj_damage = 80
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 
 	var/regen_cooldown = 0
 	var/rideable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds asteroid ore veins to asteroid generation, with the spawning weighted toward higher tier veins

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Since the mining rework, there hasn't been much reason to visit asteroids anymore as their ore generation has been slashed and ore veins present a much more efficient way to mine.

Having high tier ore veins on the asteroids should make them desirable places to mine again, and a reliable if dangerous option to find sites the higher tier drilling missions at the outpost. Having to contend with zero gravity and EVA should present an interesting challenge while drilling.

## Changelog

:cl:
add: Asteroid ore veins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
