### PR TITLE
Reduces the number of skulls spawned by crystal legion by 1

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -355,7 +355,6 @@
 	icon_living = "disfigured_legion"
 	icon_aggro = "disfigured_legion"
 	icon_dead = "disfigured_legion"
-	difficulty = 2
 	brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/crystal
 	loot = list(/obj/item/organ/regenerative_core/legion/crystal)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Here, catch.
![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/bd6ab17a-383e-4555-93de-ad55253e94e5)


## Why It's Good For The Game

Reduces the capacity for crystal legion to instakill people by shitting out 2 skulls which immediately fly over to people and shit out shrapnel when killed. It's like a mine but it chases you. If you can't get to a safe distance the pattern almost guarantees getting hit twice.

## Changelog

:cl:
balance: crystal legion spawn 1 less skull per spawn wave, now 1 (like normal legion)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
