### PR TITLE
(STANDBY FOR TITANFALL) Adds a new jungle ruin.

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
@@ -177,8 +177,9 @@
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
 "hq" = (
-/obj/item/ammo_casing/a762_40,
-/mob/living/simple_animal/hostile/venus_human_trap,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	faction = s
+	},
 /turf/open/floor/plating/dirt/jungle/wasteland{
 	icon_state = "wasteland9"
 	},
@@ -273,13 +274,10 @@
 	},
 /area/overmap_encounter/planetoid/jungle/explored)
 "le" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/mob/living/simple_animal/hostile/venus_human_trap{
+	faction = list("jungle")
 	},
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/plating/dirt/jungle/wasteland{
-	icon_state = "wasteland9"
-	},
+/turf/closed/wall/r_wall,
 /area/overmap_encounter/planetoid/jungle/explored)
 "lB" = (
 /obj/machinery/light/directional/east,
@@ -458,7 +456,9 @@
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
 "tB" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	faction = list("jungle")
+	},
 /turf/open/floor/plating/dirt/jungle/wasteland{
 	icon_state = "wasteland9"
 	},
@@ -544,10 +544,8 @@
 	},
 /area/overmap_encounter/planetoid/jungle/explored)
 "yd" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
 "yy" = (
@@ -578,21 +576,12 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/dirt/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"AI" = (
-/obj/effect/decal/cleanable/blood/drip,
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/plating/dirt/jungle/wasteland{
-	icon_state = "wasteland9"
-	},
-/area/overmap_encounter/planetoid/jungle/explored)
 "AJ" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
 "Bx" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 6
-	},
+/obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
 "CH" = (
@@ -609,13 +598,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/dirt/jungle/wasteland{
 	icon_state = "wasteland9"
-	},
-/area/overmap_encounter/planetoid/jungle/explored)
-"Dp" = (
-/obj/item/ammo_casing/spent,
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/plating/dirt/jungle/wasteland{
-	icon_state = "wasteland0"
 	},
 /area/overmap_encounter/planetoid/jungle/explored)
 "Dq" = (
@@ -1019,13 +1001,13 @@ Da
 fH
 Nt
 Db
-ug
+tB
 gU
 yy
 ug
 ug
 ug
-FY
+hq
 ug
 Da
 bd
@@ -1045,8 +1027,8 @@ fe
 xq
 qd
 ug
-Dp
-ug
+Ky
+tB
 cU
 vU
 Da
@@ -1133,11 +1115,11 @@ ug
 FY
 dn
 ug
-ug
+tB
 Wl
 yP
 kH
-le
+kH
 fr
 JD
 Oz
@@ -1174,15 +1156,15 @@ CH
 ug
 Fh
 CL
-ug
-AI
+tB
+Oz
 ug
 rk
 qU
 ug
 Oz
 ug
-CL
+le
 CL
 CL
 CL
@@ -1267,7 +1249,7 @@ JT
 JT
 Re
 CL
-hq
+tB
 Oa
 ug
 Bx

--- a/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
@@ -49,7 +49,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/paper/crumpled/fluff{
-	default_raw_text = We cant hold them anymore, the perimeter has been breached and even with the mechs they keep coming. I fear this is the end..
+	default_raw_text = ''Wecantholdthemanymore,theperimeterhasbeenbreachedandevenwiththemechs,theykeepcoming.Ifearthisistheend...''
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland{
 	icon_state = "wasteland9"
@@ -401,7 +401,7 @@
 "rl" = (
 /obj/structure/table,
 /obj/item/paper{
-	default_raw_text = We were not supposed to be here. I've got no idea who punched in the coords for that drop, but im sure as shit they wanted us gone. Alpha and Gamma landed close, the remaining sensors of my pods can see them. Personally i got encased in rock, the shutters wont open, rocks blocking them. I think im gonna run out of food if they dont find a way to get me out. 
+	default_raw_text = ''Wewerenotsupposedtobehere.I'vegotnoideawhopunchedinthecoordsforthatdrop,butimsureasshittheywantedusgone.AlphaandGammalandedclose,theremainingsensorsofmypodscanseethem.PersonallyIgotencasedinrock,theshutterswontopen,rocksblockingthem.Ithinkimgonnarunoutoffoodiftheydontfindawaytogetmeout.''
 	},
 /turf/open/floor/engine/airless,
 /area/overmap_encounter/planetoid/jungle/explored)
@@ -483,7 +483,7 @@
 "vb" = (
 /obj/structure/table,
 /obj/item/paper{
-	default_raw_text = Both Alpha and gamma landed somewhat safely. Gamma hit rock, but most where fine, Beta on the other hand, is completely entombed. With what little equipement we have, not much we can do really. We've made a small FOB around the crash site, and rescue should not be too long... hopefully.
+	default_raw_text = ''BothAlphaandGammalandedsomewhatsafely.Gammahitrock,butmostwherefine,Betaontheotherhand,iscompletelyentombed.Withwhatlittleequipementwehave,notmuchwecandoreally.Atleastwecanuseit'shullascover.We'vemadeasmallFOBaroundthecrashsite,andrescueshouldnotbetoolong...hopefully.''
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland{
 	icon_state = "wasteland9"

--- a/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_crash_mech.dmm
@@ -1,0 +1,1369 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"al" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"am" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/mecha/combat/durand,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"at" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "splatter1";
+	pixel_x = 18;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"bb" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bd" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "pirateshutters";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bj" = (
+/obj/item/trash/cheesie,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bv" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/paper/crumpled/fluff{
+	default_raw_text = We cant hold them anymore, the perimeter has been breached and even with the mechs they keep coming. I fear this is the end..
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"cU" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland5"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"dn" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"dr" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"dx" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"ef" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/random_gun_protolathe_lootdrop,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 3
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fd" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree3"
+	},
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fe" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"fr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"fz" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"fH" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree6"
+	},
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fI" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/wall/directional/west,
+/obj/item/clothing/mask/breath{
+	pixel_y = 0;
+	pixel_x = -6
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 6
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gU" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"gZ" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"hk" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hq" = (
+/obj/item/ammo_casing/a762_40,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"hQ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"hT" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"is" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 3
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iv" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iC" = (
+/obj/structure/mecha_wreckage/durand,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"iK" = (
+/obj/structure/table,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"jM" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma/ten,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"kj" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"kJ" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"kY" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland_dug"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"le" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"lB" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lE" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"lZ" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"mu" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland5"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"no" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree3"
+	},
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nA" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oC" = (
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oG" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"oK" = (
+/obj/effect/turf_decal/rechargefloor,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oP" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland1"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"pX" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qd" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"qo" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/item/trash/energybar,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qU" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"rc" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "splatter1";
+	pixel_x = 18;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"rk" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "coatblood"
+	},
+/turf/closed/wall/r_wall,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rl" = (
+/obj/structure/table,
+/obj/item/paper{
+	default_raw_text = We were not supposed to be here. I've got no idea who punched in the coords for that drop, but im sure as shit they wanted us gone. Alpha and Gamma landed close, the remaining sensors of my pods can see them. Personally i got encased in rock, the shutters wont open, rocks blocking them. I think im gonna run out of food if they dont find a way to get me out. 
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rD" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rI" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rM" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"rN" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rV" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 3
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sD" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"sN" = (
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tm" = (
+/obj/item/trash/pistachios,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tB" = (
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"tI" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland_dug";
+	light_color = "#a0ad20";
+	light_range = 3
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"ug" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"uV" = (
+/obj/structure/table,
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vb" = (
+/obj/structure/table,
+/obj/item/paper{
+	default_raw_text = Both Alpha and gamma landed somewhat safely. Gamma hit rock, but most where fine, Beta on the other hand, is completely entombed. With what little equipement we have, not much we can do really. We've made a small FOB around the crash site, and rescue should not be too long... hopefully.
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"vc" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"vs" = (
+/obj/item/trash/can/food/beans,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vU" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"wb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"wg" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wN" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/wall/directional/north,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath{
+	pixel_y = 0;
+	pixel_x = -6
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xq" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"yd" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yy" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"yP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"zC" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"zT" = (
+/obj/structure/flora/ausbushes,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"AB" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"AI" = (
+/obj/effect/decal/cleanable/blood/drip,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"AJ" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bx" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 6
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CH" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CL" = (
+/turf/closed/wall/r_wall,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Da" = (
+/turf/closed/indestructible/rock,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Db" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dp" = (
+/obj/item/ammo_casing/spent,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dq" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fh" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"FQ" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"FY" = (
+/mob/living/simple_animal/hostile/jungle/mega_arachnid,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ge" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Gf" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree9"
+	},
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HR" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IE" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"IT" = (
+/obj/structure/rack,
+/obj/item/poster/random_minutemen,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"JD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"JT" = (
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ky" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Lj" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Lm" = (
+/obj/structure/table,
+/obj/item/trash/raisins,
+/obj/item/trash/tray,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"LK" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"LW" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "coatblood"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mo" = (
+/turf/closed/mineral/strong,
+/area/overmap_encounter/planetoid/jungle/explored)
+"MD" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Nt" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland_dug"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"ND" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"NT" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 3
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Oa" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Oz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"OE" = (
+/turf/open/floor/plating/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PW" = (
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PZ" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/obj/structure/bonfire,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qn" = (
+/obj/structure/table,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qs" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/mecha_wreckage/durand,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Re" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ri" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland4"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"SG" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"SV" = (
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland7"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"SZ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/item/trash/can/food/peaches,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Tt" = (
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TX" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UZ" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/wall/directional/east,
+/obj/item/clothing/mask/breath{
+	pixel_y = 0;
+	pixel_x = -6
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 6
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vg" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vi" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vr" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vx" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland0"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"VT" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/engine/airless,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wl" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"XA" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "coatblood"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"Zp" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/dirt/jungle/wasteland{
+	icon_state = "wasteland9"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+
+(1,1,1) = {"
+fd
+OE
+ug
+zT
+Gf
+OE
+OE
+rN
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+"}
+(2,1,1) = {"
+AB
+OE
+OE
+OE
+fH
+OE
+OE
+fH
+Mo
+Da
+Da
+Da
+CL
+CL
+CL
+CL
+CL
+Da
+Da
+Da
+"}
+(3,1,1) = {"
+Gf
+ug
+Db
+Db
+Db
+Db
+ND
+Db
+dr
+Da
+Da
+CL
+CL
+Vr
+fI
+ef
+hk
+iv
+Da
+Da
+"}
+(4,1,1) = {"
+zT
+ug
+Db
+rM
+Oz
+ug
+mu
+at
+SV
+ug
+Da
+Da
+bd
+tm
+SZ
+VT
+Lm
+rl
+Da
+Da
+"}
+(5,1,1) = {"
+fH
+Nt
+Db
+ug
+gU
+yy
+ug
+ug
+ug
+FY
+ug
+Da
+bd
+JT
+rD
+VT
+AJ
+Ge
+sN
+Da
+"}
+(6,1,1) = {"
+fd
+ug
+oG
+fe
+xq
+qd
+ug
+Dp
+ug
+cU
+vU
+Da
+bd
+bj
+qo
+vs
+lZ
+oC
+CL
+Da
+"}
+(7,1,1) = {"
+OE
+ug
+ug
+Nt
+Nt
+hQ
+kJ
+ug
+Zp
+Zp
+Ri
+CL
+CL
+am
+wg
+is
+hT
+TX
+Da
+Da
+"}
+(8,1,1) = {"
+fH
+ug
+Nt
+zC
+ug
+iC
+ug
+lE
+PZ
+Dq
+xq
+Nt
+CL
+CL
+CL
+CL
+CL
+CL
+CL
+Da
+"}
+(9,1,1) = {"
+OE
+ug
+Db
+kY
+Db
+rc
+zC
+FY
+bv
+Oa
+Ky
+XA
+Db
+dx
+tI
+vb
+iK
+Vx
+jM
+Da
+"}
+(10,1,1) = {"
+OE
+fd
+MD
+ug
+FY
+dn
+ug
+ug
+Wl
+yP
+kH
+le
+fr
+JD
+Oz
+Oa
+tB
+ug
+jM
+Da
+"}
+(11,1,1) = {"
+OE
+Gf
+Db
+IE
+xq
+ug
+LW
+ug
+wb
+xq
+oP
+Qs
+Db
+qU
+sD
+vc
+ug
+ug
+IT
+Da
+"}
+(12,1,1) = {"
+CH
+ug
+Fh
+CL
+ug
+AI
+ug
+rk
+qU
+ug
+Oz
+ug
+CL
+CL
+CL
+CL
+CL
+CL
+CL
+Da
+"}
+(13,1,1) = {"
+fH
+ug
+CL
+CL
+Vi
+Vi
+HR
+CL
+CL
+ug
+ug
+CL
+CL
+oK
+pX
+rV
+hk
+iv
+Da
+Da
+"}
+(14,1,1) = {"
+Gf
+Ky
+CL
+PW
+JT
+JT
+Tt
+oK
+CL
+Oz
+NK
+ug
+yd
+JT
+rD
+JT
+Qn
+oC
+CL
+Da
+"}
+(15,1,1) = {"
+OE
+oG
+CL
+wN
+NT
+Vg
+NT
+nA
+CL
+ug
+Nt
+ug
+Bx
+JT
+rD
+JT
+AJ
+Ge
+Da
+Da
+"}
+(16,1,1) = {"
+no
+ug
+SG
+Tt
+Tt
+JT
+JT
+Re
+CL
+hq
+Oa
+ug
+Bx
+JT
+rD
+JT
+lZ
+Da
+Da
+Da
+"}
+(17,1,1) = {"
+CH
+Nt
+fz
+Tt
+rI
+JT
+Qn
+FQ
+CL
+Db
+Db
+CL
+CL
+al
+UZ
+Da
+Da
+Da
+Da
+Da
+"}
+(18,1,1) = {"
+AB
+ug
+Db
+Tt
+lB
+Lj
+uV
+bb
+CL
+ug
+ug
+oG
+CL
+CL
+CL
+Da
+Da
+Da
+Da
+Da
+"}
+(19,1,1) = {"
+OE
+ug
+Db
+fz
+CL
+sN
+CL
+LK
+CL
+Ky
+yy
+ug
+ug
+SG
+Da
+Da
+Da
+Da
+Da
+Da
+"}
+(20,1,1) = {"
+fd
+ug
+ug
+ug
+ug
+ug
+ug
+ug
+ug
+ug
+rN
+kj
+gZ
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+"}

--- a/_maps/map_catalogue.txt
+++ b/_maps/map_catalogue.txt
@@ -117,6 +117,10 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 		Size = (x = 36)(y = 35)(z = 1)
 		Tags = "Medium Combat Challenge", "Medium Loot", "Antag Gear", "Necropolis Loot", "Liveable"
 
+		File Name ''_maps\RandomRuins\JungleRuins\jungle_crash_mech.dmm
+		Size = (x = 20)(y = 20)(x = 1)
+		Tags = "Medium Combat Challenge", "Hazardous", "Liveable", "Major Loot"
+
 	LavaRuins:
 		File Name = "_maps\RandomRuins\LavaRuins\lavaland_biodome_beach.dmm"
 		Size = (x = 30)(y = 30)(z = 1)

--- a/code/datums/ruins/jungle.dm
+++ b/code/datums/ruins/jungle.dm
@@ -125,3 +125,9 @@
 	id = "abandoned-library"
 	description = "A forgotten library, with a few angry monkeys."
 	suffix = "jungle_abandoned_library.dmm"
+
+/datum/map_template/ruin/jungle/MechCrash
+	name = "Crashed mech Droppods"
+	id = "Crashed-mech"
+	description = "A few crashed mech droppods, dropped for orbit and forgotten"
+	suffix = "jungle_crash_mech.dmm"

--- a/code/game/area/areas/ruins/jungle.dm
+++ b/code/game/area/areas/ruins/jungle.dm
@@ -145,3 +145,8 @@
 /area/ruin/jungle/cavecrew/dormitories
 	name = "Cave Base dormitories"
 	icon_state = "crew_quarters"
+
+//Crash Mechs
+/area/ruin/jungle/MechCrash
+	name = "Crashed mechs"
+	icon_state = "blue"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new ruin: the crashed mech pods, to the jungle. 
![image](https://github.com/shiptest-ss13/Shiptest/assets/56667232/8b73a278-8611-4f1a-a5f9-0334d0c5c596)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More ruins with content. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Adds the crashed mech pods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
