### PR TITLE
Weapon power cells can be charged in weapon rechargers and fixes e-40 laser charging.

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -22,6 +22,7 @@
 		/obj/item/modular_computer,
 		/obj/item/gun/ballistic/automatic/powered,
 		/obj/item/gun/ballistic/automatic/assault/e40,
+		/obj/item/stock_parts/cell/gun
 		))
 
 /obj/machinery/recharger/RefreshParts()
@@ -31,19 +32,22 @@
 /obj/machinery/recharger/examine(mob/user)
 	. = ..()
 	if(!in_range(user, src) && !issilicon(user) && !isobserver(user))
-		. += "<span class='warning'>You're too far away to examine [src]'s contents and display!</span>"
+		. += span_warning("You're too far away to examine [src]'s contents and display!")
 		return
 
 	if(charging)
-		. += {"<span class='notice'>\The [src] contains:</span>
-		<span class='notice'>- \A [charging].</span>"}
+		. += span_notice("\The [src] contains:")
+		. += span_notice("- \A [charging].")
 
 	if(!(machine_stat & (NOPOWER|BROKEN)))
-		. += "<span class='notice'>The status display reads:</span>"
-		. += "<span class='notice'>- Recharging <b>[recharge_coeff*10]%</b> cell charge per cycle.</span>"
+		. += span_notice("The status display reads:")
+		. += span_notice("- Recharging <b>[recharge_coeff*10]%</b> cell charge per cycle.")
 		if(charging)
 			var/obj/item/stock_parts/cell/C = charging.get_cell()
-			. += "<span class='notice'>- \The [charging]'s cell is at <b>[C.percent()]%</b>.</span>"
+			if(istype(charging, /obj/item/stock_parts/cell))
+				. += span_notice("- \The [charging]'s charge is at <b>[C.percent()]%</b>.")
+			else
+				. += span_notice("- \The [charging]'s cell is at <b>[C.percent()]%</b>.")
 
 
 /obj/machinery/recharger/proc/setCharging(new_charging)
@@ -62,11 +66,11 @@
 /obj/machinery/recharger/attackby(obj/item/G, mob/user, params)
 	if(G.tool_behaviour == TOOL_WRENCH)
 		if(charging)
-			to_chat(user, "<span class='notice'>Remove the charging item first!</span>")
+			to_chat(user, span_notice("Remove the charging item first!"))
 			return
 		set_anchored(!anchored)
 		power_change()
-		to_chat(user, "<span class='notice'>You [anchored ? "attached" : "detached"] [src].</span>")
+		to_chat(user, span_notice("You [anchored ? "attached" : "detached"] [src]."))
 		G.play_tool_sound(src)
 		return
 
@@ -80,13 +84,13 @@
 			//Checks to make sure he's not in space doing it, and that the area got proper power.
 			var/area/a = get_area(src)
 			if(!isarea(a) || a.power_equip == 0)
-				to_chat(user, "<span class='notice'>[src] blinks red as you try to insert [G].</span>")
+				to_chat(user, span_notice("[src] blinks red as you try to insert [G]."))
 				return TRUE
 
 			if (istype(G, /obj/item/gun/energy))
 				var/obj/item/gun/energy/E = G
 				if(!E.can_charge)
-					to_chat(user, "<span class='notice'>Your gun has no external power connector.</span>")
+					to_chat(user, span_notice("Your gun has no external power connector."))
 					return TRUE
 
 			if(!user.transferItemToLoc(G, src))
@@ -94,7 +98,7 @@
 			setCharging(G)
 
 		else
-			to_chat(user, "<span class='notice'>[src] isn't connected to anything!</span>")
+			to_chat(user, span_notice("[src] isn't connected to anything!"))
 		return TRUE
 
 	if(anchored && !charging)

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -262,8 +262,8 @@
 	secondary.pre_fire(target, user, message, flag, params, zone_override, bonus_spread)
 
 
-/obj/item/gun/ballistic/automatic/powered/get_cell()
-	return cell
+/obj/item/gun/ballistic/automatic/assault/e40/get_cell()
+	return secondary.get_cell()
 
 /obj/item/gun/ballistic/automatic/assault/e40/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now directly put a weapons power cell into a weapons recharger to recharge it.

Also fixes e40s not being able to charge in rechargers. It used the wrong proc for get_cell.

Changes spans to macros for rechargers.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

QOL change, you don't have to go through the repetitive motions of repeatedly swapping in empty cells into your e-gun in order to charge them, since you can directly put them in to charge. 

It's also intuitive, and I've seen multiple people get confused about why you cant charge the weapon cell in it while they pointlessly bonk the cell against it.

Bug fixes are good too.

## Changelog

:cl:
add: Weapon cells can be inserted directly into weapon chargers to charge them.
fix: e40s not charging in weapons rechargers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
