### PR TITLE
Reduces ship spawn limit for everything to 1

### DIFF
--- a/_maps/configs/independent_beluga.json
+++ b/_maps/configs/independent_beluga.json
@@ -12,7 +12,7 @@
 		"Service"
 	],
 	"starting_funds": 4000,
-	"limit": 2,
+	"limit": 1,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain",

--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -14,7 +14,6 @@
 	"map_short_name": "Kilo-class",
 	"starting_funds": 1500,
 	"map_path": "_maps/shuttles/independent/independent_kilo.dmm",
-	"limit": 2,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/western",

--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -14,6 +14,7 @@
 	"map_short_name": "Kilo-class",
 	"starting_funds": 1500,
 	"map_path": "_maps/shuttles/independent/independent_kilo.dmm",
+	"limit": 2,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/western",

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -14,7 +14,7 @@
 		"SPACE"
 	],
 	"map_path": "_maps/shuttles/independent/independent_mudskipper.dmm",
-	"limit": 2,
+	"limit": 1,
 	"starting_funds": 1500,
 	"job_slots": {
 		"Salvage Leader": {

--- a/_maps/configs/independent_schmiedeberg.json
+++ b/_maps/configs/independent_schmiedeberg.json
@@ -14,7 +14,7 @@
 		"SUNS",
 		"GENERAL"
 	],
-	"limit": 2,
+	"limit": 1,
 	"job_slots": {
 		"Chief Pharmacist": {
 			"outfit": "/datum/outfit/job/independent/cmo/pharma",

--- a/_maps/configs/nanotrasen_gecko.json
+++ b/_maps/configs/nanotrasen_gecko.json
@@ -14,7 +14,7 @@
 		"Mining",
 		"Engineering"
 	],
-	"limit": 2,
+	"limit": 1,
 	"starting_funds": 5000,
 	"job_slots": {
 		"Captain": {

--- a/_maps/example_ship_config.json
+++ b/_maps/example_ship_config.json
@@ -5,7 +5,7 @@
 	"prefix": "STSV",
 	"namelists": ["GENERAL", "SPACE", "MYTHOLOGICAL", "WEAPONS"],
 	"map_path": "_maps/shuttles/shiptest/null.dmm",
-	"limit": 2,
+	"limit": 1,
 	"spawn_time_coeff": 1.5,
 	"officer_time_coeff": 0.5,
 	"job_slots": {

--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -134,7 +134,7 @@
 			"description": "The amount of ships that can be spawned in by players in a round at once.",
 			"minimum": 0,
 			"maximum": 100,
-			"default": 2
+			"default": 1
 		},
 		"starting_funds":{
 			"title": "Ship Starting Funds",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the spawn limit for every ship to 1, and makes the default limit for new ships 1.

## Why It's Good For The Game

Nearly every ship was already set to a limit of 1. Making it the default just saves time. Most of the handful of ships that still had a cap of 2- mudskipper, li tieguai, and delta, for instance - were ships that would just compete for pop or nudge each other out of their niche if double-spawned, and a greater variety of ships are available to accept players after existing ones fill up than there previously were.

## Changelog

:cl:
balance: reduced default ship spawn limit to 1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
