### PR TITLE
Allows penlights and flashlights to be used to diagnose eye health again

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -62,7 +62,7 @@
 			to_chat(user, "<span class='warning'>[M] doesn't have a head!</span>")
 			return
 
-		if(light_power < 1)
+		if(light_power < 0.3)
 			to_chat(user, "<span class='warning'>\The [src] isn't bright enough to see anything!</span> ")
 			return
 


### PR DESCRIPTION
## About The Pull Request

As perhaps maybe the only person to know you can diagnose eye health with flashlights, I was surprised to see penlights in fact did not work to diagnose eye health! In fact, no light at all worked! This PR changes a single number to make diagnoses via lights function again.

## Why It's Good For The Game

I rather enjoy being able to do medical RP and having options like this is pretty fun! Also, functioning parts of the code are pretty nice and I think this adds flavor to medical examinations.

Before:
![image](https://github.com/user-attachments/assets/10965f9e-4677-48e2-8011-b867f24f3602)
After:
![image](https://github.com/user-attachments/assets/1052ea93-bc6e-447c-ba3c-eccc0d7eebd9)


## Changelog

:cl:
fix: Medical Examinations via Flashlight is now an option again. Check eye health or see what's in someone's mouth!
/:cl: