### PR TITLE
Miskilamo Style Consistency

### DIFF
--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -13,7 +13,7 @@
 		"NATURAL"
 	],
 	"map_short_name": "Kilo-class",
-	"starting_funds": 3500,
+	"starting_funds": 1500,
 	"map_path": "_maps/shuttles/independent/independent_kilo.dmm",
 	"job_slots": {
 		"Captain": {

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -19,7 +19,7 @@
 	"starting_funds": 1500,
 	"job_slots": {
 		"Salvage Leader": {
-			"outfit": "/datum/outfit/job/independent/captain",
+			"outfit": "/datum/outfit/job/independent/captain/cheap",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -7,7 +7,7 @@
 /area/ship/cargo)
 "ak" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/hull,
 /area/ship/engineering)
 "am" = (
 /obj/machinery/autolathe,
@@ -15,11 +15,12 @@
 /area/ship/cargo)
 "ar" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "kilothrusters"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering)
@@ -34,6 +35,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table_frame,
 /obj/item/shard,
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "ay" = (
@@ -57,7 +59,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/port)
 "aJ" = (
@@ -66,7 +68,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
@@ -93,12 +94,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "aZ" = (
 /obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "bg" = (
@@ -129,14 +128,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/shuttle/engine/electric,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/hull,
 /area/ship/engineering)
 "by" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bA" = (
@@ -145,7 +143,6 @@
 	icon_state = "4-6"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/beer{
 	list_reagents = null;
 	pixel_x = -14;
@@ -175,7 +172,6 @@
 /area/ship/cargo)
 "bH" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -193,7 +189,6 @@
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "bM" = (
@@ -219,7 +214,7 @@
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "bT" = (
@@ -232,7 +227,6 @@
 /obj/structure/cable/pink{
 	icon_state = "4-9"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bU" = (
@@ -295,7 +289,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bZ" = (
@@ -311,7 +304,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ca" = (
@@ -336,11 +328,14 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"cc" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance/fore)
 "cf" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
@@ -354,6 +349,9 @@
 	},
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
+"cg" = (
+/turf/closed/wall/rust,
+/area/ship/crew/dorm)
 "ci" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -407,6 +405,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-10"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "cw" = (
@@ -490,6 +489,7 @@
 	pixel_x = -19;
 	pixel_y = 13
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance/fore)
 "cK" = (
@@ -506,7 +506,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/pink{
 	icon_state = "6-8"
 	},
@@ -515,10 +514,10 @@
 "cP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating/airless,
 /area/ship/hallway/port)
 "cV" = (
@@ -538,7 +537,6 @@
 /obj/structure/sink/kitchen{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 20;
@@ -556,6 +554,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cZ" = (
@@ -566,7 +565,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "da" = (
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "dc" = (
@@ -577,9 +575,11 @@
 	icon_state = "0-1"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old{
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
@@ -602,6 +602,7 @@
 /obj/machinery/vending/cigarette,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "dF" = (
@@ -634,7 +635,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "fu" = (
@@ -648,12 +648,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"fT" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/bridge)
 "gp" = (
 /obj/structure/closet/wall/blue/directional/north{
 	name = "Captain's locker"
@@ -695,9 +691,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"gw" = (
-/turf/closed/wall/rust,
-/area/ship/crew/dorm)
 "gC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/item/storage/toolbox/electrical{
@@ -720,9 +713,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"hx" = (
-/turf/closed/wall/rust,
-/area/ship/bridge)
 "hN" = (
 /obj/machinery/mineral/processing_unit{
 	input_dir = 8
@@ -739,7 +729,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "hS" = (
@@ -765,7 +755,6 @@
 	pixel_x = 8;
 	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "im" = (
@@ -797,6 +786,9 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"iK" = (
+/turf/closed/wall/rust,
+/area/ship/hallway/central)
 "iM" = (
 /obj/structure/cable/pink{
 	icon_state = "2-6"
@@ -808,7 +800,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
@@ -822,9 +813,6 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/crew)
-"je" = (
-/turf/closed/wall/rust,
-/area/ship/hallway/central)
 "jl" = (
 /obj/machinery/mineral/processing_unit_console{
 	dir = 8;
@@ -897,8 +885,8 @@
 "kA" = (
 /turf/closed/wall/r_wall,
 /area/ship/engineering)
-"mg" = (
-/turf/closed/wall/r_wall/rust,
+"lr" = (
+/turf/closed/wall/rust,
 /area/ship/crew)
 "mr" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -929,7 +917,6 @@
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "nd" = (
@@ -955,7 +942,6 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/glass,
 /obj/structure/cable/pink{
 	icon_state = "4-5"
 	},
@@ -993,7 +979,11 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden,
 /obj/machinery/cell_charger,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
+/area/ship/engineering)
+"oO" = (
+/turf/closed/wall/rust,
 /area/ship/engineering)
 "oP" = (
 /obj/structure/table,
@@ -1008,9 +998,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"pf" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/cargo)
+"pI" = (
+/turf/closed/wall/rust,
+/area/ship/bridge)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "kiloconveyor";
@@ -1065,9 +1055,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
-"rA" = (
-/turf/closed/wall/rust,
-/area/ship/engineering)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1117,7 +1104,6 @@
 /obj/structure/cable/pink{
 	icon_state = "6-10"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "sW" = (
@@ -1133,7 +1119,7 @@
 "vv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1142,12 +1128,8 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
-"vZ" = (
-/turf/closed/wall/rust,
-/area/ship/maintenance/fore)
 "wc" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1197,6 +1179,9 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
+"xO" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "yd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1289,6 +1274,9 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew)
+"AA" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering)
 "AB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/patterned,
@@ -1305,6 +1293,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "AP" = (
@@ -1314,7 +1303,6 @@
 	target_pressure = 500
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "AQ" = (
@@ -1331,14 +1319,12 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Bm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Bu" = (
@@ -1348,7 +1334,6 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
@@ -1386,7 +1371,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/storage/firstaid/regular,
@@ -1394,13 +1378,9 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Da" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
-"Db" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/hallway/port)
 "Ds" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 8
@@ -1454,9 +1434,6 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_x = -5
-	},
 /obj/item/cigbutt,
 /obj/machinery/computer/cryopod/retro/directional/west,
 /obj/effect/turf_decal/industrial/warning{
@@ -1464,6 +1441,9 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
+"Gp" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "GK" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
@@ -1499,6 +1479,7 @@
 	},
 /obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "HP" = (
@@ -1529,6 +1510,9 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/yesdiag,
 /area/ship/maintenance/fore)
+"Ju" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/hallway/port)
 "Kz" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 5
@@ -1549,7 +1533,6 @@
 /obj/machinery/atmospherics/components/binary/valve/layer4,
 /obj/effect/decal/cleanable/oil/streak,
 /obj/item/cigbutt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
@@ -1603,25 +1586,20 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/shuttle,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "kilothrusters"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"MR" = (
-/turf/closed/wall/rust,
-/area/ship/crew)
 "MY" = (
 /obj/structure/chair/sofa/brown/old/corner/directional/north,
 /obj/structure/sign/poster/random{
 	pixel_x = -32;
 	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_x = -5
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
@@ -1681,17 +1659,17 @@
 	pixel_x = -12;
 	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/greenglow,
 /obj/item/storage/pill_bottle/happy{
 	pixel_x = 12;
 	pixel_y = 12
 	},
 /mob/living/simple_animal/hostile/cockroach,
+/obj/effect/decal/cleanable/vomit/old{
+	pixel_x = -5
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew)
 "NT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "NU" = (
@@ -1711,6 +1689,9 @@
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
+"Oe" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "Of" = (
 /turf/closed/wall/r_wall,
 /area/ship/maintenance/fore)
@@ -1738,6 +1719,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "PS" = (
@@ -1745,6 +1727,7 @@
 /obj/machinery/microwave,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "PW" = (
@@ -1757,7 +1740,7 @@
 "Rq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1781,7 +1764,6 @@
 	pixel_x = 6;
 	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/pink{
 	icon_state = "2-8"
 	},
@@ -1800,7 +1782,7 @@
 "Ti" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1812,7 +1794,6 @@
 	},
 /obj/item/bedsheet/dorms,
 /obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "To" = (
@@ -1850,7 +1831,7 @@
 "Ua" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1861,7 +1842,7 @@
 "Un" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1877,7 +1858,6 @@
 /area/template_noop)
 "UY" = (
 /obj/structure/chair/sofa/brown/old/right/directional/north,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Va" = (
@@ -1910,10 +1890,13 @@
 /obj/machinery/light/small/directional/east{
 	pixel_y = 8
 	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = -2
-	},
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "amogusthrusters";
+	name = "Thruster Lockdown";
+	pixel_x = 21
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Vh" = (
@@ -1922,6 +1905,8 @@
 	dir = 8;
 	piping_layer = 2
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Vq" = (
@@ -1938,7 +1923,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -1983,11 +1967,9 @@
 /obj/effect/turf_decal/corner/opaque/neutral/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"XF" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/engineering)
 "XQ" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -2013,6 +1995,7 @@
 	pixel_x = -9;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "YL" = (
@@ -2030,7 +2013,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ZG" = (
@@ -2051,7 +2033,7 @@ AQ
 bn
 bn
 bn
-rA
+oO
 ak
 AQ
 aa
@@ -2060,7 +2042,7 @@ aa
 (2,1,1) = {"
 aa
 aa
-XF
+AA
 ar
 kA
 MI
@@ -2138,7 +2120,7 @@ aa
 Ua
 aS
 ca
-gw
+cg
 cq
 cq
 cq
@@ -2150,7 +2132,7 @@ aa
 (8,1,1) = {"
 aa
 aa
-Db
+Ju
 TG
 cC
 cq
@@ -2187,7 +2169,7 @@ XR
 XR
 zH
 XR
-MR
+lr
 XR
 yF
 aa
@@ -2247,10 +2229,10 @@ Ud
 XR
 XR
 rO
-MR
+lr
 NB
 XR
-mg
+Gp
 "}
 (15,1,1) = {"
 Nq
@@ -2262,7 +2244,7 @@ cB
 im
 dt
 sD
-je
+iK
 NI
 zc
 yF
@@ -2324,7 +2306,7 @@ GM
 jK
 bF
 bF
-hx
+pI
 bP
 "}
 (20,1,1) = {"
@@ -2344,7 +2326,7 @@ bP
 "}
 (21,1,1) = {"
 aa
-pf
+xO
 hN
 jl
 OH
@@ -2376,11 +2358,11 @@ aa
 aa
 KB
 bm
-vZ
+cc
 kb
 cJ
-fT
-fT
+Oe
+Oe
 BS
 BS
 BS

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -333,9 +333,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"cc" = (
-/turf/closed/wall/rust,
-/area/ship/maintenance/fore)
 "cf" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
@@ -349,9 +346,6 @@
 	},
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
-"cg" = (
-/turf/closed/wall/rust,
-/area/ship/crew/dorm)
 "ci" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -497,7 +491,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "cM" = (
 /obj/structure/cable/pink{
@@ -612,7 +606,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "eo" = (
 /obj/machinery/power/port_gen/pacman{
@@ -786,9 +780,6 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"iK" = (
-/turf/closed/wall/rust,
-/area/ship/hallway/central)
 "iM" = (
 /obj/structure/cable/pink{
 	icon_state = "2-6"
@@ -885,9 +876,9 @@
 "kA" = (
 /turf/closed/wall/r_wall,
 /area/ship/engineering)
-"lr" = (
+"lw" = (
 /turf/closed/wall/rust,
-/area/ship/crew)
+/area/ship/bridge)
 "mr" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -982,9 +973,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"oO" = (
-/turf/closed/wall/rust,
-/area/ship/engineering)
 "oP" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
@@ -998,9 +986,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"pI" = (
-/turf/closed/wall/rust,
-/area/ship/bridge)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "kiloconveyor";
@@ -1116,6 +1101,15 @@
 /obj/effect/turf_decal/industrial/outline/yellow,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
+"tb" = (
+/turf/closed/wall/rust,
+/area/ship/crew/dorm)
+"tW" = (
+/turf/closed/wall/rust,
+/area/ship/crew)
+"vl" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/hallway/port)
 "vv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1166,6 +1160,9 @@
 "xk" = (
 /turf/closed/wall,
 /area/ship/hallway/central)
+"xn" = (
+/turf/closed/wall/rust,
+/area/ship/hallway/central)
 "xF" = (
 /obj/structure/cable/pink{
 	icon_state = "8-9"
@@ -1179,9 +1176,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
-"xO" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/cargo)
 "yd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1274,9 +1268,6 @@
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew)
-"AA" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/engineering)
 "AB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/patterned,
@@ -1348,6 +1339,9 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/bridge)
+"Ce" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance/fore)
 "Co" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
@@ -1441,9 +1435,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
-"Gp" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/crew)
 "GK" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
@@ -1510,9 +1501,6 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/yesdiag,
 /area/ship/maintenance/fore)
-"Ju" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/hallway/port)
 "Kz" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 5
@@ -1689,9 +1677,6 @@
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
-"Oe" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/bridge)
 "Of" = (
 /turf/closed/wall/r_wall,
 /area/ship/maintenance/fore)
@@ -1711,6 +1696,9 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"OQ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering)
 "Pg" = (
 /obj/machinery/computer/helm/retro{
 	dir = 8
@@ -1722,6 +1710,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
+"PJ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "PS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -1809,6 +1800,9 @@
 	},
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
+"Tr" = (
+/turf/closed/wall/rust,
+/area/ship/engineering)
 "TD" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
@@ -1828,6 +1822,9 @@
 "TG" = (
 /turf/closed/wall,
 /area/ship/hallway/port)
+"TY" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "Ua" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1916,7 +1913,7 @@
 /obj/effect/turf_decal/miskilamo_small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Vx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -1930,7 +1927,7 @@
 /obj/effect/turf_decal/miskilamo_small/left{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "We" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -1980,6 +1977,9 @@
 /area/ship/hallway/central)
 "XR" = (
 /turf/closed/wall,
+/area/ship/crew)
+"Yn" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew)
 "Yu" = (
 /obj/structure/grille,
@@ -2033,7 +2033,7 @@ AQ
 bn
 bn
 bn
-oO
+Tr
 ak
 AQ
 aa
@@ -2042,7 +2042,7 @@ aa
 (2,1,1) = {"
 aa
 aa
-AA
+OQ
 ar
 kA
 MI
@@ -2120,7 +2120,7 @@ aa
 Ua
 aS
 ca
-cg
+tb
 cq
 cq
 cq
@@ -2132,7 +2132,7 @@ aa
 (8,1,1) = {"
 aa
 aa
-Ju
+vl
 TG
 cC
 cq
@@ -2169,7 +2169,7 @@ XR
 XR
 zH
 XR
-lr
+tW
 XR
 yF
 aa
@@ -2229,10 +2229,10 @@ Ud
 XR
 XR
 rO
-lr
+tW
 NB
 XR
-Gp
+Yn
 "}
 (15,1,1) = {"
 Nq
@@ -2244,7 +2244,7 @@ cB
 im
 dt
 sD
-iK
+xn
 NI
 zc
 yF
@@ -2306,7 +2306,7 @@ GM
 jK
 bF
 bF
-pI
+lw
 bP
 "}
 (20,1,1) = {"
@@ -2326,7 +2326,7 @@ bP
 "}
 (21,1,1) = {"
 aa
-xO
+PJ
 hN
 jl
 OH
@@ -2358,11 +2358,11 @@ aa
 aa
 KB
 bm
-cc
+Ce
 kb
 cJ
-Oe
-Oe
+TY
+TY
 BS
 BS
 BS

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -11,9 +11,6 @@
 /area/ship/engineering)
 "am" = (
 /obj/machinery/autolathe,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "ar" = (
@@ -37,7 +34,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table_frame,
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "ay" = (
 /obj/effect/decal/cleanable/glass,
@@ -65,35 +62,27 @@
 /area/ship/hallway/port)
 "aJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/structure/chair/bench/olive/directional/east,
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "aS" = (
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/secure_closet/engineering_personal{
-	populate = 0;
-	anchored = 1
+	anchored = 1;
+	populate = 0
 	},
 /obj/item/storage/backpack/industrial,
 /obj/item/clothing/under/rank/engineering/engineer,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/head/hardhat/dblue,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "aU" = (
 /obj/structure/cable/cyan{
@@ -104,20 +93,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "aZ" = (
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "bg" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -132,8 +114,8 @@
 	pixel_x = -5
 	},
 /obj/machinery/light_switch{
-	pixel_x = 5;
 	dir = 1;
+	pixel_x = 5;
 	pixel_y = -19
 	},
 /turf/open/floor/plating,
@@ -155,7 +137,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bA" = (
 /obj/structure/chair/plastic,
@@ -163,16 +145,14 @@
 	icon_state = "4-6"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 5;
+	list_reagents = null;
 	pixel_x = -14;
-	list_reagents = null
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "bF" = (
 /turf/closed/wall,
@@ -191,19 +171,16 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bH" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "bL" = (
 /obj/structure/cable/pink{
@@ -256,7 +233,7 @@
 	icon_state = "4-9"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bU" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -299,16 +276,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "bY" = (
 /obj/structure/cable/pink{
@@ -321,7 +296,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bZ" = (
 /obj/structure/closet/crate/secure/exo,
@@ -337,10 +312,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ca" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -352,33 +326,28 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -19
 	},
 /obj/structure/extinguisher_cabinet/directional/south{
 	pixel_x = -6
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cb" = (
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "cf" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "kilofield";
-	dir = 8
+	dir = 8;
+	id = "kilofield"
 	},
 /obj/structure/cable/pink{
 	icon_state = "0-10"
@@ -427,7 +396,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "cq" = (
 /turf/closed/wall,
@@ -437,7 +407,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "cw" = (
 /obj/structure/table/wood,
@@ -448,20 +418,16 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 7;
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 10);
 	pixel_x = -6;
-	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 10)
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "cB" = (
 /obj/structure/closet/secure_closet/miner{
-	populate = 0;
-	anchored = 1
+	anchored = 1;
+	populate = 0
 	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -505,7 +471,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "cJ" = (
 /obj/structure/chair/handrail{
@@ -513,12 +480,6 @@
 	},
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = -21
-	},
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "space";
-	pixel_y = 2;
-	pixel_x = 6;
-	paint_colour = "#FF0000"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable/pink{
@@ -529,7 +490,7 @@
 	pixel_x = -19;
 	pixel_y = 13
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance/fore)
 "cK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -549,7 +510,7 @@
 /obj/structure/cable/pink{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "cP" = (
 /obj/structure/grille,
@@ -561,9 +522,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/hallway/port)
 "cV" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/pink{
 	icon_state = "2-9"
 	},
@@ -571,10 +529,12 @@
 	icon_state = "2-5"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "cW" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/sink/kitchen{
 	dir = 8
 	},
@@ -584,7 +544,9 @@
 	pixel_x = 20;
 	pixel_y = -12
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "cY" = (
 /obj/structure/cable/pink{
@@ -594,22 +556,18 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cZ" = (
 /obj/machinery/power/ship_gravity,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "da" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "dc" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -619,17 +577,13 @@
 	icon_state = "0-1"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/item/stack/tile/plasteel{
-	pixel_x = 7;
-	pixel_y = -8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "de" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cryogenics"
-	},
 /obj/structure/cable/pink{
 	icon_state = "2-9"
 	},
@@ -637,15 +591,18 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 1;
+	name = "Cryo Room"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "dt" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "dF" = (
 /obj/effect/turf_decal/miskilamo_small/right{
@@ -663,15 +620,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "eN" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/grid,
@@ -683,11 +634,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "fu" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -700,12 +648,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
+"fT" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "gp" = (
 /obj/structure/closet/wall/blue/directional/north{
 	name = "Captain's locker"
@@ -727,10 +675,9 @@
 /obj/structure/cable/pink{
 	icon_state = "4-10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "gs" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
 	icon_state = "4-10"
 	},
@@ -745,8 +692,12 @@
 	dir = 6
 	},
 /obj/item/cigbutt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
+"gw" = (
+/turf/closed/wall/rust,
+/area/ship/crew/dorm)
 "gC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/item/storage/toolbox/electrical{
@@ -759,16 +710,19 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/item/clothing/glasses/welding{
-	pixel_y = -9;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "hh" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
+"hx" = (
+/turf/closed/wall/rust,
+/area/ship/bridge)
 "hN" = (
 /obj/machinery/mineral/processing_unit{
 	input_dir = 8
@@ -786,7 +740,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "hS" = (
 /obj/structure/chair/sofa/brown/old/left/directional/east,
@@ -797,12 +751,8 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -811,9 +761,9 @@
 	pixel_x = 17
 	},
 /obj/item/reagent_containers/glass/bucket{
+	list_reagents = list(/datum/reagent/water = 20);
 	pixel_x = 8;
-	pixel_y = 7;
-	list_reagents = list(/datum/reagent/water = 20)
+	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -844,16 +794,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "iM" = (
 /obj/structure/cable/pink{
 	icon_state = "2-6"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
 /obj/structure/chair/bench/beige/directional/east{
 	dir = 8
 	},
@@ -861,26 +809,30 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "iT" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/food/flour,
 /mob/living/simple_animal/hostile/cockroach,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
+"je" = (
+/turf/closed/wall/rust,
+/area/ship/hallway/central)
 "jl" = (
 /obj/machinery/mineral/processing_unit_console{
-	pixel_y = 0;
+	dir = 8;
+	machinedir = 1;
 	output_dir = 4;
 	pixel_x = 20;
-	dir = 8;
-	machinedir = 1
+	pixel_y = 0
 	},
-/obj/effect/turf_decal/industrial/warning/corner,
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 5
 	},
@@ -889,8 +841,8 @@
 /area/ship/cargo)
 "jx" = (
 /obj/machinery/conveyor{
-	id = "kiloconveyor";
-	dir = 4
+	dir = 4;
+	id = "kiloconveyor"
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -905,16 +857,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = -19
 	},
 /obj/structure/cable/pink{
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "jU" = (
@@ -940,11 +892,14 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance/fore)
 "kA" = (
 /turf/closed/wall/r_wall,
 /area/ship/engineering)
+"mg" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "mr" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -953,16 +908,16 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
 /obj/effect/turf_decal/box/corners,
 /obj/structure/cable/pink{
 	icon_state = "1-5"
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
@@ -984,14 +939,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
 	icon_state = "8-9"
 	},
 /obj/structure/cable/pink{
 	icon_state = "1-5"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ng" = (
 /obj/structure/cable/pink{
@@ -1009,28 +963,28 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "nJ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/button/door{
+	dir = 4;
 	id = "kilocargo";
 	name = "blast door control";
 	pixel_x = -20;
-	pixel_y = 7;
-	dir = 4
+	pixel_y = 7
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = -2;
+	id = "kilofield";
 	pixel_x = -19;
-	id = "kilofield"
+	pixel_y = -2
 	},
 /obj/item/clothing/head/cone{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "nO" = (
 /turf/closed/wall/r_wall,
@@ -1048,18 +1002,21 @@
 	},
 /obj/item/stack/sheet/mineral/plasma/ten,
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 11;
+	list_reagents = null;
 	pixel_x = -13;
-	list_reagents = null
+	pixel_y = 11
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
+"pf" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "kiloconveyor";
+	layer = 3.09;
 	pixel_x = 11;
-	pixel_y = 14;
-	layer = 3.09
+	pixel_y = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
@@ -1069,7 +1026,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "qw" = (
 /obj/machinery/door/airlock/external{
@@ -1079,7 +1037,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "rc" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1106,6 +1065,9 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
+"rA" = (
+/turf/closed/wall/rust,
+/area/ship/engineering)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1123,7 +1085,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "rW" = (
 /turf/closed/wall/yesdiag,
@@ -1158,13 +1121,14 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "sW" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/machinery/computer/cargo/retro{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "vv" = (
 /obj/structure/grille,
@@ -1179,8 +1143,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"vZ" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance/fore)
 "wc" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1190,13 +1157,13 @@
 	pixel_y = 22
 	},
 /obj/item/reagent_containers/food/snacks/sandwich{
-	pixel_y = 9;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 9
 	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "wh" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew/dorm)
 "xe" = (
 /obj/machinery/door/airlock/external/glass{
@@ -1211,7 +1178,8 @@
 /obj/structure/cable/pink{
 	icon_state = "6-10"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "xk" = (
 /turf/closed/wall,
@@ -1227,14 +1195,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "yd" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1244,10 +1207,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "yn" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge{
 	populate = 0
 	},
@@ -1272,15 +1235,14 @@
 /obj/effect/spawner/lootdrop/ration,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "yF" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew)
 "zc" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
 /obj/structure/curtain,
 /obj/machinery/shower{
 	dir = 1
@@ -1291,6 +1253,9 @@
 /obj/item/bikehorn/rubberducky/plasticducky{
 	pixel_x = -9;
 	pixel_y = -7
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 6
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
@@ -1311,22 +1276,22 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Dormitory";
+	dir = 8;
+	name = "Dormitory"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#E3994E";
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 4
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew)
 "AB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "AE" = (
 /obj/structure/closet/cabinet,
@@ -1340,11 +1305,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "AP" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -1354,7 +1315,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "AQ" = (
 /turf/closed/wall,
@@ -1377,11 +1338,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Bu" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1390,21 +1348,18 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/turf_decal/borderfloor/corner{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "BS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
-	id = "kilobridge";
-	dir = 4
+	dir = 4;
+	id = "kilobridge"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/bridge)
@@ -1436,13 +1391,16 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/storage/firstaid/regular,
 /obj/item/roller,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Da" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"Db" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/hallway/port)
 "Ds" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 8
@@ -1456,7 +1414,11 @@
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1466,8 +1428,8 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -19
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
@@ -1477,7 +1439,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "EG" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -1485,7 +1446,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "EU" = (
 /obj/structure/cable/pink{
@@ -1496,13 +1459,13 @@
 	},
 /obj/item/cigbutt,
 /obj/machinery/computer/cryopod/retro/directional/west,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "GK" = (
 /obj/structure/table,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 20
@@ -1534,7 +1497,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "HP" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -1546,20 +1511,16 @@
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -5
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/confetti,
 /obj/item/cigbutt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Ih" = (
 /obj/structure/cable/pink{
 	icon_state = "1-6"
 	},
 /obj/structure/ore_box,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Jf" = (
 /turf/closed/wall/r_wall,
@@ -1586,13 +1547,11 @@
 /area/ship/maintenance/fore)
 "KM" = (
 /obj/machinery/atmospherics/components/binary/valve/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/oil/streak,
 /obj/item/cigbutt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "KR" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -1601,20 +1560,17 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/borderfloor,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "La" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/item/clothing/head/cone{
-	pixel_y = 4;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = 7
@@ -1623,7 +1579,10 @@
 	pixel_y = -5
 	},
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "LC" = (
 /obj/structure/cable/cyan{
@@ -1632,11 +1591,7 @@
 /obj/structure/cable/pink{
 	icon_state = "2-5"
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Mj" = (
 /obj/machinery/mineral/unloading_machine,
@@ -1656,16 +1611,19 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"MR" = (
+/turf/closed/wall/rust,
+/area/ship/crew)
 "MY" = (
 /obj/structure/chair/sofa/brown/old/corner/directional/north,
 /obj/structure/sign/poster/random{
-	pixel_y = 0;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_x = -5
 	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Ng" = (
 /obj/structure/cable/pink{
@@ -1691,17 +1649,18 @@
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/cargo)
 "NB" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 8;
-	name = "Bathroom"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Restroom"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "NI" = (
 /obj/structure/sink{
@@ -1728,15 +1687,12 @@
 	pixel_y = 12
 	},
 /mob/living/simple_animal/hostile/cockroach,
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew)
 "NT" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "NU" = (
 /obj/structure/table/wood,
@@ -1750,8 +1706,8 @@
 	pixel_y = 3
 	},
 /obj/structure/sign/poster/random{
-	pixel_y = 0;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -1772,19 +1728,24 @@
 /obj/structure/cable/pink{
 	icon_state = "2-10"
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Pg" = (
 /obj/machinery/computer/helm/retro{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "PS" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "PW" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1809,31 +1770,32 @@
 	dir = 6
 	},
 /obj/machinery/button/door{
-	pixel_y = 20;
-	pixel_x = -6;
 	id = "kilowindows";
-	name = "Window Lockdown"
+	name = "Window Lockdown";
+	pixel_x = -6;
+	pixel_y = 20
 	},
 /obj/machinery/button/door{
-	pixel_y = 20;
-	pixel_x = 6;
 	id = "kilobridge";
-	name = "Bridge Lockdown"
+	name = "Bridge Lockdown";
+	pixel_x = 6;
+	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/pink{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Sx" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/table/reinforced,
 /obj/item/cutting_board{
 	anchored = 1
 	},
 /obj/item/kitchen/knife,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "Ti" = (
 /obj/structure/grille,
@@ -1861,8 +1823,8 @@
 	icon_state = "0-6"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "kilofield";
-	dir = 4
+	dir = 4;
+	id = "kilofield"
 	},
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
@@ -1870,14 +1832,17 @@
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/megaphone/cargo{
-	pixel_y = 5;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /obj/item/cigbutt{
-	pixel_y = 5;
-	pixel_x = -17
+	pixel_x = -17;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "TG" = (
 /turf/closed/wall,
@@ -1903,17 +1868,17 @@
 /area/ship/hallway/port)
 "Uv" = (
 /obj/docking_port/stationary{
-	width = 30;
-	height = 15;
+	dir = 4;
 	dwidth = 15;
-	dir = 4
+	height = 15;
+	width = 30
 	},
 /turf/template_noop,
 /area/template_noop)
 "UY" = (
 /obj/structure/chair/sofa/brown/old/right/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Va" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -1929,7 +1894,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/item/ammo_box/a12g,
 /obj/item/gun/ballistic/shotgun/doublebarrel/no_mag,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Vd" = (
 /obj/structure/cable/pink{
@@ -1942,9 +1907,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/east{
 	pixel_y = 8
 	},
@@ -1952,18 +1914,15 @@
 	pixel_y = -2
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Vh" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Vq" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -2011,26 +1970,30 @@
 "Xd" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_y = 4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /obj/item/pen/fourcolor,
 /obj/machinery/airalarm/directional/south,
 /obj/item/radio/intercom/wideband/directional/west,
 /obj/item/reagent_containers/food/drinks/coffee{
-	pixel_y = 7;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"XF" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering)
 "XQ" = (
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "XR" = (
@@ -2047,10 +2010,10 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 12;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 12
 	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "YL" = (
 /obj/structure/chair/sofa/brown/old/directional/east,
@@ -2058,7 +2021,7 @@
 	dir = 5
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2067,12 +2030,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ZG" = (
 /obj/structure/cable/pink{
@@ -2092,7 +2051,7 @@ AQ
 bn
 bn
 bn
-AQ
+rA
 ak
 AQ
 aa
@@ -2101,7 +2060,7 @@ aa
 (2,1,1) = {"
 aa
 aa
-kA
+XF
 ar
 kA
 MI
@@ -2179,7 +2138,7 @@ aa
 Ua
 aS
 ca
-cq
+gw
 cq
 cq
 cq
@@ -2191,7 +2150,7 @@ aa
 (8,1,1) = {"
 aa
 aa
-Jf
+Db
 TG
 cC
 cq
@@ -2228,7 +2187,7 @@ XR
 XR
 zH
 XR
-XR
+MR
 XR
 yF
 aa
@@ -2288,10 +2247,10 @@ Ud
 XR
 XR
 rO
-XR
+MR
 NB
 XR
-yF
+mg
 "}
 (15,1,1) = {"
 Nq
@@ -2303,7 +2262,7 @@ cB
 im
 dt
 sD
-xk
+je
 NI
 zc
 yF
@@ -2365,7 +2324,7 @@ GM
 jK
 bF
 bF
-bF
+hx
 bP
 "}
 (20,1,1) = {"
@@ -2385,7 +2344,7 @@ bP
 "}
 (21,1,1) = {"
 aa
-ac
+pf
 hN
 jl
 OH
@@ -2417,11 +2376,11 @@ aa
 aa
 KB
 bm
-KB
+vZ
 kb
 cJ
-bP
-bP
+fT
+fT
 BS
 BS
 BS

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -72,6 +72,9 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"cl" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "cn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -81,6 +84,7 @@
 	pixel_x = -3;
 	pixel_y = 23
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "cs" = (
@@ -156,6 +160,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/ship/crew)
 "dT" = (
@@ -196,6 +203,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-10"
+	},
+/obj/structure/chair/handrail{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -259,9 +269,6 @@
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"fZ" = (
-/turf/closed/wall/r_wall,
-/area/ship/bridge)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -330,12 +337,12 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "gT" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "hn" = (
@@ -405,6 +412,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "js" = (
@@ -468,6 +478,9 @@
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"ms" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -537,9 +550,9 @@
 	},
 /area/ship/cargo)
 "nm" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "nx" = (
@@ -675,9 +688,6 @@
 /obj/structure/bedsheetbin,
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
-"pL" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/crew)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -724,9 +734,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
-"ri" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/bridge)
 "rr" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -740,6 +747,9 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"ru" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "rO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -755,7 +765,6 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sa" = (
-/obj/structure/chair,
 /obj/machinery/newscaster/directional/east{
 	pixel_y = -6
 	},
@@ -766,8 +775,12 @@
 	},
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"sc" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/cryo)
 "sf" = (
 /obj/effect/turf_decal/corner/opaque/neutral/half{
 	dir = 8
@@ -873,9 +886,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
-"ur" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/toilet)
 "uz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/industrial/hatch/yellow,
@@ -1196,6 +1206,7 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "BW" = (
@@ -1277,12 +1288,6 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"Dz" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
-/area/ship/hallway/central)
 "DC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -1418,6 +1423,9 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
+"Gn" = (
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "Gq" = (
 /turf/closed/wall,
 /area/ship/crew)
@@ -1510,6 +1518,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "JS" = (
@@ -1526,9 +1535,6 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"Kb" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/cryo)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -1576,11 +1582,14 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
-"Lc" = (
+"Lf" = (
 /turf/closed/wall/r_wall,
-/area/ship/maintenance)
+/area/ship/engineering/engine)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 4
@@ -1597,8 +1606,14 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
+"LU" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering/engine)
 "LV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1737,10 +1752,10 @@
 /turf/closed/wall,
 /area/ship/bridge)
 "OD" = (
-/obj/structure/chair{
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/plastic{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Pr" = (
@@ -1789,9 +1804,6 @@
 "PU" = (
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
-"Qk" = (
-/turf/closed/wall/r_wall,
-/area/ship/hallway/aft)
 "Qp" = (
 /turf/closed/wall,
 /area/ship/hallway/aft)
@@ -1955,6 +1967,9 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
+"SN" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/toilet)
 "ST" = (
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -1991,6 +2006,12 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"Tp" = (
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
 "TV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2040,9 +2061,6 @@
 "Uo" = (
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/crew/cryo)
-"Uv" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/engineering/engine)
 "UF" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -2162,6 +2180,9 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
+"WU" = (
+/turf/closed/wall/r_wall,
+/area/ship/hallway/aft)
 "Xc" = (
 /obj/machinery/blackbox_recorder,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2205,9 +2226,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
-"XF" = (
-/turf/closed/wall/r_wall,
-/area/ship/engineering/engine)
 "XI" = (
 /turf/closed/wall/r_wall/rust,
 /area/ship/cargo)
@@ -2226,11 +2244,11 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "XU" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Yc" = (
@@ -2265,6 +2283,9 @@
 "Yi" = (
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/maintenance)
+"Yo" = (
+/turf/closed/wall/r_wall,
+/area/ship/maintenance)
 "Yq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
@@ -2298,6 +2319,9 @@
 	},
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "YL" = (
@@ -2334,18 +2358,15 @@
 /turf/open/floor/carpet,
 /area/ship/crew)
 "ZJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"ZY" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew)
 
 (1,1,1) = {"
 cs
@@ -2370,16 +2391,16 @@ cs
 cs
 hX
 IU
-XF
-XF
+Lf
+Lf
 MF
 zx
 MF
 MF
 zx
 MF
-Uv
-XF
+LU
+Lf
 IU
 hX
 cs
@@ -2389,7 +2410,7 @@ cs
 cs
 hX
 cs
-XF
+Lf
 kX
 QF
 en
@@ -2398,7 +2419,7 @@ Vo
 qE
 ao
 yY
-XF
+Lf
 cs
 hX
 cs
@@ -2417,7 +2438,7 @@ KA
 eu
 hY
 sI
-XF
+Lf
 IU
 hX
 hX
@@ -2427,7 +2448,7 @@ cs
 hX
 cs
 cs
-Uv
+LU
 Ud
 Hk
 AN
@@ -2436,7 +2457,7 @@ dw
 hr
 xU
 YL
-XF
+Lf
 cs
 cs
 hX
@@ -2445,8 +2466,8 @@ cs
 (6,1,1) = {"
 hX
 IU
-fZ
-fZ
+Gn
+Gn
 OB
 UF
 OB
@@ -2455,8 +2476,8 @@ js
 OB
 js
 Qp
-Qk
-Qk
+WU
+WU
 Ti
 hX
 cs
@@ -2464,7 +2485,7 @@ cs
 (7,1,1) = {"
 cs
 cs
-fZ
+Gn
 Xc
 ic
 ak
@@ -2483,7 +2504,7 @@ cs
 (8,1,1) = {"
 cs
 cs
-fZ
+Gn
 Rv
 Oc
 Dp
@@ -2502,7 +2523,7 @@ MB
 (9,1,1) = {"
 cs
 cs
-ri
+cl
 nM
 rr
 oC
@@ -2513,7 +2534,7 @@ qy
 OB
 JN
 CG
-Qk
+WU
 IU
 cs
 cs
@@ -2521,8 +2542,8 @@ cs
 (10,1,1) = {"
 hX
 IU
-fZ
-fZ
+Gn
+Gn
 OB
 oG
 OB
@@ -2532,7 +2553,7 @@ Gk
 OB
 Nj
 yV
-Qk
+WU
 IU
 hX
 cs
@@ -2579,7 +2600,7 @@ cs
 hX
 cs
 cs
-Qk
+WU
 sT
 vn
 Qp
@@ -2588,7 +2609,7 @@ ar
 sa
 eL
 gT
-Qk
+WU
 cs
 cs
 hX
@@ -2597,8 +2618,8 @@ cs
 (14,1,1) = {"
 hX
 IU
-ZY
-ZY
+ms
+ms
 Ne
 Gq
 Gq
@@ -2607,8 +2628,8 @@ Pr
 dc
 oU
 oU
-ur
-ur
+SN
+SN
 IU
 hX
 cs
@@ -2616,7 +2637,7 @@ cs
 (15,1,1) = {"
 cs
 cs
-ZY
+ms
 Vy
 UZ
 Ft
@@ -2627,7 +2648,7 @@ Xh
 oU
 kB
 xp
-ur
+SN
 cs
 cs
 cs
@@ -2673,18 +2694,18 @@ cs
 (18,1,1) = {"
 hX
 cs
-pL
+ru
 Gq
 Wm
 Gq
 Ne
-Dz
+Tp
 mC
 iY
 MK
 MK
 Wk
-Lc
+Yo
 cs
 hX
 cs
@@ -2703,7 +2724,7 @@ PO
 Rn
 wi
 pF
-Lc
+Yo
 cs
 hX
 cs
@@ -2711,7 +2732,7 @@ cs
 (20,1,1) = {"
 hX
 IU
-Kb
+sc
 qN
 IP
 GI
@@ -2722,7 +2743,7 @@ xk
 MK
 cn
 KT
-Lc
+Yo
 IU
 hX
 cs
@@ -2731,7 +2752,7 @@ cs
 cs
 cs
 Uo
-Kb
+sc
 ev
 ev
 ev
@@ -2740,7 +2761,7 @@ TV
 dc
 MK
 MK
-Lc
+Yo
 Yi
 cs
 cs

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -1,7 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/engineering/engine)
 "ac" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21,10 +18,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull,
 /area/ship/engineering/engine)
 "ak" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -67,7 +63,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "bS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
@@ -77,26 +72,6 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"bZ" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/window/eastleft{
-	layer = 3.1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "mudskipper_engine"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "cn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -119,7 +94,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
@@ -134,7 +108,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
@@ -145,9 +118,6 @@
 /area/ship/hallway/central)
 "dw" = (
 /obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/button/door{
 	dir = 8;
 	id = "mudskipper_engine";
@@ -157,6 +127,7 @@
 	},
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "dN" = (
@@ -185,7 +156,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ship/crew)
 "dT" = (
@@ -230,7 +200,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ec" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -266,6 +235,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "ev" = (
@@ -289,6 +259,9 @@
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"fZ" = (
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -321,7 +294,6 @@
 /area/ship/cargo)
 "gR" = (
 /obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
@@ -407,7 +379,6 @@
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
 "ic" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
@@ -416,10 +387,10 @@
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "iy" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -470,7 +441,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/west{
 	bulb_power = 0.5
 	},
@@ -489,7 +459,7 @@
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull,
 /area/ship/engineering/engine)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -559,7 +529,6 @@
 /obj/effect/turf_decal/miskilamo_small/left{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -568,15 +537,11 @@
 	},
 /area/ship/cargo)
 "nm" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"nw" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew)
 "nx" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -593,13 +558,13 @@
 /obj/machinery/computer/helm/viewscreen/computer,
 /obj/machinery/airalarm/directional/east,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "nR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "nV" = (
@@ -646,8 +611,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "oC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -658,9 +621,6 @@
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
-/area/ship/bridge)
-"oF" = (
-/turf/closed/wall/r_wall/rust,
 /area/ship/bridge)
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -715,6 +675,9 @@
 /obj/structure/bedsheetbin,
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
+"pL" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -737,6 +700,7 @@
 /obj/machinery/computer/crew/retro{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "qE" = (
@@ -760,17 +724,20 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
+"ri" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "rr" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 22;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "rO" = (
@@ -788,7 +755,6 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sa" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/east{
 	pixel_y = -6
@@ -802,9 +768,6 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"sd" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/cryo)
 "sf" = (
 /obj/effect/turf_decal/corner/opaque/neutral/half{
 	dir = 8
@@ -823,11 +786,9 @@
 /obj/machinery/meter/atmos/layer2{
 	name = "waste to external meter"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "sA" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -876,7 +837,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ti" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/warning/incident{
 	pixel_x = -32
 	},
@@ -889,7 +849,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "tI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
@@ -911,10 +870,12 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "uk" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"ur" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/toilet)
 "uz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/industrial/hatch/yellow,
@@ -974,7 +935,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/cable{
 	icon_state = "1-5"
@@ -995,7 +955,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "wj" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1007,17 +966,10 @@
 "ws" = (
 /turf/closed/wall,
 /area/ship/engineering/engine)
-"wB" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
-/area/ship/hallway/central)
 "xk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 25;
@@ -1058,6 +1010,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "xU" = (
@@ -1067,15 +1020,12 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east{
 	bulb_power = 0.2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "yg" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = -5
 	},
@@ -1103,7 +1053,6 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "yS" = (
@@ -1121,7 +1070,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/ship/hallway/aft)
 "yY" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/west{
 	bulb_power = 0.5
 	},
@@ -1135,21 +1083,16 @@
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "mudskipper_engine"
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "mudskipper_engine"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "zR" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1168,7 +1111,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -1222,7 +1164,6 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -1233,13 +1174,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "Bw" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
@@ -1260,9 +1198,6 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
-"BT" = (
-/turf/closed/wall/r_wall,
-/area/ship/maintenance)
 "BW" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/plastic,
@@ -1281,6 +1216,7 @@
 /obj/item/storage/pill_bottle/charcoal/less,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ch" = (
@@ -1317,11 +1253,9 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Dj" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
@@ -1343,6 +1277,12 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Dz" = (
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
 "DC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -1377,7 +1317,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Eg" = (
@@ -1385,7 +1324,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/number/eight{
 	dir = 4
 	},
@@ -1408,11 +1346,7 @@
 	},
 /turf/open/floor/carpet,
 /area/ship/crew)
-"EC" = (
-/turf/closed/wall/r_wall,
-/area/ship/engineering/engine)
 "EP" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -1456,7 +1390,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 3;
@@ -1485,9 +1418,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
-"Gl" = (
-/turf/closed/wall/r_wall,
-/area/ship/bridge)
 "Gq" = (
 /turf/closed/wall,
 /area/ship/crew)
@@ -1501,7 +1431,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "GW" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "6-10"
 	},
@@ -1578,14 +1507,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "JS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1599,6 +1526,9 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"Kb" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/cryo)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -1627,14 +1557,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "KT" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "KU" = (
@@ -1649,6 +1578,9 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
+"Lc" = (
+/turf/closed/wall/r_wall,
+/area/ship/maintenance)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 4
@@ -1709,19 +1641,15 @@
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/window/eastright{
-	layer = 3.1
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "mudskipper_engine"
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "mudskipper_engine"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
@@ -1787,8 +1715,6 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "NN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1798,13 +1724,13 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "NU" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Oc" = (
 /obj/item/paper_bin,
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "OB" = (
@@ -1841,13 +1767,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "PO" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -1863,9 +1787,11 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"Qk" = (
+/turf/closed/wall/r_wall,
+/area/ship/hallway/aft)
 "Qp" = (
 /turf/closed/wall,
 /area/ship/hallway/aft)
@@ -1904,12 +1830,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
-"Rb" = (
-/turf/closed/wall/r_wall,
-/area/ship/hallway/aft)
 "Rc" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband/table{
@@ -2004,6 +1926,7 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "So" = (
@@ -2033,7 +1956,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "ST" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/structure/closet/secure_closet/freezer{
@@ -2043,6 +1965,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "Ti" = (
@@ -2104,6 +2027,7 @@
 	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "Ui" = (
@@ -2116,9 +2040,9 @@
 "Uo" = (
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/crew/cryo)
-"UA" = (
+"Uv" = (
 /turf/closed/wall/r_wall/rust,
-/area/ship/crew)
+/area/ship/engineering/engine)
 "UF" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -2151,6 +2075,7 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "UZ" = (
@@ -2181,8 +2106,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Vy" = (
@@ -2193,9 +2116,6 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
-"VA" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/toilet)
 "VP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -2248,7 +2168,8 @@
 /obj/machinery/light/small/directional/north{
 	pixel_x = -6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "Xh" = (
 /obj/structure/table/reinforced,
@@ -2262,12 +2183,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Xk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
@@ -2287,6 +2205,9 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
+"XF" = (
+/turf/closed/wall/r_wall,
+/area/ship/engineering/engine)
 "XI" = (
 /turf/closed/wall/r_wall/rust,
 /area/ship/cargo)
@@ -2314,7 +2235,6 @@
 /area/ship/hallway/aft)
 "Yc" = (
 /obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
 /obj/item/gps/mining{
 	gpstag = "SCAV1"
@@ -2360,13 +2280,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Yv" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -5
@@ -2414,20 +2331,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ship/crew)
 "ZJ" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"ZY" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew)
 
 (1,1,1) = {"
 cs
@@ -2452,16 +2370,16 @@ cs
 cs
 hX
 IU
-EC
-EC
-bZ
-zx
-bZ
+XF
+XF
 MF
 zx
 MF
-ab
-EC
+MF
+zx
+MF
+Uv
+XF
 IU
 hX
 cs
@@ -2471,7 +2389,7 @@ cs
 cs
 hX
 cs
-EC
+XF
 kX
 QF
 en
@@ -2480,7 +2398,7 @@ Vo
 qE
 ao
 yY
-EC
+XF
 cs
 hX
 cs
@@ -2499,7 +2417,7 @@ KA
 eu
 hY
 sI
-EC
+XF
 IU
 hX
 hX
@@ -2509,7 +2427,7 @@ cs
 hX
 cs
 cs
-ab
+Uv
 Ud
 Hk
 AN
@@ -2518,7 +2436,7 @@ dw
 hr
 xU
 YL
-EC
+XF
 cs
 cs
 hX
@@ -2527,8 +2445,8 @@ cs
 (6,1,1) = {"
 hX
 IU
-Gl
-Gl
+fZ
+fZ
 OB
 UF
 OB
@@ -2537,8 +2455,8 @@ js
 OB
 js
 Qp
-Rb
-Rb
+Qk
+Qk
 Ti
 hX
 cs
@@ -2546,7 +2464,7 @@ cs
 (7,1,1) = {"
 cs
 cs
-Gl
+fZ
 Xc
 ic
 ak
@@ -2565,7 +2483,7 @@ cs
 (8,1,1) = {"
 cs
 cs
-Gl
+fZ
 Rv
 Oc
 Dp
@@ -2584,7 +2502,7 @@ MB
 (9,1,1) = {"
 cs
 cs
-oF
+ri
 nM
 rr
 oC
@@ -2595,7 +2513,7 @@ qy
 OB
 JN
 CG
-Rb
+Qk
 IU
 cs
 cs
@@ -2603,8 +2521,8 @@ cs
 (10,1,1) = {"
 hX
 IU
-Gl
-Gl
+fZ
+fZ
 OB
 oG
 OB
@@ -2614,7 +2532,7 @@ Gk
 OB
 Nj
 yV
-Rb
+Qk
 IU
 hX
 cs
@@ -2661,7 +2579,7 @@ cs
 hX
 cs
 cs
-Rb
+Qk
 sT
 vn
 Qp
@@ -2670,7 +2588,7 @@ ar
 sa
 eL
 gT
-Rb
+Qk
 cs
 cs
 hX
@@ -2679,8 +2597,8 @@ cs
 (14,1,1) = {"
 hX
 IU
-nw
-nw
+ZY
+ZY
 Ne
 Gq
 Gq
@@ -2689,8 +2607,8 @@ Pr
 dc
 oU
 oU
-VA
-VA
+ur
+ur
 IU
 hX
 cs
@@ -2698,7 +2616,7 @@ cs
 (15,1,1) = {"
 cs
 cs
-nw
+ZY
 Vy
 UZ
 Ft
@@ -2709,7 +2627,7 @@ Xh
 oU
 kB
 xp
-VA
+ur
 cs
 cs
 cs
@@ -2755,18 +2673,18 @@ cs
 (18,1,1) = {"
 hX
 cs
-UA
+pL
 Gq
 Wm
 Gq
 Ne
-wB
+Dz
 mC
 iY
 MK
 MK
 Wk
-BT
+Lc
 cs
 hX
 cs
@@ -2785,7 +2703,7 @@ PO
 Rn
 wi
 pF
-BT
+Lc
 cs
 hX
 cs
@@ -2793,7 +2711,7 @@ cs
 (20,1,1) = {"
 hX
 IU
-sd
+Kb
 qN
 IP
 GI
@@ -2804,7 +2722,7 @@ xk
 MK
 cn
 KT
-BT
+Lc
 IU
 hX
 cs
@@ -2813,7 +2731,7 @@ cs
 cs
 cs
 Uo
-sd
+Kb
 ev
 ev
 ev
@@ -2822,7 +2740,7 @@ TV
 dc
 MK
 MK
-BT
+Lc
 Yi
 cs
 cs

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -72,9 +72,6 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"cl" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/bridge)
 "cn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -475,12 +472,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"ms" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -747,9 +740,9 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"ru" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/crew)
+"rG" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/toilet)
 "rO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -778,9 +771,6 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"sc" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/cryo)
 "sf" = (
 /obj/effect/turf_decal/corner/opaque/neutral/half{
 	dir = 8
@@ -951,6 +941,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
+"vP" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "wi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1034,6 +1027,9 @@
 	bulb_power = 0.2
 	},
 /turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
+"xZ" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/engineering/engine)
 "yg" = (
 /obj/structure/extinguisher_cabinet/directional/west{
@@ -1135,6 +1131,9 @@
 "zX" = (
 /turf/closed/wall/r_wall/rust,
 /area/ship/crew/cryo)
+"Ag" = (
+/turf/closed/wall/r_wall,
+/area/ship/hallway/aft)
 "Ak" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1253,6 +1252,9 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
+"Cv" = (
+/turf/closed/wall/r_wall,
+/area/ship/maintenance)
 "CG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/suit/space/eva,
@@ -1288,6 +1290,9 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"DA" = (
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "DC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -1318,6 +1323,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
+"DU" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/cryo)
 "Ed" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -1423,9 +1431,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
-"Gn" = (
-/turf/closed/wall/r_wall,
-/area/ship/bridge)
 "Gq" = (
 /turf/closed/wall,
 /area/ship/crew)
@@ -1505,7 +1510,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "IU" = (
-/obj/structure/catwalk,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "JN" = (
@@ -1587,9 +1591,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
-"Lf" = (
-/turf/closed/wall/r_wall,
-/area/ship/engineering/engine)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 4
@@ -1611,9 +1612,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
-"LU" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/engineering/engine)
 "LV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1623,6 +1621,12 @@
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
+/area/ship/hallway/central)
+"LY" = (
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
@@ -1758,6 +1762,9 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"OR" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew)
 "Pr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -1967,9 +1974,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
-"SN" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/toilet)
 "ST" = (
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -2006,12 +2010,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"Tp" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
-/area/ship/hallway/central)
 "TV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2180,9 +2178,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
-"WU" = (
-/turf/closed/wall/r_wall,
-/area/ship/hallway/aft)
 "Xc" = (
 /obj/machinery/blackbox_recorder,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2283,9 +2278,6 @@
 "Yi" = (
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/maintenance)
-"Yo" = (
-/turf/closed/wall/r_wall,
-/area/ship/maintenance)
 "Yq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
@@ -2302,6 +2294,9 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
+/area/ship/engineering/engine)
+"Yu" = (
+/turf/closed/wall/r_wall,
 /area/ship/engineering/engine)
 "Yv" = (
 /obj/structure/closet/crate/bin,
@@ -2350,6 +2345,9 @@
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/cargo)
+"Zx" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "ZC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -2391,16 +2389,16 @@ cs
 cs
 hX
 IU
-Lf
-Lf
+Yu
+Yu
 MF
 zx
 MF
 MF
 zx
 MF
-LU
-Lf
+xZ
+Yu
 IU
 hX
 cs
@@ -2410,7 +2408,7 @@ cs
 cs
 hX
 cs
-Lf
+Yu
 kX
 QF
 en
@@ -2419,7 +2417,7 @@ Vo
 qE
 ao
 yY
-Lf
+Yu
 cs
 hX
 cs
@@ -2438,7 +2436,7 @@ KA
 eu
 hY
 sI
-Lf
+Yu
 IU
 hX
 hX
@@ -2448,7 +2446,7 @@ cs
 hX
 cs
 cs
-LU
+xZ
 Ud
 Hk
 AN
@@ -2457,7 +2455,7 @@ dw
 hr
 xU
 YL
-Lf
+Yu
 cs
 cs
 hX
@@ -2466,8 +2464,8 @@ cs
 (6,1,1) = {"
 hX
 IU
-Gn
-Gn
+DA
+DA
 OB
 UF
 OB
@@ -2476,8 +2474,8 @@ js
 OB
 js
 Qp
-WU
-WU
+Ag
+Ag
 Ti
 hX
 cs
@@ -2485,7 +2483,7 @@ cs
 (7,1,1) = {"
 cs
 cs
-Gn
+DA
 Xc
 ic
 ak
@@ -2504,7 +2502,7 @@ cs
 (8,1,1) = {"
 cs
 cs
-Gn
+DA
 Rv
 Oc
 Dp
@@ -2523,7 +2521,7 @@ MB
 (9,1,1) = {"
 cs
 cs
-cl
+vP
 nM
 rr
 oC
@@ -2534,7 +2532,7 @@ qy
 OB
 JN
 CG
-WU
+Ag
 IU
 cs
 cs
@@ -2542,8 +2540,8 @@ cs
 (10,1,1) = {"
 hX
 IU
-Gn
-Gn
+DA
+DA
 OB
 oG
 OB
@@ -2553,7 +2551,7 @@ Gk
 OB
 Nj
 yV
-WU
+Ag
 IU
 hX
 cs
@@ -2600,7 +2598,7 @@ cs
 hX
 cs
 cs
-WU
+Ag
 sT
 vn
 Qp
@@ -2609,7 +2607,7 @@ ar
 sa
 eL
 gT
-WU
+Ag
 cs
 cs
 hX
@@ -2618,8 +2616,8 @@ cs
 (14,1,1) = {"
 hX
 IU
-ms
-ms
+OR
+OR
 Ne
 Gq
 Gq
@@ -2628,8 +2626,8 @@ Pr
 dc
 oU
 oU
-SN
-SN
+rG
+rG
 IU
 hX
 cs
@@ -2637,7 +2635,7 @@ cs
 (15,1,1) = {"
 cs
 cs
-ms
+OR
 Vy
 UZ
 Ft
@@ -2648,7 +2646,7 @@ Xh
 oU
 kB
 xp
-SN
+rG
 cs
 cs
 cs
@@ -2694,18 +2692,18 @@ cs
 (18,1,1) = {"
 hX
 cs
-ru
+Zx
 Gq
 Wm
 Gq
 Ne
-Tp
+LY
 mC
 iY
 MK
 MK
 Wk
-Yo
+Cv
 cs
 hX
 cs
@@ -2724,7 +2722,7 @@ PO
 Rn
 wi
 pF
-Yo
+Cv
 cs
 hX
 cs
@@ -2732,7 +2730,7 @@ cs
 (20,1,1) = {"
 hX
 IU
-sc
+DU
 qN
 IP
 GI
@@ -2743,7 +2741,7 @@ xk
 MK
 cn
 KT
-Yo
+Cv
 IU
 hX
 cs
@@ -2752,7 +2750,7 @@ cs
 cs
 cs
 Uo
-sc
+DU
 ev
 ev
 ev
@@ -2761,7 +2759,7 @@ TV
 dc
 MK
 MK
-Yo
+Cv
 Yi
 cs
 cs

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -1,4 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering/engine)
 "ac" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9,7 +12,7 @@
 	icon_state = "0-1"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "ag" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -21,10 +24,6 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "ak" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8;
-	color = "#543C30"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -32,31 +31,24 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ao" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Plasma to Engines";
-	dir = 1
+	dir = 1;
+	name = "Plasma to Engines"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -70,7 +62,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "bS" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -79,7 +73,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "bZ" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -96,6 +92,9 @@
 	dir = 4;
 	id = "mudskipper_engine"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "cn" = (
@@ -104,50 +103,45 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "cs" = (
 /turf/template_noop,
 /area/template_noop)
 "cx" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/miskilamo_small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "cB" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/carpet,
 /area/ship/crew)
 "dc" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/hallway/central)
 "dw" = (
 /obj/structure/window/reinforced/spawner,
@@ -156,31 +150,30 @@
 	},
 /obj/machinery/button/door{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 15;
 	id = "mudskipper_engine";
-	name = "Engine Shutters"
+	name = "Engine Shutters";
+	pixel_x = 22;
+	pixel_y = 15
 	},
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "dN" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/neutral,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "dQ" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -193,7 +186,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
 "dT" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -207,41 +200,44 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "dZ" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/glass,
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = 5
 	},
 /obj/machinery/button/door{
 	dir = 4;
-	pixel_x = -33;
-	pixel_y = -7;
 	id = "mudskipper_door";
-	name = "Cargo Door"
+	name = "Cargo Door";
+	pixel_x = -33;
+	pixel_y = -7
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_x = -21;
-	pixel_y = -7;
 	id = "mudskipper_shield";
-	name = "Cargo Holofield"
+	name = "Cargo Holofield";
+	pixel_x = -21;
+	pixel_y = -7
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ec" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "ee" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -250,19 +246,15 @@
 	},
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plasteel/tech/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "en" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "eu" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 8
 	},
@@ -276,6 +268,9 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
+"ev" = (
+/turf/closed/wall,
+/area/ship/crew/cryo)
 "eL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -283,21 +278,18 @@
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 4
-	},
 /obj/item/toy/cards/deck{
 	pixel_y = 3
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "eX" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "gf" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -310,6 +302,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "5-6"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "gB" = (
@@ -318,7 +314,10 @@
 	dir = 4;
 	id = "mudskipper_door"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "gR" = (
 /obj/effect/turf_decal/box,
@@ -327,8 +326,8 @@
 	icon_state = "floor4"
 	},
 /obj/structure/closet/crate/secure{
-	name = "scavenging supplies";
 	desc = "A secure crate. This one is particularly large.";
+	name = "scavenging supplies";
 	storage_capacity = 40
 	},
 /obj/item/reagent_containers/glass/chem_jug/thermite,
@@ -350,24 +349,28 @@
 /obj/item/multitool,
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/gun/energy/plasmacutter,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "gT" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"hn" = (
+/turf/closed/wall/rust/yesdiag,
+/area/ship/external/dark)
 "hr" = (
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -375,20 +378,20 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "hH" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/yesdiag,
 /area/ship/external/dark)
 "hX" = (
 /obj/structure/grille,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "hY" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "ib" = (
@@ -401,7 +404,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
 "ic" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -411,7 +414,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-6"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -420,47 +423,46 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "iY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-9"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/sign/poster/random{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"js" = (
+/turf/closed/wall/rust,
+/area/ship/bridge)
+"jz" = (
+/turf/closed/wall/rust,
+/area/ship/engineering/engine)
 "kB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "kV" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "kX" = (
@@ -472,17 +474,17 @@
 /obj/machinery/light/dim/directional/west{
 	bulb_power = 0.5
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "kY" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
+"lg" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew/toilet)
 "lj" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -490,11 +492,11 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "ma" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -506,24 +508,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock{
-	name = "Bathroom"
+	dir = 1;
+	name = "Restroom"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/toilet)
 "mC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -533,10 +525,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
 "mF" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall,
 /area/ship/cargo)
 "mS" = (
 /obj/structure/catwalk,
@@ -551,12 +544,12 @@
 	dir = 1;
 	id = "mudskipper_shield"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "nj" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 28
 	},
@@ -566,63 +559,53 @@
 /obj/effect/turf_decal/miskilamo_small/left{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "nm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair,
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 9
-	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"nw" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew)
 "nx" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
 "nM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/light/small/directional/north{
 	pixel_x = 6
 	},
 /obj/machinery/computer/helm/viewscreen/computer,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "nR" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "nV" = (
 /obj/structure/closet/wall/blue/directional/west{
-	secure = 1;
-	locked = 1
+	locked = 1;
+	secure = 1
 	},
 /obj/item/gun/energy/laser/scatter,
 /obj/item/stock_parts/cell/gun/upgraded,
@@ -640,38 +623,29 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ot" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/number/four{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "ov" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "oC" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4;
-	color = "#543C30"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
@@ -680,26 +654,22 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "4-10"
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"oF" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/bridge)
 "oG" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -709,10 +679,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Office"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "oU" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/crew/toilet)
 "po" = (
 /obj/structure/catwalk,
@@ -726,7 +701,10 @@
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	id = "mudskipper_shield"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "pF" = (
 /obj/machinery/firealarm/directional/west{
@@ -735,57 +713,52 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/ship/bridge)
-"qy" = (
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 4
-	},
-/obj/machinery/computer/crew{
-	dir = 8;
-	icon_state = "computer-right"
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = -21;
-	name = "Bridge Lockdown";
-	id = "mudskipper_bridge"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"qy" = (
+/obj/machinery/button/door{
+	dir = 1;
+	id = "mudskipper_bridge";
+	name = "Bridge Lockdown";
+	pixel_x = -6;
+	pixel_y = -21
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/computer/crew/retro{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "qE" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "qN" = (
-/obj/machinery/cryopod,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
+/obj/machinery/cryopod{
+	dir = 8
 	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/north{
 	pixel_x = -3
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "rr" = (
 /obj/structure/chair/office{
@@ -798,11 +771,10 @@
 	pixel_x = 22;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "rO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
@@ -812,15 +784,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5;
-	color = "#543C30"
-	},
 /obj/machinery/newscaster/directional/east{
 	pixel_y = -6
 	},
@@ -829,17 +798,22 @@
 	pixel_x = 22;
 	pixel_y = 5
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"sd" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/cryo)
 "sf" = (
-/obj/machinery/computer/helm{
-	dir = 8;
-	icon_state = "computer-left"
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 6
+/obj/effect/turf_decal/box,
+/obj/machinery/computer/helm/retro{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "sp" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer4{
@@ -850,12 +824,9 @@
 	name = "waste to external meter"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "sA" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -863,19 +834,17 @@
 /obj/effect/turf_decal/miskilamo_small/right{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/mono{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "sH" = (
 /obj/structure/catwalk,
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "sI" = (
-/obj/effect/turf_decal/techfloor,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -891,23 +860,20 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "th" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/traffic,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ti" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -917,6 +883,9 @@
 /obj/machinery/computer/cargo/retro{
 	dir = 4
 	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "tI" = (
@@ -924,9 +893,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-6"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "tK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -937,23 +908,14 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "uk" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uz" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/structure/railing{
@@ -963,17 +925,12 @@
 	pixel_x = 7;
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uW" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Bridge";
-	req_one_access_txt = "20"
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
@@ -984,6 +941,15 @@
 	dir = 2;
 	id = "mudskipper_bridge"
 	},
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/command{
+	dir = 1;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "vn" = (
@@ -992,11 +958,11 @@
 /obj/structure/sign/poster/contraband/punch_shit{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "vI" = (
 /obj/structure/cable{
@@ -1010,7 +976,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "wi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1023,21 +992,28 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "wj" = (
-/obj/effect/turf_decal/industrial/outline/red,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ws" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/engineering/engine)
+"wB" = (
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
 "xk" = (
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -1050,6 +1026,12 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
 	},
+/obj/structure/cable{
+	icon_state = "5-9"
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "xo" = (
@@ -1061,9 +1043,7 @@
 	pixel_x = 22;
 	pixel_y = -6
 	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
-	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "xp" = (
 /obj/structure/toilet{
@@ -1071,21 +1051,16 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /obj/structure/curtain,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "xH" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "xU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -1101,9 +1076,6 @@
 /area/ship/engineering/engine)
 "yg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = -5
 	},
@@ -1115,24 +1087,24 @@
 	pixel_x = -22;
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "yv" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "yB" = (
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "yS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -1141,7 +1113,12 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
+/area/ship/hallway/aft)
+"yV" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/hallway/aft)
 "yY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1152,10 +1129,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "zx" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
@@ -1169,6 +1143,9 @@
 	dir = 4;
 	id = "mudskipper_engine"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "zR" = (
@@ -1176,39 +1153,44 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/grimy,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "zW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "zX" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew/cryo)
 "Ak" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "AN" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -1217,9 +1199,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/light_switch{
@@ -1227,11 +1206,13 @@
 	pixel_x = 22;
 	pixel_y = -14
 	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Bj" = (
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_y = -32
@@ -1242,7 +1223,10 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Bn" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
@@ -1251,17 +1235,18 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "Bw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "BA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -1273,11 +1258,11 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
+"BT" = (
+/turf/closed/wall/r_wall,
+/area/ship/maintenance)
 "BW" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/plastic,
@@ -1296,7 +1281,7 @@
 /obj/item/storage/pill_bottle/charcoal/less,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ch" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1308,7 +1293,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Cr" = (
 /obj/structure/table/reinforced,
@@ -1316,6 +1301,9 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "CG" = (
@@ -1323,44 +1311,23 @@
 /obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Dj" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/traffic,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Dp" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken2"
-	},
-/area/ship/bridge)
-"DC" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -1371,59 +1338,62 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-9"
 	},
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"DC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "DS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ed" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Eg" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/number/eight{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "Ey" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1434,39 +1404,41 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-9"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
+"EC" = (
+/turf/closed/wall/r_wall,
+/area/ship/engineering/engine)
 "EP" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/button/shieldwallgen{
 	dir = 1;
-	pixel_x = -6;
-	pixel_y = -21;
 	id = "mudskipper_shield";
-	name = "Cargo Holofield"
+	name = "Cargo Holofield";
+	pixel_x = -6;
+	pixel_y = -21
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	pixel_x = 6;
-	pixel_y = -21;
 	id = "mudskipper_door";
-	name = "Cargo Door"
+	name = "Cargo Door";
+	pixel_x = 6;
+	pixel_y = -21
 	},
 /obj/effect/turf_decal/number/six{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "EQ" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -1475,6 +1447,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Ft" = (
@@ -1484,10 +1459,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -21;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -21
 	},
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "FN" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -1497,39 +1472,42 @@
 	},
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gk" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "mudskipper_bridge"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
+"Gl" = (
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
 "Gq" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/crew)
 "GI" = (
 /obj/machinery/cryopod{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "GW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
+/obj/structure/cable{
+	icon_state = "6-10"
 	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Hk" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -1539,37 +1517,29 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Id" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/item/stack/sheet/metal/five{
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/glass/five{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "IL" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "IP" = (
@@ -1588,18 +1558,18 @@
 	pixel_y = 3
 	},
 /obj/item/radio{
-	pixel_y = 3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 3
 	},
 /obj/item/radio{
-	pixel_y = 3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "IU" = (
 /obj/structure/catwalk,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "JN" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
@@ -1609,10 +1579,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "JS" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1625,10 +1595,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1637,14 +1606,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "KA" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/paper_bin,
 /obj/item/analyzer{
-	pixel_y = 3;
-	pixel_x = 13
+	pixel_x = 13;
+	pixel_y = 3
 	},
 /obj/item/pen,
 /obj/structure/cable{
@@ -1656,14 +1630,12 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "KT" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "KU" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -1671,11 +1643,11 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
@@ -1686,40 +1658,42 @@
 	pixel_x = -22;
 	pixel_y = -9
 	},
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod/retro/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "LV" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
 /area/space)
 "Mi" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "MB" = (
@@ -1746,27 +1720,23 @@
 	dir = 4;
 	id = "mudskipper_engine"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "MK" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/maintenance)
+"Ne" = (
+/turf/closed/wall/rust,
+/area/ship/crew)
 "Ni" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Nj" = (
 /obj/machinery/door/airlock/external{
@@ -1778,12 +1748,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
 "Nl" = (
@@ -1791,7 +1756,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
 "NJ" = (
 /obj/effect/turf_decal/box,
@@ -1813,51 +1778,48 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "NN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "NU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Oc" = (
 /obj/item/paper_bin,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "OB" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/bridge)
 "OD" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Pr" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -1871,66 +1833,69 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Canteen"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "PO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "PR" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Qp" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/hallway/aft)
 "Qt" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Qu" = (
 /obj/machinery/autolathe/hacked,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Qx" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-9"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "QF" = (
 /obj/machinery/power/terminal{
@@ -1940,11 +1905,11 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
+"Rb" = (
+/turf/closed/wall/r_wall,
+/area/ship/hallway/aft)
 "Rc" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/wideband/table{
@@ -1952,24 +1917,23 @@
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	pixel_x = 6;
-	pixel_y = -21;
 	id = "mudskipper_window";
-	name = "Window Shutters"
+	name = "Window Shutters";
+	pixel_x = 6;
+	pixel_y = -21
 	},
 /obj/machinery/light/small/directional/west{
-	pixel_y = -6;
-	bulb_power = 0.6
+	bulb_power = 0.6;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Rl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 8
-	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = 10;
 	pixel_y = 5
@@ -1979,11 +1943,13 @@
 	pixel_y = 2
 	},
 /obj/item/paper/pamphlet{
+	name = "Salvage And You";
 	pixel_x = -3;
-	pixel_y = 2;
-	name = "Salvage And You"
+	pixel_y = 2
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Rn" = (
 /obj/machinery/door/firedoor/border_only,
@@ -1995,15 +1961,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Utility Closet"
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance)
 "Rv" = (
 /obj/item/gps/mining{
-	pixel_y = 6;
-	gpstag = "SCAV0"
+	gpstag = "SCAV0";
+	pixel_y = 6
 	},
 /obj/item/clipboard{
 	pixel_x = 5;
@@ -2021,10 +1988,8 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "RR" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -2035,19 +2000,13 @@
 /obj/structure/filingcabinet/double,
 /obj/item/folder,
 /obj/machinery/light/small/directional/west{
-	pixel_y = 6;
-	bulb_power = 0.6
+	bulb_power = 0.6;
+	pixel_y = 6
 	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "So" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/airlock{
-	name = "Crew Quarters"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2057,7 +2016,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Sq" = (
 /obj/structure/curtain,
@@ -2071,9 +2034,6 @@
 /area/ship/crew/toilet)
 "ST" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/structure/closet/secure_closet/freezer{
@@ -2082,17 +2042,17 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "Ti" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
 	name = "airlock waste injector"
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Tn" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2105,19 +2065,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "TV" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4;
-	name = "Cargo Bay"
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -2133,7 +2084,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/machinery/door/airlock/mining{
+	dir = 8;
+	name = "Cargo Bay"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ud" = (
 /obj/effect/turf_decal/box,
@@ -2152,8 +2111,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Uo" = (
+/turf/closed/wall/r_wall/yesdiag,
+/area/ship/crew/cryo)
+"UA" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "UF" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -2165,12 +2130,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -2180,7 +2139,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "UL" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -2188,6 +2148,9 @@
 /obj/machinery/light/directional/west,
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "UZ" = (
@@ -2197,16 +2160,17 @@
 /obj/item/flashlight/lamp/green{
 	pixel_y = 4
 	},
-/turf/open/floor/wood/walnut,
+/obj/structure/cable{
+	icon_state = "5-6"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Vn" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/wrapping,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Vo" = (
@@ -2219,9 +2183,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Vy" = (
@@ -2230,38 +2191,26 @@
 /obj/structure/curtain/bounty,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
+"VA" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/toilet)
 "VP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "VW" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/external/dark)
+"Wk" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance)
 "Wm" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4;
-	name = "Cryogenic Storage"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -2271,7 +2220,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Cryo Room"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Wz" = (
 /obj/structure/sink{
@@ -2286,7 +2240,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Xc" = (
 /obj/machinery/blackbox_recorder,
@@ -2294,35 +2248,48 @@
 /obj/machinery/light/small/directional/north{
 	pixel_x = -6
 	},
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Xh" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Xk" = (
-/obj/effect/turf_decal/industrial/outline/red,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Xm" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
+"XI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "XK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -2331,22 +2298,19 @@
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "6-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "XU" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10;
-	color = "#543C30"
-	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Yc" = (
 /obj/effect/turf_decal/box,
@@ -2368,16 +2332,19 @@
 /obj/item/kitchen/knife/combat/survival,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Yd" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/crew)
+"Yi" = (
+/turf/closed/wall/r_wall/yesdiag,
+/area/ship/maintenance)
 "Yq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
@@ -2387,45 +2354,37 @@
 	target_pressure = 1000
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer2{
-	name = "Scrubbers to External";
-	dir = 1
+	dir = 1;
+	name = "Scrubbers to External"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Yv" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "YK" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-9"
 	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "YL" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
@@ -2435,7 +2394,6 @@
 /area/ship/engineering/engine)
 "Zi" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -2443,39 +2401,32 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "ZC" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
 "ZJ" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 
 (1,1,1) = {"
@@ -2490,7 +2441,7 @@ ag
 ag
 lj
 ag
-ws
+jz
 cs
 cs
 cs
@@ -2501,16 +2452,16 @@ cs
 cs
 hX
 IU
-ws
-ws
+EC
+EC
 bZ
 zx
 bZ
 MF
 zx
 MF
-ws
-ws
+ab
+EC
 IU
 hX
 cs
@@ -2520,7 +2471,7 @@ cs
 cs
 hX
 cs
-ws
+EC
 kX
 QF
 en
@@ -2529,7 +2480,7 @@ Vo
 qE
 ao
 yY
-ws
+EC
 cs
 hX
 cs
@@ -2548,7 +2499,7 @@ KA
 eu
 hY
 sI
-ws
+EC
 IU
 hX
 hX
@@ -2558,7 +2509,7 @@ cs
 hX
 cs
 cs
-ws
+ab
 Ud
 Hk
 AN
@@ -2567,7 +2518,7 @@ dw
 hr
 xU
 YL
-ws
+EC
 cs
 cs
 hX
@@ -2576,18 +2527,18 @@ cs
 (6,1,1) = {"
 hX
 IU
-OB
-OB
+Gl
+Gl
 OB
 UF
 OB
+js
+js
 OB
-OB
-OB
-OB
+js
 Qp
-Qp
-Qp
+Rb
+Rb
 Ti
 hX
 cs
@@ -2595,7 +2546,7 @@ cs
 (7,1,1) = {"
 cs
 cs
-OB
+Gl
 Xc
 ic
 ak
@@ -2614,7 +2565,7 @@ cs
 (8,1,1) = {"
 cs
 cs
-OB
+Gl
 Rv
 Oc
 Dp
@@ -2633,18 +2584,18 @@ MB
 (9,1,1) = {"
 cs
 cs
-OB
+oF
 nM
 rr
 oC
-OB
+js
 dN
 sf
 qy
 OB
 JN
 CG
-Qp
+Rb
 IU
 cs
 cs
@@ -2652,8 +2603,8 @@ cs
 (10,1,1) = {"
 hX
 IU
-OB
-OB
+Gl
+Gl
 OB
 oG
 OB
@@ -2662,8 +2613,8 @@ Gk
 Gk
 OB
 Nj
-Qp
-Qp
+yV
+Rb
 IU
 hX
 cs
@@ -2710,7 +2661,7 @@ cs
 hX
 cs
 cs
-Qp
+Rb
 sT
 vn
 Qp
@@ -2719,7 +2670,7 @@ ar
 sa
 eL
 gT
-Qp
+Rb
 cs
 cs
 hX
@@ -2728,9 +2679,9 @@ cs
 (14,1,1) = {"
 hX
 IU
-Gq
-Gq
-Gq
+nw
+nw
+Ne
 Gq
 Gq
 dc
@@ -2738,8 +2689,8 @@ Pr
 dc
 oU
 oU
-oU
-oU
+VA
+VA
 IU
 hX
 cs
@@ -2747,7 +2698,7 @@ cs
 (15,1,1) = {"
 cs
 cs
-Gq
+nw
 Vy
 UZ
 Ft
@@ -2758,7 +2709,7 @@ Xh
 oU
 kB
 xp
-oU
+VA
 cs
 cs
 cs
@@ -2777,7 +2728,7 @@ Qx
 mt
 Ch
 Wz
-oU
+lg
 cs
 cs
 cs
@@ -2789,14 +2740,14 @@ Yd
 xo
 cB
 dQ
-Gq
+Ne
 DS
 Mi
 ZJ
 oU
 tK
 Sq
-oU
+lg
 IU
 hX
 cs
@@ -2804,18 +2755,18 @@ cs
 (18,1,1) = {"
 hX
 cs
-Gq
+UA
 Gq
 Wm
 Gq
-Gq
-dc
+Ne
+wB
 mC
 iY
 MK
 MK
-MK
-MK
+Wk
+BT
 cs
 hX
 cs
@@ -2827,14 +2778,14 @@ zX
 KU
 zW
 Lw
-zX
+ev
 Vn
 DC
 PO
 Rn
 wi
 pF
-MK
+BT
 cs
 hX
 cs
@@ -2842,18 +2793,18 @@ cs
 (20,1,1) = {"
 hX
 IU
-zX
+sd
 qN
 IP
 GI
-zX
+ev
 Yv
 LV
 xk
 MK
 cn
 KT
-MK
+BT
 IU
 hX
 cs
@@ -2861,18 +2812,18 @@ cs
 (21,1,1) = {"
 cs
 cs
-zX
-zX
-zX
-zX
-zX
+Uo
+sd
+ev
+ev
+ev
 dc
 TV
 dc
 MK
 MK
-MK
-MK
+BT
+Yi
 cs
 cs
 cs
@@ -2939,7 +2890,7 @@ cs
 hX
 IU
 mF
-mF
+XI
 uz
 gR
 Xk
@@ -2984,7 +2935,7 @@ gB
 gB
 gB
 mS
-mF
+XI
 IU
 IU
 hX
@@ -2996,7 +2947,7 @@ cs
 cs
 cs
 VW
-hH
+hn
 Nl
 kY
 ib
@@ -3034,14 +2985,14 @@ cs
 cs
 cs
 cs
-hH
-hH
+hn
+hn
 cs
 cs
 cs
 cs
 hH
-hH
+hn
 cs
 cs
 cs
@@ -3059,7 +3010,7 @@ cs
 cs
 cs
 cs
-hH
+hn
 cs
 cs
 cs

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -462,6 +462,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/trash/candy,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "en" = (
@@ -850,6 +851,17 @@
 /obj/machinery/computer/cryopod/retro/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
+"ht" = (
+/obj/structure/bed,
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/dorms,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/dorm)
 "hv" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1129,6 +1141,7 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "jC" = (
@@ -1406,9 +1419,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
-"mq" = (
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "ms" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1762,6 +1772,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "pI" = (
@@ -3668,6 +3679,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"Fe" = (
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "FE" = (
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
@@ -4647,6 +4661,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "NR" = (
@@ -5630,17 +5645,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
-"Wo" = (
-/obj/structure/bed,
-/obj/structure/curtain/bounty,
-/obj/item/bedsheet/dorms,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/dorm)
 "Wq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6908,7 +6912,7 @@ OU
 ao
 Ok
 uh
-Wo
+ht
 mJ
 mJ
 mJ
@@ -6981,7 +6985,7 @@ gq
 wQ
 MT
 pl
-mq
+Fe
 xZ
 qO
 CH

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -131,11 +131,17 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "bm" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
@@ -169,6 +175,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
 "bD" = (
@@ -335,6 +342,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "5-9"
+	},
+/obj/structure/chair/handrail{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -703,6 +713,9 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "gc" = (
@@ -767,6 +780,9 @@
 "gt" = (
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "gF" = (
@@ -851,17 +867,6 @@
 /obj/machinery/computer/cryopod/retro/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
-"ht" = (
-/obj/structure/bed,
-/obj/structure/curtain/bounty,
-/obj/item/bedsheet/dorms,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/dorm)
 "hv" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -997,6 +1002,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "is" = (
@@ -1090,6 +1096,9 @@
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "jj" = (
@@ -1248,6 +1257,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/starboard)
 "ki" = (
@@ -1256,6 +1266,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "kt" = (
@@ -1605,6 +1618,9 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "of" = (
@@ -1739,6 +1755,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "ph" = (
@@ -1857,6 +1876,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 1
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "qa" = (
@@ -1954,6 +1976,9 @@
 	pixel_y = -20
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2440,6 +2465,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "uM" = (
@@ -2448,6 +2476,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
 	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
@@ -2472,6 +2503,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "va" = (
@@ -2550,6 +2582,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
+"vL" = (
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "vN" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable/yellow{
@@ -2953,6 +2991,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "yP" = (
@@ -3377,6 +3416,9 @@
 "CF" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "CH" = (
@@ -3580,6 +3622,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
 "EA" = (
@@ -3665,6 +3708,9 @@
 /area/ship/crew/janitor)
 "ER" = (
 /obj/effect/turf_decal/industrial/warning,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "EX" = (
@@ -3677,11 +3723,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"Fe" = (
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "FE" = (
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
@@ -3751,6 +3795,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 24
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "Gw" = (
@@ -4023,6 +4068,9 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -21
 	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/starboard)
 "IJ" = (
@@ -4156,6 +4204,9 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
 	dir = 9
+	},
+/obj/structure/chair/handrail{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
@@ -4304,6 +4355,17 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/engine/vacuum,
 /area/ship/engineering/engine)
+"Li" = (
+/obj/structure/bed,
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/dorms,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/dorm)
 "Ll" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4484,6 +4546,9 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
+"Mf" = (
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "Mk" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -4491,6 +4556,13 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
+"Ml" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/starboard)
 "Mr" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -5004,6 +5076,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
+"Qu" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/port)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5142,6 +5223,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/port)
 "Ry" = (
@@ -5433,6 +5517,9 @@
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Ug" = (
@@ -5551,6 +5638,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "VN" = (
@@ -5588,6 +5676,9 @@
 /area/ship/engineering/engine)
 "VS" = (
 /obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/fore)
 "VV" = (
@@ -5690,6 +5781,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "WB" = (
@@ -5706,6 +5800,9 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -5743,6 +5840,9 @@
 /area/ship/bridge)
 "Xg" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "Xh" = (
@@ -5800,6 +5900,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "XJ" = (
@@ -5808,6 +5911,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "XK" = (
@@ -6546,7 +6650,7 @@ fz
 "}
 (18,1,1) = {"
 BL
-bm
+Qu
 CF
 XY
 we
@@ -6568,7 +6672,7 @@ sk
 RP
 rJ
 pY
-ER
+Ml
 iG
 OU
 "}
@@ -6703,7 +6807,7 @@ Gy
 ND
 jY
 Kn
-ZV
+vL
 rr
 fW
 fW
@@ -6871,7 +6975,7 @@ aI
 aI
 aI
 iz
-ZV
+vL
 rr
 sX
 su
@@ -6912,7 +7016,7 @@ OU
 ao
 Ok
 uh
-ht
+Li
 mJ
 mJ
 mJ
@@ -6985,7 +7089,7 @@ gq
 wQ
 MT
 pl
-Fe
+Mf
 xZ
 qO
 CH

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -244,7 +244,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "cD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -422,6 +422,7 @@
 	pixel_x = -20;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "dT" = (
@@ -475,6 +476,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "es" = (
@@ -512,7 +514,7 @@
 "ez" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/computer/helm/viewscreen/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "eC" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
@@ -838,7 +840,6 @@
 /area/ship/hallway/fore)
 "hp" = (
 /obj/structure/table,
-/obj/machinery/computer/cryopod/directional/west,
 /obj/machinery/newscaster/directional/south,
 /obj/item/cigbutt{
 	pixel_x = -10;
@@ -846,6 +847,7 @@
 	},
 /obj/item/cigbutt,
 /obj/item/reagent_containers/food/snacks/chips,
+/obj/machinery/computer/cryopod/retro/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "hv" = (
@@ -1182,7 +1184,7 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "jY" = (
 /turf/closed/wall,
@@ -1404,6 +1406,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
+"mq" = (
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "ms" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1850,7 +1855,8 @@
 "qb" = (
 /obj/structure/crate_shelf,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "qg" = (
 /obj/structure/closet/secure_closet/engineering_personal{
@@ -2196,7 +2202,10 @@
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "su" = (
 /obj/structure/disposalpipe/segment,
@@ -2561,6 +2570,9 @@
 "vV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/kirbyplants/fullysynthetic,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
 "vX" = (
@@ -2688,6 +2700,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "amogusthrusters"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -2964,6 +2979,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "yY" = (
@@ -3107,7 +3126,8 @@
 /obj/effect/turf_decal/box,
 /obj/item/tank/internals/oxygen/red,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Ab" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -3156,7 +3176,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Ax" = (
 /obj/structure/table/wood,
@@ -3414,7 +3434,10 @@
 /obj/item/pickaxe,
 /obj/effect/turf_decal/box,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dm" = (
 /obj/machinery/cryopod{
@@ -3672,7 +3695,7 @@
 	id = "amogusdoors";
 	name = "Cargo Bay Blast Door"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "Gg" = (
 /obj/machinery/light/dim/directional/south,
@@ -3699,7 +3722,10 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/head/hardhat/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gt" = (
 /obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
@@ -3973,6 +3999,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "IE" = (
@@ -4194,6 +4221,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Kq" = (
@@ -4318,6 +4348,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "amogusthrusters"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -4531,9 +4564,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"MV" = (
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "Na" = (
 /turf/closed/wall/rust,
 /area/ship/crew/canteen)
@@ -4548,13 +4578,17 @@
 "Ne" = (
 /obj/structure/crate_shelf,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ni" = (
 /obj/structure/bed,
 /obj/structure/curtain/bounty,
 /obj/item/bedsheet/dorms,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "Nl" = (
@@ -4870,6 +4904,9 @@
 	dir = 4;
 	id = "amogusthrusters"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "PR" = (
@@ -5025,6 +5062,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "amogusthrusters"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -5292,7 +5332,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Tk" = (
 /obj/structure/cable{
@@ -5318,7 +5358,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "TO" = (
 /obj/machinery/firealarm/directional/south,
@@ -5358,6 +5398,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "TX" = (
@@ -5421,7 +5462,7 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "UJ" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "UT" = (
 /obj/machinery/recharger,
@@ -5556,7 +5597,8 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "We" = (
 /turf/closed/wall/r_wall/rust/yesdiag,
@@ -5585,8 +5627,20 @@
 /obj/structure/crate_shelf,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"Wo" = (
+/obj/structure/bed,
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/dorms,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/dorm)
 "Wq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -5609,7 +5663,7 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "Ws" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
@@ -5662,6 +5716,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "WM" = (
@@ -5950,6 +6005,10 @@
 	dir = 8
 	},
 /obj/structure/curtain,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "ZJ" = (
@@ -5958,8 +6017,8 @@
 	},
 /obj/structure/curtain,
 /obj/item/soap,
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew/toilet)
@@ -6849,7 +6908,7 @@ OU
 ao
 Ok
 uh
-Ni
+Wo
 mJ
 mJ
 mJ
@@ -6922,7 +6981,7 @@ gq
 wQ
 MT
 pl
-MV
+mq
 xZ
 qO
 CH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![mudskipper](https://github.com/user-attachments/assets/85d29f5d-ed85-48a9-ac6f-aa1d485b0416)
![kilo](https://github.com/user-attachments/assets/32e04076-29e0-438b-a212-4649de4d4abf)
![shetland](https://github.com/user-attachments/assets/57f46122-4ba8-4140-b003-a3a3ac3bec75)

- Re-palettes the Mudskipper, Kilo, and Shetland for aesthetic consistency across the Miskilamo ships
- Changes Mudskipper to use the same cheap captain outfit as shetland and kilo
- Cuts Kilo's starting funds to 1500, same as Shetland
- fixes Mudskipper's wires :)

## Why It's Good For The Game

Manufacturer consistency good and kilo had a bit too much money

## Changelog

:cl:
balance: Changed decoration on Miskilamo ships to look similar to each other
balance: reduced Kilo starting funds to 1500
fix: fixed wires on Mudskipper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
