### PR TITLE
Removes extra fire extinguisher from the Talos

### DIFF
--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -874,7 +874,6 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone put an extra fire extinguisher on the IRMV Talos in the crew area on the exact same spot as the APC. It's gone now.

Before:
![361094061-bfe52a48-e487-4cc8-b4d3-7fb02705d3ca](https://github.com/user-attachments/assets/7cb71846-75df-4a01-848b-f4af26be1653)

After:
![image](https://github.com/user-attachments/assets/c57e4a2d-a44b-48f1-8e3c-4853940eb53c)

Fixes #3305

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'd like to be able to click the APC without grabbing a fire extinguisher

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: Vekter
fix: Removed an extra fire extinguisher from the crew quarters on the IRMV Talos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
