### PR TITLE
Cargo Typos (Contender)

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -81,7 +81,7 @@
 */
 
 /datum/supply_pack/ammo/winchester_ammo
-	name = "Flaming Arrow and Detective Special .38 Ammo Boxes"
+	name = ".38 Ammo Boxes Crate"
 	desc = "Contains two 50 round ammo boxes for refilling .38 weapons."
 	cost = 250
 	contains = list(/obj/item/ammo_box/c38_box,

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -149,7 +149,7 @@
 	crate_name = "rifle crate"
 
 /datum/supply_pack/gun/beacon
-	name = "Contender Break Action Rifle Crate"
+	name = "Beacon Break Action Rifle Crate"
 	desc = "Contains a single shot break action rifle to hunt wildlife that annoys you in particular. Chambered in devastating .45-70 rounds. Warranty voided if sawed off."
 	cost = 2250
 	contains = list(/obj/item/storage/guncase/beacon)


### PR DESCRIPTION
## About The Pull Request

Beacon got renamed a long while ago

## Why It's Good For The Game

Yeah

## Changelog

:cl:
fix: Contender is now called the Beacon in cargo
fix: .38 is now .38 and no longer has a bunch of random letters in front of it
/:cl: