### PR TITLE
removes megafauna gibbing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/codename_claw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/codename_claw.dm
@@ -315,7 +315,7 @@
 	status_flags &= ~GODMODE
 
 /mob/living/simple_animal/hostile/megafauna/claw/proc/phase2_dramatic()
-	explosion(src, 0, 5, 10)
+	explosion(src, 0, 1, 5)
 	empulse(src, 5, 8)
 	new /obj/effect/gibspawner/human(get_turf(src))
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -14,7 +14,7 @@
 	movement_type = FLYING
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
-	stat_attack = DEAD
+	stat_attack = HARD_CRIT
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	damage_coeff = list(BRUTE = 1, BURN = 0.5, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	minbodytemp = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes megafauna not target dead people
this might not catch ALL gibbing, i didnt test every megafauna.
I also reduced the explosion from the codeclaw since its already a really tough fight with a fakeout that catches crew off guard.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RR is generally bad for ship test and loosing a fight to a mega fauna is a lame way to get RRed
hugbox pr c:
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: megafauna should RR less.
balance: codename claw explosion should tear a smaller hole in your ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
