### PR TITLE
Fixes Vox sprites for a few clothing items

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -259,7 +259,7 @@
 	desc = "A snazzy looking pair of ballistic goggles with an integrated security hud. The opaque visor provides flash protection."
 	icon_state = "inteq_goggles"
 	item_state = "inteq_goggles"
-	supports_variations = KEPORI_VARIATION
+	supports_variations = KEPORI_VARIATION | VOX_VARIATION
 	glass_colour_type = /datum/client_colour/glass_colour/orange
 
 /obj/item/clothing/glasses/hud/health/prescription

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -501,7 +501,7 @@
 	icon_state = "inteq_swat"
 	item_state = "inteq_swat"
 	flags_inv = HIDEHAIR
-	supports_variations = KEPORI_VARIATION
+	supports_variations = KEPORI_VARIATION | VOX_VARIATION
 	content_overlays = TRUE
 
 /obj/item/clothing/head/helmet/inteq
@@ -510,7 +510,7 @@
 	icon_state = "inteq_helmet"
 	icon_state = "inteq_helmet"
 	can_flashlight = TRUE
-	supports_variations = KEPORI_VARIATION
+	supports_variations = KEPORI_VARIATION | VOX_VARIATION
 	content_overlays = TRUE
 
 /obj/item/clothing/head/solgov


### PR DESCRIPTION

## About The Pull Request

A few items that had Vox variations at some point stopped properly displaying them. This makes them appear as they should again. The Inteq SWAT helmet, standard Inteq helmet and Inteq HUD goggles now properly show their sprite on Vox.

## Why It's Good For The Game

Items having sprites is generally a good thing.

## Changelog

:cl: Cloudbreak
fix: A few clothing items now properly display again for Vox.
/:cl: