### PR TITLE
Parity for small ships

### DIFF
--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -31,7 +31,7 @@
 		},
 		"Deckhand": {
 			"outfit": "/datum/outfit/job/independent/assistant",
-			"slots": 2
+			"slots": 1
 		}
 	},
 	"enabled": true

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -15,7 +15,7 @@
 		"SPACE"
 	],
 	"map_path": "_maps/shuttles/independent/independent_mudskipper.dmm",
-	"limit": 1,
+	"limit": 2,
 	"starting_funds": 1500,
 	"job_slots": {
 		"Salvage Leader": {
@@ -29,7 +29,7 @@
 		},
 		"Salvage Technician": {
 			"outfit": "/datum/outfit/job/independent/engineer",
-			"slots": 2
+			"slots": 1
 		}
 	},
 	"enabled": true

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -29,7 +29,7 @@
 		},
 		"Salvage Technician": {
 			"outfit": "/datum/outfit/job/independent/engineer",
-			"slots": 1
+			"slots": 2
 		}
 	},
 	"enabled": true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nixes the extra deckhand from Kilo and increases the Mudskipper's spawn limit by 1. Hopefully we don't just get those maxed out every single round.

## Why It's Good For The Game

Brings the two smallest ships in the game into parity with each other, and provides at least a little more flexibility for players that respawn or come in late.

## Changelog

:cl:
balance: increased mudskipper limit to 2
balance: cut a deckhand slot from kilo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
