### PR TITLE
Removes shoddy 'active' state for holopads that was causing negative power draw.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -451,11 +451,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/SetLightsAndPower()
 	var/total_users = LAZYLEN(masters) + LAZYLEN(holo_calls)
-	if(total_users > 0)
-		set_active_power()
-	else
-		set_idle_power()
-	active_power_usage = initial(active_power_usage) * total_users
+	//active_power_usage = initial(active_power_usage) * total_users
 	if(total_users || replay_mode)
 		set_light(2)
 	else

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -375,22 +375,3 @@
 		tray.pestlevel = rand(8, 10)
 		tray.weedlevel = rand(8, 10)
 		tray.toxic = rand(45, 55)
-
-/obj/effect/proc_holder/spell/targeted/revenant/recall
-	charge_max = 100
-	name = "Return"
-	desc = "Return to your cursed object."
-	action_icon = 'icons/mob/actions/actions_revenant.dmi'
-	action_icon_state = "r_nightvision"
-	action_background_icon_state = "bg_revenant"
-
-/obj/effect/proc_holder/spell/targeted/revenant/recall/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
-	var/object = user.marked_object
-	if(!object)
-		for(var/obj/item/thing in loc.contents)
-			user.marked_object = thing
-			to_chat(src, "<span class='revenminor'>You bind your soul to the [thing], You may return to it at will.</span>")
-			return
-	else
-		src.forceMove(object)
-

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -375,3 +375,22 @@
 		tray.pestlevel = rand(8, 10)
 		tray.weedlevel = rand(8, 10)
 		tray.toxic = rand(45, 55)
+
+/obj/effect/proc_holder/spell/targeted/revenant/recall
+	charge_max = 100
+	name = "Return"
+	desc = "Return to your cursed object."
+	action_icon = 'icons/mob/actions/actions_revenant.dmi'
+	action_icon_state = "r_nightvision"
+	action_background_icon_state = "bg_revenant"
+
+/obj/effect/proc_holder/spell/targeted/revenant/recall/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
+	var/object = user.marked_object
+	if(!object)
+		for(var/obj/item/thing in loc.contents)
+			user.marked_object = thing
+			to_chat(src, "<span class='revenminor'>You bind your soul to the [thing], You may return to it at will.</span>")
+			return
+	else
+		src.forceMove(object)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I implemented the active state for this wrong, and it's better if it doesn't have one for now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs bad functional power good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: infinite negative power draw while calling your grandmother no longer happens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
