### PR TITLE
Removes a ton of access requirements on downloadable programs.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -6,7 +6,6 @@
 	size = 12
 	requires_ntnet = FALSE
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
-	transfer_access = ACCESS_HEADS
 	available_on_ntnet = TRUE
 	tgui_id = "NtosAiRestorer"
 	program_icon = "laptop-code"

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -5,7 +5,6 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of cyborgs."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_ROBOTICS
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
 	program_icon = "project-diagram"

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -11,7 +11,6 @@
 	filedesc = "Plexagon Access Management"
 	program_icon_state = "id"
 	extended_desc = "Program for programming standarized ID cards to access doors across the sector."
-	transfer_access = ACCESS_HEADS
 	requires_ntnet = 0
 	size = 8
 	tgui_id = "NtosCard"

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -7,7 +7,7 @@
 	requires_ntnet = TRUE
 	required_access = ACCESS_NETWORK	//NETWORK CONTROL IS A MORE SECURE PROGRAM.
 	transfer_access = ACCESS_NETWORK
-	available_on_ntnet = TRUE
+	available_on_ntnet = FALSE
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"
 

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -6,6 +6,7 @@
 	size = 12
 	requires_ntnet = TRUE
 	required_access = ACCESS_NETWORK	//NETWORK CONTROL IS A MORE SECURE PROGRAM.
+	transfer_access = ACCESS_NETWORK
 	available_on_ntnet = TRUE
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -6,8 +6,6 @@
 	program_icon_state = "power_monitor"
 	extended_desc = "This program connects to sensors around the sector to provide information about electrical systems"
 	ui_header = "power_norm.gif"
-	transfer_access = ACCESS_ENGINE
-	usage_flags = PROGRAM_CONSOLE
 	requires_ntnet = 0
 	size = 9
 	tgui_id = "NtosPowerMonitor"

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -211,7 +211,6 @@
 	filedesc = "Lifeline"
 	extended_desc = "This program allows for tracking of crew members via their suit sensors."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_MEDICAL
 	available_on_ntnet = TRUE
 	program_icon = "heartbeat"
 

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -4,7 +4,6 @@
 	filedesc = "BotKeeper"
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
-	transfer_access = null
 	requires_ntnet = TRUE
 	size = 12
 	tgui_id = "NtosRoboControl"

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -5,7 +5,6 @@
 	program_icon_state = "smmon_0"
 	extended_desc = "Crystal Integrity Monitoring System, connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_CONSTRUCTION
 	size = 5
 	tgui_id = "NtosSupermatterMonitor"
 	program_icon = "radiation"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a ton of access requirements on downloadable programs. Wirecarp is NO LONGER AVAILABLE for download.

Tested by spawning as a deckhand on a riggs and tested downloading a couple.

I dont know how shiptest admins feel about NTnet in general so I dont want to touch much.

## Why It's Good For The Game

Nearly all ntnet programs don't need to be gated on shiptest. Removed wirecarp availability as it's abilities just troll the server.

## Changelog

:cl:
del: Removed permissions on a bunch of NTNet programs
add: WireCarp removed as a downloadable program from ntnet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
