### PR TITLE
Tweaks Runner-class and replaces weapons with factory subtype on the Elder

### DIFF
--- a/_maps/shuttles/roumain/srm_elder.dmm
+++ b/_maps/shuttles/roumain/srm_elder.dmm
@@ -273,7 +273,6 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -497,7 +496,6 @@
 /obj/machinery/button/door{
 	id = "elderengineshuts";
 	name = "Engine Shutters";
-	dir = 2;
 	pixel_x = 7;
 	pixel_y = 21
 	},
@@ -955,7 +953,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -1170,7 +1167,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -1242,7 +1238,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -1259,14 +1254,12 @@
 /obj/machinery/door/window/eastright{
 	dir = 8
 	},
-/obj/item/gun/ballistic/shotgun/flamingarrow{
-	pixel_y = -5
-	},
-/obj/item/gun/ballistic/shotgun/flamingarrow{
-	pixel_y = 0
-	},
+/obj/item/gun/ballistic/shotgun/flamingarrow/factory,
 /obj/item/gun/ballistic/shotgun/flamingarrow/bolt{
 	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/flamingarrow/factory{
+	pixel_y = -5
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/storage)
@@ -1275,7 +1268,6 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -1774,7 +1766,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "elderatriumshuts"
 	},
 /turf/open/floor/plating,
@@ -2187,17 +2178,17 @@
 /obj/machinery/door/window{
 	dir = 8
 	},
-/obj/item/gun/ballistic/rifle/illestren{
+/obj/item/gun/ballistic/rifle/illestren/factory{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/gun/ballistic/rifle/illestren/factory{
 	pixel_x = -4;
 	pixel_y = -5
 	},
-/obj/item/gun/ballistic/rifle/illestren{
+/obj/item/gun/ballistic/rifle/illestren/factory{
 	pixel_x = -4;
 	pixel_y = -1
-	},
-/obj/item/gun/ballistic/rifle/illestren{
-	pixel_x = -4;
-	pixel_y = 3
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/storage)
@@ -2278,7 +2269,6 @@
 	pixel_x = 4
 	},
 /obj/item/reagent_containers/food/snacks/meat/steak{
-	pixel_y = 0;
 	pixel_x = -9
 	},
 /obj/item/reagent_containers/food/snacks/meat/steak{
@@ -2542,9 +2532,7 @@
 	pixel_x = 3;
 	pixel_y = -6
 	},
-/obj/item/storage/toolbox/fishing{
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/fishing,
 /turf/open/floor/wood/ebony,
 /area/ship/storage)
 "Fu" = (
@@ -2926,7 +2914,6 @@
 	pixel_x = -2
 	},
 /obj/item/weldingtool{
-	pixel_y = 0;
 	pixel_x = -5
 	},
 /turf/open/floor/wood/ebony,
@@ -3015,8 +3002,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medical Bay";
-	dir = 2
+	name = "Medical Bay"
 	},
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 1
@@ -3073,7 +3059,6 @@
 	pixel_x = 21
 	},
 /obj/item/binoculars{
-	pixel_y = 0;
 	pixel_x = -4
 	},
 /obj/item/megaphone{
@@ -3497,8 +3482,7 @@
 	pixel_x = 5
 	},
 /obj/item/cultivator/rake{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /turf/open/floor/grass/ship/jungle,
 /area/ship/roumain)
@@ -3763,8 +3747,7 @@
 	pixel_y = -4
 	},
 /obj/item/pickaxe{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/pickaxe{
 	pixel_x = 1;

--- a/_maps/shuttles/subshuttles/syndicate_runner.dmm
+++ b/_maps/shuttles/subshuttles/syndicate_runner.dmm
@@ -74,9 +74,7 @@
 /obj/effect/turf_decal/trimline/opaque/bar/filled/corner,
 /obj/machinery/power/terminal,
 /obj/effect/landmark/ert_shuttle_spawn,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -168,14 +166,14 @@
 "co" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line,
-/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -213,9 +211,7 @@
 	dir = 4;
 	id = "runner_sub_holo"
 	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "fa" = (
@@ -227,6 +223,15 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
+"fQ" = (
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "gi" = (
 /obj/item/storage/backpack/duffelbag/med/surgery{
@@ -325,14 +330,31 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"mN" = (
+/obj/docking_port/mobile{
+	dir = 2;
+	name = "trauma team shuttle";
+	port_direction = 8;
+	preferred_direction = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "runner_sub_door"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "runner_sub_holo"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/bridge)
 "nP" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line,
-/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -389,13 +411,13 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/bar/filled/warning,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/opaque/bar/line,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "DP" = (
@@ -420,23 +442,11 @@
 /turf/open/floor/engine/hull,
 /area/ship/external)
 "Or" = (
-/obj/docking_port/mobile{
-	dir = 2;
-	name = "trauma team shuttle";
-	port_direction = 8;
-	preferred_direction = 4
-	},
-/obj/machinery/door/poddoor{
-	id = "runner_sub_door"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "runner_sub_holo"
-	},
 /obj/structure/cable{
-	icon_state = "0-1"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Pq" = (
 /turf/template_noop,
@@ -568,29 +578,29 @@ gs
 te
 "}
 (4,1,1) = {"
-Pq
 bz
+fQ
 co
 gA
 SE
 ku
 zS
+Or
 dB
-Pq
 "}
 (5,1,1) = {"
-Pq
 sl
+fQ
 nP
 ZN
 kM
 iR
 zS
 Or
-Pq
+mN
 "}
 (6,1,1) = {"
-Pq
+PD
 PD
 cF
 hJ
@@ -598,7 +608,7 @@ ac
 hB
 bG
 PD
-Pq
+PD
 "}
 (7,1,1) = {"
 Pq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. The Runner-class should now be able to dock, and the Elder's Illestrens + Arrows were replaced with factory variants.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Ship working good.
* Elder is an SRM ship, which uses Hunter's Pride weapons. The factory variants are intended for SRM ships.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: The Elder's Illesterns and Arrows are now factory-variant.
fix: The Runner should be able to dock now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
