### PR TITLE
Crying Sun Bridge Crew is now a Bridge Officer

### DIFF
--- a/_maps/configs/pgf_crying_sun.json
+++ b/_maps/configs/pgf_crying_sun.json
@@ -23,6 +23,7 @@
 		},
 		"Bridge Officer": {
 			"outfit": "/datum/outfit/job/gezena/hop",
+			"officer": true,
 			"slots": 1
 		},
 		"Navy Engineer": {

--- a/_maps/configs/pgf_crying_sun.json
+++ b/_maps/configs/pgf_crying_sun.json
@@ -21,8 +21,8 @@
 			"officer": true,
 			"slots": 1
 		},
-		"Bridge Crew": {
-			"outfit": "/datum/outfit/job/gezena/assistant/bridge",
+		"Bridge Officer": {
+			"outfit": "/datum/outfit/job/gezena/hop",
 			"slots": 1
 		},
 		"Navy Engineer": {


### PR DESCRIPTION
## About The Pull Request

As title.

## Why It's Good For The Game

Visually distinguishes a role from crewmates when they're meant to be one of three people on a ship that can access the bridge. The Crying Sun isn't large enough to warrant a standard bridge crew that is the effective rank of a crewmate (something that's already covered by current slots).

I wasn't present for the initial discussion of Crying Sun job roles but I understand this as a popular change for nearly anyone who's played PGF. Plus, it incorporates a currently unused cloak sprite (which is good and unique to show off).

If maptainers prefer this sort of change to incorporate a respective locker, such can be done.

## Changelog

:cl:
config: The Crying Suns has had its bridge crew slot replaced with a bridge officer
/:cl:
