### PR TITLE
The Frontier Ablaze: Ramzi's Molotov Cookbook

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -479,7 +479,13 @@
 			break
 	if(firestarter && active)
 		hit_atom.fire_act()
-		new /obj/effect/hotspot(get_turf(hit_atom))
+		var/turf/T = get_turf(hit_atom)
+		T.IgniteTurf(30)
+		var/turf/otherT
+		for(var/direction in GLOB.cardinals)
+			otherT = get_step(T, direction)
+			otherT.IgniteTurf(30)
+			new /obj/effect/hotspot(otherT)
 	..()
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attackby(obj/item/I, mob/user, params)

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -126,7 +126,7 @@
 		T.IgniteTurf(reac_volume)
 		new /obj/effect/hotspot(T, reac_volume * 1, FIRE_MINIMUM_TEMPERATURE_TO_EXIST + reac_volume * 10)
 		var/turf/otherT
-		for(var/direction in GLOB.cardinals)
+		for(var/direction in GLOB.alldirs)
 			otherT = get_step(T, direction)
 			otherT.IgniteTurf(reac_volume)
 			new /obj/effect/hotspot(otherT, reac_volume * 1, FIRE_MINIMUM_TEMPERATURE_TO_EXIST + reac_volume * 10)


### PR DESCRIPTION
## About The Pull Request

**The World Aflame**
![theworldaflame](https://github.com/user-attachments/assets/75b4f565-ab87-48c2-9526-3ef9f7163204)

Molotovs now create turf fires on its own turf and adjacent ones. As Hearthwine does something similar with a trickier conditional (contact), it creates turf fires beyond adjacent turfs now.

## Why It's Good For The Game

Molotov's are exceedingly Nothing, and this should ignite An Inferno within every spacer's heart. Burns much less fiercely and causes less firestacks than hearthwine in absence of combustible material, but should be enough to deny people access to chokepoints or to cause a panic.

## Changelog

:cl:
balance: Molotov cocktails now create turf fires
balance: Hearthwine now create turf fires in a 3x3 area
/:cl: