### PR TITLE
removes the atmospherics hardsuit from the cargo

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -72,14 +72,6 @@
 	crate_name = "engineering space suit crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
-/datum/supply_pack/spacesuit_armor/atmos_hardsuit
-	name = "Atmospherics Hardsuit Crate"
-	desc = "The iconic hardsuit of Nanotrasen's Atmosphere Corps, this hardsuit is known across space as a symbol of defiance in the face of sudden decompression. Smells faintly of plasma."
-	cost = 2500
-	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos)
-	crate_name = "atmospherics hardsuit crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-
 /datum/supply_pack/spacesuit_armor/swat
 	name = "SWAT Crate"
 	desc = "Contains one fullbody set of tough, fireproof, pressurized suit designed in a joint effort by IS-ERI and Nanotrasen. The set contains a suit, helmet, and combat belt."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

no

## Why It's Good For The Game

its faction gear!!!!!!!!!! you're not getting that
## Changelog

:cl:

del: The outpost has received a cease and desist letter originating from Nanotrasen, and no longer offer their iconic atmospherics hardsuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
