### PR TITLE
Fixes N+S Captain loadout

### DIFF
--- a/code/modules/clothing/outfits/factions/nanotrasen.dm
+++ b/code/modules/clothing/outfits/factions/nanotrasen.dm
@@ -53,13 +53,13 @@
 
 	head = /obj/item/clothing/head/nanotrasen/cap/supply
 	uniform = /obj/item/clothing/under/nanotrasen/supply/qm
-	suit = NULL
-	alt_suit = NULL
+	suit = null
+	alt_suit = null
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/cargo
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	glasses = /obj/item/clothing/glasses/sunglasses
-	gloves = NULL
-	neck = NULL
+	gloves = null
+	neck = null
 	l_hand = /obj/item/clipboard
 
 	chameleon_extras = /obj/item/stamp/qm

--- a/code/modules/clothing/outfits/factions/nanotrasen.dm
+++ b/code/modules/clothing/outfits/factions/nanotrasen.dm
@@ -53,9 +53,13 @@
 
 	head = /obj/item/clothing/head/nanotrasen/cap/supply
 	uniform = /obj/item/clothing/under/nanotrasen/supply/qm
+	suit = NULL
+	alt_suit = NULL
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/cargo
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	glasses = /obj/item/clothing/glasses/sunglasses
+	gloves = NULL
+	neck = NULL
 	l_hand = /obj/item/clipboard
 
 	chameleon_extras = /obj/item/stamp/qm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to set some slots on the N+S Captain loadout to NULL, causing them to inherit normal Nanotrasen items. This PR nulls them out, making the N+S Captain effectively dressed as a Quartermaster, as he should be.

## Why It's Good For The Game

bugfixes good

## Changelog

:cl:
fix: N+S Captains no longer spawn with Nanotrasen coats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
