### PR TITLE
Granularizes defib crate at the outpost

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -61,10 +61,9 @@
 
 /datum/supply_pack/medical/defibs
 	name = "Defibrillator Crate"
-	desc = "Contains two defibrillators for bringing the recently deceased back to life."
-	cost = 1500
-	contains = list(/obj/item/defibrillator/loaded,
-					/obj/item/defibrillator/loaded)
+	desc = "Contains a defibrillators for bringing the recently deceased back to life."
+	cost = 750
+	contains = list(/obj/item/defibrillator/loaded)
 	crate_name = "defibrillator crate"
 
 /datum/supply_pack/medical/surgery

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -61,7 +61,7 @@
 
 /datum/supply_pack/medical/defibs
 	name = "Defibrillator Crate"
-	desc = "Contains a defibrillators for bringing the recently deceased back to life."
+	desc = "Contains a defibrillator for bringing the recently deceased back to life."
 	cost = 750
 	contains = list(/obj/item/defibrillator/loaded)
 	crate_name = "defibrillator crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Defib crates now contain a single defib, and desc and price changed accordingly.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fine control over your orders are good, and you can always buy that second defib anyways if you really need it.

## Changelog

:cl:
tweak: Defib crate now contains a single defib, priced 750
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
