### PR TITLE
adds telegraphing to brimdemon attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -150,7 +150,6 @@
 	balloon_alert(src, "brimbeam fired")
 	cut_overlay("brimdemon_telegraph_dir")
 	for(var/obj/effect/brimbeam/beam in beamparts)
-		beam.alpha = 255
 		var/turf/affected_turf = get_turf(beam)
 		START_PROCESSING(SSfastprocess, beam)
 		for(var/mob/living/hit_mob in affected_turf.contents)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -14,7 +14,7 @@
 	emote_hear = list("cackles","screeches")
 	stat_attack = CONSCIOUS
 	ranged_cooldown_time = 5 SECONDS
-	vision_range = 9
+	vision_range = 6
 	retreat_distance = 2
 	speed = 3
 	move_to_delay = 5

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -98,7 +98,7 @@
 	visible_message(span_danger("[src] starts charging!"))
 	balloon_alert(src, "charging...")
 	to_chat(src, "<span class='warning'>You begin to charge up...</span>")
-	addtimer(CALLBACK(src, PROC_REF(fire_laser)), 1 SECONDS)
+	fire_laser()
 	COOLDOWN_START(src, ranged_cooldown, ranged_cooldown_time)
 
 /mob/living/simple_animal/hostile/asteroid/brimdemon/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
@@ -115,10 +115,6 @@
 /mob/living/simple_animal/hostile/asteroid/brimdemon/proc/fire_laser()
 	if(stat == DEAD)
 		return
-	visible_message(span_danger("[src] fires a brimbeam!"))
-	balloon_alert(src, "brimbeam fired")
-	playsound(src, 'sound/creatures/brimdemon.ogg', 150, FALSE, 0, 3)
-	cut_overlay("brimdemon_telegraph_dir")
 	var/turf/target_turf = get_ranged_target_turf(src, dir, BRIMBEAM_RANGE)
 	var/turf/origin_turf = get_turf(src)
 	var/list/affected_turfs = get_line(origin_turf, target_turf) - origin_turf
@@ -135,15 +131,31 @@
 		var/atom/new_brimbeam = new /obj/effect/brimbeam(affected_turf)
 		new_brimbeam.dir = dir
 		beamparts += new_brimbeam
-		for(var/mob/living/hit_mob in affected_turf.contents)
-			hit_mob.adjustFireLoss(35)
-			to_chat(hit_mob, span_userdanger("You're hit by [src]'s brimbeam!"))
+		animate(new_brimbeam, 1 SECONDS, alpha = 255)
 	if(length(beamparts))
 		var/atom/last_brimbeam = beamparts[length(beamparts)]
 		last_brimbeam.icon_state = "brimbeam_end"
 		var/atom/first_brimbeam = beamparts[1]
 		first_brimbeam.icon_state = "brimbeam_start"
-	addtimer(CALLBACK(src, PROC_REF(end_laser)), 2 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(kill_people)), 1 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(end_laser)), 3 SECONDS)
+
+/// Tells the lasers to start murdering people
+/mob/living/simple_animal/hostile/asteroid/brimdemon/proc/kill_people()
+	if(stat == DEAD)
+		end_laser()
+		return
+	playsound(src, 'sound/creatures/brimdemon.ogg', 150, FALSE, 0, 3)
+	visible_message(span_danger("[src] fires a brimbeam!"))
+	balloon_alert(src, "brimbeam fired")
+	cut_overlay("brimdemon_telegraph_dir")
+	for(var/obj/effect/brimbeam/beam in beamparts)
+		beam.alpha = 255
+		var/turf/affected_turf = get_turf(beam)
+		START_PROCESSING(SSfastprocess, beam)
+		for(var/mob/living/hit_mob in affected_turf.contents)
+			hit_mob.adjustFireLoss(35)
+			to_chat(hit_mob, span_userdanger("You're hit by [src]'s brimbeam!"))
 
 /// Deletes all the brimbeam parts and sets variables back to their initial ones.
 /mob/living/simple_animal/hostile/asteroid/brimdemon/proc/end_laser()
@@ -163,14 +175,11 @@
 	icon_state = "brimbeam_mid"
 	layer = ABOVE_MOB_LAYER
 	plane = -2
+	alpha = 150
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	light_color = LIGHT_COLOR_BLOOD_MAGIC
 	light_power = 3
 	light_range = 2
-
-/obj/effect/brimbeam/Initialize()
-	. = ..()
-	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/brimbeam/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Brimdemon beams now fade in before activating

Reduces brimdemon base vision range from 9 to 6 so you won't piss them off before even being able to see them

https://github.com/shiptest-ss13/Shiptest/assets/24857008/994e9111-7504-43e2-bfea-ad05e86e6399


## Why It's Good For The Game

Silence, tester. Offscreen brimdemon blast. -35.

## Changelog

:cl:
balance: brimdemon beams now have a fade-in effect before dealing damage, making it harder to get instantly chunked for a quarter of your health
balance: brimdemons can no longer aggro on you before you can see them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
