### PR TITLE
Adds welding goggles to autolathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -146,6 +146,14 @@
 	build_path = /obj/item/clothing/head/welding
 	category = list("initial","Tools")
 
+/datum/design/welding_goggles
+	name = "Welding Goggles"
+	id = "welding_goggles"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/clothing/glasses/welding
+	category = list("initial", "Tools")
+
 /datum/design/cable_coil
 	name = "Cable Coil"
 	id = "cable_coil"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -67,15 +67,6 @@
 //////////////////Misc///////////////////
 /////////////////////////////////////////
 
-/datum/design/welding_goggles
-	name = "Welding Goggles"
-	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
-	id = "welding_goggles"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
-	build_path = /obj/item/clothing/glasses/welding
-	category = list("Equipment")
-
 /datum/design/welding_mask
 	name = "Welding Gas Mask"
 	desc = "A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves welding goggles out of misc_designs.dm and into autolathe designs. They retain the PROTOLATHE flag, so protolathes should still be able to print them out.

## Why It's Good For The Game

This PR makes it so that you no longer require RnD in order to print welding goggles out.

## Changelog

:cl:
add: Added welding goggles to the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
