### PR TITLE
Adds a rubbershot box to cargo

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -76,6 +76,12 @@
 	cost = 210
 	contains = list(/obj/item/storage/box/techshot)
 
+/datum/supply_pack/ammo/rubbershot
+	name = "Rubbershot Crate"
+	desc = "Contains a box of twenty-five rubbershot shells for use in crowd control or training."
+	cost = 500
+	contains = list(/obj/item/ammo_box/a12g/rubbershot)
+
 /*
 		.38 ammo
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This should add a box of rubbershot ammo to the outpost cargo market.

## Why It's Good For The Game

This will allow players the ability to purchase rubbershot for training activities without having to require RnD beforehand.

## Changelog

:cl:
add: Adds a rubbershot box to the outpost market
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
