### PR TITLE
Guncrate fixes

### DIFF
--- a/code/game/objects/items/storage/guncases.dm
+++ b/code/game/objects/items/storage/guncases.dm
@@ -44,7 +44,7 @@
 
 /obj/item/storage/guncase/beacon
 /obj/item/storage/guncase/beacon/PopulateContents()
-	new /obj/item/gun/ballistic/shotgun/doublebarrel/beacon(src)
+	new /obj/item/gun/ballistic/shotgun/doublebarrel/beacon/no_mag(src)
 
 /obj/item/storage/guncase/scout
 /obj/item/storage/guncase/scout/PopulateContents()
@@ -79,7 +79,7 @@
 
 /obj/item/storage/guncase/wt550
 /obj/item/storage/guncase/wt550/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/smg/wt550(src)
+	new /obj/item/gun/ballistic/automatic/smg/wt550/no_mag(src)
 	new /obj/item/ammo_box/magazine/wt550m9/empty(src)
 	new /obj/item/ammo_box/magazine/wt550m9/empty(src)
 

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -120,14 +120,14 @@
 	name = "Hellfire Shotgun Crate"
 	desc = "For when you need to deal with 8 hooligans. Contains a pump shotgun, with a 8-round capacity."
 	cost = 2000
-	contains = list(/obj/item/gun/ballistic/shotgun/hellfire)
+	contains = list(/obj/item/storage/guncase/hellfire)
 	crate_name = "shotgun crate"
 
 /datum/supply_pack/gun/brimstone_shotgun
 	name = "Brimstone Shotgun Crate"
 	desc = "For when you need to deal with 5 hooligans, and QUICKLY. Contains a slamfire shotgun, with a 5-round capacity. Warranty voided if sawed off."
 	cost = 2000
-	contains = list(/obj/item/gun/ballistic/shotgun/brimstone)
+	contains = list(/obj/item/storage/guncase/brimstone)
 	crate_name = "shotgun crate"
 
 /*
@@ -159,7 +159,7 @@
 	name = "Scout Sniper Rifle Crate"
 	desc = "Contains a traditional scoped rifle to hunt wildlife and big game from a respectful distance. Chambered in powerful .300 Magnum."
 	cost = 5500
-	contains = list(/obj/item/gun/ballistic/rifle/scout)
+	contains = list(/obj/item/storage/guncase/scout)
 	crate_name = "rifle crate"
 
 /datum/supply_pack/gun/cobra20

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -56,7 +56,7 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/skm_762_40/empty
-	start_empty = FALSE
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/skm_762_40/extended
 	name = "extended assault rifle magazine (7.62x40mm CLIP)"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -755,7 +755,7 @@ EMPTY_GUN_HELPER(shotgun/bulldog/inteq)
 		recoil = 2
 		recoil_unwielded = 4
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/beacon
+/obj/item/gun/ballistic/shotgun/doublebarrel/beacon/no_mag
 	spawnwithmagazine = FALSE
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/beacon/factory

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -63,8 +63,8 @@
 		cell = new cell_type(src)
 	else
 		cell = new(src)
-	if(!dead_cell)
-		cell.give(cell.maxcharge)
+	if(dead_cell)
+		cell.use(cell.maxcharge)
 	update_ammo_types()
 	recharge_newshot(TRUE)
 	if(selfcharge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The beacon now has a proper subtype for not being loaded with ammo rather than having that be its default state
The WT-550 no longer starts full in its guncase
SKM magazines no longer start full in their guncases either
Energy weapons which are meant to start empty now actually start empty
The brimstone, hellfire, and scout now come with their respective guncases when ordered via cargo

## Why It's Good For The Game

jjjjjjjjjjjjjjjjjjjjjj

## Changelog

:cl:
fix: gun cargo packs now act more as they would be expected to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
