### PR TITLE
New items and rebalances for Outpost Cargo Exploration Tab + Underground Scanner detection change

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -356,6 +356,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/resonator,
 		/obj/item/mining_scanner,
+		/obj/item/pinpointer/mineral,
 		/obj/item/pickaxe,
 		/obj/item/shovel,
 		/obj/item/stack/sheet/animalhide,

--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -8,13 +8,13 @@
 
 /datum/supply_pack/exploration/lava
 	name = "Lava Exploration Kit"
-	desc = "Contains two pickaxes, 60 lavaproof rods, and goggles to protect eyes from the heat"
-	cost = 1500
+	desc = "Contains two pickaxes, 60 lavaproof rods, two pocket extinguishers and goggles to protect yourself from the heat."
+	cost = 500
 	contains = list(
 		/obj/item/pickaxe/mini,
 		/obj/item/pickaxe/mini,
-		/obj/item/clothing/glasses/heat,
-		/obj/item/clothing/glasses/heat,
+		/obj/item/extinguisher/mini,
+		/obj/item/extinguisher/mini,
 		/obj/item/clothing/glasses/heat,
 		/obj/item/clothing/glasses/heat,
 		/obj/item/stack/rods/lava/thirty,
@@ -22,33 +22,44 @@
 	)
 	crate_name = "Lava Exploration Kit"
 
+/datum/supply_pack/exploration/lavaproof_ords
+	name ="Lavaproof Rods Crate"
+	desc = "Contains 60 lavaproof rods for safely traversing molten pits."
+	cost = 200
+	contains = list(
+		/obj/item/stack/rods/lava/thirty,
+		/obj/item/stack/rods/lava/thirty,
+		)
+	crate_name = "Lavaproof Rod Crate"
+
 /datum/supply_pack/exploration/ice
 	name = "Ice Exploration Kit"
-	desc = "Contains two pickaxes, winter clothes, and goggles to protect eyes from the cold"
-	cost = 1500
+	desc = "Contains two pickaxes, 2 sets of winter clothes and ice hiking boots, along with goggles to protect eyes from the cold."
+	cost = 750
 	contains = list(
 		/obj/item/pickaxe/mini,
 		/obj/item/pickaxe/mini,
 		/obj/item/clothing/glasses/cold,
 		/obj/item/clothing/glasses/cold,
-		/obj/item/clothing/glasses/cold,
-		/obj/item/clothing/glasses/cold,
-		/obj/item/clothing/shoes/winterboots,
-		/obj/item/clothing/shoes/winterboots,
-		/obj/item/clothing/shoes/winterboots,
-		/obj/item/clothing/shoes/winterboots,
+		/obj/item/clothing/suit/hooded/wintercoat,
+		/obj/item/clothing/suit/hooded/wintercoat,
+		/obj/item/clothing/shoes/winterboots/ice_boots,
+		/obj/item/clothing/shoes/winterboots/ice_boots,
 	)
 	crate_name = "Ice Exploration Kit"
 
 /datum/supply_pack/exploration/jungle
 	name = "Jungle Exploration Kit"
-	desc = "Contains hatchets, picks, and antivenom, great for dense jungles!"
-	cost = 750
+	desc = "Contains a hatchets, two picks and lanterns, plus antivenom pills, great for dense jungles!"
+	cost = 500
 	contains = list(
 		/obj/item/pickaxe/mini,
 		/obj/item/pickaxe/mini,
+		/obj/item/flashlight/lantern,
+		/obj/item/flashlight/lantern,
 		/obj/item/storage/pill_bottle/charcoal,
 		/obj/item/storage/pill_bottle/charcoal,
+		/obj/item/hatchet,
 		/obj/item/hatchet,
 	)
 	crate_name = "Jungle Exploration Kit"
@@ -76,16 +87,45 @@
 	crate_name = "Beach Kit"
 
 /*
-		Heavy Duty Exploration Gear
+		General Exploration Gear
 */
 
 /datum/supply_pack/exploration/capsules
-	name = "Bluespace Shelter Capsules"
-	desc = "A trio of Bluespace Shelter Capsules, for instant shelter in rough situations."
-	cost = 3000
+	name = "Bluespace Shelter Capsule"
+	desc = "Contains a Bluespace Shelter Capsule, for instant shelter in rough situations."
+	cost = 500
 	contains = list(
-		/obj/item/survivalcapsule,
-		/obj/item/survivalcapsule,
-		/obj/item/survivalcapsule,
+		/obj/item/survivalcapsule
 	)
 
+/datum/supply_pack/exploration/binocular
+	name = "Binoculars"
+	desc = "One pair of binoculars for surveying terrain."
+	cost = 200
+	contains = list(
+		/obj/item/binoculars
+	)
+
+/datum/supply_pack/exploration/anom_neutralizer
+	name = "Anomaly Neutralizer"
+	desc = "A single use anomaly neutralizer for stabalizing hazardous anomalies."
+	cost = 250
+	contains = list(
+		/obj/item/anomaly_neutralizer
+	)
+
+/datum/supply_pack/exploration/mineral_scanner
+	name = "Underground Mineral Scanner"
+	desc = "Contains an underground mineral scanner for locating veins of ore beneath the earth. Deep core laser drill for extracting said ores not included."
+	cost = 250
+	contains = list(
+		/obj/item/pinpointer/mineral
+	)
+
+/datum/supply_pack/exploration/binocular
+	name = "GPS"
+	desc = "Contains a GPS device, useful for finding lost things and not getting lost yourself."
+	cost = 100
+	contains = list(
+		/obj/item/gps
+	)

--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -35,7 +35,7 @@
 /datum/supply_pack/exploration/ice
 	name = "Ice Exploration Kit"
 	desc = "Contains two pickaxes, 2 sets of winter clothes and ice hiking boots, along with goggles to protect eyes from the cold."
-	cost = 750
+	cost = 500
 	contains = list(
 		/obj/item/pickaxe/mini,
 		/obj/item/pickaxe/mini,

--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -122,7 +122,7 @@
 		/obj/item/pinpointer/mineral
 	)
 
-/datum/supply_pack/exploration/binocular
+/datum/supply_pack/exploration/gps
 	name = "GPS"
 	desc = "Contains a GPS device, useful for finding lost things and not getting lost yourself."
 	cost = 100

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -11,7 +11,7 @@
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/explorer
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/pinpointer/mineral, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
 	resistance_flags = FIRE_PROOF
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
 
@@ -65,7 +65,7 @@
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	slowdown = 0
 	armor = list("melee" = 70, "bullet" = 40, "laser" = 30, "energy" = 45, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/pinpointer/mineral, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
 
 /obj/item/clothing/suit/space/hostile_environment/Initialize()
 	. = ..()
@@ -167,7 +167,7 @@
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/survivor_hood
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 20, "fire" = 50, "acid" = 30)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/pinpointer/mineral, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
 	resistance_flags = FIRE_PROOF
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
 

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -126,6 +126,7 @@
 /obj/item/pinpointer/mineral/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>It is currently set to [scanmode ? "scan underground" : "scan the surface"].</span>"
+	. ++ span_notice("You can use the scanner on an vein on harm intent to mark them as sites of no interest, causing them to no longer show up on scans.")
 
 /obj/item/pinpointer/mineral/AltClick(mob/user) //switching modes
 	..()
@@ -204,7 +205,7 @@
 	var/located_dist
 	var/obj/structure/located_vein
 	for(var/obj/structure/vein/I in GLOB.ore_veins)
-		if(I.z == 0 || I.virtual_z() != here.virtual_z())
+		if(I.z == 0 || I.virtual_z() != here.virtual_z() || I.detectable == FALSE)
 			continue
 		if(located_vein)
 			var/new_dist = get_dist(here, get_turf(I))
@@ -223,6 +224,16 @@
 	if(!proximity || !istype(O,/obj/structure/vein))
 		return
 	playsound(src, 'sound/effects/fastbeep.ogg', 10)
+	if(user.a_intent == INTENT_HARM)
+		if(O.detectable == TRUE)
+			to_chat(user,span_notice("You blacklist the vein from the scanner's telemetry, and will no longer be detected as a site of interest to the scanner."))
+			O.detectable = FALSE
+			return
+		else
+			to_chat(user,span_notice("You mark vein into the scanner's telemetry, allowing it be located by underground scans."))
+			O.detectable = TRUE
+			return
+
 	if(O.vein_contents.len > 0)
 		to_chat(user, "<span class='notice'>Class [O.vein_class] ore vein with [O.mining_charges] possible ore lodes found.</span>")
 		for(var/re in O.vein_contents)

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -126,7 +126,7 @@
 /obj/item/pinpointer/mineral/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>It is currently set to [scanmode ? "scan underground" : "scan the surface"].</span>"
-	. ++ span_notice("You can use the scanner on an vein on harm intent to mark them as sites of no interest, causing them to no longer show up on scans.")
+	. += span_notice("You can use the scanner on an vein on harm intent to mark them as sites of no interest, causing them to no longer show up on scans.")
 
 /obj/item/pinpointer/mineral/AltClick(mob/user) //switching modes
 	..()

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -10,6 +10,8 @@ GLOBAL_LIST_EMPTY(ore_veins)
 	move_resist = INFINITY
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
+	//Whether the mining scanner is able to locate this vein.
+	var/detectable = TRUE
 	var/mining_charges = 6
 	//Classification of the quality of possible ores within a vein
 	//Used to determine difficulty & ore amounts
@@ -75,6 +77,11 @@ GLOBAL_LIST_EMPTY(ore_veins)
 			ore_list.Remove(picked)
 	GLOB.ore_veins += src
 
+/obj/structure/vein/examine(mob/user)
+	. = ..()
+	if(!detectable)
+		. += span_notice("This vein has been marked as a site of no interest, and will not show up on deep core scans.")
+
 /obj/structure/vein/Destroy()
 	GLOB.ore_veins -= src
 	return ..()
@@ -104,6 +111,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 
 /obj/structure/vein/proc/toggle_spawning()
 	spawning_started = SEND_SIGNAL(src, COMSIG_SPAWNER_TOGGLE_SPAWNING, spawning_started)
+
 
 //
 //	Planetary and Class Subtypes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Rebalances the prices of old packs in the exploration tab, and adds some new items.
- Lava Exploration Kit: Price: 1500 -> 500, adds two pocket extinguishers
- Ice Exploration Kit:  Price: 1500 -> 500, swaps out the boots for ice hiking boots, adds two winter coats
- Jungle Exploration Ki:  Price: 750-> 500, adds two lanterns
- Bluespace shelter capsules:  Price: 3000 -> 500, only contains a single capsule now

Adds some new packs:
- Lavaproof rods crate, 200 credits
- Binoculars 200 credits
- Deep core drill scanner, 250 credits
- Anomaly neutralizer, 250 credits
- GPS, 100 credits

You can now click a vein with a deep core scanner on harm intent so the scanner no longer picks it up, or hit it again to readd it to tracking.

The deep core scanner fits in explorer webbing storage and explorer suits.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A lot of the exploration packs were comically overcosted for what they were. For 1500, the ice exploration pack got you.... two pickaxes, boots that didnt protect from the ice, and cosmetic goggles. For 1500 you could get two actual mining crates which would serve you a lot better. The new prices should hopefully make them more worthwhile purchases.

The new packs are meant to be generally useful items to aid in exploration. 
Lavaproof rods are a useful, if niche nice to have if you're penned in by lava.
Binocs and GPS are good for general exploration.
Anomaly neutralizers are handy for difficult anomalies that hard or impossible to approach normally. Case in point:

https://github.com/user-attachments/assets/cabbdb99-d425-4227-863b-ffdd6549fff1

Adds the deep core mining scanner as an individual purchase so you don't have to pay a 1000 credit buy in for the drill if you only intend to do missions.

Detectability changes for veins are meant to be QOL, and streamline finding the type of vein you want, as you can now remove unwanted veins from being tracked instead of wandering aimlessly hoping to get close enough to another vein for the scanner to lock on.

## Changelog


:cl:
add: Adds  binocs, lavaproof rods, gps, deep core mining scanner, anomaly neutralizer to exploration cargo
add: You can hit veins with a deep core scanner on harm intent to stop it tracking, and hit it again to readd it.
add: Deep core scanner fits in explorer webbing and explorer suits.
balance: Outpost Cargo exploration tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
