### PR TITLE
Fixes Comet Trail, Molten Bubbles, and Sunset Sarsaparilla sprites

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -487,6 +487,8 @@
 	description = "Extra refreshing for those long desert days."
 	color = "#af9938"
 	taste_description = "root-beer and asbestos"
+	glass_name = "glass of Sandblast Sarsaparilla"
+	glass_desc = "A glass of Sandblast Sarsaparilla. Perfect for those long desert days.
 
 /datum/reagent/consumable/lemon_lime
 	name = "Lemon Lime"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -488,7 +488,7 @@
 	color = "#af9938"
 	taste_description = "root-beer and asbestos"
 	glass_name = "glass of Sandblast Sarsaparilla"
-	glass_desc = "A glass of Sandblast Sarsaparilla. Perfect for those long desert days.
+	glass_desc = "A glass of Sandblast Sarsaparilla. Perfect for those long desert days."
 
 /datum/reagent/consumable/lemon_lime
 	name = "Lemon Lime"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -416,7 +416,7 @@
 	description = "A citrusy drink from the Kepori space installation known as The Ring."
 	color = "#c4ff2d" // rgb: 16, 32, 0
 	taste_description = "sweet citrus soda"
-	glass_icon_state = "Comet_trail_glass"
+	glass_icon_state = "comet_trail_glass"
 	glass_name = "glass of Comet Trail"
 	glass_desc = "A glass of Comet Trail. Taste the stars!"
 
@@ -461,7 +461,7 @@
 	description = "A spicy soft drink made from a coca-like plant from Kalixcis. Popularly served both cold -and- hot, depending on the weather."
 	color = "#5f2010"
 	taste_description = "spiced cola"
-	glass_icon_state = "molten_glass"
+	glass_icon_state = "glass_brown"
 	glass_name = "glass of Molten Bubbles"
 	glass_desc = "A glass of Molten Bubbles. The spices tickle your nose."
 


### PR DESCRIPTION
## About The Pull Request

Comet Trail typo made the sprite invisible. Molten Bubbles has a glass sprite now, and Sunset Sarsaparilla, which is a typepath of Molten Bubbles, has a "unique" glass name and description instead of also being invisible.

## Why It's Good For The Game

Fixes https://github.com/shiptest-ss13/Shiptest/issues/3160

## Changelog

:cl:
fix: Fixed Comet Trail, Molten Bubbles, and Sunset Sarsaparilla glass sprites
/:cl: