### PR TITLE
More Rust Reds

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -264,7 +264,7 @@
 
 	price_min = 1500
 	price_max = 2500
-	stock = 3
+	stock_max = 3
 	availability_prob = 30
 
 /datum/blackmarket_item/clothing/frontiersmen_hardsuit

--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -264,7 +264,7 @@
 
 	price_min = 1500
 	price_max = 2500
-	stock = 1
+	stock = 3
 	availability_prob = 30
 
 /datum/blackmarket_item/clothing/frontiersmen_hardsuit


### PR DESCRIPTION
## About The Pull Request

Increases rust reds on the black market from maximum 1 to a maximum of 3

## Why It's Good For The Game

Makes them about as available as the other suits on the market. They Suck, shouldn't really matter

## Changelog

:cl:
balance: Rust Reds on the blackmarket are now available to a maximum of 3
/:cl: