### PR TITLE
Restores scooping reagents from water turfs, and repaths acid turfs under water

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_camp_combination.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_camp_combination.dmm
@@ -1066,7 +1066,7 @@
 /turf/open/floor/wood,
 /area/ruin)
 "Ok" = (
-/turf/open/acid/whitesands,
+/turf/open/water/acid/whitesands,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ov" = (
 /obj/item/clothing/head/cowboy{

--- a/code/datums/mapgen/planetary/SandGenerator.dm
+++ b/code/datums/mapgen/planetary/SandGenerator.dm
@@ -173,10 +173,10 @@
 	)
 
 /datum/biome/sand/acid //plains
-	open_turf_types = list(/turf/open/floor/plating/asteroid/whitesands/lit = 10, /turf/open/acid/whitesands = 1)
+	open_turf_types = list(/turf/open/floor/plating/asteroid/whitesands/lit = 10, /turf/open/water/acid/whitesands = 1)
 
 /datum/biome/sand/acid/total
-	open_turf_types = list(/turf/open/acid/whitesands = 1)
+	open_turf_types = list(/turf/open/water/acid/whitesands = 1)
 	flora_spawn_chance = 0
 	feature_spawn_chance = 0
 	mob_spawn_chance = 0
@@ -228,4 +228,4 @@
 	open_turf_types = list(/turf/open/floor/plating/asteroid/whitesands/dried = 7, /turf/open/lava = 1)
 
 /datum/biome/cave/sand/volcanic/acidic
-	open_turf_types = list(/turf/open/floor/plating/asteroid/whitesands/dried = 8, /turf/open/acid/whitesands = 1)
+	open_turf_types = list(/turf/open/floor/plating/asteroid/whitesands/dried = 8, /turf/open/water/acid/whitesands = 1)

--- a/code/game/turfs/open/acid.dm
+++ b/code/game/turfs/open/acid.dm
@@ -1,8 +1,8 @@
-/turf/open/acid
+/turf/open/water/acid
 	name = "acid lake"
+	desc = "A lake of acid."
 	icon_state = "acid"
-	gender = PLURAL
-	baseturfs = /turf/open/acid
+	baseturfs = /turf/open/water/acid
 	slowdown = 2
 
 	light_range = 2
@@ -10,90 +10,77 @@
 	light_color = LIGHT_COLOR_SLIME_LAMP
 	bullet_bounce_sound = 'sound/items/welder2.ogg'
 
+	planetary_atmos = FALSE
 	footstep = FOOTSTEP_LAVA
 	barefootstep = FOOTSTEP_LAVA
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
 
-/turf/open/acid/CanAllowThrough(atom/movable/passing_atom, turf/target)
+	reagent_to_extract = /datum/reagent/toxin/acid
+	extracted_reagent_visible_name = "acid"
+
+/turf/open/water/acid/CanAllowThrough(atom/movable/passing_atom, turf/target)
 	if(ishostile(passing_atom))
 		return FALSE
 	return ..()
 
-/turf/open/acid/ex_act(severity, target)
+/turf/open/water/acid/ex_act(severity, target)
 	contents_explosion(severity, target)
 
-/turf/open/acid/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
-	return
-
-/turf/open/acid/Melt()
+/turf/open/water/acid/Melt()
 	to_be_destroyed = FALSE
 	return src
 
-/turf/open/acid/acid_act(acidpwr, acid_volume)
+/turf/open/water/acid/acid_act(acidpwr, acid_volume)
 	return
 
-/turf/open/acid/MakeDry(wet_setting = TURF_WET_WATER)
+/turf/open/water/acid/MakeDry(wet_setting = TURF_WET_WATER)
 	return
 
-/turf/open/acid/airless
+/turf/open/water/acid/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
-/turf/open/acid/Entered(atom/movable/AM)
+/turf/open/water/acid/Entered(atom/movable/AM)
 	. = ..()
 	if(melt_stuff(AM))
 		START_PROCESSING(SSobj, src)
 
-/turf/open/acid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+/turf/open/water/acid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(melt_stuff(AM))
 		START_PROCESSING(SSobj, src)
 
-/turf/open/acid/process()
+/turf/open/water/acid/process()
 	if(!melt_stuff())
 		STOP_PROCESSING(SSobj, src)
 
-/turf/open/acid/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_FLOORWALL)
-			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
-	return FALSE
-
-/turf/open/acid/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
-	return FALSE
-
-/turf/open/acid/singularity_act()
+/turf/open/water/acid/singularity_act()
 	return
 
-/turf/open/acid/singularity_pull(S, current_size)
+/turf/open/water/acid/singularity_pull(S, current_size)
 	return
 
-/turf/open/acid/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+/turf/open/water/acid/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = 'icons/turf/floors.dmi'
 	underlay_appearance.icon_state = "basalt"
 	return TRUE
 
-/turf/open/acid/attackby(obj/item/C, mob/user, params)
+/turf/open/water/acid/attackby(obj/item/_item, mob/user, params)
 	..()
-	if(istype(C, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = C
+	if(istype(_item, /obj/item/stack/rods))
+		var/obj/item/stack/rods/R = _item
 		var/obj/structure/lattice/H = locate(/obj/structure/lattice, src)
 		if(H)
-			to_chat(user, "<span class='warning'>There is already a lattice here!</span>")
+			to_chat(user, span_warning("There is already a lattice here!"))
 			return
 		if(R.use(2))
-			to_chat(user, "<span class='notice'>You construct a catwalk.</span>")
+			to_chat(user, span_notice("You construct a catwalk."))
 			playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
 			new /obj/structure/lattice/catwalk(locate(x, y, z))
 		else
-			to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")
+			to_chat(user, span_warning("You need one rod to build a lattice."))
 		return
 
-/turf/open/acid/proc/is_safe_to_cross()
+/turf/open/water/acid/proc/is_safe_to_cross()
 	//if anything matching this typecache is found in the lava, we don't burn things
 	var/static/list/acid_safeties_typecache = typecacheof(list(/obj/structure/catwalk, /obj/structure/stone_tile, /obj/structure/lattice/))
 	var/list/found_safeties = typecache_filter_list(contents, acid_safeties_typecache)
@@ -103,7 +90,7 @@
 	return LAZYLEN(found_safeties)
 
 
-/turf/open/acid/proc/melt_stuff(thing_to_melt)
+/turf/open/water/acid/proc/melt_stuff(thing_to_melt)
 	if(is_safe_to_cross())
 		return FALSE
 	. = FALSE
@@ -156,6 +143,6 @@
 			if(L) //mobs turning into object corpses could get deleted here.
 				L.acid_act(50, 100)
 
-/turf/open/acid/whitesands
+/turf/open/water/acid/whitesands
 	planetary_atmos = TRUE
 	initial_gas_mix = WHITESANDS_ATMOS

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -18,27 +18,32 @@
 	var/datum/reagent/reagent_to_extract = /datum/reagent/water
 	var/extracted_reagent_visible_name = "water"
 
-/*
-/turf/open/water/attackby(obj/item/tool, mob/user, params)
-	if(!reagent_to_extract)
-		return ..()
-	var/obj/item/reagent_containers/glass/container = tool
-	if(!istype(tool, /obj/item/reagent_containers))
-		return ..()
-	if(container.reagents.total_volume >= container.volume)
-		to_chat(user, "<span class='danger'>[container] is full.</span>")
-		return
-	container.reagents.add_reagent(reagent_to_extract, rand(5, 10))
-	user.visible_message("<span class='notice'>[user] scoops [extracted_reagent_visible_name] from the [src] with \the [container].</span>", "<span class='notice'>You scoop out [extracted_reagent_visible_name] from the [src] using \the [container].</span>")
-	return TRUE
-*/
-
-/turf/open/water/attackby(obj/item/fish, mob/user, params)
+/turf/open/water/examine(mob/user)
 	. = ..()
-	if(istype(fish, /obj/item/fish))
-		to_chat(user, "<span class='notice'>You toss the [fish.name] into the water.</span>")
-		playsound(fish, "sound/effects/bigsplash.ogg", 90)
-		qdel(fish)
+	. += span_notice("You could probably scoop some of the [extracted_reagent_visible_name] if you had a beaker...")
+
+/turf/open/water/attackby(obj/item/_item, mob/user, params)
+	if(istype(_item, /obj/item/fish))
+		to_chat(user, span_notice("You toss the [_item.name] into the [name]."))
+		playsound(_item, "sound/effects/bigsplash.ogg", 90)
+		qdel(_item)
+	if(istype(_item, /obj/item/reagent_containers/glass))
+		extract_reagents(_item,user,params)
+
+	. = ..()
+
+/turf/open/water/proc/extract_reagents(obj/item/reagent_containers/glass/container, mob/user, params)
+	if(!reagent_to_extract)
+		return FALSE
+	if(!container.is_refillable())
+		to_chat(user, span_danger("\The [container]'s cap is on! Take it off first."))
+		return FALSE
+	if(container.reagents.total_volume >= container.volume)
+		to_chat(user, span_danger("\The [container] is full."))
+		return FALSE
+	container.reagents.add_reagent(reagent_to_extract, rand(5, 10))
+	user.visible_message(span_notice("[user] scoops [extracted_reagent_visible_name] from the [src] with \the [container]."), span_notice("You scoop out [extracted_reagent_visible_name] from the [src] using \the [container]."))
+	return TRUE
 
 /turf/open/water/can_have_cabling()
 	return FALSE
@@ -52,7 +57,7 @@
 /turf/open/water/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
+			to_chat(user, span_notice("You build a floor."))
 			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
 	return FALSE
@@ -85,7 +90,7 @@
 
 /turf/open/water/tar
 	name = "tar pit"
-	desc = "Shallow tar. Will slow you down significantly. You could use a beaker to scoop some out..."
+	desc = "Shallow tar. Will slow you down significantly."
 	color = "#473a3a"
 	light_range = 0
 	slowdown = 2

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -20,7 +20,8 @@
 
 /turf/open/water/examine(mob/user)
 	. = ..()
-	. += span_notice("You could probably scoop some of the [extracted_reagent_visible_name] if you had a beaker...")
+	if(reagent_to_extract)
+		. += span_notice("You could probably scoop some of the [extracted_reagent_visible_name] if you had a beaker...")
 
 /turf/open/water/attackby(obj/item/_item, mob/user, params)
 	if(istype(_item, /obj/item/fish))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -87,7 +87,7 @@
 
 	else if(reagents.total_volume && is_drainable())
 		switch(user.a_intent)
-			if(INTENT_HELP)
+			if(INTENT_DISARM)
 				attempt_pour(target, user)
 			if(INTENT_HARM)
 				user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can once again scoop reagents from a water turf using a beaker. Adds an examine hint for the action.
Repaths acid turfs under water so they inherit the scooping behavior.

Pouring from a reagent container is now bound to disarm instead of help.

Changes the span classes to span macros

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Reagent scooping got disabled and commented out in #1900 I think due to conflicting with the fishing code. This PR cleans up the scooping code so it works again. 

Pouring out a container is now bound to using disarm instead of help intent. I feel it's more intuitive, and should cut down on accidentally spilling your hard earned reagents on the floor due to a misclick.

Repaths acid under water mainly so it inherits the scooping behavior, and it seems logical to be able to scoop from it since it's also a liquid. Changes all the relevant turfs to the new paths.

THE TAR NO LONGER LIES TO ME ABOUT BEING ABLE TO SCOOP IT.

## Changelog

:cl:
fix: water turfs reagent scooping
code: span classes to span macros
refactor: acid turfs repathed under water
refactor: Pouring out a reagent container is now bound to disarm intent instead of help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
