### PR TITLE
Moves everything from autolathe contraband. Removes a couple items from autolathe in general.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -286,7 +286,7 @@
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 750)
 	build_path = /obj/item/tank/internals/emergency_oxygen/engi/empty
-	category = list("hacked","Misc","Equipment")
+	category = list("initial", "Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/plasmaman_tank_belt
@@ -295,7 +295,7 @@
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 800)
 	build_path = /obj/item/tank/internals/plasmaman/belt/empty
-	category = list("hacked","Misc","Equipment")
+	category = list("initial", "Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/generic_gas_tank
@@ -515,14 +515,6 @@
 	build_path = /obj/item/hatchet
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
-/datum/design/foilhat
-	name = "Tinfoil Hat"
-	id = "tinfoil_hat"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 5500)
-	build_path = /obj/item/clothing/head/foilhat
-	category = list("hacked", "Misc")
 
 /datum/design/scalpel
 	name = "Scalpel"
@@ -772,31 +764,13 @@
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Misc")
 
-//hacked autolathe recipes
-//WS - emagged recipies
-/datum/design/flamethrower
-	name = "Flamethrower"
-	id = "flamethrower"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500)
-	build_path = /obj/item/flamethrower/full
-	category = list("hacked", "Security")
-
-/datum/design/electropack
-	name = "Electropack"
-	id = "electropack"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2500)
-	build_path = /obj/item/electropack
-	category = list("hacked", "Tools")
-
 /datum/design/handcuffs
 	name = "Handcuffs"
 	id = "handcuffs"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/restraints/handcuffs
-	category = list("hacked", "Security")
+	category = list("initial", "Security")
 
 /datum/design/receiver
 	name = "Modular Receiver"
@@ -804,7 +778,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 15000)
 	build_path = /obj/item/weaponcrafting/receiver
-	category = list("hacked", "Security")
+	category = list("initial", "Security")
 
 /datum/design/c38_surplus
 	name = "Ammo Box (.38 surplus)"
@@ -828,7 +802,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 1000) //Discount for making individually - no box = less metal!
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
-	category = list("hacked", "Security")
+	category = list("initial", "Security")
 
 /datum/design/riot_darts
 	name = "Foam Riot Dart Box"
@@ -836,15 +810,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
-	category = list("hacked", "Security")
-
-/datum/design/a357
-	name = ".357 Casing"
-	id = "a357"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/a357
-	category = list("emagged", "Security")
+	category = list("initial", "Security")
 
 /datum/design/c10mm_surplus
 	name = "Ammo Box (10mm surplus)"
@@ -900,7 +866,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 18000)
 	build_path = /obj/item/kitchen/knife/butcher
-	category = list("hacked", "Dinnerware")
+	category = list("initial", "Dinnerware")
 
 /datum/design/spraycan
 	name = "Spraycan"
@@ -984,14 +950,6 @@
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/modular_computer/tablet
 	category = list("initial","Misc")
-
-/datum/design/slime_scanner
-	name = "Slime Scanner"
-	id = "slime_scanner"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 300, /datum/material/glass = 200)
-	build_path = /obj/item/slime_scanner
-	category = list("initial", "Misc")
 
 /datum/design/pet_carrier
 	name = "Pet Carrier"
@@ -1084,7 +1042,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
 	build_path = /obj/item/toy/gun
-	category = list("hacked", "Misc")
+	category = list("initial", "Misc")
 
 /datum/design/capbox
 	name = "Box of Cap Gun Shots"
@@ -1092,7 +1050,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 20, /datum/material/glass = 5)
 	build_path = /obj/item/toy/ammo/gun
-	category = list("hacked", "Misc")
+	category = list("initial", "Misc")
 
 /datum/design/toy_balloon
 	name = "Plastic Balloon"
@@ -1100,7 +1058,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/plastic = 1200)
 	build_path = /obj/item/toy/balloon
-	category = list("hacked", "Misc")
+	category = list("initial", "Misc")
 
 /datum/design/toy_meteor
 	name = "Plastic Toy Meteor"
@@ -1108,15 +1066,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/plastic = 1000)
 	build_path = /obj/item/toy/minimeteor
-	category = list("hacked", "Misc")
-
-/datum/design/toy_armblade
-	name = "Plastic Armblade"
-	id = "toy_armblade"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/plastic = 2000)
-	build_path = /obj/item/toy/foamblade
-	category = list("hacked", "Misc")
+	category = list("initial", "Misc")
 
 /datum/design/plastic_tree
 	name = "Plastic Potted Plant"
@@ -1181,7 +1131,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 20000)
 	build_path = /obj/item/ammo_box/magazine/zip_ammo_9mm
-	category = list("hacked", "Security")
+	category = list("initial", "Security")
 
 /datum/design/pipedispenser
 	name = "Pipe Dispenser (Machine Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Everything you needed to hack for before, you no longer have to.
Also axes these items completely because:
- foilhat - meme item
- flamethrower - printable gun, probably not good
- electropack - Did anyone like, use it, ever? It's very gimmicky on station servers too.
- .357 casing - It was locked behind emag, and emags died. Plus, ammo in the lathe is usually surplus version.
- slime scanner - slimes died
- toy armblade - clings aren't that common in the setting, iirc
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hacking as a mechanic is very very dumb.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Moved everything out of autolathe contraband - you no longer have to hack it, ever.
del: Removed foilhat, flamethrower, electropack, .357 casing and slime scanner from the autolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
