### PR TITLE
Mindbreaker Tweak

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -255,6 +255,7 @@
 	name = "Mindbreaker Toxin"
 	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patients. it counteracts their symptoms and anchors them to reality."
 	color = "#B31008" // rgb: 139, 166, 233
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	toxpwr = 0
 	taste_description = "sourness"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A small followup to https://github.com/shiptest-ss13/Shiptest/pull/3017, this considerably slows the metabolism on chemical mindbreaker.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
With the old implementation, chemical mindbreaker could hardly be used to treat RDS. A 50u dose would last only a few minutes, and destroy your liver in the process. This makes RDS actually viable to treat. 

Also, if you're taking chemical mindbreaker recreationally, you naughty dog you, this allows you the chance to hallucinate for more than a brief moment, given how hallucinations are weighted. Not a very useful recreational substance if it exits your system within thirty seconds.
## Changelog

:cl:
balance: chemical mindbreaker is now ten times as potent! Be gay, do crime, and hallucinate in the process
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
