### PR TITLE
Cleans up plushies in the loadout.

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -866,8 +866,7 @@
 
 /obj/item/choice_beacon/plushie
 	name = "box of plushes"
-	desc = "Contains two plushies!"
-	uses = 2
+	desc = "Contains a little friend!"
 
 /obj/item/choice_beacon/plushie/generate_display_names()
 	var/static/list/plushies
@@ -879,7 +878,45 @@
 			/obj/item/toy/plush/snakeplushie,
 			/obj/item/toy/plush/slimeplushie,
 			/obj/item/toy/plush/beeplushie,
+			/obj/item/toy/plush/goatplushie,
 			/obj/item/toy/plush/realgoat,
+			/obj/item/toy/plush/spider,
+			/obj/item/toy/plush/flushed,
+			/obj/item/toy/plush/blahaj)
+		for(var/V in templist)
+			var/atom/A = V
+			plushies[initial(A.name)] = A
+	return plushies
+
+/obj/item/choice_beacon/plushie/rilena
+	name = "box of RILENA plushes"
+	desc = "Contains merch from the hit webcomic!"
+
+/obj/item/choice_beacon/plushie/rilena/generate_display_names()
+	var/static/list/plushies
+	if(!plushies)
+		plushies = list()
+		var/list/templist = list(
+			/obj/item/toy/plush/rilena,
+			/obj/item/toy/plush/tali,
+			/obj/item/toy/plush/sharai,
+			/obj/item/toy/plush/xader,
+			/obj/item/toy/plush/mora,
+			/obj/item/toy/plush/kari)
+		for(var/V in templist)
+			var/atom/A = V
+			plushies[initial(A.name)] = A
+	return plushies
+
+/obj/item/choice_beacon/plushie/moth
+	name = "box of moth plushes"
+	desc = "Contains an exceptionally fuzzy plushie."
+
+/obj/item/choice_beacon/plushie/moth/generate_display_names()
+	var/static/list/plushies
+	if(!plushies)
+		plushies = list()
+		var/list/templist = list(
 			/obj/item/toy/plush/moth,
 			/obj/item/toy/plush/moth/luna,
 			/obj/item/toy/plush/moth/atlas,
@@ -894,16 +931,7 @@
 			/obj/item/toy/plush/moth/poison,
 			/obj/item/toy/plush/moth/ragged,
 			/obj/item/toy/plush/moth/snow,
-			/obj/item/toy/plush/moth/moonfly,
-			/obj/item/toy/plush/spider,
-			/obj/item/toy/plush/flushed,
-			/obj/item/toy/plush/blahaj,
-			/obj/item/toy/plush/rilena,
-			/obj/item/toy/plush/tali,
-			/obj/item/toy/plush/sharai,
-			/obj/item/toy/plush/xader,
-			/obj/item/toy/plush/mora,
-			/obj/item/toy/plush/kari)
+			/obj/item/toy/plush/moth/moonfly)
 		for(var/V in templist)
 			var/atom/A = V
 			plushies[initial(A.name)] = A

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -863,3 +863,48 @@
 	var/mutable_appearance/base_overlay_among = mutable_appearance(icon, "plushie_among_visor")
 	base_overlay_among.appearance_flags = RESET_COLOR
 	add_overlay(base_overlay_among)
+
+/obj/item/choice_beacon/plushie
+	name = "box of plushes"
+	desc = "Contains two plushies!"
+	uses = 2
+
+/obj/item/choice_beacon/plushie/generate_display_names()
+	var/static/list/plushies
+	if(!plushies)
+		plushies = list()
+		var/list/templist = list(
+			/obj/item/toy/plush/carpplushie,
+			/obj/item/toy/plush/lizardplushie,
+			/obj/item/toy/plush/snakeplushie,
+			/obj/item/toy/plush/slimeplushie,
+			/obj/item/toy/plush/beeplushie,
+			/obj/item/toy/plush/realgoat,
+			/obj/item/toy/plush/moth,
+			/obj/item/toy/plush/moth/luna,
+			/obj/item/toy/plush/moth/atlas,
+			/obj/item/toy/plush/moth/redish,
+			/obj/item/toy/plush/moth/royal,
+			/obj/item/toy/plush/moth/gothic,
+			/obj/item/toy/plush/moth/lovers,
+			/obj/item/toy/plush/moth/whitefly,
+			/obj/item/toy/plush/moth/punished,
+			/obj/item/toy/plush/moth/firewatch,
+			/obj/item/toy/plush/moth/deadhead,
+			/obj/item/toy/plush/moth/poison,
+			/obj/item/toy/plush/moth/ragged,
+			/obj/item/toy/plush/moth/snow,
+			/obj/item/toy/plush/moth/moonfly,
+			/obj/item/toy/plush/spider,
+			/obj/item/toy/plush/flushed,
+			/obj/item/toy/plush/blahaj,
+			/obj/item/toy/plush/rilena,
+			/obj/item/toy/plush/tali,
+			/obj/item/toy/plush/sharai,
+			/obj/item/toy/plush/xader,
+			/obj/item/toy/plush/mora,
+			/obj/item/toy/plush/kari)
+		for(var/V in templist)
+			var/atom/A = V
+			plushies[initial(A.name)] = A
+	return plushies

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -94,49 +94,9 @@
 	display_name = "cane"
 	path = /obj/item/cane
 
-/datum/gear/lizard
-	display_name = "toy, lizard plushie"
-	path = /obj/item/toy/plush/lizardplushie
-
-/datum/gear/snake
-	display_name = "toy, snake plushie"
-	path = /obj/item/toy/plush/snakeplushie
-
-/datum/gear/moth
-	display_name = "toy, moth plushie"
-	path = /obj/item/toy/plush/moth
-
-/datum/gear/hornet
-	display_name = "toy, marketable hornet plushie"
-	path = /obj/item/toy/plush/hornet
-
-/datum/gear/gayhornet
-	display_name = "toy, gay hornet plushie"
-	path = /obj/item/toy/plush/hornet/gay
-	description = "Hornet says lesbian rights."
-
-/datum/gear/knight
-	display_name = "toy, marketable knight plushie"
-	path = /obj/item/toy/plush/knight
-
-/datum/gear/ri
-	display_name = "toy, rilena ri plushie"
-	path = /obj/item/toy/plush/rilena
-
-/datum/gear/tali
-	display_name = "toy, rilena tali plushie"
-	path = /obj/item/toy/plush/tali
-
-// Shiptest edit
-/datum/gear/amongus
-	display_name = "toy, suspicious pill plushie"
-	path = /obj/item/toy/plush/among
-
-/datum/gear/amongus/New()
-	. = ..()
-	var/obj/item/toy/plush/among/temp = new path()
-	description = "[capitalize(pick(temp.among_colors))] sus."
-	qdel(temp)
+/datum/gear/plushie
+	display_name = "box of plushes"
+	path = /obj/item/choice_beacon/plushie
 
 /datum/gear/hairspray
 	display_name = "hair dye"
@@ -149,8 +109,6 @@
 /datum/gear/tablebell
 	display_name = "table bell, brass"
 	path = /obj/item/table_bell/brass
-
-// End Shiptest
 
 /datum/gear/flashlight
 	display_name = "tool, flashlight"

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -95,8 +95,16 @@
 	path = /obj/item/cane
 
 /datum/gear/plushie
-	display_name = "box of plushes"
+	display_name = "box of plushes, standard"
 	path = /obj/item/choice_beacon/plushie
+
+/datum/gear/plushie/rilena
+	display_name = "box of plushes, RILENA"
+	path = /obj/item/choice_beacon/plushie/rilena
+
+/datum/gear/plushie/moth
+	display_name = "box of plushes, moths"
+	path = /obj/item/choice_beacon/plushie/moth
 
 /datum/gear/hairspray
 	display_name = "hair dye"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Waiting for #3169.
This replaces all of plushies in the loadout, with three choice beacons: Moth, RILENA and Standard. So, you can get less plushies in total, but selection is greater, without taking up half a screen.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
What if I want to start with a firewatch moth plushie? Huh?
Allows characters to get ultra specific with plushie preference, while tidying up the _general_ tab of loadout.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added three plushie choice beacons into loadout. You can get nearly every plush from them.
del: Removed all individual plushies from the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
