### PR TITLE
Granularizes mech equipment

### DIFF
--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -109,7 +109,7 @@ Mech Equipment
 		/obj/item/mecha_parts/mecha_equipment/drill
 	)
 
-/datum/supply_pack/mech/equipment/scanners
+/datum/supply_pack/mech/equipment/scanner
 	name = "Mech scanner kit"
 	desc = "A trio of electronic mining scanners, graded to interface with a mech."
 	cost = 350

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -111,7 +111,7 @@ Mech Equipment
 
 /datum/supply_pack/mech/equipment/scanner
 	name = "Mech scanner kit"
-	desc = "A trio of electronic mining scanners, graded to interface with a mech."
+	desc = "An electronic mining scanner, graded to interface with a mech."
 	cost = 350
 	contains = list(
 		/obj/item/mecha_parts/mecha_equipment/mining_scanner

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -103,21 +103,17 @@ Mech Equipment
 
 /datum/supply_pack/mech/equipment/drill
 	name = "Mech drill kit"
-	desc = "A trio of mechanized drills"
-	cost = 1500
+	desc = "Contains one mechanized drill for heavy duty digging."
+	cost = 500
 	contains = list(
-		/obj/item/mecha_parts/mecha_equipment/drill,
-		/obj/item/mecha_parts/mecha_equipment/drill,
 		/obj/item/mecha_parts/mecha_equipment/drill
 	)
 
 /datum/supply_pack/mech/equipment/scanners
 	name = "Mech scanner kit"
-	desc = "A trio of electronic mining scanners, graded to interface with a mech"
-	cost = 1000
+	desc = "A trio of electronic mining scanners, graded to interface with a mech."
+	cost = 350
 	contains = list(
-		/obj/item/mecha_parts/mecha_equipment/mining_scanner,
-		/obj/item/mecha_parts/mecha_equipment/mining_scanner,
 		/obj/item/mecha_parts/mecha_equipment/mining_scanner
 	)
 
@@ -131,10 +127,9 @@ Mech Equipment
 
 /datum/supply_pack/mech/equipment/clamp
 	name = "Mech clamp kit"
-	desc = "Two clamps designed for mechanized freight hauling."
-	cost = 700
+	desc = "Contains a clamp designed for mechanized freight hauling."
+	cost = 350
 	contains = list(
-		/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
 		/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp
 	)
 
@@ -148,7 +143,7 @@ Mech Equipment
 
 /datum/supply_pack/mech/equipment/ripley_upgrade
 	name = "APLU upgrade kit"
-	desc = "The components needed to upgrade an APLU MK-I to be spaceworthy"
+	desc = "Contains an APLU MK II upgrade kit. The upgrade will replace the cockpit with a spaceworthy canopy, but the added weight makes it slower."
 	cost = 1500
 	contains = list(
 		/obj/item/mecha_parts/mecha_equipment/conversion_kit/ripley
@@ -159,7 +154,7 @@ weapons
 */
 
 /datum/supply_pack/mech/equipment/pka
-	name = "Proto-Kinetic Accelerator kit"
+	name = "Mech Mounted Proto-Kinetic Accelerator kit"
 	desc = "A ranged mining attachment for any mech."
 	cost = 1500
 	contains = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Granularizes mech equipment in the outpost catalogue and adjusts some of the descs.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More fine control how much you need to order at the outpost is good. And honestly? Who needs three drills?

## Changelog

:cl:
tweak: Granularizes mech equipment
tweak: mech cargo pack descs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
