### PR TITLE
Remove superfluous logic in revolver/rack()

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -282,7 +282,7 @@
 		to_chat(user, "<span class='notice'>You rack the [bolt_wording] of \the [src].</span>")
 		playsound(src, rack_sound, rack_sound_volume, rack_sound_vary)
 
-	if((!safety && !semi_auto) || (!safety && !semi_auto))
+	if(!safety && !semi_auto)
 		chamber_round(TRUE)
 	SEND_SIGNAL(src, COMSIG_UPDATE_AMMO_HUD)
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request
I was reviewing `revolver.dm` and noticed a bit of duplicated logic.

While "twice to be sure" is usually a good idea for using a gun, it's probably not necessary here.

## Why It's Good For The Game
Clean code is good code?

## Changelog
:cl:
fix: Cleaned up some logic in revolver safety
/:cl:
