### PR TITLE
Changes the ingredients of two Gezenan drinks to better reflect their descriptions.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -373,7 +373,7 @@
 	desc = "A popular Gezenan drink made of fermented honey and spices, known as Gezenan Dark Mead, or GDM for short."
 	icon_state = "beer"
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 30)
-	foodtype = GRAIN | ALCOHOL
+	foodtype = SUGAR | ALCOHOL
 	custom_price = 60
 
 /obj/item/reagent_containers/food/drinks/beer/light

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -202,10 +202,10 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/kahlua
 	name = "Keh'Lu'Tex Liqueur"
-	desc = "An adapted recipe of a caffeine-mixed liqueur originating from Reh'himl, which replaces it's original ingredient with coffee from Terra."
+	desc = "An adapted recipe of a caffeine-mixed liqueur originating from Reh'himl, which replaces its original ingredient with coffee from Terra."
 	icon_state = "kahluabottle"
 	list_reagents = list(/datum/reagent/consumable/ethanol/kahlua = 100)
-	foodtype = VEGETABLES
+	foodtype = SUGAR | ALCOHOL //it's coffee and rum .
 
 /obj/item/reagent_containers/food/drinks/bottle/goldschlager
 	name = "Student-Union's Gold Standard"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -125,6 +125,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	description = "A widely known coffee-flavoured liqueur. Still labeled under an old name from Earth, despite the loss of history."
 	color = "#664300" // rgb: 102, 67, 0
 	boozepwr = 45
+	taste_description = "a bitter combination"
 	glass_icon_state = "kahluaglass"
 	glass_name = "glass of coffee liquor"
 	glass_desc = "Bitter from the coffee and alcohol alike!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the foodtypes of the Gezenan Dark Mead and Keh'Lu'Tex Liqueur to more accurately reflect their descriptions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This change is good for the game as it will enable Sarathi to enjoy drinks which are referenced to be popular Gezenan drinks. Both of the changed drinks are described to be made without the use of grain or vegetable products. This PR simply adjusts their foodtypes to reflect this and permit Gezena's majority population to enjoy native beverages.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed the foodtype of two Gezenan drinks to match their descriptions
add: added a taste description to Keh'Lu'Tex Liqueur
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
