### PR TITLE
Pants Accessories

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -137,6 +137,7 @@
 	icon_state = "bronze"
 	custom_materials = list(/datum/material/iron=1000)
 	resistance_flags = FIRE_PROOF
+	attachment_slot = null
 	var/medaltype = "medal" //Sprite used for medalbox
 	var/commended = FALSE
 
@@ -409,6 +410,7 @@
 	icon_state = "holster"
 	item_state = "holster"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
+	attachment_slot = null
 
 /obj/item/clothing/accessory/holster/detective
 	name = "detective's shoulder holster"
@@ -477,7 +479,7 @@
 	icon_state = "rilena_pin"
 	above_suit = FALSE
 	minimize_when_attached = TRUE
-	attachment_slot = CHEST
+	attachment_slot = null
 
 /obj/item/clothing/accessory/rilena_pin/on_uniform_equip(obj/item/clothing/under/U, user)
 	var/mob/living/L = user


### PR DESCRIPTION
## About The Pull Request

Most accessories fit on pants now

## Why It's Good For The Game

I should be able to pin my captain's medal on the turtleneck I'm wearing with my black pants.

## Changelog

:cl:
balance: Most common accessories now fit on pants
/:cl: