### PR TITLE
Changes what items can fit in wallets

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -19,26 +19,20 @@
 		/obj/item/spacecash/bundle,
 		/obj/item/holochip,
 		/obj/item/card,
-		/obj/item/clothing/mask/cigarette,
 		/obj/item/flashlight/pen,
 		/obj/item/seeds,
-		/obj/item/stack/medical,
 		/obj/item/toy/crayon,
 		/obj/item/coin,
 		/obj/item/dice,
 		/obj/item/disk,
-		/obj/item/implanter,
 		/obj/item/lighter,
+		/obj/item/key/ship,
 		/obj/item/lipstick,
 		/obj/item/match,
 		/obj/item/paper,
 		/obj/item/pen,
 		/obj/item/photo,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/screwdriver,
-		/obj/item/stamp),
-		list(/obj/item/screwdriver/power))
+		/obj/item/stamp))
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -27,6 +27,7 @@
 		/obj/item/disk,
 		/obj/item/lighter,
 		/obj/item/key/ship,
+		/obj/item/gun/ballistic/derringer,
 		/obj/item/lipstick,
 		/obj/item/match,
 		/obj/item/paper,


### PR DESCRIPTION
## About The Pull Request

Removes a few strange items from fitting in wallets. Most notably, screwdrivers, cigarettes, medical stacks (gauze, sutures, regen mesh, brutepacks, that sorta thing). Allows you to fit ship keys and derringers within instead.

## Why It's Good For The Game

It was annoying as fuck to accidentally lose my screwdriver and cigarettes in my Fucking Wallet for the 3000th time a round. And I think I would Kill Myself if I saw another wallet full of medical supplies. None of you are free from sin.

## Changelog

:cl:
del: Removed a bunch of random items from fitting in wallets (notably screwdrivers, cigarettes, suture / mesh / gauze)
add: Ship keys and derringers can now fit in wallets
/:cl: