### PR TITLE
reduces recruit slots on colossus to 2

### DIFF
--- a/_maps/configs/inteq_colossus.json
+++ b/_maps/configs/inteq_colossus.json
@@ -42,7 +42,7 @@
 		},
 		"Recruit": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
-			"slots": 5
+			"slots": 2
 		}
 	},
 	"enabled": true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

## Changelog

:cl:
balance: Colossus now only has 2 recruit slots instead of a whopping !!5!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
