### PR TITLE
makes lighting a bit moodier

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -20,8 +20,13 @@
 #define LIGHTING_FALLOFF 1
 /// use lambertian shading for light sources
 #define LIGHTING_LAMBERTIAN 0
-/// height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_HEIGHT 1
+/// The (square of the) cardinal offset added to the distance of any light corner from a light source; you should probably leave this alone
+#define LIGHTING_HEIGHT 0.25
+/// The offset added to the post-sqrt distance of any light corner from a light source: can be negative! 
+#define LIGHTING_FREE_DIST -0.125
+/// The exponent used to cut down the strength of a light as corners get further from the source
+#define LIGHT_FALLOFF_EXPONENT 2.5
+
 /// Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 #define LIGHTING_ROUND_VALUE (1 / 64)
 

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -22,7 +22,7 @@
 #define LIGHTING_LAMBERTIAN 0
 /// The (square of the) cardinal offset added to the distance of any light corner from a light source; you should probably leave this alone
 #define LIGHTING_HEIGHT 0.25
-/// The offset added to the post-sqrt distance of any light corner from a light source: can be negative! 
+/// The offset added to the post-sqrt distance of any light corner from a light source: can be negative!
 #define LIGHTING_FREE_DIST -0.125
 /// The exponent used to cut down the strength of a light as corners get further from the source
 #define LIGHT_FALLOFF_EXPONENT 2.5

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -19,7 +19,7 @@
 	var/static/datum/gas_mixture/immutable/space/space_gas
 	plane = PLANE_SPACE
 	layer = SPACE_LAYER
-	light_power = 0.25
+	light_power = 0.125
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 	bullet_bounce_sound = null
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -101,7 +101,7 @@
 // If you're wondering what's with the backslashes, the backslashes cause BYOND to not automatically end the line.
 // As such this all gets counted as a single line.
 // The braces and semicolons are there to be able to do this on a single line.
-#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
+#define LUM_FALLOFF(C, T) (1 - CLAMP01((sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) + LIGHTING_FREE_DIST) / max(1, light_range))) ** LIGHT_FALLOFF_EXPONENT
 
 #define APPLY_CORNER(C)                          \
 	. = LUM_FALLOFF(C, pixel_turf);              \


### PR DESCRIPTION
## About The Pull Request

Adds some new constants to lighting falloff calculations, and updates some old ones, as well as cuts the brightness of starlight in half. The ultimate result is that lighting is, generally, moodier and darker.

## Why It's Good For The Game

I think lighting looks better if it's moodier! Our lights are too bright, right now.

## Changelog

:cl:
add: Made a number of changes to lighting, making it substantially moodier.
/:cl:
