### PR TITLE
Makes oxygen tanks at the outpost very cheap.

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -21,7 +21,7 @@
 	crate_name = "internals crate"
 
 /datum/supply_pack/emergency/plasmaman_tank
-	name = "Plasmaman Tank Kit"
+	name = "Plasmaman Internals Crate"
 	desc = "Contains two plasmaman belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
 	cost = 200
 	contains = list(/obj/item/tank/internals/plasmaman/belt,

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -8,7 +8,7 @@
 
 /datum/supply_pack/emergency/internals
 	name = "Internals Crate"
-	desc = "Contains four breathing masks and four oxygen tanks of varying size. Oxygen canister sold separately."
+	desc = "Contains four breathing masks, three advanced emergency oxygen tanks and one large oxygen tank. Oxygen canister sold separately."
 	cost = 100
 	contains = list(/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -14,7 +14,7 @@
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
-					/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/tank/internals/emergency_oxygen/engi,
 					/obj/item/tank/internals/emergency_oxygen/engi,
 					/obj/item/tank/internals/emergency_oxygen/engi,
 					/obj/item/tank/internals/oxygen)

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -23,7 +23,7 @@
 /datum/supply_pack/emergency/plasmaman_tank
 	name = "Plasmaman Internals Crate"
 	desc = "Contains two plasmaman belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
-	cost = 200
+	cost = 100
 	contains = list(/obj/item/tank/internals/plasmaman/belt,
 					/obj/item/tank/internals/plasmaman/belt)
 	crate_name = "plasmaman internals crate"

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -8,25 +8,25 @@
 
 /datum/supply_pack/emergency/internals
 	name = "Internals Crate"
-	desc = "Two gas masks, two breathing masks, and four empty oxygen tanks of varying size. Oxygen canister sold separately."
-	cost = 500
-	contains = list(/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
+	desc = "Contains four breathing masks and four oxygen tanks of varying size. Oxygen canister sold separately."
+	cost = 100
+	contains = list(/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath,
-					/obj/item/tank/internals/emergency_oxygen/empty,
-					/obj/item/tank/internals/emergency_oxygen/empty,
-					/obj/item/tank/internals/oxygen/empty,
-					/obj/item/tank/internals/oxygen/empty)
+					/obj/item/clothing/mask/breath,
+					/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/tank/internals/emergency_oxygen/engi,
+					/obj/item/tank/internals/emergency_oxygen/engi,
+					/obj/item/tank/internals/oxygen)
 	crate_name = "internals crate"
 
 /datum/supply_pack/emergency/plasmaman_tank
 	name = "Plasmaman Tank Kit"
-	desc = "Contains two empty plasmaman belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately. Warranty void if filled with flammable gas."
-	cost = 500
-	contains = list(/obj/item/tank/internals/plasmaman/belt/empty,
-					/obj/item/tank/internals/plasmaman/belt/empty)
-	crate_name = "plasmaman tank kit"
+	desc = "Contains two plasmaman belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
+	cost = 200
+	contains = list(/obj/item/tank/internals/plasmaman/belt,
+					/obj/item/tank/internals/plasmaman/belt)
+	crate_name = "plasmaman internals crate"
 
 /datum/supply_pack/emergency/plasmaman_suit
 	name = "Plasmaman Suit Kit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
What if internals were cheap AF at the outpost? Would people actually buy them, instead of stealing from legions/hermits? Probably not, but worth a try.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## About The Pull Request
Reduces the price of internals crate to a whopping 100 credits and changes the contents:
2 gas masks, 2 breathe masks -> 4 breathe masks
2 empty small tanks, 2 empty big tanks -> 3 full adv tanks, 1 full big tank

Reduces the price of plasmaman tank kit to 100 credits, makes the tanks full, renames to "plasmaman internals crate".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
tweak: Internals Crate now costs 100 credits and contains full oxygen tanks.
tweak: Plasmaman Tank Kit renamed to Plasmaman Internals Crate. It now costs 100 credits and contains full plasma tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
