### PR TITLE
Reduces the cost of food/botany items in the outpost and makes the grill not suck as much.

### DIFF
--- a/code/datums/components/sizzle.dm
+++ b/code/datums/components/sizzle.dm
@@ -3,9 +3,11 @@
 	var/sizzlealpha = 0
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-/datum/component/sizzle/Initialize()
+/datum/component/sizzle/Initialize(_alpha)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
+	if(_alpha)
+		sizzlealpha = _alpha
 	setup_sizzle()
 
 /datum/component/sizzle/InheritComponent(datum/component/C, i_am_original)

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -8,7 +8,7 @@
 /datum/supply_pack/food/donkpockets
 	name = "Donk Pocket Variety Crate"
 	desc = "Featuring a line up of Donk Co.'s most popular pastry!"
-	cost = 750
+	cost = 500
 	contains = list(/obj/item/storage/box/donkpockets/donkpocketspicy,
 					/obj/item/storage/box/donkpockets/donkpocketteriyaki,
 					/obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -25,7 +25,7 @@
 /datum/supply_pack/food/pizza
 	name = "Pizza Crate"
 	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99.5% anomaly-free!"
-	cost = 1000// Best prices this side of the galaxy.
+	cost = 750// Best prices this side of the galaxy.
 	contains = list(/obj/item/pizzabox/margherita,
 					/obj/item/pizzabox/mushroom,
 					/obj/item/pizzabox/meat,
@@ -78,14 +78,15 @@
 
 /datum/supply_pack/food/ingredients_condiments
 	name = "Condiments Crate"
-	desc = "A variety of garnishes for topping off your dish with a little extra pizzaz. Contains a bottle of enzyme, a salt shaker, a pepper mill, a bottle of ketchup, a bottle of hot sauce, and a bottle of cream."
+	desc = "A variety of garnishes for topping off your dish with a little extra pizzaz. Contains a bottle of enzyme, a salt shaker, a pepper mill, a bottle of ketchup, a bottle of hot sauce, a bottle of BBQ sauce, and a bottle of cream."
 	cost = 250
 	contains = list(/obj/item/reagent_containers/food/condiment/enzyme,
 					/obj/item/reagent_containers/food/condiment/saltshaker,
 					/obj/item/reagent_containers/food/condiment/peppermill,
 					/obj/item/reagent_containers/food/condiment/ketchup,
 					/obj/item/reagent_containers/food/condiment/hotsauce,
-					/obj/item/reagent_containers/food/drinks/bottle/cream
+					/obj/item/reagent_containers/food/drinks/bottle/cream,
+					/obj/item/reagent_containers/food/condiment/bbqsauce
 	)
 	crate_name = "condiments crate"
 	crate_type = /obj/structure/closet/crate/freezer

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -8,7 +8,7 @@
 /datum/supply_pack/food/donkpockets
 	name = "Donk Pocket Variety Crate"
 	desc = "Featuring a line up of Donk Co.'s most popular pastry!"
-	cost = 2000
+	cost = 750
 	contains = list(/obj/item/storage/box/donkpockets/donkpocketspicy,
 					/obj/item/storage/box/donkpockets/donkpocketteriyaki,
 					/obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -25,7 +25,7 @@
 /datum/supply_pack/food/pizza
 	name = "Pizza Crate"
 	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99.5% anomaly-free!"
-	cost = 3000// Best prices this side of the galaxy.
+	cost = 1000// Best prices this side of the galaxy.
 	contains = list(/obj/item/pizzabox/margherita,
 					/obj/item/pizzabox/mushroom,
 					/obj/item/pizzabox/meat,
@@ -42,6 +42,19 @@
 			fourfiveeight.boxtag = P.boxtag
 			qdel(P)
 
+/datum/supply_pack/food/ration
+	name = "Ration Crate"
+	desc = "6 standerd issue rations."
+	cost = 500
+	contains = list(/obj/effect/spawner/lootdrop/ration,
+					/obj/effect/spawner/lootdrop/ration,
+					/obj/effect/spawner/lootdrop/ration,
+					/obj/effect/spawner/lootdrop/ration,
+					/obj/effect/spawner/lootdrop/ration,
+					/obj/effect/spawner/lootdrop/ration)
+	crate_name = "ration crate"
+	crate_type = /obj/structure/closet/crate
+
 /*
 		Ingredients
 */
@@ -49,7 +62,7 @@
 /datum/supply_pack/food/ingredients_basic
 	name = "Basic Ingredients Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, two slabs of meat, some flour, some rice, a bottle of milk, a bottle of soymilk, and a bag of sugar."
-	cost = 1000
+	cost = 300
 	contains = list(/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/rice,
@@ -63,10 +76,10 @@
 	crate_name = "food crate"
 	crate_type = /obj/structure/closet/crate/freezer
 
-/datum/supply_pack/food/ingredients_specialized
-	name = "Advanced Cooking Crate"
-	desc = "For the discerning chef. Contains a bottle of enzyme, a salt shaker, a pepper mill, a bottle of ketchup, a bottle of hot sauce, and a bottle of cream."
-	cost = 2000
+/datum/supply_pack/food/ingredients_condiments
+	name = "Condiments Crate"
+	desc = "A variety of garnishes for topping off your dish with a little extra pizzaz. Contains a bottle of enzyme, a salt shaker, a pepper mill, a bottle of ketchup, a bottle of hot sauce, and a bottle of cream."
+	cost = 250
 	contains = list(/obj/item/reagent_containers/food/condiment/enzyme,
 					/obj/item/reagent_containers/food/condiment/saltshaker,
 					/obj/item/reagent_containers/food/condiment/peppermill,
@@ -80,7 +93,7 @@
 /datum/supply_pack/food/ingredients_randomized
 	name = "Exotic Meat Crate"
 	desc = "The best cuts in the whole galaxy. Probably."
-	cost = 1000
+	cost = 500
 	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
 					/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
 					/obj/item/reagent_containers/food/snacks/meat/slab/bear,
@@ -103,7 +116,7 @@
 /datum/supply_pack/food/ingredients_randomized/meat
 	name = "Standard Meat Crate"
 	desc = "Less interesting cuts of meat, but filling nonetheless."
-	cost = 1500
+	cost = 300
 	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab,
 					/obj/item/reagent_containers/food/snacks/meat/slab/chicken,
 					/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
@@ -116,7 +129,7 @@
 /datum/supply_pack/food/ingredients_randomized/vegetables
 	name = "Vegetables Crate"
 	desc = "Grown in vats."
-	cost = 1300
+	cost = 250
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/chili,
 					/obj/item/reagent_containers/food/snacks/grown/corn,
 					/obj/item/reagent_containers/food/snacks/grown/tomato,
@@ -132,7 +145,7 @@
 /datum/supply_pack/food/ingredients_randomized/fruits
 	name = "Fruit Crate"
 	desc = "Rich of vitamins, may contain oranges."
-	cost = 1500
+	cost = 250
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
 					/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 					/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
@@ -147,7 +160,7 @@
 /datum/supply_pack/food/ingredients_randomized/grains
 	name = "Grains Crate"
 	desc = "A crate full of various grains. How interesting."
-	cost = 1000
+	cost = 250
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/wheat,
 					/obj/item/reagent_containers/food/snacks/grown/wheat,
 					/obj/item/reagent_containers/food/snacks/grown/wheat, //Weighted to be more common
@@ -162,7 +175,7 @@
 /datum/supply_pack/food/ingredients_randomized/bread
 	name = "Bread Crate"
 	desc = "A crate full of various breads. Bready to either be eaten or made into delicious meals."
-	cost = 1000
+	cost = 300
 	contains = list(/obj/item/food/bread/plain,
 					/obj/item/food/breadslice/plain,
 					/obj/item/food/breadslice/plain,
@@ -181,17 +194,16 @@
 /datum/supply_pack/food/grill
 	name = "Grilling Starter Kit"
 	desc = "Sometimes the stresses of the world are too much to bear. Some times, for God's sake, you just want to grill. This crate is for those times."
-	cost = 5000
+	cost = 1000
 	contains = list(/obj/item/stack/sheet/mineral/coal/five,
-					/obj/machinery/grill/unwrenched,
-					/obj/item/reagent_containers/food/drinks/soda_cans/xeno_energy)
+					/obj/machinery/grill/unwrenched)
 	crate_name = "grilling starter kit crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/food/grillfuel
 	name = "Grilling Fuel Kit"
 	desc = "Contains propane and propane accessories. (Note: doesn't contain any actual propane.)"
-	cost = 2000
+	cost = 250
 	contains = list(/obj/item/stack/sheet/mineral/coal/ten)
 	crate_name = "grilling fuel kit crate"
 
@@ -202,7 +214,7 @@
 /datum/supply_pack/food/hydrotank
 	name = "Hydroponics Backpack Crate"
 	desc = "Bring on the flood with this high-capacity backpack crate. Contains 500 units of life-giving H2O."
-	cost = 1000
+	cost = 750
 	contains = list(/obj/item/watertank)
 	crate_name = "hydroponics backpack crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
@@ -210,7 +222,7 @@
 /datum/supply_pack/food/gardening
 	name = "Gardening Crate"
 	desc = "Supplies for growing a great garden! Contains two bottles of ammonia, two Plant-B-Gone spray bottles, a hatchet, cultivator, plant analyzer, as well as a pair of leather gloves and a botanist's apron."
-	cost = 1500
+	cost = 500
 	contains = list(/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
@@ -227,7 +239,7 @@
 /datum/supply_pack/food/weedcontrol
 	name = "Weed Control Crate"
 	desc = "Contains a scythe, gasmask, and two anti-weed defoliant grenades, for when your garden grows out of control."
-	cost = 1500
+	cost = 750
 	contains = list(/obj/item/scythe,
 					/obj/item/clothing/mask/gas,
 					/obj/item/grenade/chem_grenade/antiweed,
@@ -238,7 +250,7 @@
 /datum/supply_pack/food/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains fourteen different seeds."
-	cost = 2000
+	cost = 750
 	contains = list(/obj/item/seeds/chili,
 					/obj/item/seeds/cotton,
 					/obj/item/seeds/berry,
@@ -259,7 +271,7 @@
 /datum/supply_pack/food/exoticseeds
 	name = "Exotic Seeds Crate"
 	desc = "Any entrepreneuring botanist's dream. Contains eleven different seeds, including two mystery seeds!"
-	cost = 3000
+	cost = 1000
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/plump,
 					/obj/item/seeds/liberty,
@@ -281,7 +293,7 @@
 /datum/supply_pack/food/beekeeping_suits
 	name = "Beekeeper Suit Crate"
 	desc = "Bee business booming? Better be benevolent and boost botany by bestowing bi-Beekeeper-suits! Contains two beekeeper suits and matching headwear."
-	cost = 2000
+	cost = 1000
 	contains = list(/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/clothing/head/beekeeper_head,
@@ -292,7 +304,7 @@
 /datum/supply_pack/food/beekeeping_fullkit
 	name = "Beekeeping Starter Crate"
 	desc = "BEES BEES BEES. Contains three honey frames, a beekeeper suit and helmet, flyswatter, bee house, and, of course, a pure-bred Nanotrasen-Standardized Queen Bee!"
-	cost = 3000
+	cost = 2000
 	contains = list(/obj/structure/beebox/unwrenched,
 					/obj/item/honey_frame,
 					/obj/item/honey_frame,
@@ -304,16 +316,5 @@
 	crate_name = "beekeeping starter crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
-/datum/supply_pack/food/ration
-	name = "Ration Crate"
-	desc = "6 standerd issue rations."
-	cost = 2000
-	contains = list(/obj/effect/spawner/lootdrop/ration,
-					/obj/effect/spawner/lootdrop/ration,
-					/obj/effect/spawner/lootdrop/ration,
-					/obj/effect/spawner/lootdrop/ration,
-					/obj/effect/spawner/lootdrop/ration,
-					/obj/effect/spawner/lootdrop/ration)
-	crate_name = "ration crate"
-	crate_type = /obj/structure/closet/crate
+
 

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -149,7 +149,7 @@
 			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
 			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
 			grilled_item.foodtype |= FRIED
-	grilled_item.AddComponent(/datum/component/sizzle, (grill_time * 5))
+	grilled_item.AddComponent(/datum/component/sizzle, (grill_time * 7.5))
 	grilled_item.foodtype |= GRILLED
 	grill_time = 0
 	grill_loop.stop()

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -9,7 +9,7 @@
 	layer = BELOW_OBJ_LAYER
 	use_power = NO_POWER_USE
 	var/grill_fuel = 0
-	var/obj/item/reagent_containers/food/grilled_item
+	var/obj/item/reagent_containers/food/snacks/grilled_item
 	var/grill_time = 0
 	var/datum/looping_sound/grill/grill_loop
 
@@ -27,68 +27,74 @@
 	else
 		icon_state = "grill_open"
 	return ..()
+
+/obj/machinery/grill/examine(mob/user)
+	. = ..()
+	if(grill_fuel)
+		. += span_notice("\The [src] has [grill_fuel] units of fuel left.")
+	else
+		. += span_warning("\The [src] is out of fuel! Add some wood or coal!")
+
 /obj/machinery/grill/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/stack/sheet/mineral/coal) || istype(I, /obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/S = I
 		var/stackamount = S.get_amount()
-		to_chat(user, "<span class='notice'>You put [stackamount] [I]s in [src].</span>")
+		to_chat(user, span_notice("You put [stackamount] [I]s in [src]."))
 		if(istype(I, /obj/item/stack/sheet/mineral/coal))
-			grill_fuel += (500 * stackamount)
-		else
 			grill_fuel += (50 * stackamount)
+		else
+			grill_fuel += (5 * stackamount)
 		S.use(stackamount)
 		update_appearance()
 		return
 	if(I.resistance_flags & INDESTRUCTIBLE)
-		to_chat(user, "<span class='warning'>You don't feel it would be wise to grill [I]...</span>")
+		to_chat(user, span_warning("You don't feel it would be wise to grill [I]..."))
 		return ..()
-	if(istype(I, /obj/item/reagent_containers))
-		if(istype(I, /obj/item/reagent_containers/food) && !istype(I, /obj/item/reagent_containers/food/drinks))
-			var/obj/item/reagent_containers/food/food_item = I
-			if(HAS_TRAIT(food_item, TRAIT_NODROP) || (food_item.item_flags & (ABSTRACT | DROPDEL)))
-				return ..()
-			else if(food_item.foodtype & GRILLED)
-				to_chat(user, "<span class='notice'>[food_item] has already been grilled!</span>")
-				return
-			else if(!grill_fuel)
-				to_chat(user, "<span class='warning'>There is not enough fuel!</span>")
-				return
-			else if(!grilled_item && user.transferItemToLoc(food_item, src))
-				grilled_item = food_item
-				grilled_item.foodtype |= GRILLED
-				to_chat(user, "<span class='notice'>You put the [grilled_item] on [src].</span>")
-				update_appearance()
-				grill_loop.start()
-				return
-		else
-			if(I.reagents.has_reagent(/datum/reagent/consumable/xeno_energy))
-				grill_fuel += (20 * (I.reagents.get_reagent_amount(/datum/reagent/consumable/xeno_energy)))
-				to_chat(user, "<span class='notice'>You pour the Monkey Energy in [src].</span>")
-				I.reagents.remove_reagent(/datum/reagent/consumable/xeno_energy, I.reagents.get_reagent_amount(/datum/reagent/consumable/xeno_energy))
-				update_appearance()
-				return
+
+	if(istype(I, /obj/item/reagent_containers/food/snacks))
+		var/obj/item/reagent_containers/food/snacks/food_item = I
+		if(HAS_TRAIT(food_item, TRAIT_NODROP) || (food_item.item_flags & (ABSTRACT | DROPDEL)))
+			return ..()
+		else if(food_item.foodtype & GRILLED)
+			to_chat(user, span_notice("[food_item] has already been grilled!"))
+			return
+		else if(grill_fuel <= 0)
+			to_chat(user, span_warning("There is not enough fuel!"))
+			return
+		else if(grilled_item)
+			to_chat(user,span_warning("\The [src] is already grilling something, take it out first!"))
+			return
+		else if(user.transferItemToLoc(food_item, src))
+			START_PROCESSING(SSmachines, src)
+			grilled_item = food_item
+			to_chat(user, span_notice("You put the [grilled_item] on [src]."))
+			update_appearance()
+			grill_loop.start()
+			return
 	..()
 
 /obj/machinery/grill/process()
 	..()
+	if(!grilled_item)
+		return PROCESS_KILL
 	update_appearance()
-	if(!grill_fuel)
+	if(grill_fuel <= 0)
+		grill_fuel = 0
+		visible_message(span_warning("\The [src] is out of fuel!"))
+		if(grilled_item)
+			grilled_item.forceMove(loc)
+			finish_grill()
 		return
-	else
-		grill_fuel -= 1
-		if(prob(1))
-			var/datum/effect_system/smoke_spread/bad/smoke = new
-			smoke.set_up(1, loc)
-			smoke.start()
-	if(grilled_item)
-		grill_time += 1
-		grill_fuel -= 10
-		grilled_item.AddComponent(/datum/component/sizzle)
+	grill_time += 1
+	grill_fuel -= 1
+	if(prob(1))
+		var/datum/effect_system/smoke_spread/bad/smoke = new
+		smoke.set_up(1, loc)
+		smoke.start()
 
 /obj/machinery/grill/Exited(atom/movable/AM)
 	if(AM == grilled_item)
 		finish_grill()
-		grilled_item = null
 	. = ..()
 
 /obj/machinery/grill/Destroy()
@@ -118,13 +124,15 @@
 
 /obj/machinery/grill/attack_hand(mob/user)
 	if(grilled_item)
-		to_chat(user, "<span class='notice'>You take out [grilled_item] from [src].</span>")
+		to_chat(user, span_notice("You take out [grilled_item] from [src]."))
 		grilled_item.forceMove(drop_location())
 		update_appearance()
 		return
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
+	if(grill_time >= 10 && grilled_item.cooked_type)
+		grilled_item = grilled_item.microwave_act()
 	switch(grill_time) //no 0-9 to prevent spam
 		if(10 to 15)
 			grilled_item.name = "lightly-grilled [grilled_item.name]"
@@ -141,8 +149,12 @@
 			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
 			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
 			grilled_item.foodtype |= FRIED
+	grilled_item.AddComponent(/datum/component/sizzle, (grill_time * 5))
+	grilled_item.foodtype |= GRILLED
 	grill_time = 0
 	grill_loop.stop()
+	grilled_item = null
+	update_appearance()
 
 /obj/machinery/grill/unwrenched
 	anchored = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Reduces and rebalances the prices of the items in the outpost food tab
- Rebrands the advanced cooking crate as the condiment crate and adds BBQ sauce.
- Fixes the grill, it used  to constantly process even when it's doing nothing and spat out smoke for no reason, plus it didn't account for having negative fuel, which then made it act like it had infinite fuel.
- The grill can now actually cook food.
- Removes the xeno-energy interaction with the grill. It no longer works as fuel.
- Changes the span classes to macros for the grill.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A lot of the food items at the outpost are prohibitively expensive, or weirdly priced. The exotic meat crate for example costed more than the normal meat crate, and donk pockets costed as much as a shotgun. Making food more accessible should hopefully encourage players to cook and make their own things without it being a huge investment instead of ```` lava-cooked goliath steak ```` for the 1000th time.

Bugfixes are also probably good for the grill, and making it less of a meme item.

## Changelog

:cl:
add: Grills can now cook food.
del: Xeno-energy working as grill fuel.
balance: Outpost food costs
fix: Grills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
