### PR TITLE
Fixes the spawners on my lavaland ruins.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -608,7 +608,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/winter_biodome/living_quarters)
 "fs" = (
@@ -896,7 +896,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/winter_biodome/living_quarters)
 "lq" = (
@@ -952,7 +952,7 @@
 "mD" = (
 /obj/effect/turf_decal/solgov/wood/center,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/wood,
 /area/ruin/unpowered/winter_biodome/living_quarters)
 "mX" = (
@@ -1081,7 +1081,7 @@
 	},
 /obj/effect/turf_decal/corner/opaque/solgovgold/diagonal,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/winter_biodome/engineering)
 "qt" = (
@@ -1467,10 +1467,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/up,
-/obj/structure/spawner/burrow/lava_planet,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/wood,
 /area/ruin/unpowered/winter_biodome/entrance)
 "Ar" = (
@@ -1925,7 +1925,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/winter_biodome/sauna)
 "Lf" = (
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/grass/snow,
 /area/ruin/unpowered/winter_biodome)
 "Lt" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
@@ -542,7 +542,7 @@
 /area/ruin/unpowered/buried_shrine)
 "nq" = (
 /obj/structure/stone_tile/surrounding,
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "nz" = (
@@ -930,7 +930,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wM" = (
-/obj/structure/stone_tile/slab,
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/center,
 /obj/structure/spawner/burrow/lava_planet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
@@ -1648,6 +1651,7 @@
 	dir = 1
 	},
 /obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "QR" = (
@@ -1864,7 +1868,7 @@
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/obj/structure/spawner/burrow/lava_planet,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface/lit,
 /area/ruin/unpowered/buried_shrine)
 "Xr" = (
@@ -3928,7 +3932,7 @@ LJ
 ta
 NN
 ta
-Xv
+wM
 Ad
 mM
 Ad
@@ -4095,7 +4099,7 @@ ee
 WZ
 WZ
 yz
-wM
+Ad
 tL
 WZ
 Yh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the mob burrows with the legions they were originally meant to be. Mob spawner rework replaced them for some reason and never fixed them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fuck my stupid mapper life
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: winter biodome and buried shrine ruins no longer have an egregious amount of creature burrows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
