### PR TITLE
Beat Them To Death With Hammers (Gorlex Edition)

### DIFF
--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -18,7 +18,6 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
-	species_exception = list(/datum/species/kepori)
 	var/wielded = FALSE // track wielded status on item
 
 /obj/item/fireaxe/Initialize()
@@ -70,3 +69,29 @@
 	. = ..()
 	AddComponent(/datum/component/two_handed, force_unwielded=5, force_wielded=23, icon_wielded="[base_icon_state]1")
 
+/*
+ * Dumb Cute Comment Title - Gorlex Hammers
+ */
+/obj/item/fireaxe/sledgehammer //add wall + structure damage later once Gristlebee's pr is merged
+	icon_state = "fire_axe0"
+	base icon_state = "fireaxe"
+	lefthand_file = 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
+	name = "breaching sledgehammer"
+	desc = "A large, slow hammer used by the Gorlex Marauder splinters. As powerful as a weapon as it is a shipbreaking and mining tool."
+	force = 5
+	armour_penetration = 40
+	attack_verb = list("bashed", "smashed", "crushed", "smacked")
+	hitsound = 'sound/weapons/smash.ogg'
+	sharpness = IS_BLUNT
+	tool_behaviour = TOOL_MINING
+	toolspeed = 0.5
+	usesound = list('sound/effects/picaxe1.ogg', 'sound/effects/picaxe2.ogg', 'sound/effects/picaxe3.ogg')
+
+/obj/item/fireaxe/sledgehammer/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/two_handed, force_unwielded=5, force_wielded=30, icon_wielded="[base_icon_state]1")
+
+/obj/item/fireaxe/sledgehammer/melee_attack_chain(mob/user, atom/target, params)
+	..()
+	user.changeNext_move(CLICK_CD_MELEE * 1.7)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -574,6 +574,24 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	else if(!target.anchored)
 		target.throw_at(throw_target, rand(1,2), 2, user, gentle = TRUE)
 
+/obj/item/melee/baseball_bat/gorlexhammer //subject to change
+	name = "Marauder warhammer"
+	desc = "A weapon popular with Gorlex Marauder's splinters after their ascent from their home. Outfitted with an integrated mass-multiplier for an unusually strong kick in a small package."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "baseball_bat"
+	item_state = "baseball_bat"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	force = 18
+	throwforce = 18
+	block_chance = 15
+	armour_penetration = 20
+	attack_verb = list("beat","smacked", "crushed", "smashed")
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BELT
+
+	// stamina damage coming 2021
+
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"
 	desc = "This bat is made of highly reflective, highly armored material."


### PR DESCRIPTION
## About The Pull Request

(no sprites yet + not mapped in + im lazy lmao)

Incredibly WIP to add both a large, two-handed sledgehammer for normal splinter use and a one-handed, fancy warhammer for captains. Two-handed is planned to have increased damage vs walls and structures like airlocks but I'll wait for That PR to be finished first. One-handed is planned to deal a small amount of stamina damage along with having baseball bat-like knockback along with fitting on the belt / armour vest slot.

## Why It's Good For The Game

A sort of captain's sabre alternative for Marauder-splinter faction captains and a funny shipbreaking / mining tool for normal crew. Also an intended weapon that the Marauders used.

## Changelog

:cl:
add: crush them with hammers
/:cl: