### PR TITLE
Exosuit Recharger Equipment in Cargo

### DIFF
--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -220,6 +220,15 @@ Mech Equipment
 		/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
 	)
 
+/datum/supply_pack/mech/equipment/recharger
+	name = "Exosuit Recharger kit"
+	desc = "Two boards for an exosuit recharger and recharger console. For the stylish exosuit bay."
+	cost = 400
+	contains = list(
+		/obj/item/circuitboard/computer/mech_bay_power_console,
+		/obj/item/circuitboard/machine/mech_recharger
+	)
+
 /*
 weapons
 */


### PR DESCRIPTION
## About The Pull Request

Adds the exosuit recharger machine and computer boards to cargo

## Why It's Good For The Game

You can't get them outside of ruins or RND and they're Way Cooler than cell-swapping

## Changelog

:cl:
add: Exosuit Recharger machines are now available from cargo
/:cl: