### PR TITLE
Fixes south-facing subshuttle prechargers

### DIFF
--- a/_maps/shuttles/subshuttles/frontiersmen_brawler.dmm
+++ b/_maps/shuttles/subshuttles/frontiersmen_brawler.dmm
@@ -370,7 +370,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)

--- a/_maps/shuttles/subshuttles/independent_kunai.dmm
+++ b/_maps/shuttles/subshuttles/independent_kunai.dmm
@@ -260,7 +260,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "polengine";
 	name = "Engine Shutters"
@@ -278,7 +280,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "polengine"
 	},

--- a/_maps/shuttles/subshuttles/inteq_anvil.dmm
+++ b/_maps/shuttles/subshuttles/inteq_anvil.dmm
@@ -67,7 +67,9 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "g" = (
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
 	dir = 1

--- a/_maps/shuttles/subshuttles/inteq_haste.dmm
+++ b/_maps/shuttles/subshuttles/inteq_haste.dmm
@@ -121,7 +121,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "K" = (

--- a/_maps/shuttles/subshuttles/syndicate_runner.dmm
+++ b/_maps/shuttles/subshuttles/syndicate_runner.dmm
@@ -1,6 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Subshuttle engine prechargers which originally faced south were changed to face east for some reason. This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Subshuttle engines should charge properly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Certain Subshuttle engine prechargers have now been correctly rotated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
