### PR TITLE
Fixes the species behavior of handle_quirk_conflict

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1435,7 +1435,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		balance -= initial(quirk_type.value)
 		switch(change_type)
 			if("species")
-				if((quirk_name in SSquirks.species_blacklist) && (pref_species.id in SSquirks.species_blacklist[quirk_name]))
+				if((quirk_name in SSquirks.species_blacklist) && (target_species.id in SSquirks.species_blacklist[quirk_name]))
 					all_quirks_new -= quirk_name
 					balance += initial(quirk_type.value)
 			if("mood")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The 1 worder changer (real) (not staged)(clickbait)
4 months ago, nefarious creature notices that something isn't behaving as it should: when species gets changed, the incompatible quirks aren't removed (horrible), this is because the harddel fixes pr swapped target_species (which was used to include in-game species changes) for pref_species

Feel free to scream at me for forgetting to bring this up after writing it down on my things to do later list:tm:, also you can ask about any other code that pertains to me if you want and won't contact me otherwise

![image](https://github.com/user-attachments/assets/6bc56505-1b29-4ff9-9693-e91fd94b0d1b)

This is literally how it happened
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an issue with the behavior of a proc, which matters for it's use in line 338 of dna.dm
![image](https://github.com/user-attachments/assets/51a21651-56e9-4b13-adbd-6f7249584849)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed handle_quirk_conflict behavior
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
