### PR TITLE
Gives SRM Cabinets Cabinet Sounds

### DIFF
--- a/code/game/MapData/shuttles/srm_elder.dm
+++ b/code/game/MapData/shuttles/srm_elder.dm
@@ -20,17 +20,23 @@
 	name = "shadow's locker"
 	desc = "The closet of equipment and attire for the aspiring shadow."
 	icon_state = "cabinet"
+	open_sound = 'sound/machines/wooden_closet_open.ogg'
+	close_sound = 'sound/machines/wooden_closet_close.ogg'
 
 /obj/structure/closet/secure_closet/flamebearer
 	name = "flamebearer's locker"
 	desc = "The closet of equipment an ascetic Flamebearer would require."
 	icon_state = "cabinet"
+	open_sound = 'sound/machines/wooden_closet_open.ogg'
+	close_sound = 'sound/machines/wooden_closet_close.ogg'
 
 /obj/structure/closet/secure_closet/hunter
 	name = "hunter's locker"
 	desc = "Everything a hunter will need, held in one secure closet."
 	icon_state = "cabinet"
 	req_access = list(ACCESS_SECURITY)
+	open_sound = 'sound/machines/wooden_closet_open.ogg'
+	close_sound = 'sound/machines/wooden_closet_close.ogg'
 
 /obj/structure/closet/secure_closet/machinist
 	name = "machinist's Locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hunter's, Flamebearer's and Shadow's lockers now get the wooden cabinet sounds, instead of metal closet ones.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sounds are sitting there, might as well use them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: SRM cabinets - namely, Hunter's, Shadow's and Flamebearer's - now use cabinet sounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
