### PR TITLE
Mine Defusal Outpost Missions

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -312,6 +312,18 @@
 	new /obj/item/clothing/mask/infiltrator(src)
 	new /obj/item/clothing/shoes/combat/sneakboots(src)
 
+/obj/item/storage/toolbox/bounty
+	name = "defused explosives case"
+	desc = "Store defused landmines in here."
+	icon_state = "infiltrator_case"
+	item_state = "infiltrator_case"
+
+/obj/item/storage/toolbox/bounty/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 8
+	STR.max_items = 4
+
 //floorbot assembly
 /obj/item/storage/toolbox/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)
 	var/list/allowed_toolbox = list(/obj/item/storage/toolbox/emergency,	//which toolboxes can be made into floorbots

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -223,7 +223,7 @@ Acquire: Anomaly
 	duration = 80 MINUTES
 	dur_mod_range = 0.4
 	container_type = /obj/item/storage/toolbox/bounty
-	objective_type = /obj/item/mine/pressure/explosive/rusty
+	objective_type = /obj/item/mine/pressure/explosive
 	num_wanted = 4
 
 /*

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -217,11 +217,11 @@ Acquire: Anomaly
 
 /datum/mission/acquire/landmine/rusted
 	name = "Defuse rusted landmines"
-	desc = "We've been issued a bounty to make the Frontier a safer place by disarming landmines. Mind your fingers."
-	weight = 3000
-	value = 3000
+	desc = "We've been issued a bounty to make the Frontier a safer place by disarming dated landmines. Mind your fingers."
+	weight = 6
+	value = 2000
 	duration = 80 MINUTES
-	dur_mod_range = 0.3
+	dur_mod_range = 0.4
 	container_type = /obj/item/storage/toolbox/bounty
 	objective_type = /obj/item/mine/pressure/explosive/rusty
 	num_wanted = 4

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -212,6 +212,21 @@ Acquire: Anomaly
 	objective_type = /mob/living/simple_animal/bot/firebot/rockplanet
 
 /*
+		Acquire: Landmines
+*/
+
+/datum/mission/acquire/landmine/rusted
+	name = "Defuse rusted landmines"
+	desc = "We've been issued a bounty to make the Frontier a safer place by disarming landmines. Mind your fingers."
+	weight = 3000
+	value = 3000
+	duration = 80 MINUTES
+	dur_mod_range = 0.3
+	container_type = /obj/item/storage/toolbox/bounty
+	objective_type = /obj/item/mine/pressure/explosive/rusty
+	num_wanted = 4
+
+/*
 		Acquire: Fishing
 */
 


### PR DESCRIPTION
## About The Pull Request

There's now an outpost mission to deliver defused landmines for money. Descriptions subject to change

## Why It's Good For The Game

I imagine several organizations would definitely offer bounties to collect leftover landmines. Cute little flavour and some more variety in outpost missions (with some danger).

## Changelog

:cl:
add: The outpost is now offering bounties to defuse landmines to Frontier vessels.
/:cl: