### PR TITLE
fixes the black market sawn illestren to actually be sawed off

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -118,7 +118,8 @@
 	item_state = "illestren_sawn"
 	sawn_off = TRUE
 	weapon_weight = WEAPON_MEDIUM
-
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/ballistic/rifle/solgov
 	name = "SSG-669C"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -386,6 +386,7 @@ EMPTY_GUN_HELPER(shotgun/bulldog/inteq)
 	sawn_off = TRUE
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT
 
 	wield_slowdown = 0.25
 	wield_delay = 0.3 SECONDS //OP? maybe


### PR DESCRIPTION
## About The Pull Request

before, buying the sawn illestren off the black market just gave you a sawn illestren except it was the same size and didn't fit on belts. no longer the case. also fixed the presawn double barrel shotgun to be the same because it behaved the same

## Why It's Good For The Game

i bought a shitty sawed off bolt action rifle i expect to get a shitty sawed off bolt action rifle

## Changelog

:cl:
fix: The black market sawed off Illestren is now actually sawed off, and can fit on your belt
fix: The presawn double barrel shotgun can now fit on the belt like normal sawn off double barrels
/:cl: