### PR TITLE
subshuttles now inherit gravity if they are docked at a ship

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1587,6 +1587,15 @@
 		if(istype(ship))
 			var/obj/docking_port/mobile/shuttle = ship.mobile_port
 			if(shuttle)
+				if(istype(shuttle.docked, /obj/docking_port/stationary))
+					var/obj/docking_port/stationary/shipfinder = shuttle.docked
+					if(shipfinder.owner_ship)
+						for(var/datum/weakref/weakref as anything in shipfinder.owner_ship.gravgen_list)
+							var/obj/machinery/power/ship_gravity/SG = weakref.resolve()
+							if(!SG)
+								shipfinder.owner_ship.gravgen_list -= weakref
+								continue
+							max_grav = max(SG.active,max_grav)
 				for(var/datum/weakref/weakref as anything in shuttle.gravgen_list)
 					var/obj/machinery/power/ship_gravity/SG = weakref.resolve()
 					if(!SG)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gravity checks now also check any docking point for gravity generators, allowing ships docked to eachother to share gravity

## Why It's Good For The Game

ghhhmhm

## Changelog

:cl:
fix: ships docked to eachother now share gravity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
