### PR TITLE
Shaves the Vaquero

### DIFF
--- a/_maps/configs/inteq_vaquero.json
+++ b/_maps/configs/inteq_vaquero.json
@@ -39,7 +39,7 @@
 		},
 		"Recruit": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
-			"slots": 2
+			"slots": 1
 		}
 	},
 	"enabled": true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Snips one recruit slot off of the Vaquero

## Why It's Good For The Game

thgvr request, also the vaq's genuinely overpopped. two recruits/deckhands is a handful even on a bigger ship, the vaq doesnt need a third of its crew to not know what they're doing

## Changelog

:cl:
balance: removed one recruit slot from the vaquero
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
