### PR TITLE
Marker Beacons can be printed in the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1255,3 +1255,4 @@
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
 	build_path = /obj/item/stack/marker_beacon
 	category = list("initial","Misc")
+

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1247,3 +1247,11 @@
 	materials = list(/datum/material/plastic = 30)
 	build_path = /obj/item/folder/biscuit/unsealed/confidental
 	category = list("initial", "Tools", "Misc")
+
+/datum/design/marker_beacon
+	name = "Marker Beacon"
+	id = "beacon"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	build_path = /obj/item/stack/marker_beacon
+	category = list("initial","Misc")

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1250,7 +1250,7 @@
 
 /datum/design/marker_beacon
 	name = "Marker Beacon"
-	id = "beacon"
+	id = "marker_beacon"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
 	build_path = /obj/item/stack/marker_beacon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Marker beacons can be printed in the autolathe under the Misc tab

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Marker beacons aren't practically obtainable outside of the occasional loot drops currently, and I think they're a nice thematic way to lay trails or mark points of interest as you navigate the planet rather than going around laying spray paint everywhere.

## Changelog

:cl:
add: Marker beacons can now be printed at the autolathe from the Misc tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
