### PR TITLE
Reduces the chance for grenades to go off in your hands

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -20,7 +20,7 @@
 	var/chem = /datum/reagent/water
 	var/safety = TRUE
 	var/refilling = FALSE
-	var/tanktype = /obj/structure/reagent_dispensers/watertank
+	var/tanktype = /obj/structure/ //A simple tanktype change won't do it
 	var/sprite_name = "fire_extinguisher"
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -20,7 +20,7 @@
 	var/chem = /datum/reagent/water
 	var/safety = TRUE
 	var/refilling = FALSE
-	var/tanktype = /obj/structure/ //A simple tanktype change won't do it
+	var/tanktype = /obj/structure/reagent_dispensers/watertank
 	var/sprite_name = "fire_extinguisher"
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -154,11 +154,12 @@
 	var/list/valid_hands = list(FALSE, FALSE)
 	if (istype(owner.held_items[1], (/obj/item/grenade)))
 		valid_hands[1] = TRUE
-		message_admins("<span class='danger'>[owner.held_items[1]]</span>")
+		message_admins("<span class='danger'>Left arm</span>")
 	if (istype(owner.held_items[2], (/obj/item/grenade)))
 		valid_hands[2] = TRUE
-		message_admins("<span class='danger'>[owner.held_items[2]]</span>")
+		message_admins("<span class='danger'>Right arm</span>")
 
+	// P.def_zone = "r_arm" and P.def_zone = "l_arm" are the way to go
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(2)) //2% chance to go off
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -148,15 +148,16 @@
 /obj/item/grenade/attack_paw(mob/user)
 	return attack_hand(user)
 //I should add a check to see if the projectile hits the active_hand_index -- hand_bodyparts [1] = left arm, [2] = right arm -- held_items[2] == type(obj/item/grenade) -- hitby.def_zone = "r_arm"
+//oooor. Since the proc already checks for it, just see if a hand isn't empty.
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
 	var/list/valid_hands = list(FALSE, FALSE)
-	//if (owner.held_items[1] == typesof(obj/item/grenade))
-	valid_hands[1] = TRUE
-	owner.visible_message("<span class='danger'>[owner.held_items[1]]</span>")
-	//if (owner.held_items[2] == typesof(obj/item/grenade))
-	valid_hands[2] = TRUE
-	owner.visible_message("<span class='danger'>[owner.held_items[2]]</span>")
+	if (istype(owner.held_items[1], (/obj/item/grenade)))
+		valid_hands[1] = TRUE
+		message_admins("<span class='danger'>[owner.held_items[1]]</span>")
+	if (istype(owner.held_items[2], (/obj/item/grenade)))
+		valid_hands[2] = TRUE
+		message_admins("<span class='danger'>[owner.held_items[2]]</span>")
 
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(2)) //2% chance to go off
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -151,10 +151,12 @@
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
 	var/list/valid_hands = list(FALSE, FALSE)
-	if (owner.held_items[1] != null)
-		valid_hands[1] = TRUE
-	if (owner.held_items[2] != null)
-		valid_hands[2] = TRUE
+	//if (owner.held_items[1] == typesof(obj/item/grenade))
+	valid_hands[1] = TRUE
+	owner.visible_message("<span class='danger'>[owner.held_items[1]]</span>")
+	//if (owner.held_items[2] == typesof(obj/item/grenade))
+	valid_hands[2] = TRUE
+	owner.visible_message("<span class='danger'>[owner.held_items[2]]</span>")
 
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(2)) //2% chance to go off
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -150,7 +150,7 @@
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
-	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(1) && prob(50))
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(0.5))
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -147,10 +147,16 @@
 
 /obj/item/grenade/attack_paw(mob/user)
 	return attack_hand(user)
-
+//I should add a check to see if the projectile hits the active_hand_index -- hand_bodyparts [1] = left arm, [2] = right arm -- held_items[2] == type(obj/item/grenade) -- hitby.def_zone = "r_arm"
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
-	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(0.5)) //0.5%, not 50%. Yeah. DM is weird like that.
+	var/list/valid_hands = list(FALSE, FALSE)
+	if (owner.held_items[1] != null)
+		valid_hands[1] = TRUE
+	if (owner.held_items[2] != null)
+		valid_hands[2] = TRUE
+
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(2)) //2% chance to go off
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -147,20 +147,21 @@
 
 /obj/item/grenade/attack_paw(mob/user)
 	return attack_hand(user)
-//I should add a check to see if the projectile hits the active_hand_index -- hand_bodyparts [1] = left arm, [2] = right arm -- held_items[2] == type(obj/item/grenade) -- hitby.def_zone = "r_arm"
-//oooor. Since the proc already checks for it, just see if a hand isn't empty.
+
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
 	var/list/valid_hands = list(FALSE, FALSE)
-	if (istype(owner.held_items[1], (/obj/item/grenade)))
-		valid_hands[1] = TRUE
-		message_admins("<span class='danger'>Left arm</span>")
-	if (istype(owner.held_items[2], (/obj/item/grenade)))
-		valid_hands[2] = TRUE
-		message_admins("<span class='danger'>Right arm</span>")
 
-	// P.def_zone = "r_arm" and P.def_zone = "l_arm" are the way to go
-	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(2)) //2% chance to go off
+	//checks if the projectile hits an arm holding a grenade
+	if (istype(owner.held_items[1], (/obj/item/grenade)))
+		if (P.def_zone == "l_arm")
+			valid_hands[1] = TRUE
+
+	if (istype(owner.held_items[2], (/obj/item/grenade)))
+		if (P.def_zone == "r_arm")
+			valid_hands[2] = TRUE
+
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && (valid_hands[1] || valid_hands[2]) && prob(5)) //5% chance to go off
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -150,7 +150,7 @@
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
-	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(15))
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(1) && prob(50))
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -150,7 +150,7 @@
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/projectile/P = hitby
-	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(0.5))
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(0.5)) //0.5%, not 50%. Yeah. DM is weird like that.
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change reduces the probability of a grenade blowing up in one's hands from 15% down to 5%.

Please let me know if this probability is too low. I just chose an oddball low number to use.

The check was also modified so that the dice roll is only made if a projectile hits a hand holding a grenade.

## Why It's Good For The Game

It always felt a little too high of a chance to me. The probability roll happens for _each_ projectile that one gets hit with, and with how often and how rapidly one can be hit in a firefight here, the chance of it blowing up in ones hands goes from being somewhat unlikely to being more likely to happen than not.

![image](https://github.com/user-attachments/assets/4a88545b-768d-480d-b8a1-38df915e1ea2)
This calculator gives the probability of the event occurring as being 68% likely, if one were shot 7 times. This is around how many shots it takes to bring someone down, on average, from my anecdotal experience.

This currently has the effect of making grenades useful in only a few very specific scenarios. 

If the probability of this were to go down, it would encourage the use of grenades more, which I feel can enhance fights.

## Changelog

:cl:
balance: rebalanced the probability of a grenade going off in one's hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
