### PR TITLE
Rebalances hardsuit slowdowns

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -305,7 +305,6 @@
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/bag/ore, /obj/item/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining/heavy
 	custom_price = 4500
-	slowdown = 0.5
 
 /obj/item/clothing/head/helmet/space/hardsuit/mining/heavy
 	name = "heavy mining helmet"
@@ -387,13 +386,11 @@
 		if(on)
 			linkedsuit.name = initial(linkedsuit.name)
 			linkedsuit.desc = initial(linkedsuit.desc)
-			linkedsuit.slowdown = 1
 			linkedsuit.clothing_flags |= STOPSPRESSUREDAMAGE
 			linkedsuit.cold_protection |= CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 		else
 			linkedsuit.name += " (combat)"
 			linkedsuit.desc = linkedsuit.alt_desc
-			linkedsuit.slowdown = linkedsuit.combat_slowdown
 			linkedsuit.clothing_flags &= ~STOPSPRESSUREDAMAGE
 			linkedsuit.cold_protection &= ~(CHEST | GROIN | LEGS | FEET | ARMS | HANDS)
 			if(linkedsuit.lightweight)
@@ -418,7 +415,7 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	jetpack = /obj/item/tank/jetpack/suit
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
-	var/combat_slowdown = 0 //slowdown when in combat mode
+	slowdown = 0.5
 	var/lightweight = 0 //used for flags when toggling
 
 //Ramzi Syndie suit
@@ -442,7 +439,7 @@
 	lightweight = 1
 	jetpack = null
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
-	combat_slowdown = 0.5
+	slowdown = 1
 	jetpack = null
 
 //Elite Syndie suit
@@ -510,7 +507,6 @@
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 35, "energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 65, "fire" = 75, "acid" = 40)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/cybersun/paramed
 	supports_variations = VOX_VARIATION
-	combat_slowdown = 0.4
 	jetpack = null
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/cybersun/paramed
@@ -667,6 +663,7 @@
 	item_state = "sec_hardsuit"
 	armor = list("melee" = 35, "bullet" = 15, "laser" = 30, "energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security
+	slowdown = 0.5
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
 
 /obj/item/clothing/suit/space/hardsuit/security/Initialize()
@@ -922,7 +919,7 @@
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 40, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi
-	slowdown = 0
+	slowdown = 0.5
 	shield_state = "shield-red"
 	shield_on = "shield-red"
 	jetpack = /obj/item/tank/jetpack/suit
@@ -1203,7 +1200,7 @@
 	armor = list("melee" = 50, "bullet" = 45, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75) //intentionally the fucking strong, this is master chief-tier armor //is this really what you call the strong?? is this the best solgov has to offer??????
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/solgov
 	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
-	slowdown = 0
+	slowdown = 0.5
 	supports_variations = DIGITIGRADE_VARIATION
 
 /obj/item/clothing/head/helmet/space/hardsuit/quixote
@@ -1227,7 +1224,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/quixote
 	jetpack = /obj/item/tank/jetpack/suit
-	slowdown = 0
+	slowdown = 0.3
 	max_heat_protection_temperature = 20000
 	var/datum/action/innate/quixotejump/jump
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -420,7 +420,7 @@
 
 //Ramzi Syndie suit
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
-	name = "rusted-red hardsuit helmet"
+	name = "rust-red hardsuit helmet"
 	desc = "A beat-up standardized dual-mode helmet derived from more advanced special operations helmets, its red rusted into a dirty brown. It is in EVA mode. Manufactured by Ramzi Clique."
 	alt_desc = "A beat-up standardized dual-mode helmet derived from more advanced special operations helmets, its red rusted into a dirty brown. It is in combat mode. Manufactured by Ramzi Clique."
 	icon_state = "hardsuit1-ramzi"
@@ -429,7 +429,7 @@
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
-	name = "rusted-red hardsuit"
+	name = "rust-red hardsuit"
 	desc = "A beat-up standardized dual-mode hardsuit derived from more advanced special operations hardsuits, its red rusted into a dirty brown. It is in EVA mode. Manufactured by Ramzi Clique."
 	alt_desc = "A beat-up standardized dual-mode hardsuit derived from more advanced special operations hardsuits, its red rusted into a dirty brown. It is in combat mode. Manufactured by Ramzi Clique."
 	icon_state = "hardsuit1-ramzi"
@@ -439,7 +439,7 @@
 	lightweight = 1
 	jetpack = null
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
-	slowdown = 1
+	slowdown = 0.7
 	jetpack = null
 
 //Elite Syndie suit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rebalances slowdown factors on various hardsuits to make some better and some worse.

- Blood-red hardsuits now have a flat 0.5 slowdown at all times; toggling modes does not affect speed
- Security hardsuits and other combat hardsuits (excluding swat suits) have a slowdown of 0.5; having worse armor than blood-reds is bad enough as it is
- the heavy mining hardsuit now has the same speed as the mining hardsuit because it was faster than its lighter counterpart for some bizarre reason
- The solgov hardsuit also got nerfed to 0.5 slowdown because it was full speed for some reason
- The quixote mobility suit, despite being rare as hen's teeth, has 0.3 slowdown because thgvr doesn't want any hardsuit to be fullspeed

## Why It's Good For The Game

Blood-red hardsuits (and their rarer sibling, the elite hardsuit) were unequivocally the kings of the armor scene, boasting both very high armor values and high mobility. if you found a blood red suit, you basically never had any reason to take it off or made any kind of trade-off for it. by contrast, security hardsuits and their relatives are extremely unpopular both for their slowdown and their mediocre armor values. this PR at least makes the slowdown much more tolerable, making all combat hardsuits (not counting swat suits) the same speed as a blood-red hardsuit in EVA mode. Ramzi suits were meant to be worse than blood reds in part because the speed boost doesn't work on them; this downside is now represented by just making them the same speed as a miner's hardsuit at all times. It still represents rusted and nonfunctioning servos and overall clunk like before.

## Changelog

:cl:
balance: Made security hardsuits faster and blood-red hardsuits slower
balance: Normalized some weird hardsuit speed outliers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
