### PR TITLE
mudskipper and shetland window fix

### DIFF
--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -1096,6 +1096,9 @@
 	dir = 4;
 	id = "mudskipper_engine"
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "zR" = (
@@ -1669,6 +1672,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "mudskipper_engine"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -2753,6 +2753,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "wU" = (
@@ -4428,6 +4431,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "Lx" = (
@@ -4994,6 +5000,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "PR" = (
@@ -5161,6 +5170,9 @@
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -1492,7 +1492,7 @@
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	id = "amogusthrusters";
+	id = "shetportthrusters";
 	name = "Thruster Lockdown";
 	pixel_y = -21
 	},
@@ -2297,7 +2297,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/button/door{
-	id = "amogusthrusters";
+	id = "shetstarboardengine";
 	name = "Thruster Lockdown";
 	pixel_y = 24
 	},
@@ -2748,7 +2748,7 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "amogusthrusters"
+	id = "shetstarboardengine"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -4426,7 +4426,7 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "amogusthrusters"
+	id = "shetportthrusters"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -4995,7 +4995,7 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "amogusthrusters"
+	id = "shetportthrusters"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -5166,7 +5166,7 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "amogusthrusters"
+	id = "shetstarboardengine"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added windows to the mudskipper and shetland's engines as well for consistency see #3434 for the Kilo fixes too.

Also seperated the Shetland's engine rooms so both buttons don't open both sides.
Now the button in each engine room will open only it's respective side.

## Changelog

:cl:
fix: Added windows to the mudskipper and shetland's engines.
fix: Adjusted the blast doors which open on the Shetland's engines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
