### PR TITLE
Removes generic_adjective sanity check

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -879,18 +879,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(generic_adjective)
-				if(!mutant_category)
-					dat += APPEARANCE_CATEGORY_COLUMN
+			// begin generic adjective
+			if(!mutant_category)
+				dat += APPEARANCE_CATEGORY_COLUMN
 
-				dat += "<h3>Character Adjective</h3>"
+			dat += "<h3>Character Adjective</h3>"
 
-				dat += "<a href='?_src_=prefs;preference=generic_adjective;task=input'>[generic_adjective]</a><BR>"
+			dat += "<a href='?_src_=prefs;preference=generic_adjective;task=input'>[generic_adjective]</a><BR>"
 
-				mutant_category++
-				if(mutant_category >= MAX_MUTANT_ROWS)
-					dat += "</td>"
-					mutant_category = 0
+			mutant_category++
+			if(mutant_category >= MAX_MUTANT_ROWS)
+				dat += "</td>"
+				mutant_category = 0
+			// end generic adjective
 
 			if("wings" in pref_species.default_features && GLOB.r_wings_list.len >1)
 				if(!mutant_category)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed the sanity check I had put in for character adjectives during a previous fix.

It was well intentioned, but as it turns out, if someone is loading a charslot that existed before guestbook was ported or never saved with one, they wouldn't have an adjective saved in their save file, resulting in nulling the variable for generic_adjective, which causes this sanity check to fail and the selection not to show. The goal was meant to prevent a guestbook malfunction from locking up prefs as runtimes can break it, but after spending hours and hours on going over prefscode and analyzing character loading and generation, it's clear that I would have to address this at the point of charslot loading.

I just want this fixed in time for wednesday uptime. BETTER handling will come later, in a separate PR, when I am SURE that they won't break charslots, as well as some other prefs fixups. There's a lot of code in prefs that does not work or do anything, but for now, let's keep it simple. Should be ready to testmerge or full merge.
## Changelog

:cl:
fix: Generic adjective selection will show for everyone.
/:cl: