### PR TITLE
Removes bulk ammo boxes from webbing storage

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -270,7 +270,15 @@
 		/obj/item/assembly/flash/handheld,
 		/obj/item/clothing/glasses,
 		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
+		/obj/item/ammo_box/magazine,
+		/obj/item/ammo_box/c38, //speed loaders don't have a common path like magazines. pain.
+		/obj/item/ammo_box/a357, //some day we should refactor these into an ammo_box/speedloader type
+		/obj/item/ammo_box/a4570, //but not today
+		/obj/item/ammo_box/a858, //oh boy stripper clips too
+		/obj/item/ammo_box/vickland_a308,
+		/obj/item/ammo_box/a300,
+		/obj/item/ammo_box/aac_300blk_stripper,
+		/obj/item/ammo_box/amagpellet_claris, //that's the last of the clips
 		/obj/item/reagent_containers/food/snacks/donut,
 		/obj/item/kitchen/knife/combat,
 		/obj/item/flashlight/seclite,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security belts and webbings can no longer store bulk ammo boxes, only magazines, stripper clips, and speed loaders.

## Why It's Good For The Game

It's a buff to the bandolier ; the more limited storage means bandoliers can be a better choice for weapons that don't use magazines or have very small clips, such as most shotguns or loading gate revolvers. Given bandoliers were designed for that anyway, it only helps push them into their niche.

## Changelog

:cl:
balance: security belts and webbings can no longer store bulk ammo boxes, only magazines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
