### PR TITLE
Makes syndicate masks smaller

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -78,6 +78,7 @@
 	desc = "A close-fitting tactical mask that can be connected to an air supply."
 	icon_state = "syndicate"
 	strip_delay = 60
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/mask/gas/syndicate/voicechanger
 	desc = "A close-fitting tactical mask that can be connected to an air supply. This one has an integrated voice changer."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes syndicate masks smaller, meaning you can now insert it back into the survival box.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Quality of life. The mask spawns inside most if not all syndicate's survival boxes but once you take it out, you can't bring it back in due to it's weight which is mildly annoying and may lead syndicate players to wear it 24/7 or to ditch it for a smaller breathing mask instead.

There shouldn't be many balance complications if at all, considering that Inteq and NT captains already seem to get a small sized mask

## Changelog

:cl: Hardly
code: Made syndicate masks smaller.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
