### PR TITLE
Nerfs hollowpoint rounds to bring them under limb crit threshold

### DIFF
--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -67,7 +67,7 @@
 
 /obj/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow point bullet"
-	damage = 45
+	damage = 40
 	armour_penetration = -20
 
 /obj/projectile/bullet/incendiary/mm712x82

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -16,7 +16,7 @@
 
 /obj/projectile/bullet/c9mm/hp
 	name = "9mm hollow point bullet"
-	damage = 40
+	damage = 35
 	armour_penetration = -50
 
 /obj/projectile/bullet/incendiary/c9mm
@@ -49,7 +49,7 @@
 
 /obj/projectile/bullet/c10mm/hp
 	name = "10mm hollow point bullet"
-	damage = 45
+	damage = 40
 	armour_penetration = -50
 
 /obj/projectile/bullet/incendiary/c10mm
@@ -82,7 +82,7 @@
 
 /obj/projectile/bullet/c45/hp
 	name = ".45 hollow point bullet"
-	damage = 45
+	damage = 40
 	armour_penetration = -50
 
 /obj/projectile/bullet/incendiary/c45

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -6,7 +6,7 @@
 
 /obj/projectile/bullet/a50AE/hp
 	name = ".50 AE hollow point bullet"
-	damage = 60
+	damage = 55
 	armour_penetration = -50
 
 // .38 (Colt Detective Special & Winchester)
@@ -110,7 +110,7 @@
 
 /obj/projectile/bullet/a357/hp
 	name = ".357 hollow point bullet"
-	damage = 50
+	damage = 45
 	armour_penetration = -50
 	ricochet_chance = 0 //mushroom on impact, no bounces
 
@@ -133,7 +133,7 @@
 
 /obj/projectile/bullet/a4570/hp
 	name = ".45-70 hollow point bullet"
-	damage = 60 //it's the pre-nerf .357 with less armor pen
+	damage = 55 //it's ALMOST the pre-nerf .357 with less armor pen
 	armour_penetration = -50
 
 /obj/projectile/bullet/a4570/explosive //for extra oof
@@ -167,5 +167,5 @@
 
 /obj/projectile/bullet/a44roum/hp
 	name = ".44 roumain bullet"
-	damage =  45
+	damage =  40
 	armour_penetration = -20

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -16,7 +16,7 @@
 /obj/projectile/bullet/a8_50rhp
 	name = "8x50mmR bullet"
 	speed = 0.3
-	damage = 55
+	damage = 49
 	armour_penetration = 0
 
 // .300 Magnum (Smile Rifle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs most hollowpoint rounds by 5 damage. Nerfs 8mm hollowpoint by 6 damage for a total of 49 damage.

## Why It's Good For The Game

This is mostly because .357 Hollowpoint does exactly 50 damage, which crits an unarmored limb (which is most players' limbs) in a single shot. The nerf doesn't hit HP so hard it isn't worth it, because you're still doing the same damage as weapons much higher up on the totem pole, but it ensures the only weapon that can crit a limb in a single shot is a .45-70 firing hollowpoint or explosive ammo. And sniper rifles like the Scout, if those ever get something like hollowpoint.

## Changelog

:cl:
balance: Reduced hollowpoint damage by 5 (and 8mm Hollowpoint by 6)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
