### PR TITLE
Fixes the "pulse carbine" on whitesands_surface_camp_saloon again

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
@@ -1029,7 +1029,8 @@
 	icon_state = "pulse_carbine";
 	name = "pulse rifle";
 	desc = "A supposedly heavy-duty, multifaceted energy rifle. The barrel looks off and the casing seems to be made of plastic";
-	item_state = "pulse"
+	item_state = "pulse";
+	icon = 'icons/obj/guns/manufacturer/nanotrasen_sharplite/48x32.dmi'
 	},
 /turf/open/floor/wood,
 /area/ruin/whitesands/saloon)

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
@@ -243,7 +243,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/stool/bar,
-/mob/living/simple_animal/hostile/human/hermit/survivor,
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
 /turf/open/floor/wood,
 /area/ruin/whitesands/saloon)
 "gC" = (
@@ -445,7 +445,6 @@
 "lI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/gambling,
-/obj/item/spacecash/bundle/loadsamoney,
 /turf/open/floor/carpet,
 /area/ruin/whitesands/saloon)
 "lV" = (
@@ -890,6 +889,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -1115,7 +1117,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/human/hermit/survivor{
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -1498,7 +1500,7 @@
 /area/ruin/whitesands/saloon)
 "Ua" = (
 /obj/structure/chair/stool/bar,
-/mob/living/simple_animal/hostile/human/hermit/survivor{
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger{
 	dir = 8
 	},
 /turf/open/floor/wood{
@@ -1673,6 +1675,7 @@
 	pixel_y = 6;
 	pixel_x = 3
 	},
+/obj/item/spacecash/bundle/loadsamoney,
 /turf/open/floor/carpet,
 /area/ruin/whitesands/saloon)
 "ZG" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the missing sprite on a varedited gun on the map. Also changes the amount of money on the map since it was brought to my attention that it had 14k credits lying about. Adds a few gunner hermits for good measure.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Invisible guns are bad. oh and ruins generally shouldnt have over 10k credits unless they warrant it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: The "pulse carbine" in the sandplanet saloon has a sprite again
tweak: Added some extra mobs to the sandplanet saloon to balance out the money in it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
