### PR TITLE
Removes tatortots and fixes recipe issues

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -112,19 +112,6 @@
 	. = ..()
 	AddElement(/datum/element/dunkable, 10)
 
-/obj/item/reagent_containers/food/snacks/tatortot
-	name = "tator tot"
-	desc = "A large fried potato nugget that may or may not try to valid you."
-	icon_state = "tatortot"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4)
-	filling_color = "FFD700"
-	tastes = list("potato" = 3, "valids" = 1)
-	foodtype = FRIED | VEGETABLES
-
-/obj/item/reagent_containers/food/snacks/tatortot/Initialize()
-	. = ..()
-	AddElement(/datum/element/dunkable, 10)
-
 /obj/item/reagent_containers/food/snacks/soydope
 	name = "soy dope"
 	desc = "Dope from a soy."

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -13,17 +13,13 @@
 	input = /obj/item/reagent_containers/food/snacks/meat/rawcutlet
 	output = /obj/item/reagent_containers/food/snacks/meat/rawbacon
 
-/datum/food_processor_process/potatowedges
-	input = /obj/item/reagent_containers/food/snacks/grown/potato/wedges
-	output = /obj/item/reagent_containers/food/snacks/fries
-
 /datum/food_processor_process/sweetpotato
 	input = /obj/item/reagent_containers/food/snacks/grown/potato/sweet
 	output = /obj/item/reagent_containers/food/snacks/yakiimo
 
 /datum/food_processor_process/potato
 	input = /obj/item/reagent_containers/food/snacks/grown/potato
-	output = /obj/item/reagent_containers/food/snacks/tatortot
+	output = /obj/item/reagent_containers/food/snacks/fries
 
 /datum/food_processor_process/carrot
 	input = /obj/item/reagent_containers/food/snacks/grown/carrot

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -29,25 +29,6 @@
 	juice_results = list(/datum/reagent/consumable/potato_juice = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/vodka
 
-/obj/item/reagent_containers/food/snacks/grown/potato/wedges
-	name = "potato wedges"
-	desc = "Slices of neatly cut potato."
-	icon_state = "potato_wedges"
-	filling_color = "#E9967A"
-	bitesize = 100
-
-
-/obj/item/reagent_containers/food/snacks/grown/potato/attackby(obj/item/W, mob/user, params)
-	if(W.get_sharpness())
-		to_chat(user, "<span class='notice'>You cut the potato into wedges with [W].</span>")
-		var/obj/item/reagent_containers/food/snacks/grown/potato/wedges/Wedges = new /obj/item/reagent_containers/food/snacks/grown/potato/wedges
-		remove_item_from_storage(user)
-		qdel(src)
-		user.put_in_hands(Wedges)
-	else
-		return ..()
-
-
 // Sweet Potato
 /obj/item/seeds/potato/sweet
 	name = "pack of sweet potato seeds"


### PR DESCRIPTION
## About The Pull Request

Potatoes no longer turn into tator tots when put into the food processor, instead becoming fries. The potato wedge to fries recipe was removed as well.

## Why It's Good For The Game

Fixes: https://github.com/shiptest-ss13/Shiptest/issues/2693, and despite tator tots existing the sprite sucks ass big time, has a flavour profile that references validhunting, and is Straight Up the only use for potato wedges for an item that is never put on the table.

This subsequently prevents potato wedges from infinitely being able to be cut into itself, and be used for normal potato recipes. 

## Changelog

:cl:
del: Removed tator tots and raw potato wedges 
/:cl: