### PR TITLE
Removes insulation from captain and combat gloves, hardsuits

### DIFF
--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -539,11 +539,11 @@
 	},
 /obj/effect/turf_decal/borderfloorwhite,
 /obj/machinery/button/door{
+	dir = 1;
 	id = "valor_surgery";
 	name = "Privacy Shutters";
-	pixel_y = 8;
-	dir = 1;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
@@ -640,10 +640,10 @@
 /area/ship/hallway/port)
 "fO" = (
 /obj/structure/closet/secure_closet{
+	icon_door = "prisoner";
 	icon_state = "prisoner";
 	name = "shuttle pilot locker";
-	req_access = list(3);
-	icon_door = "prisoner"
+	req_access = list(3)
 	},
 /obj/item/clothing/head/beret/sec/inteq,
 /obj/item/clothing/head/soft/inteq,
@@ -1951,6 +1951,7 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_gray/full,
 /obj/machinery/cell_charger,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "sc" = (
@@ -2884,8 +2885,8 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/syringe{
-	pixel_y = -4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -4
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
@@ -4034,11 +4035,11 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/borderfloorwhite,
 /obj/machinery/button/door{
+	dir = 1;
 	id = "valor_surgery";
 	name = "Privacy Shutters";
-	pixel_y = -23;
-	dir = 1;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
@@ -4532,8 +4533,8 @@
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
 	dir = 8;
-	pixel_y = 7;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
@@ -5124,8 +5125,8 @@
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency/shuttle{
-	pixel_y = 9;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 9
 	},
 /obj/item/gps{
 	pixel_x = 6;

--- a/_maps/shuttles/solgov/solgov_chronicle.dmm
+++ b/_maps/shuttles/solgov/solgov_chronicle.dmm
@@ -1,8 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -58,8 +58,8 @@
 /area/ship/engineering/engine)
 "aB" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 4
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/crew)
@@ -69,10 +69,10 @@
 	},
 /obj/machinery/button/door{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 10;
+	id = "sgc_airlock1";
 	name = "blast door control";
-	id = "sgc_airlock1"
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -22
@@ -130,8 +130,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 8
+	dir = 8;
+	id = "sgc_bridge"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -214,11 +214,11 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/button/door{
-	pixel_y = 11;
-	pixel_x = 22;
 	dir = 8;
+	id = "sgc_dorm";
 	name = "window shutter control";
-	id = "sgc_dorm"
+	pixel_x = 22;
+	pixel_y = 11
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
@@ -251,8 +251,8 @@
 /area/ship/crew)
 "bH" = (
 /obj/structure/closet/secure_closet/captains{
-	populate = 0;
-	anchored = 1
+	anchored = 1;
+	populate = 0
 	},
 /obj/item/clothing/under/solgov/formal/captain,
 /obj/item/clothing/shoes/laceup,
@@ -304,9 +304,9 @@
 /area/ship/engineering)
 "cw" = (
 /obj/docking_port/mobile{
+	dir = 2;
 	port_direction = 8;
-	preferred_direction = 4;
-	dir = 2
+	preferred_direction = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew)
@@ -398,11 +398,11 @@
 	dir = 1
 	},
 /obj/machinery/button/door{
-	pixel_y = -22;
-	pixel_x = -9;
+	dir = 1;
 	id = "sgc_overseer";
 	name = "window shutter control";
-	dir = 1
+	pixel_x = -9;
+	pixel_y = -22
 	},
 /turf/open/floor/wood,
 /area/ship/crew/crewtwo)
@@ -477,8 +477,8 @@
 /obj/structure/table/wood/fancy/purple,
 /obj/item/paper_bin,
 /obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 12
 	},
 /obj/item/pen/solgov,
 /obj/effect/turf_decal/spline/fancy/wood{
@@ -504,9 +504,9 @@
 	},
 /obj/machinery/button/door{
 	dir = 4;
-	pixel_y = -10;
+	id = "sgc_engine";
 	pixel_x = -22;
-	id = "sgc_engine"
+	pixel_y = -10
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engine)
@@ -553,9 +553,9 @@
 /area/ship/engineering/engine)
 "fl" = (
 /obj/structure/closet/secure_closet/miner{
+	anchored = 1;
 	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
+	populate = 0
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
@@ -609,9 +609,9 @@
 	dir = 1
 	},
 /obj/machinery/computer/bookmanagement{
-	pixel_y = 7;
+	dir = 8;
 	icon_state = "laptop";
-	dir = 8
+	pixel_y = 7
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -766,8 +766,8 @@
 	pixel_y = -3
 	},
 /obj/item/reagent_containers/food/snacks/grown/cabbage{
-	pixel_y = 6;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 6
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/crew)
@@ -782,10 +782,10 @@
 	dir = 5
 	},
 /obj/machinery/button/door{
-	pixel_y = 23;
-	pixel_x = 10;
 	id = "sgc_captain";
-	name = "window shutter control"
+	name = "window shutter control";
+	pixel_x = 10;
+	pixel_y = 23
 	},
 /turf/open/floor/wood,
 /area/ship/crew/office)
@@ -799,8 +799,8 @@
 /obj/machinery/firealarm/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "applebush";
-	pixel_y = 16;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 16
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-11";
@@ -836,9 +836,9 @@
 "hx" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-11";
+	layer = 2.89;
 	pixel_x = -12;
-	pixel_y = 19;
-	layer = 2.89
+	pixel_y = 19
 	},
 /obj/effect/turf_decal/spline/fancy/wood{
 	dir = 1
@@ -850,8 +850,8 @@
 	dir = 6
 	},
 /obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 21
 	},
 /turf/open/floor/wood,
 /area/ship/crew/crewtwo)
@@ -911,8 +911,8 @@
 "hU" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06";
-	pixel_y = 16;
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -936,9 +936,9 @@
 /area/ship/crew/crewtwo)
 "id" = (
 /obj/structure/closet/secure_closet/security{
-	populate = 0;
+	anchored = 1;
 	name = "sonnensöldners's locker";
-	anchored = 1
+	populate = 0
 	},
 /obj/item/clothing/head/solgov/sonnensoldner,
 /obj/structure/sign/poster/solgov/sonnensoldner{
@@ -996,10 +996,10 @@
 	dir = 10
 	},
 /obj/machinery/button/door{
-	pixel_y = 22;
-	pixel_x = 9;
 	id = "sgc_engi";
-	name = "window shutter control"
+	name = "window shutter control";
+	pixel_x = 9;
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/engineering)
@@ -1036,12 +1036,12 @@
 "jd" = (
 /obj/structure/table/wood,
 /obj/structure/railing/wood{
-	dir = 6;
-	color = "#792f27"
+	color = "#792f27";
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/grown/cabbage{
 	pixel_y = 4
@@ -1057,11 +1057,11 @@
 "jJ" = (
 /obj/machinery/button/door{
 	dir = 4;
-	pixel_y = -8;
-	pixel_x = -22;
 	id = "sgc_airlock2";
-	req_one_access = list(20,19);
-	name = "blast door control"
+	name = "blast door control";
+	pixel_x = -22;
+	pixel_y = -8;
+	req_one_access = list(20,19)
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -1070,8 +1070,8 @@
 	dir = 10
 	},
 /obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 21
 	},
 /obj/machinery/light/small/directional/west{
 	pixel_y = 1
@@ -1138,8 +1138,8 @@
 /obj/structure/table/wood/fancy/purple,
 /obj/machinery/computer/secure_data/laptop{
 	dir = 8;
-	pixel_y = 5;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/spline/fancy/wood{
 	dir = 4
@@ -1163,8 +1163,8 @@
 "kz" = (
 /obj/machinery/telecomms/hub{
 	autolinkers = list("solgov","broadcasterA","receiverA","solgovPDA","SolHub");
-	network = "SolNet";
-	id = "Solgov Hub"
+	id = "Solgov Hub";
+	network = "SolNet"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1273,8 +1273,8 @@
 	dir = 5
 	},
 /obj/structure/sign/warning{
-	pixel_y = 9;
-	pixel_x = -23
+	pixel_x = -23;
+	pixel_y = 9
 	},
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -1558,9 +1558,9 @@
 	req_one_access = list(61,11)
 	},
 /obj/machinery/telecomms/bus{
+	autolinkers = list("processor7","solgov");
 	id = "bus mainframe";
-	network = "SolNet";
-	autolinkers = list("processor7","solgov")
+	network = "SolNet"
 	},
 /turf/open/floor/circuit,
 /area/ship/engineering)
@@ -1704,8 +1704,8 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	req_access = list(11);
-	name = "Equipment Room"
+	name = "Equipment Room";
+	req_access = list(11)
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1888,9 +1888,9 @@
 "sE" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24;
-	req_ship_access = 1;
 	req_access = null;
-	req_one_access = list(1,48)
+	req_one_access = list(1,48);
+	req_ship_access = 1
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
 	dir = 4
@@ -1997,8 +1997,8 @@
 	},
 /obj/machinery/telecomms/message_server{
 	autolinkers = list("solgovPDA");
-	network = "SolNet";
-	calibrating = 0
+	calibrating = 0;
+	network = "SolNet"
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/circuit/red,
@@ -2034,8 +2034,8 @@
 /area/ship/engineering)
 "un" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -2161,8 +2161,8 @@
 "vR" = (
 /obj/machinery/door/window{
 	dir = 8;
-	opacity = 1;
-	name = "Tinted Interior Door"
+	name = "Tinted Interior Door";
+	opacity = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2201,8 +2201,8 @@
 	},
 /obj/machinery/light/floor,
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = -29
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
@@ -2214,8 +2214,8 @@
 /area/ship/cargo)
 "wU" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
@@ -2232,8 +2232,8 @@
 "wW" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-11";
-	pixel_x = 10;
-	layer = 2.89
+	layer = 2.89;
+	pixel_x = 10
 	},
 /obj/structure/table/wood/fancy/purple,
 /obj/item/paper/crumpled,
@@ -2263,8 +2263,8 @@
 /area/ship/engineering/engine)
 "xt" = (
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname,
@@ -2326,8 +2326,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_captain";
-	dir = 4
+	dir = 4;
+	id = "sgc_captain"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2364,8 +2364,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 8
+	dir = 8;
+	id = "sgc_bridge"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2411,8 +2411,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Dorm";
-	dir = 4
+	dir = 4;
+	name = "Dorm"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2454,12 +2454,12 @@
 "yQ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-17";
-	pixel_y = 23;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood,
@@ -2469,12 +2469,12 @@
 	req_access = null
 	},
 /obj/structure/railing/wood{
-	dir = 4;
-	color = "#792f27"
+	color = "#792f27";
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 4
 	},
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/milk,
@@ -2491,8 +2491,8 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	id = "sgc_engine";
-	dir = 4
+	dir = 4;
+	id = "sgc_engine"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -2533,9 +2533,9 @@
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/structure/closet/crate/secure/gear{
-	populate = 0;
-	name = "emergency sauerkraut supplies";
 	desc = "For emergency use only";
+	name = "emergency sauerkraut supplies";
+	populate = 0;
 	req_access = list(19)
 	},
 /obj/item/reagent_containers/food/snacks/grown/cabbage,
@@ -2650,8 +2650,8 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = -29
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
@@ -2686,11 +2686,11 @@
 /obj/item/pen/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
 /obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
 /obj/machinery/light/directional/west,
 /obj/structure/sign/poster/solgov/random{
 	pixel_y = 30
 	},
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Au" = (
@@ -2708,8 +2708,8 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 21
 	},
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov,
@@ -2746,16 +2746,16 @@
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	pixel_y = -22;
-	pixel_x = 8;
 	id = "sgc_cargo";
-	name = "blast door control"
+	name = "blast door control";
+	pixel_x = 8;
+	pixel_y = -22
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 1;
-	pixel_y = -20;
+	id = "sgc_cs";
 	pixel_x = -2;
-	id = "sgc_cs"
+	pixel_y = -20
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -2791,8 +2791,8 @@
 "AV" = (
 /obj/machinery/telecomms/processor{
 	autolinkers = list("processor7");
-	network = "SolNet";
-	id = "Processor"
+	id = "Processor";
+	network = "SolNet"
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/brigdoor/westleft{
@@ -2822,8 +2822,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ship/crew/crewtwo)
@@ -2838,8 +2838,8 @@
 /area/ship/engineering/engine)
 "Bs" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/bridge)
@@ -2859,8 +2859,8 @@
 /area/ship/security/armory)
 "BZ" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2900,8 +2900,8 @@
 /area/ship/crew/crewtwo)
 "Cf" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3056,8 +3056,8 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 22
 	},
 /turf/open/floor/wood,
 /area/ship/crew/office)
@@ -3152,14 +3152,14 @@
 /area/ship/crew/dorm)
 "EF" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/item/kirbyplants{
 	icon_state = "applebush";
-	pixel_y = 19;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 19
 	},
 /turf/open/floor/wood,
 /area/ship/crew/crewtwo)
@@ -3186,8 +3186,8 @@
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
-	pixel_y = 11;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 11
 	},
 /turf/open/floor/wood,
 /area/ship/crew/office)
@@ -3204,31 +3204,31 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
 "Fh" = (
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = 28
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/ship/external)
 "Fl" = (
 /obj/docking_port/stationary{
 	dir = 4;
-	height = 15;
 	dwidth = 15;
+	height = 15;
 	width = 30
 	},
 /turf/template_noop,
 /area/template_noop)
 "Fm" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -3249,8 +3249,8 @@
 /area/ship/crew/crewtwo)
 "FG" = (
 /obj/structure/railing/wood{
-	dir = 6;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 6
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -3322,8 +3322,8 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/vacuum/external{
-	pixel_y = 10;
-	pixel_x = -30
+	pixel_x = -30;
+	pixel_y = 10
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -3396,8 +3396,8 @@
 /area/ship/security/armory)
 "Hb" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 5
@@ -3454,8 +3454,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_overseer";
-	dir = 4
+	dir = 4;
+	id = "sgc_overseer"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3479,8 +3479,8 @@
 /area/ship/engineering)
 "In" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
@@ -3667,8 +3667,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_captain";
-	dir = 4
+	dir = 4;
+	id = "sgc_captain"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3774,8 +3774,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_captain";
-	dir = 4
+	dir = 4;
+	id = "sgc_captain"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3823,8 +3823,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/structure/railing/wood{
 	color = "#543C30";
@@ -4004,8 +4004,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_overseer";
-	dir = 4
+	dir = 4;
+	id = "sgc_overseer"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -4028,9 +4028,9 @@
 	dir = 4
 	},
 /obj/structure/chair/plastic{
+	desc = "Welcome to the shower";
 	dir = 4;
-	name = "shower chair";
-	desc = "Welcome to the shower"
+	name = "shower chair"
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/freezer,
@@ -4071,8 +4071,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 4
+	dir = 4;
+	id = "sgc_bridge"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -4131,8 +4131,8 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-10"
@@ -4150,10 +4150,10 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	pixel_y = 9;
-	pixel_x = 6;
 	id = "sgc_bridge";
-	name = "bridge window lockdown"
+	name = "bridge window lockdown";
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /obj/item/reagent_containers/glass/maunamug{
 	pixel_x = -3
@@ -4178,8 +4178,8 @@
 	},
 /obj/machinery/light/floor,
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = -29
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
@@ -4356,8 +4356,8 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	req_access = list(11);
-	name = "Engine Room"
+	name = "Engine Room";
+	req_access = list(11)
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4406,8 +4406,8 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	req_access = list(11);
-	name = "Engineering"
+	name = "Engineering";
+	req_access = list(11)
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -4436,9 +4436,9 @@
 /obj/item/kitchen/knife,
 /obj/machinery/newscaster/directional/north,
 /obj/structure/sink{
-	pixel_y = 20;
+	layer = 2.79;
 	pixel_x = -15;
-	layer = 2.79
+	pixel_y = 20
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/crew)
@@ -4471,8 +4471,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 22
 	},
 /turf/open/floor/wood,
 /area/ship/crew/crewtwo)
@@ -4485,8 +4485,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_y = 3;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea{
 	pixel_x = 10
@@ -4521,7 +4521,7 @@
 /obj/item/pen/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
 /obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "SH" = (
@@ -4536,8 +4536,8 @@
 /area/ship/crew/dorm)
 "SJ" = (
 /obj/machinery/telecomms/receiver/preset_left{
-	network = "SolNet";
-	id = "Receiver"
+	id = "Receiver";
+	network = "SolNet"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4667,11 +4667,11 @@
 	},
 /obj/machinery/button/door{
 	dir = 8;
+	id = "sgc_piss";
+	name = "bathroom lock";
 	pixel_x = 22;
 	pixel_y = -9;
-	id = "sgc_piss";
-	specialfunctions = 3;
-	name = "bathroom lock"
+	specialfunctions = 3
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/freezer,
@@ -4757,8 +4757,8 @@
 "US" = (
 /obj/structure/table/wood,
 /obj/item/desk_flag/solgov{
-	pixel_y = 2;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
@@ -5026,8 +5026,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 4
+	dir = 4;
+	id = "sgc_bridge"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -5090,8 +5090,8 @@
 	},
 /obj/machinery/door/airlock{
 	dir = 4;
-	name = "Bathroom";
-	id_tag = "sgc_piss"
+	id_tag = "sgc_piss";
+	name = "Bathroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -5132,8 +5132,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)

--- a/_maps/shuttles/solgov/solgov_inkwell.dmm
+++ b/_maps/shuttles/solgov/solgov_inkwell.dmm
@@ -117,10 +117,10 @@
 	dir = 8;
 	id = "sgi_captainbolt";
 	name = "bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = 20;
 	pixel_y = 6;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	specialfunctions = 4
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm/dormtwo)
@@ -152,7 +152,7 @@
 /obj/item/pen/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
 /obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/industrial/outline/orange,
 /obj/item/clothing/glasses/meson/prescription,
@@ -161,9 +161,9 @@
 /area/ship/engineering)
 "bu" = (
 /obj/structure/closet/secure_closet/security{
-	populate = 0;
+	anchored = 1;
 	name = "sonnensöldners's locker";
-	anchored = 1
+	populate = 0
 	},
 /obj/item/clothing/head/solgov/sonnensoldner,
 /obj/item/radio{
@@ -220,8 +220,8 @@
 /area/ship/crew/library)
 "ce" = (
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = 28
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
@@ -256,8 +256,8 @@
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
-	pixel_y = 11;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -292,9 +292,9 @@
 /area/ship/crew/toilet)
 "cI" = (
 /obj/structure/closet/secure_closet/security{
-	populate = 0;
+	anchored = 1;
 	name = "sonnensöldners's locker";
-	anchored = 1
+	populate = 0
 	},
 /obj/item/clothing/head/solgov/sonnensoldner,
 /obj/item/radio{
@@ -433,9 +433,9 @@
 	},
 /obj/machinery/door/airlock/solgov{
 	dir = 4;
-	req_one_access = list(20);
+	id_tag = "sgi_captainbolt";
 	name = "Captain's Quarters";
-	id_tag = "sgi_captainbolt"
+	req_one_access = list(20)
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -482,10 +482,10 @@
 	},
 /obj/machinery/button/door{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 10;
+	id = "sgi_cafeteria";
 	name = "external shutters control";
-	id = "sgi_cafeteria"
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -551,9 +551,9 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = 2;
+	id = "sgi_holocargo1";
 	pixel_x = -18;
-	id = "sgi_holocargo1"
+	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono,
@@ -614,8 +614,8 @@
 /area/ship/cargo)
 "eq" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/railing/corner/wood{
 	color = "#543C30"
@@ -664,9 +664,9 @@
 	dir = 4;
 	id = "sgi_bolt";
 	name = "bathroom lock";
+	normaldoorcontrol = 1;
 	pixel_x = -20;
 	pixel_y = 7;
-	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -1059,8 +1059,8 @@
 "hm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 7;
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 7
 	},
 /obj/item/paper_bin,
 /obj/item/pen/solgov,
@@ -1308,11 +1308,11 @@
 /obj/structure/table/wood,
 /obj/structure/closet/wall/directional/east,
 /obj/machinery/button/door{
-	pixel_y = -21;
-	pixel_x = -8;
 	dir = 1;
 	id = "sgi_dorms";
-	name = "dorms shutters control"
+	name = "dorms shutters control";
+	pixel_x = -8;
+	pixel_y = -21
 	},
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
 /obj/item/clothing/suit/hooded/wintercoat/solgov,
@@ -1717,8 +1717,8 @@
 "li" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 7;
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 7
 	},
 /obj/item/folder/solgov,
 /obj/machinery/light/directional/south,
@@ -1730,8 +1730,8 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/turretid/lethal{
-	pixel_y = 0;
-	pixel_x = -26
+	pixel_x = -26;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/stairs/wood/left{
 	dir = 1
@@ -1836,8 +1836,8 @@
 "mf" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush";
-	pixel_y = 2;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 2
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/birch,
@@ -1880,8 +1880,8 @@
 /area/ship/hallway/starboard)
 "mD" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/walnut,
@@ -2153,8 +2153,8 @@
 /area/ship/bridge)
 "nV" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/railing/wood{
 	color = "#543C30";
@@ -2213,8 +2213,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor{
-	id = "sgi_engine";
-	dir = 4
+	dir = 4;
+	id = "sgi_engine"
 	},
 /obj/machinery/door/window/westright{
 	dir = 4
@@ -2373,8 +2373,8 @@
 /area/ship/crew/dorm)
 "pu" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -2399,8 +2399,8 @@
 	color = "#D5A66E"
 	},
 /obj/structure/railing/wood{
-	dir = 1;
-	color = "#D5A66E"
+	color = "#D5A66E";
+	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light_switch{
@@ -2534,10 +2534,10 @@
 "qE" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/letter_opener{
-	pixel_x = -13;
 	icon_state = "letter_opener_b";
-	pixel_y = 4;
-	name = "boxcutter"
+	name = "boxcutter";
+	pixel_x = -13;
+	pixel_y = 4
 	},
 /obj/item/storage/box/shipping,
 /obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
@@ -2556,8 +2556,8 @@
 "qM" = (
 /obj/machinery/light/floor,
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = 28
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
@@ -2593,8 +2593,8 @@
 /area/ship/crew/cryo)
 "rb" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/plasteel/mono,
@@ -2640,9 +2640,9 @@
 /area/ship/cargo)
 "rN" = (
 /obj/structure/closet/secure_closet/miner{
+	anchored = 1;
 	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
+	populate = 0
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
@@ -2957,22 +2957,22 @@
 /area/ship/cargo)
 "ti" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /obj/machinery/button/door{
-	pixel_y = -21;
-	pixel_x = -8;
 	dir = 1;
 	id = "sgi_captain";
-	name = "external shutters control"
+	name = "external shutters control";
+	pixel_x = -8;
+	pixel_y = -21
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/walnut,
@@ -2986,9 +2986,9 @@
 /area/ship/crew/dorm/dormthree)
 "tr" = (
 /obj/structure/closet/secure_closet/miner{
+	anchored = 1;
 	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
+	populate = 0
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
@@ -3035,8 +3035,8 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	id = "sgi_engine";
-	dir = 4
+	dir = 4;
+	id = "sgi_engine"
 	},
 /obj/machinery/door/window/westright{
 	dir = 4
@@ -3085,8 +3085,8 @@
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/east,
 /obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -3344,14 +3344,14 @@
 "vn" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-11";
+	layer = 2.89;
 	pixel_x = -12;
-	pixel_y = 19;
-	layer = 2.89
+	pixel_y = 19
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-17";
-	pixel_y = 3;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 3
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -3396,8 +3396,8 @@
 /area/ship/hallway/starboard)
 "vz" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 1
 	},
 /obj/structure/railing/wood{
 	color = "#543C30"
@@ -3553,8 +3553,8 @@
 /area/ship/cargo)
 "wk" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#543C30"
@@ -3584,9 +3584,9 @@
 /obj/item/storage/backpack/satchel,
 /obj/item/kitchen/knife/letter_opener,
 /obj/structure/closet/secure_closet/quartermaster{
-	populate = 0;
 	anchored = 1;
-	name = "\proper logistics deck officer's locker"
+	name = "\proper logistics deck officer's locker";
+	populate = 0
 	},
 /obj/item/clothing/suit/solgov/overcoat,
 /obj/item/clothing/head/flatcap/solgov,
@@ -3631,9 +3631,9 @@
 /area/ship/cargo)
 "wB" = (
 /obj/structure/closet/secure_closet/security{
-	populate = 0;
+	anchored = 1;
 	name = "sonnensöldners's locker";
-	anchored = 1
+	populate = 0
 	},
 /obj/item/clothing/head/solgov/sonnensoldner,
 /obj/item/radio{
@@ -3887,8 +3887,8 @@
 /area/ship/bridge)
 "yD" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 9
 	},
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -3989,8 +3989,8 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/telecomms/relay{
-	network = "SolNet";
-	autolinkers = list("SolHub")
+	autolinkers = list("SolHub");
+	network = "SolNet"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/port)
@@ -4187,8 +4187,8 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /obj/item/pen/solgov,
 /turf/open/floor/carpet/blue,
@@ -4199,8 +4199,8 @@
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-17";
-	pixel_y = 3;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/solgov/random{
@@ -4226,9 +4226,9 @@
 	},
 /obj/machinery/door/airlock/solgov{
 	dir = 4;
+	id_tag = "sgi_quartermaster";
 	name = "Logistics Deck Officer's Quarters";
-	req_one_access = list(41);
-	id_tag = "sgi_quartermaster"
+	req_one_access = list(41)
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -4256,8 +4256,8 @@
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
-	pixel_y = 11;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 11
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
@@ -4425,8 +4425,8 @@
 /area/ship/hallway/starboard)
 "BY" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -4538,8 +4538,8 @@
 	pixel_y = 4
 	},
 /obj/item/stamp/solgov{
-	pixel_y = 11;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 11
 	},
 /obj/item/paper_bin{
 	pixel_x = -5;
@@ -4588,9 +4588,9 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = 2;
+	id = "sgi_holocargo2";
 	pixel_x = -18;
-	id = "sgi_holocargo2"
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
@@ -5422,9 +5422,9 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/machinery/button/door{
-	pixel_y = 23;
 	id = "sgi_office";
-	name = "external shutters control"
+	name = "external shutters control";
+	pixel_y = 23
 	},
 /turf/open/floor/carpet/blue,
 /area/ship/crew/office)
@@ -5740,8 +5740,8 @@
 /area/ship/cargo)
 "KX" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch{
@@ -5955,10 +5955,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/button/door{
-	pixel_y = 23;
 	id = "sgi_qm";
 	name = "logistics deck officer shutters control";
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 23
 	},
 /turf/open/floor/wood/birch,
 /area/ship/crew/dorm/dormthree)
@@ -5970,8 +5970,8 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	id = "sgi_engine";
-	dir = 4
+	dir = 4;
+	id = "sgi_engine"
 	},
 /obj/machinery/door/window/westright{
 	dir = 4
@@ -6204,8 +6204,8 @@
 "Or" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 0
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/hallway/starboard)
@@ -6222,9 +6222,9 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = -2;
+	id = "sgi_holocargo1";
 	pixel_x = -18;
-	id = "sgi_holocargo1"
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
@@ -6239,17 +6239,17 @@
 	pixel_y = 8
 	},
 /obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/food/drinks/mug/coco{
 	pixel_x = -7;
 	pixel_y = -2
 	},
 /obj/machinery/button/door{
-	pixel_y = 23;
 	id = "sgi_bridge";
-	name = "external shutters control"
+	name = "external shutters control";
+	pixel_y = 23
 	},
 /turf/open/floor/wood/maple,
 /area/ship/bridge)
@@ -6396,11 +6396,11 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	pixel_y = -23;
-	pixel_x = -4;
 	dir = 1;
 	id = "sgi_engine";
-	name = "engine blast door control"
+	name = "engine blast door control";
+	pixel_x = -4;
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -6440,8 +6440,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 4;
-	color = "#D5A66E"
+	color = "#D5A66E";
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6602,8 +6602,8 @@
 "Ru" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /obj/item/binoculars,
 /turf/open/floor/wood/walnut,
@@ -6675,7 +6675,7 @@
 /obj/item/pen/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
 /obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/industrial/outline/orange,
 /obj/item/clothing/glasses/meson/prescription,
@@ -6863,9 +6863,9 @@
 /area/ship/cargo)
 "Td" = (
 /obj/structure/closet/secure_closet/miner{
+	anchored = 1;
 	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
+	populate = 0
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
@@ -7093,13 +7093,13 @@
 /area/ship/bridge)
 "Vk" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#543C30";
+	dir = 8
 	},
 /obj/structure/dresser,
 /obj/item/desk_flag/trans{
-	pixel_y = 8;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
@@ -7203,8 +7203,8 @@
 	},
 /obj/machinery/door/airlock{
 	dir = 4;
-	name = "Bathroom";
-	id_tag = "sgi_bolt"
+	id_tag = "sgi_bolt";
+	name = "Bathroom"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -7268,8 +7268,8 @@
 	color = "#D5A66E"
 	},
 /obj/structure/railing/corner/wood{
-	dir = 4;
-	color = "#D5A66E"
+	color = "#D5A66E";
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7298,9 +7298,9 @@
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/structure/closet/crate/secure/gear{
-	populate = 0;
-	name = "emergency sauerkraut supplies";
 	desc = "For emergency use only";
+	name = "emergency sauerkraut supplies";
+	populate = 0;
 	req_access = list(19)
 	},
 /obj/item/reagent_containers/food/snacks/grown/cabbage,
@@ -7375,9 +7375,9 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = -2;
+	id = "sgi_holocargo2";
 	pixel_x = -18;
-	id = "sgi_holocargo2"
+	pixel_y = -2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono,
@@ -7476,10 +7476,10 @@
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue,
 /obj/machinery/button/door{
-	pixel_y = 24;
-	pixel_x = -4;
 	id = "sgi_engine";
-	name = "engine blast door control"
+	name = "engine blast door control";
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -7506,8 +7506,8 @@
 "XZ" = (
 /obj/docking_port/mobile{
 	can_move_docking_ports = 1;
-	preferred_direction = 4;
-	port_direction = 4
+	port_direction = 4;
+	preferred_direction = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/security/armory)
@@ -7620,11 +7620,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/button/door{
-	pixel_y = -23;
-	pixel_x = -8;
 	dir = 1;
 	id = "sgi_external";
-	name = "blast door control"
+	name = "blast door control";
+	pixel_x = -8;
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
@@ -7689,8 +7689,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor{
-	id = "sgi_engine";
-	dir = 4
+	dir = 4;
+	id = "sgi_engine"
 	},
 /obj/machinery/door/window/westright{
 	dir = 4
@@ -7751,8 +7751,8 @@
 "ZB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-17";
-	pixel_y = 3;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 3
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7820,10 +7820,10 @@
 	dir = 8;
 	id = "sgi_quartermaster";
 	name = "bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = 20;
 	pixel_y = -6;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	specialfunctions = 4
 	},
 /turf/open/floor/wood/birch,
 /area/ship/crew/dorm/dormthree)

--- a/_maps/shuttles/solgov/solgov_paracelsus.dmm
+++ b/_maps/shuttles/solgov/solgov_paracelsus.dmm
@@ -193,8 +193,8 @@
 /area/ship/hallway/port)
 "cf" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#332521"
+	color = "#332521";
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/ebony,
@@ -248,8 +248,8 @@
 "cy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -437,9 +437,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/airlock/medical{
+	id_tag = "sg_par_surgery_one";
 	name = "Surgery";
-	req_one_access = list(5,69);
-	id_tag = "sg_par_surgery_one"
+	req_one_access = list(5,69)
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
@@ -583,8 +583,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#792f27"
+	color = "#792f27";
+	dir = 1
 	},
 /obj/structure/sign/poster/solgov/random{
 	pixel_y = 30
@@ -657,8 +657,8 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
-	id = "sg_par_cargo3";
-	dir = 8
+	dir = 8;
+	id = "sg_par_cargo3"
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -687,8 +687,8 @@
 "hd" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
-	pixel_y = 8;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
 /obj/effect/turf_decal/borderfloorwhite{
@@ -708,10 +708,10 @@
 	dir = 8;
 	id = "sg_par_surgery_one";
 	name = "bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = 20;
 	pixel_y = -5;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
@@ -1015,8 +1015,8 @@
 /obj/docking_port/mobile{
 	dir = 4;
 	launch_status = 0;
-	preferred_direction = 4;
-	port_direction = 2
+	port_direction = 2;
+	preferred_direction = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -1043,9 +1043,9 @@
 "kF" = (
 /obj/machinery/door/airlock/solgov{
 	dir = 4;
-	req_one_access = list(20);
+	id_tag = "sg_par_bolt";
 	name = "Captain's Quarters";
-	id_tag = "sg_par_bolt"
+	req_one_access = list(20)
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -1150,10 +1150,10 @@
 /area/ship/cargo)
 "lu" = (
 /obj/docking_port/stationary{
-	width = 30;
-	height = 15;
+	dir = 2;
 	dwidth = 15;
-	dir = 2
+	height = 15;
+	width = 30
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1178,8 +1178,8 @@
 "lJ" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 8
 	},
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/table{
@@ -1243,8 +1243,8 @@
 	pixel_y = 7
 	},
 /obj/item/desk_flag/trans{
-	pixel_y = 2;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 2
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/starboard)
@@ -1333,11 +1333,11 @@
 /area/ship/cargo/office)
 "nG" = (
 /obj/machinery/button/door{
-	pixel_y = -22;
-	pixel_x = 7;
 	dir = 1;
 	id = "sg_par_office";
-	name = "shutter control"
+	name = "shutter control";
+	pixel_x = 7;
+	pixel_y = -22
 	},
 /obj/structure/chair/sofa/brown/left/directional/north,
 /obj/machinery/airalarm/directional/west,
@@ -1358,8 +1358,8 @@
 /area/ship/medical/surgery)
 "op" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#332521"
+	color = "#332521";
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/ebony,
@@ -1380,8 +1380,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/medical{
-	name = "Surgery";
 	id_tag = "sg_par_surgery_two";
+	name = "Surgery";
 	req_one_access = list(5,69)
 	},
 /turf/open/floor/plasteel/dark,
@@ -1397,8 +1397,8 @@
 "ow" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded{
-	pixel_y = 3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /obj/item/defibrillator/loaded,
 /turf/open/floor/plasteel/mono/white,
@@ -1450,8 +1450,8 @@
 /obj/item/bedsheet/solgov,
 /obj/structure/curtain/cloth,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#332521"
+	color = "#332521";
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
@@ -1601,8 +1601,8 @@
 /area/ship/cargo)
 "qe" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
 	dir = 4;
+	name = "Treatment Center";
 	req_one_access = list(5,45)
 	},
 /obj/effect/turf_decal/industrial/warning{
@@ -1692,24 +1692,24 @@
 "qM" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door{
-	pixel_y = 8;
 	id = "sg_par_captain";
 	name = "captain privacy shutters control";
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /obj/machinery/button/door{
-	pixel_y = 8;
 	id = "sg_par_bolt";
 	name = "captain door bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = 6;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	pixel_y = 8;
+	specialfunctions = 4
 	},
 /obj/machinery/button/door{
-	pixel_y = -2;
 	id = "sg_par_captain_window";
 	name = "captain privacy shutters control";
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -2
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew)
@@ -1744,7 +1744,7 @@
 	name = "engineer's locker";
 	req_access = list(11)
 	},
-/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/head/hardhat/solgov,
 /obj/item/clothing/under/solgov/formal,
 /obj/item/storage/toolbox/mechanical,
@@ -1775,9 +1775,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/medical{
+	id_tag = "sg_par_chem_bolt";
 	name = "Chemistry";
-	req_one_access = list(5,10,45);
-	id_tag = "sg_par_chem_bolt"
+	req_one_access = list(5,10,45)
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
@@ -1901,18 +1901,18 @@
 /area/ship/medical/surgery)
 "sC" = (
 /obj/machinery/button/door{
-	pixel_y = -23;
-	pixel_x = -8;
 	dir = 1;
 	id = "sg_par_cargo1";
-	name = "cargo blast door control"
+	name = "cargo blast door control";
+	pixel_x = -8;
+	pixel_y = -23
 	},
 /obj/machinery/button/door{
-	pixel_y = -23;
-	pixel_x = 6;
 	dir = 1;
 	id = "sg_par_cargo2";
-	name = "cargo blast door control"
+	name = "cargo blast door control";
+	pixel_x = 6;
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2031,8 +2031,8 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/telecomms/relay{
-	network = "SolNet";
-	autolinkers = list("SolHub")
+	autolinkers = list("SolHub");
+	network = "SolNet"
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/bridge)
@@ -2222,15 +2222,15 @@
 "wi" = (
 /obj/machinery/button/shieldwallgen{
 	dir = 1;
+	id = "sg_par_holocargo1";
 	pixel_x = -5;
-	pixel_y = -21;
-	id = "sg_par_holocargo1"
+	pixel_y = -21
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 1;
+	id = "sg_par_holocargo2";
 	pixel_x = 5;
-	pixel_y = -21;
-	id = "sg_par_holocargo2"
+	pixel_y = -21
 	},
 /obj/structure/railing/wood{
 	dir = 4
@@ -2245,8 +2245,8 @@
 /area/ship/cargo/office)
 "wk" = (
 /obj/machinery/door/airlock/solgov{
-	name = "Psychologist Office";
-	id_tag = "sg_par_psychlock"
+	id_tag = "sg_par_psychlock";
+	name = "Psychologist Office"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -2482,8 +2482,8 @@
 /obj/item/stamp/solgov,
 /obj/item/clothing/suit/armor/solgov_trenchcoat,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#792f27"
+	color = "#792f27";
+	dir = 1
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/mahogany,
@@ -2510,8 +2510,8 @@
 "yw" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical{
-	pixel_y = 4;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 4
 	},
 /obj/item/storage/belt/medical{
 	pixel_x = -2
@@ -2601,8 +2601,8 @@
 "zc" = (
 /obj/structure/table/wood,
 /obj/item/desk_flag/solgov{
-	pixel_y = 2;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 2
 	},
 /obj/item/reagent_containers/food/drinks/mug/coco{
 	pixel_x = -6;
@@ -2685,8 +2685,8 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_y = 12;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 12
 	},
 /obj/machinery/button/door{
 	dir = 1;
@@ -2729,8 +2729,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#792f27"
+	color = "#792f27";
+	dir = 1
 	},
 /turf/open/floor/wood/mahogany,
 /area/ship/bridge)
@@ -2832,8 +2832,8 @@
 "BQ" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
-	pixel_y = 16;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 16
 	},
 /obj/effect/turf_decal/borderfloorwhite{
 	dir = 1
@@ -2898,8 +2898,8 @@
 /area/ship/hallway/starboard)
 "Cf" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#332521"
+	color = "#332521";
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2930,8 +2930,8 @@
 /area/ship/cargo/office)
 "Cp" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 1
 	},
 /obj/structure/fluff/hedge/opaque,
 /turf/open/floor/wood/yew,
@@ -3535,8 +3535,8 @@
 "IO" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
-	pixel_y = 8;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = 4;
@@ -3895,10 +3895,10 @@
 	dir = 4;
 	id = "sg_par_chem_bolt";
 	name = "bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = -20;
 	pixel_y = -6;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	specialfunctions = 4
 	},
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/white,
@@ -3951,16 +3951,16 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	pixel_y = 24;
+	id = "sg_par_exterior";
 	name = "external shutters control";
-	id = "sg_par_exterior"
+	pixel_y = 24
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "Mr" = (
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4128,8 +4128,8 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_y = 12;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 12
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -4181,8 +4181,8 @@
 "OS" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
-	pixel_y = 8;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
 /obj/effect/turf_decal/borderfloorwhite{
@@ -4202,10 +4202,10 @@
 	dir = 4;
 	id = "sg_par_surgery_two";
 	name = "bolt control";
+	normaldoorcontrol = 1;
 	pixel_x = -20;
 	pixel_y = -5;
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
@@ -4267,8 +4267,8 @@
 /area/ship/crew/crewtwo)
 "Pg" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#332521"
+	color = "#332521";
+	dir = 8
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/ebony,
@@ -4381,8 +4381,8 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	id = "sg_par_cargo3";
-	dir = 8
+	dir = 8;
+	id = "sg_par_cargo3"
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -4506,11 +4506,11 @@
 "Rs" = (
 /obj/effect/turf_decal/techfloor,
 /obj/machinery/button/door{
-	pixel_y = -23;
-	pixel_x = -4;
 	dir = 1;
 	id = "sg_par_engine";
-	name = "Engine Blast Door Control"
+	name = "Engine Blast Door Control";
+	pixel_x = -4;
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/terminal{
@@ -4659,10 +4659,10 @@
 	dir = 1
 	},
 /obj/machinery/button/door{
-	pixel_y = 24;
-	pixel_x = -4;
 	id = "sg_par_engine";
-	name = "engine blast door control"
+	name = "engine blast door control";
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/terminal{
@@ -4821,8 +4821,8 @@
 /area/ship/crew/toilet)
 "Uc" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#332521"
+	color = "#332521";
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -4898,8 +4898,8 @@
 /area/ship/bridge)
 "UO" = (
 /obj/machinery/smartfridge/bloodbank/preloaded{
-	pixel_y = 32;
-	density = 0
+	density = 0;
+	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
@@ -4914,18 +4914,18 @@
 "UV" = (
 /obj/structure/curtain/cloth,
 /obj/machinery/button/door{
-	pixel_y = 24;
-	pixel_x = -6;
 	id = "sg_par_psychlock";
 	name = "psychology office door bolt";
 	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 24;
 	specialfunctions = 4
 	},
 /obj/machinery/button/door{
-	pixel_y = 24;
-	pixel_x = 6;
 	id = "sg_par_psych";
-	name = "psychology office privacy shutters"
+	name = "psychology office privacy shutters";
+	pixel_x = 6;
+	pixel_y = 24
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
@@ -5162,12 +5162,12 @@
 	pixel_y = 15
 	},
 /obj/item/cigbutt{
-	pixel_y = 9;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 9
 	},
 /obj/item/clothing/mask/cigarette/robust{
-	pixel_y = 10;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/maintenance/port)

--- a/_maps/shuttles/syndicate/syndicate_gorlex_hyena.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_hyena.dmm
@@ -177,8 +177,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -1027,12 +1027,13 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -16;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -16
 	},
 /obj/item/clothing/under/syndicate/ngr,
 /obj/item/clothing/suit/hazardvest/ngr,
 /obj/item/clothing/head/hardhat/ngr,
+/obj/item/clothing/gloves/color/red/insulated,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage)
 "rM" = (
@@ -1268,8 +1269,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -16;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance/port)
@@ -1330,8 +1331,8 @@
 "wP" = (
 /obj/effect/turf_decal/industrial/outline,
 /obj/structure/closet/crate{
-	name = "desert equipment crate";
-	desc = "A rectangular steel crate containing supplies to survive a desert environment more easily."
+	desc = "A rectangular steel crate containing supplies to survive a desert environment more easily.";
+	name = "desert equipment crate"
 	},
 /obj/item/clothing/neck/shemagh/ngr,
 /obj/item/clothing/neck/shemagh/ngr,
@@ -1752,8 +1753,8 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/starboard)
@@ -1852,8 +1853,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -16;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -1944,9 +1945,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light_switch{
+	dir = 4;
 	pixel_x = -20;
-	pixel_y = 12;
-	dir = 4
+	pixel_y = 12
 	},
 /turf/open/floor/carpet/red,
 /area/ship/crew)
@@ -2852,8 +2853,8 @@
 /obj/effect/turf_decal/trimline/opaque/red/filled/corner,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -16;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
@@ -3131,8 +3132,8 @@
 	req_access = null
 	},
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 23
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security/armory)

--- a/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
@@ -212,10 +212,10 @@
 	},
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child{
-	faction = list("neutral","playerSyndicate");
-	name = "Goliath";
+	desc = "A little guy.";
 	environment_smash = 0;
-	desc = "A little guy."
+	faction = list("neutral","playerSyndicate");
+	name = "Goliath"
 	},
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/tech,
@@ -332,8 +332,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = 21
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/mineral/plastitanium,
@@ -513,9 +513,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -23;
+	dir = 1;
 	pixel_x = 3;
-	dir = 1
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/stairs{
 	dir = 8
@@ -1175,6 +1175,7 @@
 	},
 /obj/item/clothing/under/syndicate/hardliners,
 /obj/item/clothing/suit/hazardvest/hardliners,
+/obj/item/clothing/gloves/color/red/insulated,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "ls" = (
@@ -1390,8 +1391,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -23;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -23
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/aft)
@@ -1418,8 +1419,8 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	id = "komodo_port";
-	pixel_y = 24;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 24
 	},
 /obj/machinery/button/door{
 	id = "Artillery1shutter";
@@ -1699,8 +1700,8 @@
 /obj/effect/turf_decal/industrial/fire,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/syndi_cakes{
-	pixel_y = 6;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 6
 	},
 /obj/item/t_scanner{
 	pixel_x = -2;
@@ -1846,16 +1847,16 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -23;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -23
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/canteen)
 "rN" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/syndie{
-	pixel_y = 5;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 5
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/fax/syndicate,
@@ -2201,8 +2202,8 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 23
 	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -8
@@ -3597,8 +3598,8 @@
 	dir = 1;
 	id = "syndiewarship_armorybay";
 	name = "Weapon Hold";
-	req_access_txt = "3";
-	pixel_y = -26
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3655,8 +3656,8 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_y = 30;
-	layer = 2.8
+	layer = 2.8;
+	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
@@ -3862,8 +3863,8 @@
 /area/ship/hallway/central)
 "Lj" = (
 /obj/item/scalpel{
-	pixel_y = 6;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
 /obj/item/hemostat,
@@ -3983,8 +3984,8 @@
 	},
 /obj/item/clothing/under/suit/waiter/syndicate,
 /obj/machinery/vending/boozeomat/syndicate_access{
-	pixel_x = 32;
-	density = 0
+	density = 0;
+	pixel_x = 32
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew/canteen)
@@ -4131,8 +4132,8 @@
 "ND" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/components/unary/tank/air{
-	piping_layer = 2;
-	dir = 8
+	dir = 8;
+	piping_layer = 2
 	},
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/greenglow,
@@ -5076,8 +5077,8 @@
 	dir = 8;
 	id = "warshipbridge";
 	name = "Bridge Window";
-	pixel_y = -1;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -1
 	},
 /obj/item/reagent_containers/food/drinks/mug{
 	pixel_x = -6;
@@ -5464,8 +5465,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -21;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -21
 	},
 /obj/machinery/firealarm/directional/south{
 	pixel_x = -6

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -211,7 +211,7 @@
 
 /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	name = "combat gloves plus"
-	desc = "These tactical gloves are fireproof and electrically insulated, and through the use of nanochip technology will teach you the martial art of krav maga."
+	desc = "These tactical gloves are fireproof, and through the use of nanochip technology will teach you the martial art of krav maga."
 	icon_state = "black"
 	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -213,7 +213,7 @@
 	name = "combat gloves plus"
 	desc = "These tactical gloves are fireproof and electrically insulated, and through the use of nanochip technology will teach you the martial art of krav maga."
 	icon_state = "black"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 	strip_delay = 80
 	cold_protection = HANDS

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -232,7 +232,7 @@
 	name = "Plate Gauntlets"
 	icon_state = "crusader"
 	desc = "They're like gloves, but made of metal."
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -177,7 +177,7 @@
 	new /obj/item/crowbar/syndie(src) //WS Begin - Cool Syndie Tools
 	new /obj/item/wirecutters/syndie(src)
 	new /obj/item/multitool/syndie(src) //WS End
-	new /obj/item/clothing/gloves/combat(src)
+	new /obj/item/clothing/gloves/color/red/insulated(src)
 
 /obj/item/storage/toolbox/syndicate/empty
 

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -217,7 +217,7 @@
 	name = "\improper PGFN Captain's Ihuz-irra Gloves"
 	desc = "As the name, “ihuz-irra”, or “sure-grip”, suggests, the gloves employed by the PGF military are designed to ensure the highest possible grip is maintained while also providing protection from blisters in work environments. Bears the silver standard of a Gezenan captain."
 	icon_state = "captaingloves"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 
 //Boots
 

--- a/code/modules/clothing/factions/suns.dm
+++ b/code/modules/clothing/factions/suns.dm
@@ -466,10 +466,10 @@
 
 /obj/item/clothing/gloves/suns/captain
 	name = "\improper SUNS captain's gloves"
-	desc = "Fancy black gloves for trusted SUNS members. Sports a complex lining that prevents the wearer from being shocked."
+	desc = "Fancy black gloves for trusted SUNS members."
 	icon_state = "suns_captaingloves"
 	item_state = "suns_blackgloves"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -177,10 +177,10 @@
 	icon_state = "brown"
 
 /obj/item/clothing/gloves/color/captain
-	desc = "Regal white gloves, with a nice gold trim, a diamond anti-shock coating, and an integrated thermal barrier, and armoured bracers. Swanky."
+	desc = "Regal white gloves, with a nice gold trim, an integrated thermal barrier, and armoured bracers. Swanky."
 	name = "captain's gloves"
 	icon_state = "captain"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
@@ -231,7 +231,7 @@
 	name = "infiltrator gloves"
 	desc = "Specialized combat gloves for carrying people around. Transfers tactical kidnapping knowledge into the user via nanochips."
 	icon_state = "infiltrator"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.3
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -42,12 +42,12 @@
 
 /obj/item/clothing/gloves/combat/maid
 	name = "combat maid sleeves"
-	desc = "These 'tactical' gloves and sleeves are fireproof and electrically insulated. Warm to boot."
+	desc = "These 'tactical' gloves and sleeves are fireproof and acid-resistant. Warm to boot."
 	icon_state = "syndimaid_arms"
 
 /obj/item/clothing/gloves/combat/maid/inteq
 	name = "inteq combat maid sleeves"
-	desc = "Tacticute and comfy, along with being both fireproof and electrically insulated."
+	desc = "Tacticute and comfy, along with being both fireproof and acid-resistant."
 	icon_state = "inteqmaid_arms"
 
 /obj/item/clothing/gloves/bracer
@@ -142,5 +142,5 @@
 
 /obj/item/clothing/gloves/combat/wizard
 	name = "enchanted gloves"
-	desc = "These gloves have been enchanted with a spell that makes them electrically insulated and fireproof."
+	desc = "These gloves have been enchanted with a spell that makes them fireproof and acid-resistant."
 	icon_state = "wizard"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -27,9 +27,9 @@
 
 /obj/item/clothing/gloves/combat
 	name = "combat gloves"
-	desc = "These tactical gloves are fireproof and electrically insulated."
+	desc = "These tactical gloves are extra-durable, offering some fire and acid protection."
 	icon_state = "combat"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 	strip_delay = 80
 	cold_protection = HANDS

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -67,7 +67,7 @@
 	name = "guerrilla gloves"
 	desc = "Superior quality combative gloves, good for performing tackle takedowns as well as absorbing electrical shocks."
 	icon_state = "combat"
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 
 /obj/item/clothing/gloves/tackler/rocket

--- a/code/modules/clothing/outfits/ert/nanotrasen_ert.dm
+++ b/code/modules/clothing/outfits/ert/nanotrasen_ert.dm
@@ -434,7 +434,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/lp/engi
 	id = /obj/item/card/id/lpengie
 	belt = /obj/item/storage/belt/utility/full
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/yellow
 	glasses = /obj/item/clothing/glasses/welding
 	back = /obj/item/storage/backpack/ert/engineer
 

--- a/code/modules/clothing/outfits/factions/frontiersmen.dm
+++ b/code/modules/clothing/outfits/factions/frontiersmen.dm
@@ -92,7 +92,7 @@
 	uniform = /obj/item/clothing/under/frontiersmen/officer
 	head = /obj/item/clothing/head/hardhat/frontier
 	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/yellow
 	belt = /obj/item/storage/belt/utility/full
 
 // Engineer

--- a/code/modules/clothing/outfits/factions/independent.dm
+++ b/code/modules/clothing/outfits/factions/independent.dm
@@ -350,7 +350,7 @@
 	head = /obj/item/clothing/head/soft/black
 	shoes = /obj/item/clothing/shoes/combat
 	l_pocket = /obj/item/kitchen/knife/combat/survival
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/red/insulated
 
 	implants = list(/obj/item/implant/radio)
 

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -91,7 +91,7 @@
 	mask = /obj/item/clothing/mask/gas/sechailer/balaclava/inteq
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/security/inteq
 	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/yellow
 	belt = /obj/item/storage/belt/utility/full
 
 	id = /obj/item/card/id/silver

--- a/code/modules/clothing/outfits/factions/minutemen.dm
+++ b/code/modules/clothing/outfits/factions/minutemen.dm
@@ -93,6 +93,7 @@
 	head = /obj/item/clothing/head/hardhat/white
 	ears = /obj/item/radio/headset/clip
 	uniform = /obj/item/clothing/under/clip
+	gloves = /obj/item/clothing/gloves/color/yellow
 	alt_uniform = null
 	suit = /obj/item/clothing/suit/toggle/lawyer/clip
 	alt_suit = null

--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -444,7 +444,7 @@
 	shoes =/obj/item/clothing/shoes/laceup
 	ears = /obj/item/radio/headset/syndicate/alt/captain
 	id = /obj/item/card/id/syndicate_command/captain_id
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/yellow
 
 /datum/outfit/job/syndicate/ce/ngr
 	name = "Syndicate - Foreman (New Gorlex Republic)"
@@ -456,7 +456,7 @@
 	suit = /obj/item/clothing/suit/ngr
 	alt_suit = null
 	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/red/insulated
 
 
 //Chief Medical Officer

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -105,7 +105,7 @@
 	max_integrity = 300
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 10, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 50, "acid" = 75)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser)
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	var/obj/item/clothing/head/helmet/space/hardsuit/helmet
 	actions_types = list(/datum/action/item_action/toggle_helmet)
 	var/helmettype = /obj/item/clothing/head/helmet/space/hardsuit
@@ -207,6 +207,7 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "hardsuit-engineering"
 	item_state = "eng_hardsuit"
+	siemens_coefficient = 0
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 100, "acid" = 75)
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
@@ -1065,6 +1066,7 @@
 	icon_state = "space-independent-eng"
 	item_state = "space-independent-eng"
 	desc = "A civilian space suit designed for construction and salvage in hazardous, low-pressure environments. Has shielding against radiation and heat and abundant storage.<br>Though they lack the physical protection of more expensive hardsuits, this type of suit is extremely common wherever construction and salvage work must be done in open space."
+	siemens_coefficient = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 20, "bomb" = 0, "bio" = 100, "rad" = 75, "fire" = 100, "acid" = 75)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo/large
 	resistance_flags = FIRE_PROOF

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -164,6 +164,7 @@
 	icon_state = "syndicate-black-engie"
 	item_state = "syndicate-black"
 	desc = "A space suit made of high-grade ballistic fabric with thermal and radiation shielding. More compact than a normal space suit while amost matching powered hardsuits for protection. Almost."
+	siemens_coefficient = 0
 	armor = list("melee" = 30, "bullet" = 10, "laser" = 10, "energy" = 40, "bomb" = 20, "bio" = 100, "rad" = 75, "fire" = 100, "acid" = 75)
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -147,10 +147,10 @@
 
 /obj/item/clothing/gloves/explorer/old
 	name = "prototype exploration gauntlets"
-	desc = "Thick-fingered gloves with a heavy layer of armor plating, meant to stop all but the most brutal of stovetop-touching accidents in the field. This premium pre-run prototype comes with an added layer of electrical insulation."
+	desc = "Thick-fingered gloves with a heavy layer of armor plating, meant to stop all but the most brutal of stovetop-touching accidents in the field."
 	icon_state = "explorerold"
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 15, "energy" = 15, "bomb" = 65, "bio" = 100, "rad" = 75, "fire" = 75, "acid" = 75)
-	siemens_coefficient = 0
+	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
 
 /obj/item/clothing/suit/hooded/survivor

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -586,7 +586,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/combatglovesplus
 	name = "Combat Gloves Plus"
-	desc = "A pair of gloves that are fireproof and electrically insulated, however unlike the regular Combat Gloves these use nanotechnology \
+	desc = "A pair of gloves that are fireproof and acid-resistant, however unlike the regular Combat Gloves these use nanotechnology \
 			to teach the martial art of krav maga to the wearer."
 	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	cost = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes electrical insulation from all gloves except for insulated gloves and their children (including captain, tackler, and combat gloves) and nixes the siemens coefficient on hardsuits that aren't engineer hardsuits of some form. Adds siemens coeff to engineering space suits. Replaces combat gloves with insulated gloves in outfit datums and locker contents for engineers.

## Why It's Good For The Game

shock protection is a bit too widely available with how many jobs spawn with combats and how many captain players are in an average round. Since electrical hazards should become a bit more significant in the future due to planned mapping hazards and potentially electrical weapons, this generally reduces it to the players directly responsible for engineering in some capacity. We shouldn’t have ships where the entire crew is shockproof at roundstart- if you want to do that it should require buying some crates, at least.

## Changelog

:cl:
balance: Removed electrical insulation from all gloves except insulated gloves
balance: Removed siemens coefficient from hardsuits, except for engi atmos and CE
balance: Added siemens coefficient to engineer space suits
balance: Replaced combat gloves with insulated gloves for some factions' engineer lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
