### PR TITLE
Hoodie/Winter Coat Storage Parity

### DIFF
--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -11,6 +11,7 @@
 					/obj/item/storage/fancy/cigarettes,
 					/obj/item/lighter,
 					/obj/item/radio,
+					/obj/item/storage/pill_bottle
 					)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) //it's just a hoodie.
 	supports_variations = KEPORI_VARIATION

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -12,14 +12,16 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	allowed = list(
-				/obj/item/flashlight,
-				/obj/item/tank/internals/emergency_oxygen,
-				/obj/item/tank/internals/plasmaman,
-				/obj/item/toy,
-				/obj/item/storage/fancy/cigarettes,
-				/obj/item/lighter,
-				)
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo/large
+	allowed = list(	/obj/item/flashlight,
+					/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/tank/internals/plasmaman,
+					/obj/item/toy,
+					/obj/item/storage/fancy/cigarettes,
+					/obj/item/lighter,
+					/obj/item/radio,
+					/obj/item/storage/pill_bottle
+					)
 
 /obj/item/clothing/head/hooded/winterhood
 	name = "winter hood"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Winter coats lost their innate storage due to an oversight in https://github.com/shiptest-ss13/Shiptest/pull/2121. This fixes that! 

Additionally, this PR matches the items you can fit in the suit storage slot across hoodies and coats.  As an added bonus, you can now fit pill bottles in both!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things working as intended is good, and one should reasonably be able to fit a pill bottle in your coat pocket.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: you can now fit radios and pill bottles in both hoodies and winter coats
fix: the innate storage on winter coats has been restored, alt click to access!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
