### PR TITLE
Fixes Posibrains/MMI pilots being permaslept on mech destruction 

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -158,7 +158,7 @@
 	return cell
 
 /obj/mecha/Destroy()
-	if(occupant && istype(occupant,/mob/living/carbon/human))
+	if(occupant && iscarbon(occupant))
 		occupant.SetSleeping(destruction_sleep_duration)
 	go_out()
 	var/mob/living/silicon/ai/AI

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -158,7 +158,7 @@
 	return cell
 
 /obj/mecha/Destroy()
-	if(occupant)
+	if(occupant && istype(occupant,/mob/living/carbon/human))
 		occupant.SetSleeping(destruction_sleep_duration)
 	go_out()
 	var/mob/living/silicon/ai/AI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #2658

Mech destruction applied sleep on the occupant no matter what, even if it couldn't naturally wake up from sleep. It checks for human mobs now so we shouldnt get edge cases like this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Posibrains/MMI pilots being permaslept on mech destruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
