### PR TITLE
Fixes mining gas masks and adds an examine hint to it

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -136,7 +136,7 @@
 
 // Mining survival box
 /obj/item/storage/box/survival/mining
-	mask_type = /obj/item/clothing/mask/gas/explorer
+	mask_type = /obj/item/clothing/mask/gas/explorer/folded
 
 /obj/item/storage/box/survival/mining/PopulateContents()
 	..()

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -49,8 +49,18 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/gas/explorer/adjustmask(user)
-	..()
-	w_class = mask_adjusted ? WEIGHT_CLASS_NORMAL : WEIGHT_CLASS_SMALL
+	. = ..()
+	// adjusted = out of the way = smaller = can fit in boxes
+	w_class = mask_adjusted ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
+
+/obj/item/clothing/mask/gas/explorer/examine(mob/user)
+	. = ..()
+	if(mask_adjusted || w_class == WEIGHT_CLASS_SMALL)
+		return
+	. += span_notice("You could fit this into a box if you adjusted it.")
+
+/obj/item/clothing/mask/gas/explorer/folded
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/mask/gas/explorer/folded/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Our current mining gas masks has a problem where the unfolded version stays at a small weight while the folded stays at normal, this PR fixes that.

Additionally, an examine hint was added when unfolded so miners can have a better time with inventory management.

![dreamseeker_aFP786YNni](https://github.com/user-attachments/assets/4d4f8519-c77b-4076-8c53-c7d24427b2fb)

Port of https://github.com/tgstation/tgstation/pull/69646

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Quality of life and inconsistency fix

## Changelog

:cl: Melbert, ported by Hardly
fix: Fixed mining gas masks staying at a inconsistent weight when folded or unfolded
code: Adds an examine hint when unfolded on how to store a mining gas mask inside your survival box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
