### PR TITLE
sawnoff weapons now call sawoff on init

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -228,7 +228,7 @@
 				update_appearance()
 			return
 	if (can_be_sawn_off)
-		if (sawoff(user, A))
+		if (try_sawoff(user, A))
 			return
 	return FALSE
 
@@ -334,43 +334,7 @@
 	rounds.Add(magazine.ammo_list(drop_all))
 	return rounds
 
-GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
-	/obj/item/gun/energy/plasmacutter,
-	/obj/item/melee/transforming/energy,
-	)))
-
-///Handles all the logic of sawing off guns,
-/obj/item/gun/ballistic/proc/sawoff(mob/user, obj/item/saw)
-	if(!saw.get_sharpness() || !is_type_in_typecache(saw, GLOB.gun_saw_types) && saw.tool_behaviour != TOOL_SAW) //needs to be sharp. Otherwise turned off eswords can cut this.
-		return
-	if(sawn_off)
-		to_chat(user, "<span class='warning'>\The [src] is already shortened!</span>")
-		return
-	user.changeNext_move(CLICK_CD_MELEE)
-	user.visible_message("<span class='notice'>[user] begins to shorten \the [src].</span>", "<span class='notice'>You begin to shorten \the [src]...</span>")
-
-	//if there's any live ammo inside the gun, makes it go off
-	if(blow_up(user))
-		user.visible_message("<span class='danger'>\The [src] goes off!</span>", "<span class='danger'>\The [src] goes off in your face!</span>")
-		return
-
-	if(do_after(user, 30, target = src))
-		if(sawn_off)
-			return
-		user.visible_message("<span class='notice'>[user] shortens \the [src]!</span>", "<span class='notice'>You shorten \the [src].</span>")
-		name = "sawn-off [src.name]"
-		desc = sawn_desc
-		w_class = WEIGHT_CLASS_NORMAL
-		item_state = "gun"
-		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
-		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-		recoil = SAWN_OFF_RECOIL
-		sawn_off = TRUE
-		update_appearance()
-		return TRUE
-
-///used for sawing guns, causes the gun to fire without the input of the user
-/obj/item/gun/ballistic/proc/blow_up(mob/user)
+/obj/item/gun/ballistic/blow_up(mob/user)
 	. = FALSE
 	for(var/obj/item/ammo_casing/AC in magazine.stored_ammo)
 		if(AC.BB)

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -121,13 +121,8 @@
 		mob_overlay_state = item_state
 
 /obj/item/gun/ballistic/rifle/illestren/sawn
-	name = "sawn-off Illestren rifle"
 	desc = "An Illestren rifle sawn down to a ridiculously small size. There was probably a reason it wasn't made this short to begin with, but it still packs a punch."
-	item_state = "illestren_sawn"
 	sawn_off = TRUE
-	weapon_weight = WEAPON_MEDIUM
-	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/ballistic/rifle/solgov
 	name = "SSG-669C"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -94,7 +94,7 @@
 /obj/item/gun/ballistic/rifle/illestren/empty //i had to name it empty instead of no_mag because else it wouldnt work with guncases. sorry!
 	spawnwithmagazine = FALSE
 
-/obj/item/gun/ballistic/rifle/illestren/sawoff(mob/user)
+/obj/item/gun/ballistic/rifle/illestren/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		spread = 24
@@ -114,7 +114,7 @@
 	icon_state = "illestren_factory"
 	item_state = "illestren_factory"
 
-/obj/item/gun/ballistic/rifle/illestren/sawoff(mob/user)
+/obj/item/gun/ballistic/rifle/illestren/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "illestren_factory_sawn"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -74,7 +74,7 @@
 	can_be_sawn_off = TRUE
 
 
-/obj/item/gun/ballistic/shotgun/brimstone/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/brimstone/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		weapon_weight = WEAPON_MEDIUM
@@ -108,7 +108,7 @@
 	rack_sound = 'sound/weapons/gun/shotgun/rack_alt.ogg'
 	fire_delay = 0.1 SECONDS
 
-/obj/item/gun/ballistic/shotgun/hellfire/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/hellfire/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		var/obj/item/ammo_box/magazine/internal/tube = magazine
@@ -316,7 +316,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	if(unique_reskin && !current_skin && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY) && (!bolt_locked))
 		reskin_obj(user)
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		weapon_weight = WEAPON_MEDIUM
@@ -361,7 +361,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	item_state = "dshotgun_srm"
 	unique_reskin = null
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/roumain/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/roumain/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "dshotgun_srm_sawn"
@@ -416,7 +416,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	if(sawn_off)
 		. += "ishotgun_sawn"
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawoff(forced = FALSE)
 	. = ..()
 	if(. && slung) //sawing off the gun removes the sling
 		new /obj/item/stack/cable_coil(get_turf(src), 10)
@@ -596,7 +596,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 		balloon_alert_to_viewers("quickly racks!")
 		fire_delay = 0 SECONDS
 
-/obj/item/gun/ballistic/shotgun/flamingarrow/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/flamingarrow/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		var/obj/item/ammo_box/magazine/internal/tube = magazine
@@ -621,7 +621,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	base_icon_state = "flamingarrow_factory"
 	item_state = "flamingarrow_factory"
 
-/obj/item/gun/ballistic/shotgun/flamingarrow/factory/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/flamingarrow/factory/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "flamingarrow_factory_sawn"
@@ -634,7 +634,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	icon_state = "flamingbolt"
 	item_state = "flamingbolt"
 
-/obj/item/gun/ballistic/shotgun/flamingarrow/bolt/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/flamingarrow/bolt/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "flamingbolt_sawn"
@@ -650,7 +650,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	sawn_desc = "A large lever-action rifle, sawn down for portability. It looks much cooler, but you should probably be using a revolver..."
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/winchester/absolution
 
-/obj/item/gun/ballistic/shotgun/flamingarrow/absolution/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/flamingarrow/absolution/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		var/obj/item/ammo_box/magazine/internal/tube = magazine
@@ -682,7 +682,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	sawn_desc = "A lever action shotgun that's been sawed down for portability. The recoil makes it mostly useless outside of point-blank range, but it hits hard for its size and, more importantly, can be flipped around stylishly."
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/winchester/conflagration
 
-/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		var/obj/item/ammo_box/magazine/internal/tube = magazine
@@ -765,7 +765,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	gun_firemodes = list(FIREMODE_SEMIAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/beacon/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/beacon/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "beacon_sawn"
@@ -788,7 +788,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	icon_state = "beacon_factory"
 	item_state = "beacon_factory"
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/beacon/factory/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/beacon/factory/sawoff(forced = FALSE)
 	. = ..()
 	if(.)
 		item_state = "beacon_factory_sawn"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -424,13 +424,7 @@ EMPTY_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 		update_appearance()
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawn
-	name = "sawn-off improvised shotgun"
-	desc = "A single-shot shotgun. Better not miss."
-	icon_state = "ishotgun_sawn"
-	item_state = "ishotgun_sawn"
-	w_class = WEIGHT_CLASS_NORMAL
 	sawn_off = TRUE
-	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact/compact
 	name = "compact compact combat shotgun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
you dont have to re declare all your sawn off variables
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
easier sawn off weapons
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: sawnoff weapons made from init now function correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
