### PR TITLE
Makes the brimstone shoot faster

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -64,6 +64,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/lethal
 	manufacturer = MANUFACTURER_HUNTERSPRIDE
 	fire_delay = 1
+	rack_delay = 2
 
 	can_be_sawn_off  = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the cooldown time between pumps from 0.5 seconds to 0.2 seconds on the brimstone, allowing it to run through its 5 shells faster than a li teg can respond to a junker

## Why It's Good For The Game

The fast shooting shotgun is now objectively faster rather than marginally faster compared to other shotguns

## Changelog

:cl:
balance: the brimstone can now be pumped faster. Enjoy your rilena.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
