### PR TITLE
Give the Talos a Corpsman

### DIFF
--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -40,9 +40,13 @@
 			"outfit": "/datum/outfit/job/inteq/security",
 			"slots": 1
 		},
+		"Corpsman": {
+			"outfit": "/datum/outfit/job/inteq/paramedic",
+			"slots": 1
+		},
 		"Recruit": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
-			"slots": 4
+			"slots": 4 
 		}
 	},
 	"enabled": true

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -4630,11 +4630,13 @@
 	},
 /obj/structure/crate_shelf,
 /obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 5
+/obj/item/storage/firstaid/brute{
+	pixel_x = -8;
+	pixel_y = 0
 	},
-/obj/item/storage/firstaid/medical{
-	pixel_x = -5
+/obj/item/storage/firstaid/fire{
+	pixel_x = 9;
+	pixel_y = 0
 	},
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/patterned/cargo_one,

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -117,7 +117,11 @@
 	ears = /obj/item/radio/headset/headset_medsec/alt
 
 	suit_store = /obj/item/flashlight/pen
-	backpack_contents = list(/obj/item/roller=1)
+	backpack_contents = list(
+	/obj/item/roller=1,
+	/obj/item/storage/firstaid/regular=1,
+	/obj/item/storage/box/syringes=1
+	)
 
 /datum/outfit/job/inteq/paramedic/empty
 	name = "IRMG - Corpsman (Naked)"

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -117,11 +117,7 @@
 	ears = /obj/item/radio/headset/headset_medsec/alt
 
 	suit_store = /obj/item/flashlight/pen
-	backpack_contents = list(
-	/obj/item/roller=1,
-	/obj/item/storage/firstaid/regular=1,
-	/obj/item/storage/box/syringes=1
-	)
+	backpack_contents = list(/obj/item/roller=1)
 
 /datum/outfit/job/inteq/paramedic/empty
 	name = "IRMG - Corpsman (Naked)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the corpsman role to the Talos,.
The talos has lost its surgery medkit, which has been replaced with a brute and burn kit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Surgery is dummy busted, not having a medic on a milship forces the role on someone else.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:phoaly
balance: Talos Corpsman has been readded with a different medkit loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
