### PR TITLE
Valor Remap, Minor Inteq Code Tweaks

### DIFF
--- a/_maps/configs/inteq_colossus.json
+++ b/_maps/configs/inteq_colossus.json
@@ -18,7 +18,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Vanguard": {
-			"outfit": "/datum/outfit/job/inteq/captain",
+			"outfit": "/datum/outfit/job/inteq/captain/empty",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/configs/inteq_hound.json
+++ b/_maps/configs/inteq_hound.json
@@ -17,7 +17,7 @@
 	"limit": 2,
 	"job_slots": {
 		"Vanguard": {
-			"outfit": "/datum/outfit/job/inteq/captain",
+			"outfit": "/datum/outfit/job/inteq/captain/empty",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -18,7 +18,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Vanguard": {
-			"outfit": "/datum/outfit/job/inteq/captain",
+			"outfit": "/datum/outfit/job/inteq/captain/empty",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/configs/inteq_valor.json
+++ b/_maps/configs/inteq_valor.json
@@ -36,10 +36,6 @@
 			"outfit": "/datum/outfit/job/inteq/paramedic/empty",
 			"slots": 2
 		},
-		"Artificer": {
-			"outfit": "/datum/outfit/job/inteq/engineer/empty",
-			"slots": 1
-		},
 		"Enforcer": {
 			"outfit": "/datum/outfit/job/inteq/security/empty",
 			"slots": 2

--- a/_maps/configs/inteq_valor.json
+++ b/_maps/configs/inteq_valor.json
@@ -23,9 +23,22 @@
 			"officer": true,
 			"slots": 1
 		},
+		"Shuttle Pilot": {
+			"outfit": "/datum/outfit/job/inteq/warden/pilot",
+			"officer": true,
+			"slots": 1
+		},
+		"Shuttle Corpsman": {
+			"outfit": "/datum/outfit/job/inteq/paramedic/empty",
+			"slots": 1
+		},
 		"Corpsman": {
 			"outfit": "/datum/outfit/job/inteq/paramedic/empty",
-			"slots": 3
+			"slots": 2
+		},
+		"Artificer": {
+			"outfit": "/datum/outfit/job/inteq/engineer/empty",
+			"slots": 1
 		},
 		"Enforcer": {
 			"outfit": "/datum/outfit/job/inteq/security/empty",

--- a/_maps/configs/inteq_vaquero.json
+++ b/_maps/configs/inteq_vaquero.json
@@ -15,7 +15,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Vanguard": {
-			"outfit": "/datum/outfit/job/inteq/captain",
+			"outfit": "/datum/outfit/job/inteq/captain/empty",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -551,19 +551,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/under/syndicate/inteq/artificer,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/under/syndicate/inteq/skirt/artificer,
-/obj/item/clothing/under/syndicate/inteq/artificer,
-/obj/item/storage/belt/utility,
-/obj/item/storage/backpack/industrial,
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	req_one_access = list(10)
-	},
+/obj/structure/closet/firecloset/wall/directional/south,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "eZ" = (
@@ -655,7 +643,7 @@
 	icon_state = "prisoner";
 	name = "shuttle pilot locker";
 	req_access = list(3);
-	icon_door = prisoner
+	icon_door = "prisoner"
 	},
 /obj/item/clothing/head/beret/sec/inteq,
 /obj/item/clothing/head/soft/inteq,

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -2859,7 +2859,6 @@
 /obj/item/reagent_containers/blood/universal,
 /obj/item/reagent_containers/blood/universal,
 /obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/medical)
 "Av" = (

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -506,6 +506,8 @@
 	pixel_x = -16;
 	pixel_y = 5
 	},
+/obj/item/clothing/mask/gas/sechailer/balaclava/inteq,
+/obj/item/clothing/mask/gas/sechailer/balaclava/inteq,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "ey" = (

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -81,27 +81,8 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "aW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Medbay"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/hallway/port)
 "bh" = (
 /obj/structure/railing{
 	dir = 6
@@ -115,34 +96,15 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "bv" = (
-/obj/effect/turf_decal/box/white/corners,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/closet/secure_closet{
-	icon_state = "med_secure";
-	name = "corpsman's locker";
-	req_access = list(5)
-	},
-/obj/item/clothing/under/syndicate/inteq/corpsman,
-/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
-/obj/item/clothing/suit/armor/inteq/corpsman,
-/obj/item/clothing/head/soft/inteq/corpsman,
-/obj/item/storage/backpack/messenger/med,
-/obj/item/storage/backpack/medic,
-/obj/item/pinpointer/crew,
-/obj/item/storage/belt/medical/webbing,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/patterned/ridged,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "bx" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/obj/structure/closet/firecloset/wall/directional/north,
-/turf/open/floor/plasteel/patterned,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "bB" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -262,14 +224,10 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/port)
 "cE" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/plasteel/patterned,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "cI" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -279,8 +237,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/light_switch{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 8
+	},
 /area/ship/cargo)
 "cW" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -389,6 +351,7 @@
 /obj/effect/turf_decal/trimline/opaque/brown/line{
 	dir = 1
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "dG" = (
@@ -457,6 +420,10 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "ec" = (
@@ -508,7 +475,6 @@
 /area/ship/bridge)
 "el" = (
 /obj/docking_port/mobile{
-	can_move_docking_ports = 1;
 	dir = 2;
 	name = "valor docking port";
 	port_direction = 8;
@@ -532,10 +498,14 @@
 /obj/item/storage/box/zipties,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/megaphone/sec,
-/obj/item/clothing/suit/armor/vest/alt,
-/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
 /obj/item/kitchen/knife/combat/survival,
 /obj/item/kitchen/knife/combat/survival,
+/obj/machinery/recharger{
+	pixel_x = -16;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "ey" = (
@@ -558,20 +528,39 @@
 "eU" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = -2;
-	pixel_y = 7
+	pixel_x = -7;
+	pixel_y = 10
 	},
 /obj/item/reagent_containers/medigel/sterilizine{
-	pixel_x = 8;
+	pixel_x = -1;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/borderfloorwhite,
+/obj/machinery/button/door{
+	id = "valor_surgery";
+	name = "Privacy Shutters";
+	pixel_y = 8;
+	dir = 1;
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "eV" = (
-/obj/structure/closet/firecloset/wall/directional/south,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/under/syndicate/inteq/artificer,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/under/syndicate/inteq/skirt/artificer,
+/obj/item/clothing/under/syndicate/inteq/artificer,
+/obj/item/storage/belt/utility,
+/obj/item/storage/backpack/industrial,
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	req_one_access = list(10)
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -600,14 +589,19 @@
 /obj/effect/spawner/lootdrop/ration,
 /obj/effect/spawner/lootdrop/ration,
 /obj/item/storage/ration/crayons,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "fj" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/medical2,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/vending/medical/syndicate_access{
+	name = "\improper InteqMed Plus"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "fE" = (
@@ -630,7 +624,8 @@
 /area/ship/cargo)
 "fK" = (
 /obj/machinery/computer/crew{
-	dir = 8
+	dir = 8;
+	icon_state = "computer-middle"
 	},
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -642,32 +637,42 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "fN" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/inteq,
-/obj/item/clothing/head/helmet/space/inteq,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/hallway/port)
 "fO" = (
 /obj/structure/closet/secure_closet{
-	icon_state = "med_secure";
-	name = "corpsman's locker";
-	req_access = list(5)
+	icon_state = "prisoner";
+	name = "shuttle pilot locker";
+	req_access = list(3);
+	icon_door = prisoner
 	},
-/obj/item/clothing/under/syndicate/inteq/corpsman,
-/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
-/obj/item/clothing/suit/armor/inteq/corpsman,
-/obj/item/clothing/head/soft/inteq/corpsman,
-/obj/effect/turf_decal/siding/thinplating,
-/obj/item/storage/backpack/messenger/med,
-/obj/item/storage/backpack/medic,
-/obj/item/pinpointer/crew,
-/obj/item/storage/belt/medical/webbing,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/patterned/ridged,
+/obj/item/clothing/head/beret/sec/inteq,
+/obj/item/clothing/head/soft/inteq,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/radio/headset/inteq,
+/obj/item/clothing/gloves/fingerless,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/clothing/glasses/hud/security/sunglasses/inteq,
+/obj/item/clothing/head/helmet/swat/inteq,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "gb" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/chair/sofa/brown/left{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
@@ -678,14 +683,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
@@ -740,14 +745,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "gq" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/patterned/ridged,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "gt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -767,11 +765,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "gZ" = (
@@ -796,6 +795,9 @@
 "hl" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/sofa/brown/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "hm" = (
@@ -870,7 +872,7 @@
 	dir = 8;
 	pixel_x = 12
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
 "id" = (
 /obj/structure/cable{
@@ -897,6 +899,7 @@
 	},
 /obj/structure/chair/sofa/brown/left/directional/west,
 /obj/structure/closet/firecloset/wall/directional/south,
+/obj/machinery/computer/helm/viewscreen/directional/east,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "ix" = (
@@ -912,13 +915,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
-"iI" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/traffic/corner,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "iN" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
@@ -971,7 +967,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "jk" = (
 /obj/structure/cable{
@@ -1017,15 +1017,9 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "jG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/stand_clear{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/obj/machinery/rnd/server,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/medical)
 "jL" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -1036,12 +1030,13 @@
 /turf/open/floor/plating,
 /area/ship/medical)
 "jN" = (
-/obj/structure/chair/office/light,
+/obj/structure/chair/office,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/half,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "jQ" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1068,14 +1063,18 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "jT" = (
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 32
+/obj/structure/rack,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_x = -1;
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/obj/item/roller{
+	pixel_x = 1;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/medical)
 "jU" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
@@ -1130,20 +1129,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"ky" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/ship/hallway/port)
 "kG" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "kH" = (
@@ -1186,19 +1176,20 @@
 "kL" = (
 /obj/machinery/light/directional/south,
 /obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "kW" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
 	},
-/obj/structure/closet/crate/bin,
-/obj/item/trash/chips,
-/obj/item/trash/energybar,
-/obj/item/trash/cheesie,
-/obj/item/trash/pistachios,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/obj/machinery/door/airlock/grunge{
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
 "lc" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
@@ -1278,10 +1269,6 @@
 /area/ship/crew/canteen)
 "lN" = (
 /obj/structure/table,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1;
-	pixel_y = 8
-	},
 /obj/machinery/door/window/southleft,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1290,6 +1277,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner/transparent/inteqbrown/full,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/office)
 "lW" = (
@@ -1361,8 +1349,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "mt" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/patterned/ridged,
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/full,
+/obj/item/tank/internals/plasmaman/full,
+/obj/item/tank/internals/plasmaman/full,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "mw" = (
 /obj/effect/turf_decal/trimline/opaque/brown/warning{
@@ -1412,30 +1403,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "mG" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "med_secure";
-	name = "corpsman's locker";
-	req_access = list(5)
-	},
-/obj/item/clothing/under/syndicate/inteq/corpsman,
-/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
-/obj/item/clothing/suit/armor/inteq/corpsman,
-/obj/item/clothing/head/soft/inteq/corpsman,
-/obj/effect/turf_decal/box/white/corners{
+/obj/effect/turf_decal/corner/transparent/inteqbrown/border{
 	dir = 1
 	},
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
+/obj/structure/table,
+/obj/item/book/manual/wiki/piloting{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 10
+/obj/item/flashlight/lamp{
+	pixel_x = -8;
+	pixel_y = 11
 	},
-/obj/item/storage/backpack/messenger/med,
-/obj/item/storage/backpack/medic,
-/obj/item/pinpointer/crew,
-/obj/item/storage/belt/medical/webbing,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/patterned/ridged,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "mH" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -1537,7 +1517,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/medical/glass{
-	name = "Surgical Bay #2"
+	name = "Surgical Bay"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
@@ -1601,13 +1581,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "oz" = (
-/obj/structure/railing{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/borderfloor/corner{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
@@ -1615,8 +1588,8 @@
 /area/ship/cargo)
 "oC" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/inteq,
-/obj/item/clothing/head/helmet/space/inteq,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
@@ -1754,10 +1727,8 @@
 /area/ship/crew/cryo)
 "pC" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
 "pL" = (
 /obj/machinery/power/terminal{
@@ -1801,21 +1772,43 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "qe" = (
-/obj/effect/turf_decal/industrial/traffic,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
-"qk" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/techfloor{
+/obj/structure/closet/secure_closet{
+	icon_state = "med_secure";
+	name = "corpsman's locker";
+	req_access = list(5)
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/pinpointer/crew,
+/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/messenger/med,
+/obj/item/clothing/head/soft/inteq/corpsman,
+/obj/item/clothing/suit/armor/inteq/corpsman,
+/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
+/obj/item/clothing/under/syndicate/inteq/corpsman,
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/medical)
+"qk" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/patterned,
+/area/ship/medical)
 "qt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1859,6 +1852,9 @@
 "qR" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "valor_surgery"
+	},
 /turf/open/floor/plating,
 /area/ship/medical)
 "qW" = (
@@ -1913,11 +1909,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -1971,7 +1966,6 @@
 "sc" = (
 /obj/structure/rack,
 /obj/machinery/firealarm/directional/east,
-/obj/item/radio/intercom/directional/south,
 /obj/item/defibrillator/loaded{
 	pixel_x = 3;
 	pixel_y = 10
@@ -1979,6 +1973,10 @@
 /obj/item/defibrillator/loaded{
 	pixel_x = -2;
 	pixel_y = 2
+	},
+/obj/machinery/smartfridge/bloodbank/preloaded{
+	density = 0;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
@@ -2004,27 +2002,24 @@
 /obj/effect/turf_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgical Bay #1"
+/obj/machinery/door/airlock/medical{
+	name = "Morgue"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "ss" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/patterned,
+/obj/structure/rack,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "su" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/opaque/brown/line{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "sy" = (
@@ -2059,7 +2054,6 @@
 /obj/item/ammo_box/magazine/co9mm,
 /obj/item/ammo_box/magazine/co9mm,
 /obj/item/ammo_box/magazine/co9mm,
-/obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "sz" = (
@@ -2118,10 +2112,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "te" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 2.9
-	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
@@ -2136,6 +2126,9 @@
 	},
 /obj/item/target/syndicate{
 	pixel_y = 5
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
@@ -2163,20 +2156,8 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "tj" = (
-/obj/structure/catwalk/over/plated_catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/industrial/traffic,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "tk" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -2218,25 +2199,17 @@
 "tS" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "tZ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/office)
 "ua" = (
-/obj/effect/turf_decal/siding/thinplating/corner,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "un" = (
@@ -2261,16 +2234,16 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "ux" = (
-/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/brown/warning{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/cargo)
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
 "uA" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 4
@@ -2293,18 +2266,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/noticeboard{
 	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
@@ -2329,12 +2299,10 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "vh" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/inteq,
-/obj/item/clothing/head/helmet/space/inteq,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/hallway/port)
 "vi" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 8
@@ -2481,7 +2449,8 @@
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/half,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "wS" = (
 /obj/machinery/power/terminal{
@@ -2506,18 +2475,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "xg" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
 "xj" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/cargo)
@@ -2529,6 +2492,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -20
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
@@ -2554,24 +2520,16 @@
 "xr" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/folder/white{
-	pixel_x = -15;
-	pixel_y = -1
-	},
 /obj/item/pen,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/toy/figure/paramedic{
-	name = "Corpsman action figure";
-	pixel_x = -13;
-	pixel_y = 14
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner/transparent/inteqbrown/full,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/office)
 "xs" = (
@@ -2672,19 +2630,15 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "yK" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/ship/medical)
+/obj/effect/turf_decal/industrial/traffic/corner,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "yN" = (
 /obj/structure/chair/office/dark,
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -2717,7 +2671,8 @@
 /area/ship/maintenance/port)
 "zi" = (
 /obj/machinery/computer/helm{
-	dir = 8
+	dir = 8;
+	icon_state = "computer-middle"
 	},
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -2741,15 +2696,17 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/fax/inteq{
-	pixel_y = 3
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "zs" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "zA" = (
@@ -2767,23 +2724,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "zC" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/smartfridge/bloodbank/preloaded{
-	density = 0;
-	pixel_y = 32
-	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/medical)
-"zD" = (
-/obj/machinery/computer/operating{
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/borderfloorwhite,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
+"zD" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
 "zE" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2823,34 +2775,20 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "zI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Cargo Bay"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/patterned,
 /area/ship/medical)
 "zK" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 15;
+	height = 15;
+	name = "valor airlock dock";
+	width = 15
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public/glass{
-	name = "Supply Storage"
-	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/turf/template_noop,
+/area/template_noop)
 "zL" = (
 /obj/structure/chair{
 	dir = 1
@@ -2868,22 +2806,10 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "zS" = (
-/obj/structure/table,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/obj/item/storage/box/masks{
-	pixel_x = -7;
-	pixel_y = 10
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/structure/sign/poster/official/walk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "zT" = (
 /obj/structure/railing,
@@ -2932,24 +2858,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "Au" = (
-/obj/structure/rack,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_x = 1;
-	pixel_y = 16
-	},
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/area/ship/medical)
 "Av" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
@@ -2958,17 +2880,25 @@
 /area/ship/maintenance/starboard)
 "AE" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/medigel/sterilizine{
-	pixel_x = 8;
-	pixel_y = 3
-	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/borderfloorwhite,
-/turf/open/floor/plasteel/white,
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_y = -4;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
 "AG" = (
 /obj/structure/bed,
@@ -3069,7 +2999,10 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "BL" = (
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -3090,14 +3023,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "BV" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "valor_external"
+/obj/effect/turf_decal/techfloor{
+	dir = 8
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Cb" = (
 /obj/effect/turf_decal/industrial/traffic{
@@ -3134,14 +3064,28 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "CC" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet{
+	icon_state = "med_secure";
+	name = "corpsman's locker";
+	req_access = list(5)
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ship/hallway/port)
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/pinpointer/crew,
+/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/messenger/med,
+/obj/item/clothing/head/soft/inteq/corpsman,
+/obj/item/clothing/suit/armor/inteq/corpsman,
+/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
+/obj/item/clothing/under/syndicate/inteq/corpsman,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/medical)
 "CF" = (
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
@@ -3309,22 +3253,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "DR" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cargo Bay"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/door/airlock/hatch{
+	name = "Port Hallway"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "DT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -3393,17 +3330,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "EE" = (
-/obj/effect/turf_decal/trimline/opaque/brown/line{
-	dir = 5
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/obj/structure/chair,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20
+/obj/effect/turf_decal/trimline/opaque/brown/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -3467,6 +3402,10 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Ff" = (
@@ -3490,18 +3429,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
-"Ft" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "FF" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -3545,9 +3472,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "FY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs,
-/area/ship/cargo)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/medical)
 "FZ" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -3571,7 +3497,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/half,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "Go" = (
 /obj/effect/turf_decal/corner/opaque/brown{
@@ -3625,8 +3552,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
@@ -3640,18 +3570,14 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Hw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "EVA Storage"
+/obj/machinery/door/airlock/hatch{
+	name = "Port Hallway"
 	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 10
-	},
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "HA" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3759,10 +3685,8 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "Io" = (
-/obj/machinery/rnd/server,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/turf/open/floor/plasteel/patterned,
+/area/ship/medical)
 "IA" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black{
 	dir = 1
@@ -3791,15 +3715,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "IL" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
+/obj/effect/turf_decal/techfloor{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
 "IM" = (
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 4
@@ -3851,6 +3772,15 @@
 "Jn" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 8;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "Jt" = (
@@ -3875,19 +3805,11 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JS" = (
-/obj/structure/railing{
-	dir = 9;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/borderfloor{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "JT" = (
 /obj/docking_port/stationary{
@@ -3937,6 +3859,10 @@
 /area/ship/crew/canteen)
 "Kn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ko" = (
@@ -3961,6 +3887,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -4000,16 +3930,7 @@
 /area/ship/crew/canteen)
 "KU" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -4096,12 +4017,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ls" = (
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/stand_clear{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "LH" = (
 /obj/machinery/light/floor,
 /obj/structure/cable{
@@ -4121,20 +4044,38 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/borderfloorwhite,
+/obj/machinery/button/door{
+	id = "valor_surgery";
+	name = "Privacy Shutters";
+	pixel_y = -23;
+	dir = 1;
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "LL" = (
-/obj/structure/rack,
-/obj/item/pickaxe/emergency,
-/obj/item/pickaxe/emergency,
-/obj/item/pickaxe/emergency,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20
+/obj/structure/closet/secure_closet{
+	icon_state = "med_secure";
+	name = "corpsman's locker";
+	req_access = list(5)
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/pinpointer/crew,
+/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/messenger/med,
+/obj/item/clothing/head/soft/inteq/corpsman,
+/obj/item/clothing/suit/armor/inteq/corpsman,
+/obj/item/clothing/under/syndicate/inteq/skirt/corpsman,
+/obj/item/clothing/under/syndicate/inteq/corpsman,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
 	},
 /turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/area/ship/medical)
 "LR" = (
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 8
@@ -4189,9 +4130,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "ME" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Office"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
@@ -4200,6 +4138,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/grunge{
+	req_access = list(3)
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/office)
@@ -4213,13 +4154,16 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "MR" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/inteq,
-/obj/item/clothing/head/helmet/space/inteq,
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_y = 32
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned/ridged,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Nh" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -4369,11 +4313,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Oj" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/inteq,
+/obj/item/clothing/head/helmet/space/inteq,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
-/obj/structure/closet/emcloset/wall/directional/north,
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Ok" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4412,40 +4358,40 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "OK" = (
-/obj/machinery/iv_drip/saline,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/medical)
 "OM" = (
 /turf/open/floor/pod,
 /area/ship/cargo)
 "OR" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
-"OT" = (
-/obj/structure/catwalk/over/plated_catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/cargo)
-"OV" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/ship/medical)
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/hallway/port)
+"OT" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
+"OV" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/hallway/port)
 "Pb" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -4505,7 +4451,8 @@
 	dir = 1;
 	pixel_y = -20
 	},
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/half,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "PL" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -4539,19 +4486,6 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
-"Qd" = (
-/obj/structure/catwalk/over/plated_catwalk,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/cargo)
 "Qk" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4583,7 +4517,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/half,
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "Qw" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -4604,6 +4539,12 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
+	},
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8;
+	pixel_y = 7;
+	pixel_x = 3
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
@@ -4648,20 +4589,11 @@
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/sign/warning/incident{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Re" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
 "Rh" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/security)
@@ -4721,6 +4653,9 @@
 "Sd" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "Sf" = (
@@ -4736,12 +4671,15 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "Sh" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
 "Sl" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -4870,17 +4808,9 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/opaque/brown/warning{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "Uj" = (
@@ -4939,7 +4869,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
 "UO" = (
@@ -4955,6 +4884,8 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ve" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "Vp" = (
@@ -4985,8 +4916,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/tech,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hallway/central)
 "VB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5121,6 +5051,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "WQ" = (
@@ -5148,11 +5079,9 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/machinery/vending/medical/syndicate_access{
-	name = "\improper InteqMed Plus"
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/mono/dark,
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "Xi" = (
 /obj/structure/chair{
@@ -5177,8 +5106,8 @@
 /area/ship/crew/dorm)
 "Xu" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/inteq,
-/obj/item/clothing/head/helmet/space/inteq,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
@@ -5200,9 +5129,23 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "Xx" = (
-/obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/corner/transparent/inteqbrown/border{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency/shuttle{
+	pixel_y = 9;
+	pixel_x = -1
+	},
+/obj/item/gps{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/gps{
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel,
 /area/ship/crew/office)
 "XD" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -5254,12 +5197,6 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/crew/canteen)
-"XU" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "Yd" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -5297,11 +5234,9 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
 "Yt" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/medical)
 "Yu" = (
 /obj/effect/turf_decal/techfloor,
 /obj/structure/closet/firecloset,
@@ -5314,9 +5249,11 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/medical)
 "Yx" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/medical)
 "YF" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -5329,14 +5266,14 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "YL" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "valor_external"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/dark,
+/area/ship/medical)
 "YM" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 1
@@ -5403,12 +5340,8 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "Zf" = (
-/obj/structure/railing{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
+/obj/structure/sign/warning/incident{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -5556,7 +5489,7 @@ Td
 Nh
 xj
 qG
-iI
+yK
 Cb
 Cb
 Cb
@@ -5589,7 +5522,7 @@ Td
 xj
 og
 FI
-qe
+tj
 OM
 OM
 OM
@@ -5622,7 +5555,7 @@ Td
 xj
 rL
 uS
-qe
+tj
 OM
 OM
 OM
@@ -5655,7 +5588,7 @@ Td
 xj
 sZ
 uS
-qe
+tj
 OM
 OM
 OM
@@ -5669,7 +5602,7 @@ Td
 bB
 LI
 ns
-qR
+LI
 pC
 zD
 LI
@@ -5688,13 +5621,13 @@ Td
 xj
 GF
 uS
-qe
+tj
 OM
 OM
 OM
 OM
 Kz
-rL
+cE
 xj
 Td
 Td
@@ -5702,9 +5635,9 @@ Td
 WC
 WO
 gp
-qR
-Yi
-bI
+LI
+FY
+OK
 LI
 "}
 (9,1,1) = {"
@@ -5721,7 +5654,7 @@ Td
 xj
 Ch
 FI
-qe
+tj
 OM
 OM
 OM
@@ -5754,7 +5687,7 @@ DU
 HC
 Zf
 oz
-qe
+tj
 OM
 OM
 OM
@@ -5780,25 +5713,25 @@ Rh
 Zu
 uB
 ua
-Wp
-CC
-ky
-CC
+OV
+aW
+aW
+aW
 DR
-Qd
-FY
+ZF
+ZF
 kH
 Mn
 Ea
-jG
+Ls
 Mn
 de
 KU
 zI
-yK
-OV
-yK
-aW
+Re
+Re
+xg
+Re
 Ui
 gU
 nK
@@ -5813,11 +5746,11 @@ jN
 lN
 gh
 zs
-HC
-HC
-HC
-HC
-HC
+fN
+OR
+OR
+OR
+Wp
 OT
 JS
 jj
@@ -5826,13 +5759,13 @@ Kp
 Kn
 dQ
 Fa
-Ft
-LI
-LI
-LI
-LI
-LI
+MR
+qk
 su
+su
+YL
+su
+ux
 rO
 qR
 Yi
@@ -5847,11 +5780,11 @@ xr
 Hg
 tS
 HC
-MR
 vh
-fN
-xj
-tj
+vh
+vh
+HC
+cI
 te
 fe
 Ok
@@ -5859,11 +5792,11 @@ Xf
 as
 HL
 ec
-xg
-xj
-Au
-Re
-OK
+Md
+LI
+LI
+LI
+LI
 LI
 EE
 oy
@@ -5880,11 +5813,11 @@ tZ
 An
 Sd
 HC
-Oj
-XU
-XU
+ss
+bx
+mt
 xj
-cI
+nX
 Jd
 qA
 UQ
@@ -5892,11 +5825,11 @@ hm
 Cc
 JJ
 zT
-Md
-xj
-XU
-XU
-cE
+nX
+LI
+jG
+Io
+Au
 LI
 LI
 dN
@@ -5913,11 +5846,11 @@ tZ
 Qc
 AP
 HC
-bx
-ss
-Sh
+gq
+gq
+gq
 Hw
-ux
+nX
 ct
 TB
 AM
@@ -5926,10 +5859,10 @@ dO
 yy
 bh
 nX
-zK
+LI
 Yt
-Yt
-IL
+Io
+jT
 LI
 zS
 pt
@@ -5946,10 +5879,10 @@ ME
 iN
 xl
 HC
-OR
 gq
-LL
-Nh
+gq
+gq
+xj
 Rc
 bF
 Hi
@@ -5959,11 +5892,11 @@ tH
 Ff
 jQ
 qX
-xj
+LI
 Yx
 Io
-mt
-LI
+Io
+kW
 zC
 Ye
 mw
@@ -5979,9 +5912,9 @@ tZ
 VD
 Um
 DT
-DT
-DT
-DT
+Oj
+Oj
+Oj
 DT
 DT
 DT
@@ -5990,13 +5923,13 @@ NE
 DT
 nz
 DT
-Tw
-Tw
 DT
 DT
-DT
-DT
-DT
+LI
+CC
+qe
+LL
+LI
 Xg
 Uj
 dl
@@ -6013,8 +5946,8 @@ ty
 dp
 DT
 Vy
-qk
-Ls
+Vy
+Vy
 DT
 fE
 sJ
@@ -6026,8 +5959,8 @@ zG
 Qw
 jU
 DT
-kW
-qk
+Vy
+Vy
 Vy
 DT
 fj
@@ -6046,7 +5979,7 @@ ma
 CH
 jk
 lc
-lc
+Sh
 lc
 ht
 jw
@@ -6060,7 +5993,7 @@ GR
 hj
 id
 lc
-lc
+Sh
 lc
 bR
 XD
@@ -6078,8 +6011,8 @@ mI
 gn
 qZ
 DT
-kG
-kG
+IL
+BV
 kG
 Tw
 Lb
@@ -6092,9 +6025,9 @@ zO
 lE
 WX
 DT
-jT
 kG
-kG
+BV
+IL
 DT
 zA
 mx
@@ -6111,9 +6044,9 @@ uA
 Pk
 Ei
 DT
-YL
-YL
-BV
+DT
+DT
+DT
 DT
 mZ
 Yd
@@ -6125,9 +6058,9 @@ Ik
 Od
 ie
 DT
-YL
-YL
-YL
+DT
+DT
+DT
 DT
 LI
 zE
@@ -6526,7 +6459,7 @@ Td
 Td
 Td
 Td
-Td
+zK
 Td
 Td
 Td

--- a/_maps/shuttles/subshuttles/inteq_haste.dmm
+++ b/_maps/shuttles/subshuttles/inteq_haste.dmm
@@ -54,15 +54,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = 10
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/black{
 	dir = 8
+	},
+/obj/structure/chair/handrail{
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
@@ -220,6 +219,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-10"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = 10
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)

--- a/code/modules/antagonists/ert/inteq.dm
+++ b/code/modules/antagonists/ert/inteq.dm
@@ -20,5 +20,5 @@
 
 /datum/antagonist/ert/inteq/leader
 	name = "Inteq Mercenary Leader"
-	outfit = /datum/outfit/job/inteq/captain
+	outfit = /datum/outfit/job/inteq/captain/empty
 	role = "Vanguard"

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -29,31 +29,40 @@
 ///captains
 
 /datum/outfit/job/inteq/captain
-	name = "IRMG - Vanguard (Naked)"
+	name = "IRMG - Vanguard"
 	id_assignment = "Vanguard"
 	jobtype = /datum/job/captain
 	job_icon = "captain"
 
-	ears = /obj/item/radio/headset/inteq/alt/captain
-	shoes = /obj/item/clothing/shoes/combat
-	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs
-	jobtype = /datum/job/captain
 	id = /obj/item/card/id/gold
-
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1)
-
-/datum/outfit/job/inteq/captain/geared
-	name = "IRMG - Vanguard"
-
 	head = /obj/item/clothing/head/beret/sec/hos/inteq
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	mask = /obj/item/clothing/mask/gas/sechailer/balaclava/inteq
-	belt = /obj/item/storage/belt/security/webbing/inteq
 	suit = /obj/item/clothing/suit/armor/hos/inteq
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/security/inteq
+	belt = /obj/item/storage/belt/security/webbing/inteq
 	gloves = /obj/item/clothing/gloves/combat
-	accessory = null
+	ears = /obj/item/radio/headset/inteq/alt/captain
+	shoes = /obj/item/clothing/shoes/combat
+
+	r_pocket = /obj/item/assembly/flash/handheld
+	l_pocket = /obj/item/restraints/handcuffs
+
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1)
+
+/datum/outfit/job/inteq/captain/empty
+	name = "IRMG - Vanguard (Naked)"
+
+	head = null
+	glasses = null
+	mask = null
+	belt = null
+	suit = null
+	dcoat = null
+	gloves = null
+
+	r_pocket = null
+	l_pocket = null
 
 /datum/outfit/job/inteq/captain/honorable
 	name = "IRMG - Honorable Vanguard"
@@ -140,6 +149,14 @@
 	satchel = /obj/item/storage/backpack/messenger/inteq
 	courierbag = /obj/item/storage/backpack/messenger/inteq
 
+/datum/outfit/job/inteq/security/empty
+	name = "IRMG - Enforcer (Naked)"
+	head = null
+	suit = null
+	belt = null
+	mask = null
+	gloves = null
+
 /datum/outfit/job/inteq/security/beluga
 	name = "IRMG - Enforcer (Beluga)"
 
@@ -155,14 +172,6 @@
 	backpack = /obj/item/storage/backpack/messenger/inteq
 	satchel = /obj/item/storage/backpack/messenger/inteq
 	courierbag = /obj/item/storage/backpack/messenger/inteq
-
-/datum/outfit/job/inteq/security/empty
-	name = "IRMG - Enforcer (Naked)"
-	head = null
-	suit = null
-	belt = null
-	mask = null
-	gloves = null
 
 ///engineers
 
@@ -200,6 +209,17 @@
 
 	courierbag = /obj/item/storage/backpack/messenger/inteq
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
+
+/datum/outfit/job/inteq/warden/pilot
+	name = "IRMG - Shuttle Pilot"
+	job_icon = "securityofficer"
+	id_assignment = "Shuttle Pilot"
+
+	head = /obj/item/clothing/head/soft/inteq
+	suit = /obj/item/clothing/suit/armor/vest/alt
+	belt = null
+	mask = /obj/item/clothing/mask/breath
+	gloves = /obj/item/clothing/gloves/fingerless
 
 // cmo
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![imagen](https://github.com/shiptest-ss13/Shiptest/assets/75212565/67b0dbfa-3b5a-45fa-b6ee-2dab27b8c755)
![imagen](https://github.com/shiptest-ss13/Shiptest/assets/75212565/8a62c180-cc96-449c-95cb-194685a789fa)

* Remaps certain parts of the Valor. The Haste has not been touched apart from a single handrail.
* The Valor now has a Shuttle Pilot, and a Shuttle Corpsman. The Shuttle Pilot gets an office and an outfit.
* The Vanguard basetype was changed to be consistent with the other outfits (e.g. empty subtype instead of being empty by default)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* there was complaints that the valor sucked
* born to map dmm is a fuck 地图 strongdmm 2019 i am maptainer 410,757,864,350 mapping sins

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Remapped the Valor, with two extra jobs (Shuttle Corpsman, Shuttle Pilot).
code: The Vanguard base outfit starts with gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
