### PR TITLE
Makes .44 and .45 not the exact same cartridge

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -157,15 +157,15 @@
 
 /obj/projectile/bullet/a44roum
 	name = ".44 roumain bullet"
-	damage =  25
+	damage =  30
 
 /obj/projectile/bullet/a44roum/rubber
 	name = ".44 roumain bullet"
-	damage =  7
+	damage =  10
 	stamina = 38
 	armour_penetration = -20
 
 /obj/projectile/bullet/a44roum/hp
 	name = ".44 roumain bullet"
-	damage =  45
+	damage =  50
 	armour_penetration = -20


### PR DESCRIPTION
## About The Pull Request

Increases .44 roumain damage to reflect the fact that .44 is a significantly more powerful round than .45

## Why It's Good For The Game

![same](https://github.com/shiptest-ss13/Shiptest/assets/139387950/a32b5b06-58a0-4508-a99b-cc819b3e7fe7)
![martin](https://github.com/shiptest-ss13/Shiptest/assets/139387950/c4a0efd6-df55-47c8-b6f5-26c47fd3b35a)
![chu](https://github.com/shiptest-ss13/Shiptest/assets/139387950/926f2690-839e-446c-848b-96cc1482c5dc)


## Changelog

:cl:
balance: .44 is no longer near-indistinguishable from the far less powerful .45 caliber, about 5 more force
/:cl: