### PR TITLE
Wormholes no longer decay when used

### DIFF
--- a/code/modules/overmap/objects/event_datum.dm
+++ b/code/modules/overmap/objects/event_datum.dm
@@ -194,54 +194,24 @@
 	chance_to_affect = 100
 	///The currently linked wormhole
 	var/datum/overmap/event/wormhole/other_wormhole
-	///Amount of times a ship can pass through before it collapses
-	var/stability
 
 /datum/overmap/event/wormhole/Initialize(position, _other_wormhole, ...)
 	. = ..()
-	stability = rand(1, 5)
 	if(_other_wormhole)
 		other_wormhole = _other_wormhole
 	if(!other_wormhole)
 		other_wormhole = new(null, src) //Create a new wormhole at a random location
-	token.color = adjust_colors()
-	token.light_color = adjust_colors()
+	token.color = "#6d80c7"
+	token.light_color = "#6d80c7"
 	token.update_appearance()
 
 /datum/overmap/event/wormhole/affect_ship(datum/overmap/ship/controlled/S)
 	if(!other_wormhole)
 		qdel(src)
-	if(--stability <= 0)
-		var/list/results = SSovermap.get_unused_overmap_square()
-		S.overmap_move(results["x"], results["y"])
-		QDEL_NULL(other_wormhole)
-		for(var/MN in GLOB.player_list)
-			var/mob/M = MN
-			if(S.shuttle_port.is_in_shuttle_bounds(M))
-				M.playsound_local(S.shuttle_port, 'sound/effects/explosionfar.ogg', 100)
-				shake_camera(M, 10, 10)
-
-		return qdel(src)
-	other_wormhole.stability = stability
+		return
 
 	S.overmap_move(other_wormhole.x, other_wormhole.y)
 	S.overmap_step(S.get_heading())
-
-	token.color = adjust_colors()
-	token.light_color = adjust_colors()
-
-/datum/overmap/event/wormhole/proc/adjust_colors()
-	switch(stability)
-		if(1)
-			return "#753214"
-		if(2)
-			return "#642f19"
-		if(3)
-			return"#654650"
-		if(4)
-			return"#5c5d8b"
-		if(5)
-			return"#6d80c7"
 
 //Carp "meteors" - throws carp at the ship
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wormholes are now permanent if one spawns on the overmap, rather than being usable a few times then deleting themselves. Ideally this will make them slightly more interactable in the event they help transit enough

## Why It's Good For The Game

I don't feel like wormholes being usable maybe up to 5 times makes them particularly more interesting than not, since there's no reason to check what is on the other side if you won't be able to use it for more than 2 round trips in the best case

## Changelog

:cl:
balance: wormholes on the overmap no longer decay when used
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
