### PR TITLE
Changes the color of the text output of health analyzers to be readable by dark mode users

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -226,12 +226,12 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#0000CC'>Damage:</font></td>\
+							<td style='width:7em;'><font color='#0d5cee'>Damage:</font></td>\
 							<td style='width:5em;'><font color='red'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='orange'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='green'><b>Toxin</b></font></td>\
 							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#0000CC'>Overall:</font></td>\
+							<tr><td><font color='#1d63e6'>Overall:</font></td>\
 							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
 							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
 							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
@@ -239,7 +239,7 @@ GENE SCANNER
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(parse_zone(org.body_zone))]:</font></td>\
+				dmgreport += "<tr><td><font color='#1d63e6'>[capitalize(parse_zone(org.body_zone))]:</font></td>\
 								<td><font color='red'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
 								<td><font color='orange'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
 			dmgreport += "</font></table>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This tweaks the color of body part lists as given by health analyzers, in an effort to enhance readability for dark mode users.

### Before the change:
| Dark Mode |
|-----------|
|![image](https://github.com/user-attachments/assets/95d5fe3e-d565-4eec-be40-4ba6b58211ec)|

| Light Mode |
|------------|
|![image](https://github.com/user-attachments/assets/45376b28-785b-40c3-9cdc-fecc49ecacaf)|


### After the change:
| Dark Mode |
|-----------|
|![dreamseeker_vtOyuEpuir](https://github.com/user-attachments/assets/756b0163-99b9-4341-9420-07ded5cc07cf)|

| Light Mode |
|------------|
|![image](https://github.com/user-attachments/assets/52b3d45d-5a57-4396-8e7f-81a976222e77)|

## Why It's Good For The Game

This should make it easier for dark mode users to know, at a glance, what body parts might be damaged on a patient. As it stands right now, one would have to highlight the text in order to see which limb(s) have been damaged. 

## Changelog

:cl:
add: Adds a bit more contrast to the output of health analyzers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
