### PR TITLE
Makes Vegan rations actually Vegan

### DIFF
--- a/code/game/objects/items/storage/ration.dm
+++ b/code/game/objects/items/storage/ration.dm
@@ -54,7 +54,7 @@
 		/obj/item/reagent_containers/food/snacks/ration/entree/vegan_chili = 1,
 		/obj/item/reagent_containers/food/snacks/ration/side/vegan_crackers = 1,
 		/obj/item/reagent_containers/food/snacks/ration/side/cornbread = 1,
-		/obj/item/reagent_containers/food/snacks/ration/snack/pizza_crackers = 1,
+		/obj/item/reagent_containers/food/snacks/ration/snack/fruit_puree = 1,
 		/obj/item/reagent_containers/food/snacks/ration/condiment/cheese_spread = 1,
 		/obj/item/reagent_containers/food/snacks/ration/pack/grape_beverage = 1,
 		/obj/item/ration_heater = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exchanges the pizza crackers snack, which is a meat foodtype, with fruit puree, in the vegan chili ration. 

## Why It's Good For The Game

It always felt like a really minor and silly oversight that pizza crackers weren't actually vegan, which, in turn, made the _vegan ration_ not actually entirely vegan. This isn't really a gamebreaking change, but I thought it might help with consistency.

## Changelog

:cl:
add: Added fruit puree to vegan rations
del: Removed pizza crackers from vegan rations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
