### PR TITLE
Strips limb armour from Gezena + normal gun storage

### DIFF
--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -36,7 +36,7 @@
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
 	togglename = "zipper"
-	body_parts_covered = CHEST|ARMS
+	body_parts_covered = CHEST
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
@@ -53,20 +53,11 @@
 	icon_state = "coat"
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
-	body_parts_covered = CHEST|ARMS|GROIN|LEGS
+	body_parts_covered = CHEST|GROIN
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 20, "energy" = 40, "bomb" = 20, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 50)
-	allowed = list(
-					/obj/item/flashlight,
-					/obj/item/tank/internals/emergency_oxygen,
-					/obj/item/tank/internals/plasmaman,
-					/obj/item/toy,
-					/obj/item/storage/fancy/cigarettes,
-					/obj/item/lighter,
-					/obj/item/radio,
-					/obj/item/gun/energy/kalix,
-					)
+	allowed = null
 
 /obj/item/clothing/suit/armor/gezena/engi
 	name = "engineer navywear coat"

--- a/code/modules/clothing/factions/srm.dm
+++ b/code/modules/clothing/factions/srm.dm
@@ -135,7 +135,7 @@
 
 /obj/item/clothing/head/cowboy/sec/roumain/montagne
 	name = "montagne's hat"
-	desc = "A very fancy hat with a large feather plume to signal that you are, in fact, a Hunter Montagne. The exotic fur lining is impeccably soft and bafflingly bulletproof."
+	desc = "A very fancy hat with a large feather plume to signal that you are, in fact, a Hunter Montagne. The exotic fur lining is impeccably soft."
 	icon_state = "rouma_montagne_hat"
 
 ///////////////


### PR DESCRIPTION
## About The Pull Request

Gezenan raksha vests and navywear used to have full limb protection for their (already pretty solid) armour vests / jackets. Also allows them to hold a greater variety of objects like regular armour vests (+1 montagne hat description change to reflect the fact it is no longer armoured)

## Why It's Good For The Game

an armoured vest with no visible limb protection should not give limb protection + they already behaved strangely compared to normal armoured vests

## Changelog

:cl:
del: Removed invisible limb armour from Gezenan marine + navywear
add: Allowed Gezenan armour to hold all guns like normal armour
fix: Fixed Montagne hat description to reflect the fact it is no longer armoured
/:cl: