### PR TITLE
Concrete Mix @ Outpost

### DIFF
--- a/code/modules/cargo/packs/material.dm
+++ b/code/modules/cargo/packs/material.dm
@@ -111,3 +111,9 @@
 	contains = list(/obj/item/stack/sheet/mineral/wood/fifty)
 	crate_name = "wood planks crate"
 
+/datum/supply_pack/material/concrete_mix
+	name = "Concrete Mix (Jug)"
+	desc = "Feeling lazy? Need a structure and quick? Use concrete! Just add water."
+	cost = 1000
+	contains = list(/obj/item/reagent_containers/glass/chem_jug/concrete_mix)
+	crate_name = "Concrete Mix"

--- a/code/modules/cargo/packs/material.dm
+++ b/code/modules/cargo/packs/material.dm
@@ -114,6 +114,6 @@
 /datum/supply_pack/material/concrete_mix
 	name = "Concrete Mix (Jug)"
 	desc = "Feeling lazy? Need a structure and quick? Use concrete! Just add water."
-	cost = 1000
+	cost = 500
 	contains = list(/obj/item/reagent_containers/glass/chem_jug/concrete_mix)
 	crate_name = "Concrete Mix"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2358,6 +2358,14 @@
 		else
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living, gib)), 5 SECONDS)
 
+/datum/reagent/concrete_mix
+	name = "Concrete Mix"
+	desc = "Pre-made concrete mix, ideal for lazy engineers."
+	color = "#c4c0bc"
+	taste_description = "chalky concrete"
+	harmful = TRUE
+	reagent_state = SOLID
+
 /datum/reagent/cement
 	name = "Cement"
 	description = "A sophisticated binding agent used to produce concrete."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2360,7 +2360,7 @@
 
 /datum/reagent/concrete_mix
 	name = "Concrete Mix"
-	desc = "Pre-made concrete mix, ideal for lazy engineers."
+	description = "Pre-made concrete mix, ideal for lazy engineers."
 	color = "#c4c0bc"
 	taste_description = "chalky concrete"
 	harmful = TRUE

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -621,7 +621,7 @@
 	mix_message = "The mixture boils off a grey vapor..."//The water boils off, leaving the cement
 
 /datum/chemical_reaction/quick_concrete
-	results = list(/datum/reagent/concrete/5)
+	results = list(/datum/reagent/concrete = 5)
 	required_reagents = list(/datum/reagent/concrete_mix = 5, /datum/reagent/water = 5)
 
 /datum/chemical_reaction/hexement

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -620,6 +620,10 @@
 	required_temp = 400
 	mix_message = "The mixture boils off a grey vapor..."//The water boils off, leaving the cement
 
+/datum/chemical_reaction/quick_concrete
+	results = list(/datum/reagent/concrete/5)
+	required_reagents = list(/datum/reagent/concrete_mix = 5, /datum/reagent/water = 5)
+
 /datum/chemical_reaction/hexement
 	results = list(/datum/reagent/cement/hexement = 1)
 	required_reagents = list(/datum/reagent/cement = 6, /datum/reagent/phenol = 1)

--- a/code/modules/reagents/reagent_containers/jug.dm
+++ b/code/modules/reagents/reagent_containers/jug.dm
@@ -148,3 +148,7 @@
 	name = "chemical jug (hexacrete)"
 	list_reagents = list(/datum/reagent/concrete/hexacrete = 150)
 
+/obj/item/reagent_containers/glass/chem_jug/concrete_mix
+	name = "chemical jug (concrete mix)"
+	desc = "Just pour out and add water!"
+	list_reagents = list(/datum/reagent/concrete_mix = 150)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I don't know how we've gotten this far without stable concrete mix. It's a staple of concrete related situations.
Adds a chemical jug of concrete mix (in an ideal world this would be a big chalky bag) to the outpost for 1000 credits.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Construction fluff. Also useful for a ship I'm planning.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: You can now purchase concrete mix at the outpost. For concrete making.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
