### PR TITLE
Fixes medical cyborgs being unable to interact with carbons

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/attackby(obj/item/W, mob/user, params)
 	var/obj/item/bodypart/BP = get_bodypart(check_zone(user.zone_selected))
 	var/has_painkillers = reagents.has_reagent(/datum/reagent/medicine/morphine, needs_metabolizing = TRUE)
-	if(W.tool_behaviour == TOOL_WELDER && IS_ROBOTIC_LIMB(BP)) //prioritize healing if we're synthetic
+	if(W.tool_behaviour == TOOL_WELDER && IS_ROBOTIC_LIMB(BP) && BP.brute_dam) //prioritize healing if we're synthetic
 		return ..()
 	if(user.a_intent != INTENT_HELP || !W.get_temperature() || !BP.can_bandage()) //this will also catch low damage synthetic welding
 		return ..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/attackby(obj/item/W, mob/user, params)
 	var/obj/item/bodypart/BP = get_bodypart(check_zone(user.zone_selected))
 	var/has_painkillers = reagents.has_reagent(/datum/reagent/medicine/morphine, needs_metabolizing = TRUE)
-	if(W.tool_behaviour == TOOL_WELDER && IS_ROBOTIC_LIMB(BP) && BP.brute_dam > 5) //prioritize healing if we're synthetic
+	if(W.tool_behaviour == TOOL_WELDER && IS_ROBOTIC_LIMB(BP)) //prioritize healing if we're synthetic
 		return ..()
 	if(user.a_intent != INTENT_HELP || !W.get_temperature() || !BP.can_bandage()) //this will also catch low damage synthetic welding
 		return ..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/attackby(obj/item/W, mob/user, params)
 	var/obj/item/bodypart/BP = get_bodypart(check_zone(user.zone_selected))
-	var/has_painkillers = user.reagents.has_reagent(/datum/reagent/medicine/morphine, needs_metabolizing = TRUE)
+	var/has_painkillers = reagents.has_reagent(/datum/reagent/medicine/morphine, needs_metabolizing = TRUE)
 	if(W.tool_behaviour == TOOL_WELDER && IS_ROBOTIC_LIMB(BP) && BP.brute_dam > 5) //prioritize healing if we're synthetic
 		return ..()
 	if(user.a_intent != INTENT_HELP || !W.get_temperature() || !BP.can_bandage()) //this will also catch low damage synthetic welding


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Painkiller checks for cauterization now check the target rather than the person applying treatmenrr. This has no player-facing effects outside fixing a runtime preventing cyborgs from interacting with people

Robotic limbs will now always have healing prioritized over cauterization if brute damage is present, since healing damage slows bleeding

## Why It's Good For The Game

Uops :3

## Changelog

:cl:
fix: cyborgs can touch people again
code: robotic limbs will always have healing prioritized over being cauterized if treated with a welder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
