### PR TITLE
Landmine Bounty Changes

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -321,8 +321,8 @@
 /obj/item/storage/toolbox/bounty/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_combined_w_class = 8
-	STR.max_items = 4
+	STR.max_combined_w_class = 4
+	STR.max_items = 2
 
 //floorbot assembly
 /obj/item/storage/toolbox/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -215,9 +215,9 @@ Acquire: Anomaly
 		Acquire: Landmines
 */
 
-/datum/mission/acquire/landmine/rusted
-	name = "Defuse rusted landmines"
-	desc = "We've been issued a bounty to make the Frontier a safer place by disarming dated landmines. Mind your fingers."
+/datum/mission/acquire/landmine
+	name = "Defuse landmines"
+	desc = "CLIP and Gezena have assigned us to offer a bounty to turn in disarmed ordnance for future ventures. We'll pay you well, but we're not responsible for any accidents."
 	weight = 6
 	value = 2000
 	duration = 80 MINUTES

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -219,12 +219,12 @@ Acquire: Anomaly
 	name = "Defuse landmines"
 	desc = "CLIP and Gezena have assigned us to offer a bounty to turn in disarmed ordnance for future ventures. We'll pay you well, but we're not responsible for any accidents."
 	weight = 6
-	value = 2000
+	value = 1500
 	duration = 80 MINUTES
 	dur_mod_range = 0.4
 	container_type = /obj/item/storage/toolbox/bounty
 	objective_type = /obj/item/mine/pressure/explosive
-	num_wanted = 4
+	num_wanted = 2
 
 /*
 		Acquire: Fishing


### PR DESCRIPTION
## About The Pull Request

Fancies up the mission description a tiny bit and correctly says the mission is for all (pressure) landmines instead of just rusted mines. Prox mines can't really be disarmed so they're not included. Also decreases the amount of landmines required (and by extension, increasing the amount of credits rewarded per mine) to allow people to actually reliably complete the missions with the flat 25% chance you get to disarm mines. 

## Why It's Good For The Game

Fine tuning the mission after my own testing and observing other people completing them.

## Changelog

:cl:
fix: Fixed the Landmine mission description and flavoured it a little
balance: Decreased the amount of landmines required for its mission and increased the value per mine slightly
/:cl: