### PR TITLE
tailthump emote tied to tail instead of species

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -106,7 +106,7 @@
 /datum/emote/living/carbon/human/tailthump/get_sound(mob/living/user)
 	if(!ishuman(user))
 		return
-	if(islizard(user) || (isvox(user)))
+	if(!isnull(user.getorgan(/obj/item/organ/tail)) || (isvox(user)))
 		return 'sound/voice/lizard/tailthump.ogg' //https://freesound.org/people/TylerAM/sounds/389665/
 
 /datum/emote/living/carbon/human/weh //lizard


### PR DESCRIPTION
## About The Pull Request

you can now tailthump if you have a tail organ instead of being specifically tied to srothy (vox can still tail thump even though they have no tail organ)

## Why It's Good For The Game

this was made for elzu in mind but you could do it if you have like a fox tail or something. the thumpers

## Changelog

:cl:
add: You can now tail thump if you have a tail instead of it being tied to species
/:cl: