### PR TITLE
Eoehoma Caseless is now available on the black market (Plus the E-40 is very slightly cheaper)

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
@@ -51,7 +51,6 @@
 	name = "Eoehoma .299 Caseless Magazine"
 	desc = "A 30 round magazine for the E-40 Hybrid Rifle."
 	item = /obj/item/ammo_box/magazine/e40
-	pair_item = /datum/blackmarket_item/ammo/c299
 
 	price_min = 750
 	price_max = 1250

--- a/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
@@ -51,10 +51,22 @@
 	name = "Eoehoma .299 Caseless Magazine"
 	desc = "A 30 round magazine for the E-40 Hybrid Rifle."
 	item = /obj/item/ammo_box/magazine/e40
+	pair_item = /datum/blackmarket_item/ammo/c299
 
 	price_min = 750
 	price_max = 1250
 	stock = 6
+	availability_prob = 0
+
+/datum/blackmarket_item/ammo/c299
+	name = "Eoehoma .299 Caseless ammo box"
+	desc = "This ammunition for the E-40 Hybrid Rifle is probably worth more than the people you're shooting it at."
+	item = /obj/item/ammo_box/c299
+
+	price_min = 250
+	price_max = 500
+	stock_min = 4
+	stock_max = 8
 	availability_prob = 0
 
 /datum/blackmarket_item/ammo/saber_mag

--- a/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
@@ -58,12 +58,12 @@
 	availability_prob = 0
 
 /datum/blackmarket_item/ammo/c299
-	name = "Eoehoma .299 Caseless ammo box"
+	name = "Eoehoma .299 Caseless Ammo Box"
 	desc = "This ammunition for the E-40 Hybrid Rifle is probably worth more than the people you're shooting it at."
 	item = /obj/item/ammo_box/c299
 
-	price_min = 250
-	price_max = 500
+	price_min = 300
+	price_max = 700
 	stock_min = 4
 	stock_max = 8
 	availability_prob = 0

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -129,7 +129,7 @@
 	name = "E-40 Hybrid Assault Rifle"
 	desc = "A dual mode hybrid assault rifle made by the now defunct Eoehoma Firearms. Capable of firing both bullets AND lasers, for the discerning dealer in death. Chambered in Eoehoma .299 Caseless."
 	item = /obj/item/gun/ballistic/automatic/assault/e40
-	pair_item = list(/datum/blackmarket_item/ammo/e40_mag)
+	pair_item = list(/datum/blackmarket_item/ammo/e40_mag, /datum/blackmarket_item/ammo/c299)
 
 	price_min = 7000
 	price_max = 10000

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -132,7 +132,7 @@
 	pair_item = list(/datum/blackmarket_item/ammo/e40_mag)
 
 	price_min = 7000
-	price_max = 15000
+	price_max = 10000
 	stock_max = 2
 	availability_prob = 10
 	spawn_weighting = FALSE

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -85,8 +85,8 @@
 	bullet_per_box = 20
 
 /obj/item/ammo_casing/caseless/c299
-	name = ".229 Eoehoma caseless bullet casing"
-	desc = "A .229 Eoehoma caseless bullet casing."
+	name = ".299 Eoehoma caseless bullet casing"
+	desc = "A .299 Eoehoma caseless bullet casing."
 	icon_state = "caseless"
 	caliber = ".299 caseless"
 	projectile_type = /obj/projectile/bullet/c299

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -521,7 +521,7 @@
 	max_ammo = 50
 
 /obj/item/ammo_box/c299
-	name = "ammo box (.299 Eoehoma caseless)
+	name = "ammo box (.299 Eoehoma caseless)"
 	desc = "A box of .299 Eoehoma caseless, for use with the E-40 hybrid assault rifle."
 	icon_state = "229box"
 	ammo_type = /obj/item/ammo_casing/caseless/c299

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -519,3 +519,10 @@
 	icon_state = "a44roum-hp"
 	ammo_type = /obj/item/ammo_casing/a44roum/hp
 	max_ammo = 50
+
+/obj/item/ammo_box/c299
+	name = "ammo box (.299 Eoehoma caseless)
+	desc = "A box of .299 Eoehoma caseless, for use with the E-40 hybrid assault rifle."
+	icon_state = "229box"
+	ammo_type = /obj/item/ammo_casing/caseless/c299
+	max_ammo = 120

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -526,3 +526,4 @@
 	icon_state = "229box"
 	ammo_type = /obj/item/ammo_casing/caseless/c299
 	max_ammo = 120
+	w_class = WEIGHT_CLASS_NORMAL // This is a lot of ammo

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -523,7 +523,7 @@
 /obj/item/ammo_box/c299
 	name = "ammo box (.299 Eoehoma caseless)"
 	desc = "A box of .299 Eoehoma caseless, for use with the E-40 hybrid assault rifle."
-	icon_state = "229box"
+	icon_state = "299box"
 	ammo_type = /obj/item/ammo_casing/caseless/c299
 	max_ammo = 120
 	w_class = WEIGHT_CLASS_NORMAL // This is a lot of ammo

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -119,7 +119,7 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/e40
-	name = "E-40 magazine (.229 Eoehoma caseless)"
+	name = "E-40 magazine (.299 Eoehoma caseless)"
 	icon_state = "e40_mag-1"
 	base_icon_state = "e40_mag"
 	ammo_type = /obj/item/ammo_casing/caseless/c299

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -141,7 +141,7 @@
 
 /obj/item/gun/ballistic/automatic/assault/e40
 	name = "\improper E-40 Hybrid Rifle"
-	desc = "A Hybrid Assault Rifle, best known for being having a dual ballistic/laser system along with an advanced ammo counter. Once an icon for bounty hunters, age has broken most down, so these end up in collector's hands or as shoddy Frontiersmen laser SMG conversions when in their inheritted stockpiles. But if one were to find one in working condition, it would be just as formidable as back then. Chambered in .229 Eoehoma caseless, and uses energy for lasers."
+	desc = "A Hybrid Assault Rifle, best known for being having a dual ballistic/laser system along with an advanced ammo counter. Once an icon for bounty hunters, age has broken most down, so these end up in collector's hands or as shoddy Frontiersmen laser SMG conversions when in their inheritted stockpiles. But if one were to find one in working condition, it would be just as formidable as back then. Chambered in .299 Eoehoma caseless, and uses energy for lasers."
 	icon = 'icons/obj/guns/manufacturer/eoehoma/48x32.dmi'
 	lefthand_file = 'icons/obj/guns/manufacturer/eoehoma/lefthand.dmi'
 	righthand_file = 'icons/obj/guns/manufacturer/eoehoma/righthand.dmi'

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -69,7 +69,7 @@
 // .299 Eoehoma Caseless (E-40)
 
 /obj/projectile/bullet/c299
-	name = ".229 Eoehoma caseless bullet"
+	name = ".299 Eoehoma caseless bullet"
 	damage = 20
 	armour_penetration = 10
 


### PR DESCRIPTION
## About The Pull Request

Adds Eoehoma Caseless boxes to the game, available only in the black market. Upper limit of the E-40 is now 10000 instead of 15000 (its still on average 100% more expensive than a standard assault rifle)

## Why It's Good For The Game

It's a cool weapon but you never get to use the ballistic part more than a few times. And I'm sure theres plenty of ammunition leftover for use to sell on the black market.

## Changelog

:cl:
add: .299 caseless is now available in the black market for the E-40
balance: E-40 is now slightly less expensive
fix: .299? .229? No more typos
/:cl: