### PR TITLE
Adjusts PGF Silk/Betzu-il cap armors/enviro protections

### DIFF
--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -6110,7 +6110,7 @@
 	pixel_y = 9;
 	pixel_x = -11
 	},
-/obj/item/clothing/suit/armor/gezena/marinecoat{
+/obj/item/clothing/suit/armor/gezena/marine/coat{
 	pixel_y = 8
 	},
 /obj/item/radio/headset/pgf/alt/captain{

--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -4713,7 +4713,7 @@
 	pixel_x = -9;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/gezena/medic/flap{
+/obj/item/clothing/head/gezena/flap/medic{
 	pixel_x = 12
 	},
 /obj/item/clothing/head/gezena/medic{
@@ -5931,16 +5931,16 @@
 /obj/item/clothing/gloves/gezena/marine{
 	pixel_y = 11
 	},
-/obj/item/clothing/head/gezena/marine/flap{
+/obj/item/clothing/head/gezena/flap/marine{
 	pixel_x = -10
 	},
-/obj/item/clothing/head/gezena/marine/flap{
+/obj/item/clothing/head/gezena/flap/marine{
 	pixel_x = -10
 	},
-/obj/item/clothing/head/gezena/marine/flap{
+/obj/item/clothing/head/gezena/flap/marine{
 	pixel_x = -10
 	},
-/obj/item/clothing/head/gezena/marine/flap{
+/obj/item/clothing/head/gezena/flap/marine{
 	pixel_x = -10
 	},
 /obj/item/clothing/head/gezena/marine{
@@ -6106,7 +6106,7 @@
 	pixel_y = 1;
 	pixel_x = -11
 	},
-/obj/item/clothing/head/gezena/marine/lead/flap{
+/obj/item/clothing/head/gezena/flap/marine/lead{
 	pixel_y = 9;
 	pixel_x = -11
 	},

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -135,7 +135,7 @@
 	desc = "The standard cap of the PGF military, in Navy colors. “betzu-il”, translating to “sun-blocker”, refers to the flap at the back for protection against natural hazards such as sunburns, sandstorms, and biting insects."
 	icon_state = "navalflap"
 	item_state = "bluecloth"
-	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //praticality for enviro prot
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //soft clothing = no armor
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
 	heat_protection = HEAD

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -36,7 +36,7 @@
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
 	togglename = "zipper"
-	body_parts_covered = CHEST
+	body_parts_covered = CHEST|ARMS
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
@@ -53,7 +53,9 @@
 	icon_state = "coat"
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
-	body_parts_covered = CHEST|GROIN
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	heat_protection = CHEST|GROIN|LEGS|ARMS
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 20, "energy" = 40, "bomb" = 20, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 50)
@@ -76,14 +78,17 @@
 	desc = "Raksha - a Kalixcian word for 'protection of the heart'. Sturdy and reliable."
 	icon_state = "marinevest"
 	item_state = "marinevest"
-	armor = list("melee" = 35, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
+	body_parts_covered = CHEST|GROIN
+	cold_protection = CHEST|GROIN
+	heat_protection = CHEST|GROIN
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
 
 /obj/item/clothing/suit/armor/gezena/marinecoat
 	name = "coated Raksha-plating"
 	desc = "Less practical with the coat than without."
 	icon_state = "marinecoat"
 	item_state = "bluecloth"
-	armor = list("melee" = 35, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //same
+	armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 30, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 50) //covers more body parts - shouldn't be an upgrade
 
 //Spacesuits
 
@@ -96,7 +101,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacesuit"
 	item_state = "spacesuit"
-	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 25, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
 	w_class = WEIGHT_CLASS_NORMAL
 	supports_variations = DIGITIGRADE_VARIATION
 
@@ -109,7 +114,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacehelmet"
 	item_state = "spacehelm"
-	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
+	armor = list("melee" = 25, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
 	w_class = WEIGHT_CLASS_NORMAL
 
 //Hats
@@ -130,6 +135,11 @@
 	desc = "The standard cap of the PGF military, in Navy colors. “betzu-il”, translating to “sun-blocker”, refers to the flap at the back for protection against natural hazards such as sunburns, sandstorms, and biting insects."
 	icon_state = "navalflap"
 	item_state = "bluecloth"
+	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //praticality for enviro prot
+	cold_protection = HEAD
+	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 
 /obj/item/clothing/head/gezena/marine
 	name = "\improper PGFMC Cap"
@@ -137,7 +147,7 @@
 	icon_state = "marinehat"
 	item_state = "marinecloth"
 
-/obj/item/clothing/head/gezena/marine/flap
+/obj/item/clothing/head/gezena/flap/marine
 	name = "\improper PGFMC Betzu-il cap"
 	desc = "The standard cap of the PGF military, in Marine Corps colors. “betzu-il”, translating to “sun-blocker”, refers to the flap at the back for protection against natural hazards such as sunburns, sandstorms, and biting insects."
 	icon_state = "marineflap"
@@ -149,7 +159,7 @@
 	icon_state = "squadhat"
 	item_state = "marinecloth"
 
-/obj/item/clothing/head/gezena/marine/lead/flap
+/obj/item/clothing/head/gezena/flap/marine/lead
 	name = "\improper PGFMC Commander's' Betzu-il cap"
 	desc = "The standard cap of the PGF military, in Marine Corps colors. “betzu-il”, translating to “sun-blocker”, refers to the flap at the back for protection against natural hazards such as sunburns, sandstorms, and biting insects. The silver markings denote it as a commander's cap."
 	icon_state = "squadflap"
@@ -161,7 +171,7 @@
 	icon_state = "medichat"
 	item_state = "whitecloth"
 
-/obj/item/clothing/head/gezena/medic/flap
+/obj/item/clothing/head/gezena/flap/medic
 	name = "\improper PGF medic Betzu-il cap"
 	desc = "The standard cap of the PGF military. “betzu-il”, translating to “sun-blocker”, refers to the flap at the back for protection against natural hazards such as sunburns, sandstorms, and biting insects. The coloring indicates the wearer as a medical officer."
 	icon_state = "medicflap"
@@ -180,7 +190,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/faction/gezena/head.dmi'
 	lefthand_file = 'icons/mob/inhands/faction/gezena/gezena_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
-	armor = list("melee" = 35, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
 	icon_state = "marinehelmet"
 	item_state = "marinehelm"
 

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -101,7 +101,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacesuit"
 	item_state = "spacesuit"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
+	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
 	w_class = WEIGHT_CLASS_NORMAL
 	supports_variations = DIGITIGRADE_VARIATION
 
@@ -114,7 +114,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacehelmet"
 	item_state = "spacehelm"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
+	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
 	w_class = WEIGHT_CLASS_NORMAL
 
 //Hats

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -79,7 +79,7 @@
 	item_state = "marinevest"
 	armor = list("melee" = 35, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
 
-/obj/item/clothing/suit/armor/gezena/marinecoat
+/obj/item/clothing/suit/armor/gezena/marine/coat
 	name = "coated Raksha-plating"
 	desc = "Less practical with the coat than without."
 	icon_state = "marinecoat"

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -36,10 +36,11 @@
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
 	togglename = "zipper"
-	body_parts_covered = CHEST|ARMS
+	body_parts_covered = CHEST|GROIN|ARMS
+	cold_protection = CHEST|GROIN|ARMS
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT //Gezena doesn't get winter coats frownie face
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
 
 //Armored suit
 
@@ -53,9 +54,7 @@
 	icon_state = "coat"
 	item_state = "bluecloth"
 	blood_overlay_type = "coat"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	cold_protection = CHEST|GROIN|LEGS|ARMS
-	heat_protection = CHEST|GROIN|LEGS|ARMS
+	body_parts_covered = CHEST|GROIN
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 20, "energy" = 40, "bomb" = 20, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 50)
@@ -78,17 +77,13 @@
 	desc = "Raksha - a Kalixcian word for 'protection of the heart'. Sturdy and reliable."
 	icon_state = "marinevest"
 	item_state = "marinevest"
-	body_parts_covered = CHEST|GROIN
-	cold_protection = CHEST|GROIN
-	heat_protection = CHEST|GROIN
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
+	armor = list("melee" = 35, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50) //the laser gun country should probably have laser armor
 
 /obj/item/clothing/suit/armor/gezena/marinecoat
 	name = "coated Raksha-plating"
 	desc = "Less practical with the coat than without."
 	icon_state = "marinecoat"
 	item_state = "bluecloth"
-	armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 30, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 50) //covers more body parts - shouldn't be an upgrade
 
 //Spacesuits
 
@@ -101,7 +96,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacesuit"
 	item_state = "spacesuit"
-	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
+	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 	w_class = WEIGHT_CLASS_NORMAL
 	supports_variations = DIGITIGRADE_VARIATION
 
@@ -114,7 +109,7 @@
 	righthand_file = 'icons/mob/inhands/faction/gezena/gezena_righthand.dmi'
 	icon_state = "spacehelmet"
 	item_state = "spacehelm"
-	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75) //softsuit
+	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 	w_class = WEIGHT_CLASS_NORMAL
 
 //Hats


### PR DESCRIPTION
## About The Pull Request

Adjusts Betzu-il caps to better respective their intended environmental protection, as well as making the silkenweave jacket not armored (as it should be), but letting it help with the cold.

## Why It's Good For The Game

Giving PGF better, reliable options to avoid taking cold tick damage while giving nuance to clothes designed for various tasks makes sense and is nice.

## Changelog

:cl:
balance: PGFN Silkenweave jackets now provide no armor but pretend to be winter coats
balance: PGF Betzu-il caps now have zero armor but provide cold/heat protection
/:cl:
