### PR TITLE
Talos QOL Improvements

### DIFF
--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -36,10 +36,6 @@
 			"outfit": "/datum/outfit/job/inteq/engineer",
 			"slots": 3
 		},
-		"Corpsman": {
-			"outfit": "/datum/outfit/job/inteq/paramedic",
-			"slots": 2
-		},
 		"Enforcer": {
 			"outfit": "/datum/outfit/job/inteq/security",
 			"slots": 1

--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -27,7 +27,7 @@
 			"officer": true,
 			"slots": 1
 		},
-		"Artificer Class II": {
+		"Honorable Artificer": {
 			"outfit": "/datum/outfit/job/inteq/ce",
 			"officer": true,
 			"slots": 1

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -297,15 +297,16 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/structure/rack,
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/pickaxe/mini,
-/obj/item/pickaxe/mini,
-/obj/item/storage/bag/ore,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "ce" = (
@@ -978,13 +979,6 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
-"gF" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "gG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1802,22 +1796,16 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "lB" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/backpack/satchel/med,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical/webbing,
-/obj/item/clothing/suit/armor/inteq/corpsman,
-/obj/item/clothing/head/soft/inteq/corpsman,
-/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
-/obj/item/clothing/under/syndicate/inteq/corpsman,
 /obj/structure/railing,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/item/storage/box/bodybags,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "lC" = (
@@ -2117,10 +2105,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
-"nh" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "nl" = (
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
@@ -2297,17 +2281,11 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering/communications)
 "oi" = (
-/obj/item/storage/firstaid/medical{
-	pixel_x = -5
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 5
-	},
 /obj/machinery/camera/autoname,
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
-/obj/structure/table,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "om" = (
@@ -3488,10 +3466,10 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "uC" = (
@@ -3527,7 +3505,8 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/machinery/iv_drip,
+/obj/structure/table,
+/obj/item/storage/box/cups,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "vi" = (
@@ -4644,7 +4623,15 @@
 	dir = 4;
 	pixel_x = -19
 	},
-/obj/machinery/autolathe,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 5
+	},
+/obj/item/storage/firstaid/medical{
+	pixel_x = -5
+	},
+/obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "BY" = (
@@ -4753,7 +4740,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
@@ -6256,8 +6242,7 @@
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	icon_state = "ce";
-	name = "artificer class II's locker";
-	req_access = null;
+	name = "honorable artificer's locker";
 	req_access_txt = "56"
 	},
 /obj/item/clothing/under/syndicate/inteq/artificer,
@@ -6273,13 +6258,13 @@
 	name = "engineering megaphone"
 	},
 /obj/item/stamp/ce{
-	name = "artificer class II's rubber stamp"
+	name = "honorable artificer's rubber stamp"
 	},
 /obj/item/clothing/glasses/meson/engine,
 /obj/item/clothing/glasses/welding,
 /obj/item/pipe_dispenser,
 /obj/item/storage/belt/utility/chief{
-	name = "\improper Artificer Class II's toolbelt"
+	name = "honorable artificer's toolbelt"
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/tech/grid,
@@ -6959,7 +6944,6 @@
 /area/ship/bridge)
 "Tq" = (
 /obj/effect/turf_decal/box/corners,
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "TA" = (
@@ -8645,7 +8629,7 @@ zh
 jc
 Lc
 uO
-gF
+Ic
 nY
 ua
 MW
@@ -8679,7 +8663,7 @@ WR
 Tj
 mX
 oi
-nh
+Oc
 iy
 qB
 Oc

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -305,6 +305,7 @@
 	},
 /obj/item/pickaxe/mini,
 /obj/item/pickaxe/mini,
+/obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "ce" = (
@@ -3879,6 +3880,15 @@
 "xj" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/cryo)
+"xk" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 5;
+	height = 15;
+	width = 15
+	},
+/turf/template_noop,
+/area/template_noop)
 "xl" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/status_display/shuttle{
@@ -3976,15 +3986,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
-"xP" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 5;
-	height = 15;
-	width = 15
-	},
-/turf/template_noop,
-/area/template_noop)
 "xT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4643,7 +4644,7 @@
 	dir = 4;
 	pixel_x = -19
 	},
-/obj/structure/ore_box,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "BY" = (
@@ -8452,7 +8453,7 @@ hT
 Zo
 Fe
 zw
-xP
+xk
 sw
 sw
 sw

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -6040,6 +6040,8 @@
 /area/ship/security/armory)
 "My" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/suit/space/hardsuit/engine/elite,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/communications)
 "MC" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -2,7 +2,7 @@
 "ab" = (
 /obj/structure/sign/number/four,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "ae" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25,14 +25,14 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "ag" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "ak" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41,25 +41,38 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "an" = (
-/obj/machinery/telecomms/processor/preset_four{
-	autolinkers = list("processor4","bus");
-	network = "irmg_commnet"
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "ao" = (
+/obj/docking_port/mobile{
+	dir = 2;
+	launch_status = 0;
+	port_direction = 8;
+	preferred_direction = 4
+	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "ap" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/hardsuit/engine/atmos,
-/obj/item/tank/jetpack/oxygen,
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "as" = (
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -82,10 +95,19 @@
 /area/ship/engineering/engine)
 "au" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/telecomms/server/presets/common{
+	autolinkers = list("common","hub");
+	freq_listening = list(1459);
+	network = "irmg_commnet"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
+"aD" = (
+/obj/machinery/computer/telecomms/monitor{
+	network = "irmg_commnet"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "aH" = (
 /obj/machinery/button/door{
 	dir = 4;
@@ -167,7 +189,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "bb" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/grunge{
@@ -232,13 +254,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/telecomms/server/presets/common{
-	autolinkers = list("common","hub");
-	freq_listening = list(1459);
-	network = "irmg_commnet"
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "bI" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -253,7 +273,7 @@
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "bM" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor{
@@ -326,7 +346,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "cn" = (
 /obj/machinery/light/directional/south,
 /obj/structure/railing{
@@ -417,9 +437,6 @@
 	name = "waste input pump";
 	on = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
@@ -445,19 +462,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "cT" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/window/northleft{
-	req_access_txt = "61"
+/obj/machinery/navbeacon/wayfinding{
+	location = "talos_workshop"
 	},
-/obj/machinery/door/window/southright{
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "cV" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
@@ -525,7 +534,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "dw" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -540,7 +549,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "dE" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -583,7 +592,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "ej" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -624,9 +633,6 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "em" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -641,6 +647,9 @@
 	piping_layer = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "eu" = (
@@ -669,13 +678,16 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "eC" = (
-/obj/structure/table,
-/obj/item/mecha_parts/mecha_equipment/rcd,
-/obj/item/mecha_parts/mecha_equipment/cable_layer,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/telecomms/broadcaster/preset_right{
+	autolinkers = list("broadcasterB","hub");
+	network = "irmg_commnet"
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "eK" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 4
@@ -749,7 +761,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "fg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -778,18 +790,27 @@
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "fo" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/telecomms/receiver/preset_right{
+	autolinkers = list("receiverB","hub");
+	freq_listening = list(1347,1359);
+	network = "irmg_commnet"
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "fr" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "fC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/opaque/yellow/warning{
@@ -820,17 +841,17 @@
 /area/ship/bridge)
 "fK" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "fN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "fU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "fX" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -913,14 +934,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "go" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "gp" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
 /obj/effect/turf_decal/siding/thinplating,
@@ -1061,18 +1082,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/structure/closet/crate{
-	name = "sandbags crate"
-	},
-/obj/item/storage/box/emptysandbags{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/storage/box/emptysandbags,
-/obj/item/storage/box/emptysandbags{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "hc" = (
@@ -1115,11 +1125,11 @@
 "hm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "hw" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "hz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -1133,7 +1143,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "hG" = (
 /obj/structure/railing{
 	dir = 6;
@@ -1245,7 +1255,7 @@
 /obj/item/cigbutt,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "im" = (
 /obj/structure/railing{
 	dir = 4
@@ -1273,7 +1283,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "iy" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
@@ -1384,19 +1394,25 @@
 	},
 /obj/item/cigbutt,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "iW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon/wayfinding{
+	location = "talos_telecomms"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "iZ" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/corner,
 /obj/effect/turf_decal/siding/thinplating/corner,
@@ -1442,7 +1458,7 @@
 "jj" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "jl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1472,7 +1488,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "jw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1486,7 +1502,7 @@
 /turf/open/floor/carpet/orange,
 /area/ship/bridge)
 "jH" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -1498,17 +1514,36 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Communications";
-	req_access_txt = "61"
+/obj/machinery/door/airlock/engineering{
+	name = "Storage Bay";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/engineering/communications)
-"jJ" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/rnd/production/circuit_imprinter/department/engi,
-/turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
+"jJ" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/folder/syndicate{
+	desc = "A slick black folder stamped 'Property of Inteq Risk Management Group.'";
+	name = "folder"
+	},
+/obj/item/pen,
+/obj/item/multitool{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/north{
+	dir = 4;
+	freerange = 1;
+	freqlock = 1;
+	frequency = 1347;
+	name = "IRMG shortwave intercom";
+	pixel_x = 31;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "jP" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -1571,13 +1606,13 @@
 /area/ship/hallway/central)
 "jW" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/computer/telecomms/server{
-	dir = 1;
-	network = "irmg_commnet"
-	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
+/obj/structure/closet/toolcloset/empty,
+/obj/item/rcl/pre_loaded,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "jX" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -1612,8 +1647,8 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light_switch{
-	pixel_x = 20;
 	dir = 8;
+	pixel_x = 20;
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/tech/grid,
@@ -1654,14 +1689,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "ks" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "kD" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -1671,7 +1706,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "kM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1732,16 +1767,13 @@
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/ship/engineering/engine)
 "ls" = (
-/obj/machinery/telecomms/server/presets/inteq{
-	autolinkers = list("inteq","hub");
-	freq_listening = list(1347);
-	network = "irmg_commnet"
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "lt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -1751,9 +1783,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "lA" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -1815,7 +1844,7 @@
 "lI" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "lM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1833,7 +1862,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "lO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1884,7 +1913,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "mi" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 4
@@ -1929,15 +1958,18 @@
 /area/ship/security)
 "ms" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/structure/sign/warning/coldtemp{
-	pixel_x = -32
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/communications)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10;
+	layer = 2.030
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "mw" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -1958,18 +1990,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "mz" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 9
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "mC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1999,7 +2024,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "mJ" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -2163,17 +2188,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "nE" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "nF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "nH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/turf_decal/industrial/warning/fulltile,
@@ -2182,7 +2207,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "nJ" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 4
@@ -2266,14 +2291,10 @@
 "od" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "og" = (
-/obj/structure/catwalk,
-/obj/structure/marker_beacon{
-	picked_color = "Burgundy"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering/communications)
 "oi" = (
 /obj/item/storage/firstaid/medical{
 	pixel_x = -5
@@ -2298,9 +2319,8 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "on" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2389,7 +2409,7 @@
 	},
 /obj/item/trash/popcorn,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "oG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2397,7 +2417,7 @@
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "oR" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -2413,7 +2433,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "oT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2456,7 +2476,7 @@
 "oY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "pb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/jukebox/boombox{
@@ -2464,7 +2484,7 @@
 	pixel_y = -11
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "pf" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2520,7 +2540,7 @@
 	valve_open = 1
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "pu" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -2561,7 +2581,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "pL" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -2626,11 +2646,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "talos_telecomms"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "qe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2672,8 +2690,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 19;
 	dir = 8;
+	pixel_x = 19;
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/patterned/grid,
@@ -2692,7 +2710,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "qr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2707,14 +2725,14 @@
 	name = "Access Door Control";
 	pixel_x = 21;
 	pixel_y = -6;
-	req_access_txt = "24"
+	req_access_txt = "56"
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 8;
 	id = "talos_tank_air";
 	pixel_x = 19;
 	pixel_y = 4;
-	req_access_txt = "24"
+	req_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -2783,8 +2801,8 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -2833,8 +2851,8 @@
 	dir = 9
 	},
 /obj/machinery/light_switch{
-	pixel_x = 20;
 	dir = 8;
+	pixel_x = 20;
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/tech,
@@ -2897,7 +2915,7 @@
 "rw" = (
 /obj/structure/chair/comfy/grey/directional/north,
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "rB" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /turf/open/floor/engine/hull/reinforced,
@@ -2921,7 +2939,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "rP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2971,30 +2989,14 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "sc" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/folder/syndicate{
-	desc = "A slick black folder stamped 'Property of Inteq Risk Management Group.'";
-	name = "folder"
-	},
-/obj/item/pen,
-/obj/item/multitool{
-	pixel_x = 12;
-	pixel_y = 8
-	},
-/obj/item/radio/intercom/directional/north{
-	freerange = 1;
-	freqlock = 1;
-	frequency = 1347;
-	name = "IRMG shortwave intercom"
-	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
+/obj/machinery/rnd/server,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "si" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "sl" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	dir = 4
@@ -3006,7 +3008,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "sn" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -3059,7 +3061,7 @@
 /area/template_noop)
 "sy" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "sA" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -3076,7 +3078,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "sD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -3084,7 +3086,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "sF" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -3242,11 +3244,11 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "ti" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "tp" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -3289,7 +3291,7 @@
 "ts" = (
 /obj/structure/sign/number/one,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "tu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -3301,8 +3303,14 @@
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "tA" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering)
@@ -3338,14 +3346,27 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
-"tO" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 1;
-	network = "irmg_commnet"
+/area/ship/maintenance/port)
+"tM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
+"tO" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "tT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3381,13 +3402,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "uc" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "ud" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -3419,10 +3440,10 @@
 	},
 /obj/item/gun/ballistic/shotgun/bulldog/inteq/no_mag{
 	pixel_x = -8;
-	pixel_y = 8;
+	pixel_y = 8
 	},
 /obj/item/gun/ballistic/shotgun/bulldog/inteq/no_mag{
-	pixel_x = -12;
+	pixel_x = -12
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -3441,7 +3462,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "up" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
@@ -3496,17 +3517,11 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "uE" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "talos_workshop"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/communications)
 "uI" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "uO" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -3519,7 +3534,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "vn" = (
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -3547,7 +3562,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "vp" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/communications)
 "vv" = (
 /obj/structure/cable/yellow{
@@ -3585,36 +3600,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "vM" = (
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	icon_state = "ce";
-	name = "artificer class II's locker";
-	req_access = null;
-	req_access_txt = "56"
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 5
 	},
-/obj/item/clothing/under/syndicate/inteq/artificer,
-/obj/item/clothing/under/syndicate/inteq/skirt/artificer,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/suit/toggle/industrial,
-/obj/item/clothing/head/hardhat/white,
-/obj/item/clothing/head/beret/sec/inteq,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/mask/gas/sechailer/balaclava/inteq,
-/obj/item/clothing/gloves/combat,
-/obj/item/megaphone/cargo{
-	name = "engineering megaphone"
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/obj/item/stamp/ce{
-	name = "artificer class II's rubber stamp"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding,
-/obj/item/pipe_dispenser,
-/obj/item/storage/belt/utility/chief{
-	name = "\improper Artificer Class II's toolbelt"
-	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "vP" = (
 /obj/item/cigbutt,
 /turf/open/floor/plasteel/dark,
@@ -3672,14 +3666,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "wb" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 4
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "wc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3724,10 +3718,16 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "wx" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "wy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3804,7 +3804,7 @@
 "wU" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "wY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
@@ -3880,12 +3880,12 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/cryo)
 "xl" = (
-/obj/machinery/telecomms/bus/preset_four{
-	autolinkers = list("hub","processor4","bus");
-	network = "irmg_commnet"
+/obj/machinery/mech_bay_recharge_port,
+/obj/machinery/status_display/shuttle{
+	pixel_y = -32
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "xn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3916,18 +3916,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "xz" = (
-/obj/machinery/telecomms/broadcaster/preset_right{
-	autolinkers = list("broadcasterB","hub");
-	network = "irmg_commnet"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/weldingtool/largetank,
+/obj/item/clothing/glasses/welding,
+/obj/item/multitool,
+/obj/item/radio/intercom/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "xB" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3954,14 +3953,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "xI" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen)
 "xK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3980,6 +3976,15 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
+"xP" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 5;
+	height = 15;
+	width = 15
+	},
+/turf/template_noop,
+/area/template_noop)
 "xT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4028,10 +4033,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/area/ship/storage)
 "yj" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -4069,7 +4084,7 @@
 /area/ship/hallway/central)
 "yp" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "yq" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -4091,14 +4106,12 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "yr" = (
-/obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/chief_engineer,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/obj/machinery/rnd/production/circuit_imprinter/department/engi,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "yx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -4140,7 +4153,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "yS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4166,7 +4179,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "zf" = (
 /obj/item/storage/backpack/messenger/inteq,
 /obj/item/storage/backpack/messenger/inteq,
@@ -4191,7 +4204,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "zh" = (
 /obj/machinery/holopad/emergency/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4221,8 +4234,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/communications)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/mecha_parts/mecha_equipment/rcd,
+/obj/item/mecha_parts/mecha_equipment/cable_layer,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "zu" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -4258,17 +4275,14 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "zB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "zE" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/cable{
@@ -4307,18 +4321,18 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "zR" = (
 /obj/machinery/firealarm/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "zT" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -4346,7 +4360,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Ag" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -4394,7 +4408,7 @@
 /area/ship/crew/toilet)
 "Ap" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Ar" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -4486,7 +4500,7 @@
 /obj/item/mop,
 /obj/item/pushbroom,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "AO" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/item/clothing/suit/space/hardsuit/engine,
@@ -4586,7 +4600,7 @@
 /obj/item/clothing/suit/space/inteq,
 /obj/item/clothing/head/helmet/space/inteq,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "BJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4614,26 +4628,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "BP" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "BS" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption{
-	dir = 4;
-	input_dir = 4;
-	output_dir = 0
 	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -19
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "BY" = (
@@ -4706,7 +4716,7 @@
 /obj/item/book/random,
 /obj/item/book/random,
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "CK" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4720,13 +4730,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "CP" = (
 /obj/effect/turf_decal/borderfloor,
-/obj/machinery/door/airlock/engineering{
-	name = "Storage Bay";
-	req_access_txt = "10"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4736,8 +4742,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Communications";
+	req_access_txt = "61"
+	},
 /turf/open/floor/plasteel/tech,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "CS" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -4813,7 +4823,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Ds" = (
@@ -4833,7 +4843,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "DC" = (
 /obj/effect/turf_decal/box/corners,
 /obj/structure/closet/crate{
@@ -4853,11 +4863,12 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "DO" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "DQ" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -4889,9 +4900,12 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "Eg" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/telecomms/bus/preset_four{
+	autolinkers = list("hub","processor4","bus");
+	network = "irmg_commnet"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "Ep" = (
 /obj/item/trash/can,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -4904,22 +4918,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/cigbutt,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Ex" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "EC" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "EL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4947,7 +4962,7 @@
 "Ff" = (
 /obj/structure/sign/number/nine,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Fh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable{
@@ -4955,7 +4970,7 @@
 	},
 /obj/item/cigbutt,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Fi" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -4965,23 +4980,17 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Fk" = (
-/obj/structure/catwalk,
-/obj/docking_port/mobile{
-	dir = 2;
-	launch_status = 0;
-	port_direction = 8;
-	preferred_direction = 4
-	},
 /obj/structure/marker_beacon{
 	picked_color = "Burgundy"
 	},
+/obj/structure/catwalk,
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Fm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5095,7 +5104,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "FV" = (
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/railing,
@@ -5139,7 +5148,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Gm" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/external,
@@ -5152,7 +5161,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Gr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
@@ -5190,7 +5199,7 @@
 /obj/item/clothing/suit/space/inteq,
 /obj/item/clothing/head/helmet/space/inteq,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Gv" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
@@ -5213,13 +5222,12 @@
 /area/ship/crew/canteen)
 "Gz" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","messaging","inteq","common","broadcasterB","receiverB");
-	id = "IRMG Communications Hub";
-	network = "irmg_commnet"
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/mecha/working/ripley/cargo{
+	name = "\improper APLU 'Big Boss'"
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/storage)
 "GA" = (
 /obj/machinery/porta_turret/ship/weak{
 	dir = 5
@@ -5253,7 +5261,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "GR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -5284,7 +5292,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "He" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -5310,22 +5318,24 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Hl" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/weldingtool/largetank,
-/obj/item/clothing/glasses/welding,
-/obj/item/multitool,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/computer/telecomms/server{
+	network = "irmg_commnet"
+	},
+/obj/item/radio/intercom/directional/north{
+	dir = 4;
+	pixel_x = 31;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Hp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5347,6 +5357,7 @@
 /area/ship/engineering)
 "HD" = (
 /obj/machinery/firealarm/directional/south,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "HI" = (
@@ -5379,7 +5390,7 @@
 "If" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Io" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -5455,7 +5466,7 @@
 /obj/item/circuitboard/machine/telecomms/message_server,
 /obj/item/circuitboard/machine/pacman,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "ID" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenic Storage"
@@ -5478,7 +5489,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "IJ" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -5534,7 +5545,7 @@
 "Jk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Jo" = (
 /obj/structure/cable{
 	icon_state = "2-5"
@@ -5556,16 +5567,16 @@
 	id = "talos_tank_fuel";
 	pixel_x = 19;
 	pixel_y = 4;
-	req_access_txt = "24"
+	req_access_txt = "56"
 	},
 /obj/machinery/button/door{
-	color = "red";
+	color = null;
 	dir = 8;
 	id = "talos_tank_fuel";
-	name = "Access Door Control (DANGER) (EXTREMELY DANGEROUS) (DO NOT PRESS)";
+	name = "Access Door Control";
 	pixel_x = 21;
 	pixel_y = -6;
-	req_access_txt = "24"
+	req_access_txt = "56"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5605,7 +5616,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "JP" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -5682,8 +5693,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Kf" = (
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/window/northleft{
+	req_access_txt = "61"
+	},
+/obj/machinery/door/window/southright{
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/communications)
 "Ks" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5727,7 +5749,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "KF" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5750,7 +5772,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "KR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5769,7 +5791,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "KY" = (
 /obj/effect/turf_decal/borderfloor,
 /obj/machinery/door/airlock/public/glass{
@@ -5847,7 +5869,7 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "LJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -5898,14 +5920,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "LU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5923,16 +5945,11 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "LV" = (
-/obj/machinery/telecomms/receiver/preset_right{
-	autolinkers = list("receiverB","hub");
-	freq_listening = list(1347,1359);
-	network = "irmg_commnet"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/ship/engineering/communications)
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage)
 "Ma" = (
 /obj/effect/turf_decal/industrial/fire{
 	dir = 4
@@ -5943,6 +5960,9 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"Me" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/template_noop)
 "Mf" = (
 /obj/structure/chair{
 	dir = 4
@@ -5994,7 +6014,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Mx" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -6012,35 +6032,28 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "My" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/communications)
 "MC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/effect/landmark/start/chief_engineer,
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "MK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -6052,7 +6065,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "MS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6075,7 +6088,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/ore_box,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate{
+	name = "sandbags crate"
+	},
+/obj/item/storage/box/emptysandbags{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/storage/box/emptysandbags,
+/obj/item/storage/box/emptysandbags{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "MX" = (
@@ -6101,17 +6126,17 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Ni" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Nj" = (
 /obj/effect/turf_decal/box/corners,
 /obj/machinery/button/shieldwallgen{
@@ -6129,6 +6154,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Nk" = (
@@ -6161,7 +6187,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "NK" = (
 /turf/open/floor/engine/air,
 /area/ship/engineering/engine)
@@ -6208,19 +6234,53 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Oc" = (
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Oi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering/communications)
-"Ok" = (
-/obj/machinery/rnd/server,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10;
+	layer = 2.030
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/storage)
+"Ok" = (
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon_state = "ce";
+	name = "artificer class II's locker";
+	req_access = null;
+	req_access_txt = "56"
+	},
+/obj/item/clothing/under/syndicate/inteq/artificer,
+/obj/item/clothing/under/syndicate/inteq/skirt/artificer,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/suit/toggle/industrial,
+/obj/item/clothing/head/hardhat/white,
+/obj/item/clothing/head/beret/sec/inteq,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/mask/gas/sechailer/balaclava/inteq,
+/obj/item/clothing/gloves/combat,
+/obj/item/megaphone/cargo{
+	name = "engineering megaphone"
+	},
+/obj/item/stamp/ce{
+	name = "artificer class II's rubber stamp"
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding,
+/obj/item/pipe_dispenser,
+/obj/item/storage/belt/utility/chief{
+	name = "\improper Artificer Class II's toolbelt"
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/communications)
 "Oq" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -6278,10 +6338,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Pf" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Pi" = (
+/obj/structure/catwalk,
+/obj/structure/marker_beacon{
+	picked_color = "Burgundy"
+	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Pk" = (
@@ -6304,7 +6371,7 @@
 /area/ship/engineering/engine)
 "Pp" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Pr" = (
 /obj/machinery/air_sensor/atmos/incinerator_tank,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -6323,7 +6390,7 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Pw" = (
 /obj/machinery/porta_turret/ship/weak{
 	dir = 10
@@ -6354,7 +6421,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "PJ" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -6483,7 +6550,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "QC" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -6512,11 +6579,8 @@
 "QS" = (
 /obj/structure/sign/number/eight,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "QU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1;
@@ -6536,7 +6600,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "QW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -6544,7 +6608,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "QZ" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 8;
@@ -6560,14 +6624,11 @@
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/ship/engineering/engine)
 "Rc" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "Rg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6586,14 +6647,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Rp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Rs" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/structure/cable{
@@ -6606,7 +6667,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Ry" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6659,16 +6720,22 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm)
+"RO" = (
+/obj/machinery/porta_turret/ship/weak{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/template_noop)
 "RT" = (
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "RV" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/plasma,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "RW" = (
 /obj/machinery/turretid/lethal{
 	pixel_y = 32
@@ -6687,7 +6754,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Si" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
@@ -6742,9 +6809,12 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Su" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/obj/machinery/telecomms/processor/preset_four{
+	autolinkers = list("processor4","bus");
+	network = "irmg_commnet"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "SB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6789,7 +6859,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "SI" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6812,14 +6882,15 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "SK" = (
-/obj/structure/closet/toolcloset/empty,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/rcl/pre_loaded,
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "SL" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -6867,14 +6938,15 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "Tg" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "Tj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6915,7 +6987,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "TH" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/effect/decal/cleanable/dirt,
@@ -6923,7 +6995,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "TK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6957,12 +7029,12 @@
 "TN" = (
 /obj/structure/falsewall/plastitanium,
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "TO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "TS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6994,7 +7066,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Uc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7094,15 +7166,15 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Uy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "UD" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "UG" = (
 /obj/machinery/button/door{
 	dir = 4;
@@ -7133,6 +7205,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"UO" = (
+/obj/machinery/light/directional/south,
+/turf/template_noop,
+/area/template_noop)
 "UP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7156,7 +7232,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Ve" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -7177,15 +7253,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Vg" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plasteel/dark,
-/area/ship/storage)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/engineering/communications)
 "Vj" = (
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/contraband/red_rum{
@@ -7213,7 +7286,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Vr" = (
 /obj/item/trash/boritos,
 /turf/open/floor/plasteel/grimy,
@@ -7224,7 +7297,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Vz" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
@@ -7305,7 +7378,7 @@
 "Wd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "We" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7334,7 +7407,7 @@
 "Wg" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Wh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7351,7 +7424,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Wp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7368,7 +7441,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Wz" = (
 /obj/machinery/computer/helm{
 	dir = 8
@@ -7537,7 +7610,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Yt" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -7599,7 +7672,15 @@
 "YI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
+"YK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark,
+/area/ship/storage)
 "YU" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/structure/cable{
@@ -7610,33 +7691,34 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "YX" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "YZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Zb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/port)
+/area/ship/maintenance/port)
 "Zc" = (
-/obj/mecha/working/ripley/cargo{
-	name = "\improper APLU 'Big Boss'"
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/storage)
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","messaging","inteq","common","broadcasterB","receiverB");
+	id = "IRMG Communications Hub";
+	network = "irmg_commnet"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "Zd" = (
 /obj/machinery/door/airlock{
 	dir = 4;
@@ -7663,7 +7745,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/airless,
-/area/ship/cargo/starboard)
+/area/ship/maintenance/starboard)
 "Zj" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
 /obj/effect/turf_decal/siding/thinplating,
@@ -7680,7 +7762,7 @@
 	name = "vanguard's spare bedsheet"
 	},
 /turf/open/floor/plating,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 "Zn" = (
 /obj/structure/closet/emcloset/empty{
 	anchored = 1;
@@ -7701,7 +7783,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "Zo" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
@@ -7727,15 +7809,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Zu" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -32
 	},
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/area/ship/engineering/communications)
 "ZB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -7777,31 +7857,33 @@
 /area/ship/engineering/engine)
 "ZU" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
+/obj/machinery/telecomms/server/presets/inteq{
+	autolinkers = list("inteq","hub");
+	freq_listening = list(1347);
+	network = "irmg_commnet"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/ship/engineering/communications)
 "ZV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/port)
+/area/ship/storage/port)
 "ZY" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
-/area/ship/maintenance/starboard)
+/area/ship/storage/starboard)
 
 (1,1,1) = {"
 sw
 sw
 sw
-sw
+Pi
 sw
 sw
 tA
@@ -7827,15 +7909,15 @@ ie
 sw
 sw
 sw
-og
+sw
 sw
 sw
 "}
 (2,1,1) = {"
 sw
+Fk
 sw
-sw
-sw
+MV
 sw
 hL
 OF
@@ -7861,15 +7943,15 @@ pU
 Ar
 sw
 sw
-MV
+sw
 sw
 sw
 "}
 (3,1,1) = {"
 sw
+MV
 sw
-sw
-sw
+MV
 sw
 ia
 bM
@@ -7895,15 +7977,15 @@ WH
 Pm
 sw
 sw
-MV
+sw
 sw
 sw
 "}
 (4,1,1) = {"
 sw
+MV
 sw
-sw
-sw
+MV
 sw
 vE
 OF
@@ -7929,19 +8011,19 @@ pU
 pU
 sw
 sw
-MV
+sw
 sw
 sw
 "}
 (5,1,1) = {"
 sw
 Bd
-sV
-sV
-sV
-sV
-sV
-sV
+vp
+vp
+vp
+vp
+vp
+vp
 AO
 cj
 qD
@@ -7959,23 +8041,23 @@ lA
 cF
 xK
 QU
-ao
-ao
-ao
-ao
-ao
+sV
+sV
+sV
+sV
+sV
 Pw
 sw
 "}
 (6,1,1) = {"
-cV
-sV
+og
+vp
 ZU
 eC
 Zu
 SK
 Ok
-sV
+vp
 HB
 MS
 yL
@@ -7998,18 +8080,18 @@ yc
 ms
 xz
 ls
-ao
-vp
+sV
+cV
 "}
 (7,1,1) = {"
-sV
+vp
 Eg
 mz
 EC
 My
 LT
 zz
-sV
+vp
 Sj
 Qq
 ek
@@ -8027,16 +8109,16 @@ bA
 pU
 lq
 mJ
-ao
+sV
 tu
 ap
 ag
 Oi
 xl
-ao
+sV
 "}
 (8,1,1) = {"
-sV
+vp
 Zc
 Vg
 Kf
@@ -8065,19 +8147,19 @@ nE
 qc
 wx
 cT
-Oi
+YK
 Gz
 ao
 "}
 (9,1,1) = {"
-sV
+vp
 Su
 Rc
 Tg
-Tg
+aD
 MC
 zR
-sV
+vp
 jY
 gk
 iE
@@ -8099,19 +8181,19 @@ nE
 zt
 vM
 wb
-Oi
+tM
 an
-ao
+sV
 "}
 (10,1,1) = {"
-cV
-sV
+og
+vp
 au
 fo
 Hl
 jJ
-sV
-sV
+vp
+vp
 sW
 sW
 sW
@@ -8129,19 +8211,19 @@ xI
 pU
 NK
 NK
-ao
+sV
 yr
 tO
 LV
 bF
-ao
-vp
+sV
+cV
 "}
 (11,1,1) = {"
 sw
 GA
-sV
-sV
+vp
+vp
 sW
 sW
 sW
@@ -8163,19 +8245,19 @@ xI
 pU
 NK
 NK
-ao
+sV
 sc
 jW
-ao
-ao
+sV
+sV
 Xa
-MV
+sw
 "}
 (12,1,1) = {"
 sw
+MV
 sw
-sw
-cV
+og
 sW
 zf
 GG
@@ -8197,17 +8279,17 @@ xI
 pU
 pU
 pU
-ao
-ao
-ao
-vp
-MV
+sV
+sV
+sV
+cV
 sw
-MV
+sw
+sw
 "}
 (13,1,1) = {"
 sw
-sw
+MV
 sw
 sw
 sW
@@ -8235,13 +8317,13 @@ An
 la
 sw
 sw
-MV
 sw
-MV
+sw
+sw
 "}
 (14,1,1) = {"
 sw
-sw
+MV
 sw
 JT
 sW
@@ -8269,13 +8351,13 @@ qo
 la
 sw
 sw
-MV
 sw
-MV
+sw
+sw
 "}
 (15,1,1) = {"
 sw
-sw
+MV
 sw
 mU
 hg
@@ -8303,13 +8385,13 @@ hT
 hT
 hT
 sw
-MV
 sw
-MV
+sw
+sw
 "}
 (16,1,1) = {"
 sw
-sw
+Pi
 sw
 mU
 Ml
@@ -8337,9 +8419,9 @@ wD
 ot
 hT
 sw
-MV
 sw
-MV
+sw
+sw
 "}
 (17,1,1) = {"
 sw
@@ -8370,10 +8452,10 @@ hT
 Zo
 Fe
 zw
+xP
 sw
-MV
 sw
-Fk
+sw
 "}
 (18,1,1) = {"
 sw
@@ -8405,7 +8487,7 @@ zo
 NC
 hT
 sw
-og
+sw
 sw
 sw
 "}
@@ -8516,7 +8598,7 @@ sw
 sw
 sw
 sw
-sw
+Me
 lC
 Ks
 IT
@@ -8584,7 +8666,7 @@ sw
 sw
 sw
 sw
-sw
+UO
 lC
 ae
 bU
@@ -8652,7 +8734,7 @@ sw
 sw
 sw
 sw
-sw
+Me
 lC
 qF
 Zj
@@ -8685,8 +8767,8 @@ sw
 sw
 sw
 sw
-sw
-sw
+Me
+RO
 lC
 UP
 gp
@@ -9622,7 +9704,7 @@ sw
 sw
 sw
 sw
-sw
+jd
 sw
 sw
 sw

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -3883,7 +3883,7 @@
 "xk" = (
 /obj/docking_port/stationary{
 	dir = 2;
-	dwidth = 5;
+	dwidth = 4;
 	height = 15;
 	width = 15
 	},
@@ -4446,7 +4446,7 @@
 "AB" = (
 /obj/docking_port/stationary{
 	dir = 4;
-	dwidth = 4;
+	dwidth = 3;
 	height = 15;
 	width = 6
 	},

--- a/code/game/area/ship_areas.dm
+++ b/code/game/area/ship_areas.dm
@@ -444,6 +444,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "storage"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
+/area/ship/storage/port
+	name = "Port Storage Bay"
+
+/area/ship/storage/starboard
+	name = "Starboard Storage Bay"
+
 /area/ship/storage/eva
 	name = "EVA Storage"
 	icon_state = "eva"

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -71,8 +71,8 @@
 ///Chief Engineer
 
 /datum/outfit/job/inteq/ce
-	name = "IRMG - Artificer Class II"
-	id_assignment = "Artificer Class II"
+	name = "IRMG - Honorable Artificer"
+	id_assignment = "Honorable Artificer"
 	job_icon = "chiefengineer"
 	jobtype = /datum/job/chief_engineer
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![talos2](https://github.com/shiptest-ss13/Shiptest/assets/60533805/f7fb731c-c2e6-4360-8c32-1375c2fe99f6)

Makes some adjustments to address common issues with the Talos.

- Areas have been changed so cargo no longer drops in the wings
- Artificer Class II is now Honorable Artificer
- Gas storage tank access buttons are restricted to Honorable Artificer
- Comms and workshop have switched places
- Crate shelves have been added to cargobay
- Additional shuttle docks have been added on the starboard side
- Added an autolathe to cargo
- Removed Corpsmen

## Why It's Good For The Game

Talos is a decent ship but had a few recurring problems. This fixes them.

## Changelog

:cl:
fix: Cargo pods no longer land in Talos maint
fix: Gas tanks on the Talos have higher security
fix: Talos now has an autolathe in cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
