### PR TITLE
Cleanbots destroy cigarette butts

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -233,7 +233,10 @@
 		target = scan(/obj/effect/decal/remains)
 
 	if(!target && trash) //Then for trash.
-		target = scan(/obj/item/trash) || (/obj/item/cigbutt)
+		target = scan(/obj/item/trash)
+
+	if(!target && trash) //Then for Chainsmokers.
+		target = scan(/obj/item/cigbutt)
 
 	if(!target && trash) //Search for dead mices.
 		target = scan(/obj/item/reagent_containers/food/snacks/deadmouse)
@@ -341,7 +344,7 @@
 	else if(istype(A, /obj/item) || istype(A, /obj/effect/decal/remains))
 		visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [A]!</span>")
 		playsound(src, 'sound/effects/spray2.ogg', 50, TRUE, -6)
-		A.acid_act(75, 10)
+		A.acid_act(100, 10)
 		target = null
 	else if(istype(A, /mob/living/simple_animal/hostile/cockroach) || istype(A, /mob/living/simple_animal/mouse))
 		var/mob/living/simple_animal/M = target

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -233,7 +233,7 @@
 		target = scan(/obj/effect/decal/remains)
 
 	if(!target && trash) //Then for trash.
-		target = scan(/obj/item/trash)
+		target = scan(/obj/item/trash) || (/obj/item/cigbutt)
 
 	if(!target && trash) //Search for dead mices.
 		target = scan(/obj/item/reagent_containers/food/snacks/deadmouse)
@@ -317,6 +317,7 @@
 		target_types += list(
 		/obj/item/trash,
 		/obj/item/reagent_containers/food/snacks/deadmouse,
+		/obj/item/cigbutt,
 		)
 
 	target_types = typecacheof(target_types)


### PR DESCRIPTION
## About The Pull Request

Cleanbots now shoot acid at cigarette butts like they do to normal trash. Increased the amount of acid cleanbots shoot out by an amount so the trash actually gets destroyed.

## Why It's Good For The Game

To restore order in a ship full of smokers

## Changelog

:cl:
add: Cleanbots now destroy cigarette butts, and dispense enough acid to do so.
/:cl: