### PR TITLE
Removes restrictions on renaming guns (You can rename all of them now)

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -7,6 +7,7 @@
 	lefthand_file = GUN_LEFTHAND_ICON
 	righthand_file = GUN_RIGHTHAND_ICON
 	flags_1 =  CONDUCT_1
+	obj_flags = UNIQUE_RENAME
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=2000)
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -665,7 +665,6 @@ EMPTY_GUN_HELPER(revolver/detective)
 
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
 	manufacturer = MANUFACTURER_HUNTERSPRIDE
-	obj_flags = UNIQUE_RENAME
 	gate_loaded = TRUE
 	unique_reskin = list("Shadow" = "shadow",
 		"Army" = "shadow_army",

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -488,7 +488,6 @@
 	mob_overlay_icon = 'icons/obj/guns/manufacturer/hunterspride/onmob.dmi'
 
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
-	obj_flags = UNIQUE_RENAME
 	semi_auto = TRUE //double action
 	safety_wording = "safety"
 	unique_reskin = list("Default" = "detective",

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -323,7 +323,6 @@ EMPTY_GUN_HELPER(shotgun/bulldog/inteq)
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 
-	obj_flags = UNIQUE_RENAME
 	unique_reskin = list("Default" = "dshotgun",
 						"Stainless Steel" = "dshotgun_white",
 						"Stained Green" = "dshotgun_green"
@@ -765,7 +764,6 @@ EMPTY_GUN_HELPER(shotgun/bulldog/inteq)
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	force = 10
-	obj_flags = UNIQUE_RENAME
 	semi_auto = TRUE
 	can_be_sawn_off = TRUE
 	pb_knockback = 3

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -6,7 +6,6 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
 	cell_type = /obj/item/stock_parts/cell/emproof
 	item_flags = NONE
-	obj_flags = UNIQUE_RENAME
 	weapon_weight = WEAPON_LIGHT
 	automatic_charge_overlays = FALSE
 	internal_cell = TRUE //prevents you from giving it an OP cell - WS Edit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This take may be steaming but I need to get it on the table
Adds the unique rename flag to all guns (removing unnecessary re-applications on guns that currently have it), allowing any gun to be renamed.
Concerns with this would be people masking the lethality of their weapons, but I think the sprites are unique and visible enough that a gun is identified by appearance rather than examine/chat text

If any gun absolutely should not be renamable for flavor purposes (trabuco or stuff like it) it can have the flag removed

## Why It's Good For The Game

Allows players to add more flavor to their equipment

## Changelog

:cl:
balance: You can now rename any and all guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
