### PR TITLE
Social Anxiety quirk fixes and tweaks

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -451,15 +451,14 @@
 
 /datum/quirk/social_anxiety/on_process()
 	var/nearby_people = 0
+	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
+		return
 	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
 		if(H.client)
 			nearby_people++
 	var/mob/living/carbon/human/H = quirk_holder
 	if(prob(2 + nearby_people))
-		H.stuttering = max(3, H.stuttering)
-	else if(prob(min(3, nearby_people)) && !H.silent)
-		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
-		H.silent = max(10, H.silent)
+		H.stuttering = max(4, H.stuttering)
 	else if(prob(0.5) && dumb_thing)
 		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 		dumb_thing = FALSE //only once per life
@@ -479,6 +478,8 @@
 /datum/quirk/social_anxiety/proc/eye_contact(datum/source, mob/living/other_mob, triggering_examiner)
 	SIGNAL_HANDLER
 
+	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
+		return
 	if(prob(75))
 		return
 	var/msg

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -169,13 +169,9 @@
 	var/static/regex/nostutter = regex(@@[aeiouAEIOU "'()[\]{}.!?,:;_`~-]@)
 	for(var/i = 1, i <= leng, i += length(rawchar))
 		rawchar = newletter = phrase[i]
-		if(prob(80) && !nostutter.Find(rawchar))
-			if(prob(10))
-				newletter = "[newletter]-[newletter]-[newletter]-[newletter]"
-			else if(prob(20))
+		if(prob(70) && !nostutter.Find(rawchar))
+			if(prob(25))
 				newletter = "[newletter]-[newletter]-[newletter]"
-			else if (prob(5))
-				newletter = ""
 			else
 				newletter = "[newletter]-[newletter]"
 		. += newletter


### PR DESCRIPTION
## About The Pull Request

Changes some things about the social anxiety quirk to make it more bearable to deal with.

- Removes the ability for it to silence you, which would eat messages players tried to send while roleplaying.
- Decreases the severity of stuttering across the board, and prevents it from removing characters in the message.
- Psicodine now actually suppresses the main effects of social anxiety while it is active, making the medicine actually usable once more.

## Why It's Good For The Game

Players were unable to use this quirk due to a variety of reasons. It would randomly silence you around people, give you an exaggerated stutter that made your runechat impossible to read, and couldn't even be suppressed because it's treatment medication was bugged and had very little use outside of it.

Now the quirk is a little more managable, and players should be able to take it and roleplay with it again. I may mess with the stutter further if needed as I still think its a little extreme in some cases.

## Changelog

:cl:
balance: the Quirk Social Anxiety no longer silences you randomly
fix: Stuttering is now far less extreme and will not delete characters
fix: Psicodine now actually suppresses the effects of social anxiety
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
