### PR TITLE
Sandbags can be bought at the outpost and deconstructed by click dragging them onto yourself

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -111,6 +111,24 @@
 	smoothing_groups = list(SMOOTH_GROUP_SANDBAGS)
 	canSmoothWith = list(SMOOTH_GROUP_SANDBAGS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SECURITY_BARRICADE)
 
+/obj/structure/barricade/sandbags/MouseDrop(over_object, src_location, over_location)
+	. = ..()
+	if(over_object == usr && Adjacent(usr))
+		if(src.flags_1 & NODECONSTRUCT_1)
+			return
+		if(!usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
+			return
+		usr.visible_message(span_notice("[usr] begins pulling apart \the [src.name]..."), span_notice("You begin pulling apart \the [src.name]..."))
+		if(do_after(usr, 30, usr))
+			deconstruct()
+
+/obj/structure/barricade/sandbags/make_debris()
+	new /obj/item/stack/sheet/mineral/sandbags(get_turf(src), 1)
+
+/obj/structure/barricade/sandbags/examine(mob/user)
+	. = ..()
+	. += span_notice("You could probably <b>pull</b> the [src.name] by dragging it onto yourself.")
+
 /obj/structure/barricade/security
 	name = "security barrier"
 	desc = "A deployable barrier. Provides good cover in fire fights."

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -30,6 +30,13 @@
 	cost = 2000
 	crate_name = "security barriers crate"
 
+/datum/supply_pack/sec_supply/empty_sandbags
+	name = "Empty Sandbags"
+	desc = "Contains one box of seven empty sandbags for deployable cover in the field. Sand not included."
+	contains = list(/obj/item/storage/box/emptysandbags)
+	cost = 200
+	crate_name = "sandbag crate"
+
 /datum/supply_pack/sec_supply/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes."

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -34,7 +34,7 @@
 	name = "Empty Sandbags"
 	desc = "Contains one box of seven empty sandbags for deployable cover in the field. Sand not included."
 	contains = list(/obj/item/storage/box/emptysandbags)
-	cost = 200
+	cost = 150
 	crate_name = "sandbag crate"
 
 /datum/supply_pack/sec_supply/wall_flash


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds empty sandbags to the outpost, 7 sandbags for 150 under the sec supply tab
Sandbags can be deconned by click dragging them onto your mob and a short do after. Adds an examine message for how to decon.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sandbags are odious to use currently, being effectively single use once deployed and just sitting there once the fight's done. If you want to clean them up afterwards you're stuck smashing them apart until they break These changes should make sandbags more accessible and practical to use. 

## Changelog

:cl:
add: Sandbags can be deconed by click dragging them onto your mob.
add: Sandbags to the outpost for 150 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
