### PR TITLE
Exosuit generator power production change and efficiency decrease

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -360,15 +360,15 @@
 
 /obj/item/mecha_parts/mecha_equipment/generator
 	name = "exosuit plasma converter"
-	desc = "An exosuit module that generates power using solid plasma as fuel. Pollutes the environment."
+	desc = "An exosuit module that generates bulk power using solid plasma as fuel. Utilizes a power generation cycle that is inefficient, compared to its ship-based counterparts, but delivers more of it, per unit time. Useful for kick-starting a dead exosuit, or maintaining energy when you need it most."
 	icon_state = "tesla"
 	range = MECHA_MELEE
 	var/coeff = 100
 	var/obj/item/stack/sheet/fuel
 	var/max_fuel = 150000
 	var/fuel_per_cycle_idle = 25
-	var/fuel_per_cycle_active = 200
-	var/power_per_cycle = 20
+	var/fuel_per_cycle_active = 4000
+	var/power_per_cycle = 400
 
 /obj/item/mecha_parts/mecha_equipment/generator/Initialize()
 	. = ..()
@@ -455,12 +455,12 @@
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear
 	name = "exonuclear reactor"
-	desc = "An exosuit module that generates power using uranium as fuel. Pollutes the environment."
+	desc = "An exosuit module that generates power using a miniature fission reactor. Useful for jumpstarting an exosuit, or keeping it running during heavy use. In an effort to keep its already staggering weight down, a substantial amount of shielding is not present. Use with caution."
 	icon_state = "tesla"
 	max_fuel = 50000
 	fuel_per_cycle_idle = 10
-	fuel_per_cycle_active = 30
-	power_per_cycle = 50
+	fuel_per_cycle_active = 600
+	power_per_cycle = 1000
 	var/rad_per_cycle = 30
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/generator_init()

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -365,7 +365,7 @@
 	range = MECHA_MELEE
 	var/coeff = 100
 	var/obj/item/stack/sheet/fuel
-	var/max_fuel = 150000
+	var/max_fuel = 120000
 	var/fuel_per_cycle_idle = 25
 	var/fuel_per_cycle_active = 4000
 	var/power_per_cycle = 400
@@ -457,7 +457,7 @@
 	name = "exonuclear reactor"
 	desc = "An exosuit module that generates power using a miniature fission reactor. Useful for jumpstarting an exosuit, or keeping it running during heavy use. In an effort to keep its already staggering weight down, a substantial amount of shielding is not present. Use with caution."
 	icon_state = "tesla"
-	max_fuel = 50000
+	max_fuel = 20000
 	fuel_per_cycle_idle = 10
 	fuel_per_cycle_active = 600
 	power_per_cycle = 1000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change increases the power produced by exosuit generators twenty-fold. It also reflavors the description of the generators. This change also decreases the maximum fuel that each generator can hold, to the point where the standard plasma generator functions for only a minute, maximum, when fully fueled. The exonuclear reactor only functions for slightly longer than this. 

## Why It's Good For The Game

Exosuit reactors are very slow, with regards to powering equipment. This change should make them more useful, both in combat, and out of combat. This change is meant to make them work more like the battery module present in FTL, which gives you an energy boost, but only for a very limited time.

## Changelog

:cl:
balance: rebalanced exosuit generators to produce more power, at the expense of longevity and total energy production
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
