### PR TITLE
Fixed: wrong cash bundle value, cash dropping upon stacking

### DIFF
--- a/code/game/objects/items/cash.dm
+++ b/code/game/objects/items/cash.dm
@@ -57,8 +57,9 @@
 			var/mob/living/carbon/human/H = user
 			H.dropItemToGround(src)
 			H.dropItemToGround(bundle)
+			H.put_in_hands(src)
 			H.put_in_hands(bundle)
-		to_chat(user, "<span class='notice'>You add [value] credits worth of money to the bundle.<br>It now holds [bundle.value] credits.</span>")
+		to_chat(user, "<span class='notice'>You add [value] credits worth of money to the bundle.<br>It now holds [bundle.value + value] credits.</span>")
 		bundle.transfer_value(bundle.value, src)
 
 /obj/item/spacecash/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixing wrong cash bundle value, cash dropping upon stacking
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Can now collect and stack money without dropping it on the floor. Working as intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Cash bundle values before (wrong):
![image](https://github.com/user-attachments/assets/65f7da39-1996-4bf0-95ba-df6b98f12342)
Cash bundle values after (right):
![image](https://github.com/user-attachments/assets/79b51f48-4a99-407a-87e0-a60a96fe2a2c)

And money stacking:
![ezgif-5-8e33dfacb3](https://github.com/user-attachments/assets/8251068a-1e51-4229-b70d-d37d740f86d0)


## Changelog

:cl:
fix: Cash bundle value will now be correct in chat, cash will not drop upon stacking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
