### PR TITLE
Bone crits are now only rolled for brute damage

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -244,7 +244,7 @@
 			burn *= 2
 
 	// Is the damage greater than the threshold, and if so, probability of damage + item force
-	if((brute_dam > bone_break_threshold) && prob(brute_dam + break_modifier))
+	if(brute && (brute_dam > bone_break_threshold) && prob(brute_dam + break_modifier))
 		break_bone()
 
 	// Bleeding is applied here


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/shiptest-ss13/Shiptest/assets/24857008/b6659939-8c1e-4ef0-9c5b-a5bc6399d9ac)

## Why It's Good For The Game

Life or random damage ticks for disabler cat

## Changelog

:cl:
fix: brute damage is now required to break bones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
