### PR TITLE
Fixes power consumption for mech movement and reduces the amount of power the durand shield consumes

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -12,7 +12,7 @@
 	force = 40
 	wreckage = /obj/structure/mecha_wreckage/durand
 	var/obj/durand_shield/shield
-	var/shield_passive_drain = 150
+	var/shield_passive_drain = 300
 
 
 /obj/mecha/combat/durand/clip
@@ -227,7 +227,7 @@ the shield is disabled by means other than the action button (like running out o
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_power(max(1, (max_integrity - obj_integrity + 10) * (10 - chassis.capacitor.rating))))
+	if(!chassis.use_power(max(1, (max_integrity - obj_integrity + 15) * (10 - chassis.capacitor.rating))))
 		chassis.cell?.charge = 0
 		chassis.defense_action.Activate(forced_state = TRUE)
 	obj_integrity = 10000

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -12,6 +12,7 @@
 	force = 40
 	wreckage = /obj/structure/mecha_wreckage/durand
 	var/obj/durand_shield/shield
+	var/shield_passive_drain = 150
 
 
 /obj/mecha/combat/durand/clip
@@ -46,7 +47,7 @@
 
 /obj/mecha/combat/durand/process()
 	. = ..()
-	if(defense_mode && !use_power(100))
+	if(defense_mode && !use_power(max(0, shield_passive_drain - (scanmod.rating * 10))))
 		defense_action.Activate(forced_state = TRUE)
 
 /obj/mecha/combat/durand/domove(direction)
@@ -226,7 +227,7 @@ the shield is disabled by means other than the action button (like running out o
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_power((max_integrity - obj_integrity) * (10 - chassis.capacitor.rating)))
+	if(!chassis.use_power(max(1, (max_integrity - obj_integrity + 10) * (10 - chassis.capacitor.rating))))
 		chassis.cell?.charge = 0
 		chassis.defense_action.Activate(forced_state = TRUE)
 	obj_integrity = 10000

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -226,7 +226,7 @@ the shield is disabled by means other than the action button (like running out o
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_power((max_integrity - obj_integrity) * 100))
+	if(!chassis.use_power((max_integrity - obj_integrity) * (10 - chassis.capacitor.rating)))
 		chassis.cell?.charge = 0
 		chassis.defense_action.Activate(forced_state = TRUE)
 	obj_integrity = 10000

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -15,6 +15,7 @@
 	internal_damage_threshold = 35
 	max_equip = 3
 	step_energy_drain = 3
+	normal_step_energy_drain = 10
 
 /obj/mecha/combat/gygax/mechturn(direction)
 	. = ..()

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -14,8 +14,7 @@
 	wreckage = /obj/structure/mecha_wreckage/gygax
 	internal_damage_threshold = 35
 	max_equip = 3
-	step_energy_drain = 3
-	normal_step_energy_drain = 10
+	base_step_energy_drain = 8
 
 /obj/mecha/combat/gygax/mechturn(direction)
 	. = ..()

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -4,7 +4,7 @@
 	icon_state = "phazon"
 	step_in = 2
 	dir_in = 2 //Facing South.
-	step_energy_drain = 3
+	base_step_energy_drain = 8
 	max_integrity = 200
 	deflect_chance = 30
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 50, "fire" = 100, "acid" = 100)

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -14,7 +14,7 @@
 	add_req_access = 0
 	internal_damage_threshold = 25
 	max_equip = 2
-	step_energy_drain = 3
+	base_step_energy_drain = 8
 	color = "#87878715"
 	stepsound = null
 	turnsound = null

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -18,9 +18,8 @@
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
-	var/normal_step_energy_drain = 10//The base amount of energy the mech should consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
-	var/base_step_energy_drain = 10
-	var/step_energy_drain = 20 // How much energy the mech actually consumes when moving after modifiers (Eg, stock parts, leg actuators)
+	var/base_step_energy_drain = 15 //The base amount of energy the mech should consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
+	var/step_energy_drain  // How much energy the mech actually consumes when moving after modifiers (Eg, stock parts, leg actuators)
 	var/melee_energy_drain = 15
 	var/overload_step_energy_drain_min = 100
 	max_integrity = 300 //max_integrity is base health
@@ -148,6 +147,7 @@
 	diag_hud_set_mechcell()
 	diag_hud_set_mechstat()
 	become_hearing_sensitive(ROUNDSTART_TRAIT)
+	update_part_values()
 
 /obj/mecha/update_icon_state()
 	if(silicon_pilot && silicon_icon_state)
@@ -226,11 +226,9 @@
 
 /obj/mecha/proc/update_part_values() ///Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
 	if(scanmod)
-		normal_step_energy_drain = min(0, base_step_energy_drain - (5 * scanmod.rating)) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
-		step_energy_drain = normal_step_energy_drain
+		step_energy_drain = max(1, base_step_energy_drain - (5 * scanmod.rating)) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
 	else
-		normal_step_energy_drain = 500
-		step_energy_drain = normal_step_energy_drain
+		step_energy_drain = 500
 	if(capacitor)
 		armor = armor.modifyRating(energy = (capacitor.rating * 5)) //Each level of capacitor protects the mech against emp by 5%
 	else //because we can still be hit without a cap, even if we can't move

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -18,8 +18,9 @@
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
-	var/normal_step_energy_drain = 10 //How much energy the mech will consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
-	var/step_energy_drain = 10
+	var/normal_step_energy_drain = 10//The base amount of energy the mech should consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
+	var/base_step_energy_drain = 10
+	var/step_energy_drain = 20 // How much energy the mech actually consumes when moving after modifiers (Eg, stock parts, leg actuators)
 	var/melee_energy_drain = 15
 	var/overload_step_energy_drain_min = 100
 	max_integrity = 300 //max_integrity is base health
@@ -225,7 +226,7 @@
 
 /obj/mecha/proc/update_part_values() ///Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
 	if(scanmod)
-		normal_step_energy_drain = 20 - (5 * scanmod.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
+		normal_step_energy_drain = min(0, base_step_energy_drain - (5 * scanmod.rating)) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
 		step_energy_drain = normal_step_energy_drain
 	else
 		normal_step_energy_drain = 500

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -179,7 +179,7 @@
 	else
 		chassis.leg_overload_mode = 0
 		chassis.step_in = initial(chassis.step_in)
-		chassis.step_energy_drain = chassis.normal_step_energy_drain
+		chassis.update_part_values()
 		chassis.occupant_message("<span class='notice'>You disable leg actuators overload.</span>")
 	UpdateButtonIcon()
 

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -8,7 +8,7 @@
 	wreckage = /obj/structure/mecha_wreckage/odysseus
 	internal_damage_threshold = 35
 	deflect_chance = 15
-	step_energy_drain = 6
+	base_step_energy_drain = 11
 
 /obj/mecha/medical/odysseus/moved_inside(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -107,7 +107,7 @@
 	light_range = 7
 	light_power = 1
 	wreckage = /obj/structure/mecha_wreckage/ripley/deathripley
-	step_energy_drain = 0
+	base_step_energy_drain = 0
 	enclosed = TRUE
 	enter_delay = 40
 	silicon_icon_state = null
@@ -171,7 +171,7 @@
 	name = "\improper CLIP APLU Mk-IV \"Rogue\""
 	icon_state = "clipripley"
 	base_icon_state = "clipripley"
-	step_energy_drain = 15 //overdriven servos are less efficient
+	base_step_energy_drain = 20 //overdriven servos are less efficient
 	wreckage = /obj/structure/mecha_wreckage/ripley/clip
 	enclosed = TRUE
 	enter_delay = 20 //slower than a mk. I, faster than the armored Ripleys


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
- renames normal_step_energy_drain to base_step_energy_drain, which holds the base energy consumption per move. step_energy_drain now handles how much power should be consumed after modifiers.
- Mechs used a hardcoded calculation instead of whatever their actual value should be for movement power consumption. This meant swapping out stock parts could give you a worse power consumption and then it already started with, and made the gygax consume 4 times more power then it shouldve with it's leg actuators. Fixes that.
- Reduces the power drain of the durand shield from being hit, and it's power efficiency is increased with better capacitors. Increases the passive drain for having it on.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Mech abilities were a trap with how much power they consumed, and would often leave you a sitting duck with no power rather than actually helping you. It's a bit unintuitive that it's more efficient to tank with your durand instead of your shield, since a single 9mm bullet would shave 2000 charge off your cell.

The shield is now more "durable" since it consumes less charge actively. Passive drain has been increased as a trade off. Being hit is less of a concern, but keeping your shield on unnecessarily will rapidly drain your battery.

Bugfixes in general are good, and the gygax should no longer consume obscene amounts of power.

## Changelog

:cl:
balance: Durand shield consumes less charge on being hit, passive drain increased.
fix: Mechs consume the correct amount of power on movement.
refactor: normal_step_energy_drain is now base_step_energy_drain

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
