### PR TITLE
typo fixes & black market fix

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -160,7 +160,7 @@
 /datum/blackmarket_item/clothing/ramzi_suit
 	name = "Rusted Red Hardsuit"
 	desc = "A vintage ICW Era Gorlex Maruader hardsuit. The previous owner said we could have it when we pried it off their cold dead hands. Dry cleaning not included."
-	item = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
+	item = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 	price_min = 1500
 	price_max = 2500

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -563,7 +563,7 @@ EMPTY_GUN_HELPER(revolver/detective)
 
 /obj/item/gun/ballistic/revolver/montagne
 	name = "\improper HP Montagne"
-	desc = "An ornate break-open revolver issued to high-ranking members of the Saint-Roumain Militia. Chambered in .45."
+	desc = "An ornate break-open revolver issued to high-ranking members of the Saint-Roumain Militia. Chambered in .44."
 	icon = 'icons/obj/guns/48x32guns.dmi'
 	icon_state = "montagne"
 	manufacturer = MANUFACTURER_HUNTERSPRIDE
@@ -694,7 +694,7 @@ EMPTY_GUN_HELPER(revolver/detective)
 
 /obj/item/gun/ballistic/revolver/shadow
 	name = "\improper HP Shadow"
-	desc = "A mid-size revolver. Despite the antiquated design, it is cheap, reliable, and stylish, making it a favorite among fast-drawing spacers and the officers of various militaries, as well as small-time police units. Chambered in .45."
+	desc = "A mid-size revolver. Despite the antiquated design, it is cheap, reliable, and stylish, making it a favorite among fast-drawing spacers and the officers of various militaries, as well as small-time police units. Chambered in .44."
 	fire_sound = 'sound/weapons/gun/revolver/cattleman.ogg'
 	icon = 'icons/obj/guns/48x32guns.dmi'
 	icon_state = "shadow"


### PR DESCRIPTION
## About The Pull Request

Changes Shadow and Montagne descriptions to reflect they're now chambered in .44. Also fixes the rusted red item from the black market to be a hardsuit instead of a helmet that disappear in your hand.

## Why It's Good For The Game

my captain accidentally bought two boxes of .45 hollow point instead of .44 because thats what the gun description said. and the rusted red i bought intending to get shot to death crumpled to ash in my hands

## Changelog

:cl:
fix: Fixed typos in the Shadow and Montagne revolvers
fix: Black market rusted reds no longer flash into dust when you purchase them
/:cl: