### PR TITLE
357 Revolver Guncase uses the correct subtype

### DIFF
--- a/code/game/objects/items/storage/guncases.dm
+++ b/code/game/objects/items/storage/guncases.dm
@@ -153,7 +153,7 @@
 
 /obj/item/storage/pistolcase/a357
 /obj/item/storage/pistolcase/a357/PopulateContents()
-	new /obj/item/gun/ballistic/revolver/no_mag(src)
+	new /obj/item/gun/ballistic/revolver/syndicate/no_mag(src)
 	new /obj/item/ammo_box/a357/empty(src)
 	new /obj/item/ammo_box/a357/empty(src)
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -557,6 +557,9 @@ EMPTY_GUN_HELPER(revolver/detective)
 /obj/item/gun/ballistic/revolver/detective/no_mag
 	spawnwithmagazine = FALSE
 
+/obj/item/gun/ballistic/revolver/syndicate/no_mag
+	spawnwithmagazine = FALSE
+
 /obj/item/gun/ballistic/revolver/no_mag
 	spawnwithmagazine = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #3200 
The guncase had the wrong subtype.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I DEMAND "Apogee-Dev" BE DEMOTED-

![image](https://github.com/user-attachments/assets/8f6881f0-3f84-4af1-8ce4-8d4977e87f5a)


## Changelog

:cl:
fix: 357 guncase spawns with the correct revolver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
