### PR TITLE
Attachments are now small instead of normal sized

### DIFF
--- a/code/game/objects/items/attachments/_attachment.dm
+++ b/code/game/objects/items/attachments/_attachment.dm
@@ -3,6 +3,7 @@
 	name = "broken attachment"
 	desc = "alert coders"
 	icon = 'icons/obj/guns/attachments.dmi'
+	w_class = WEIGHT_CLASS_SMALL
 
 	//Slot the attachment goes on, also used in descriptions so should be player readable
 	var/slot = ATTACHMENT_SLOT_RAIL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows attachments to be carried in things like boxes and pockets.

## Why It's Good For The Game

This is mostly useless since there is very little reason to not have an attachment glued to a gun after buying it, but suppressors being untenable to store (either taking up a bunch of bag space or making a gun potentially impossible to stow) is a bit silly

## Changelog

:cl:
balance: gun attachments are now small instead of normal sized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
