### PR TITLE
Simple mobs now can be hit with bolas and beartraps

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -295,7 +295,11 @@
 				snap = FALSE
 
 			var/def_zone = BODY_ZONE_CHEST
-			if(snap && iscarbon(L))
+			if(snap && isanimal(L))
+				var/mob/living/simple_animal/SA = L
+				if(SA.mob_size <= MOB_SIZE_TINY) //don't close the trap if they're as small as a mouse.
+					snap = FALSE
+			if(snap && (iscarbon(L) || isanimal(L)))
 				var/mob/living/carbon/C = L
 				if(C.body_position == STANDING_UP)
 					def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
@@ -305,10 +309,6 @@
 						C.update_equipment_speed_mods()
 						C.update_inv_legcuffed()
 						SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-			else if(snap && isanimal(L))
-				var/mob/living/simple_animal/SA = L
-				if(SA.mob_size <= MOB_SIZE_TINY) //don't close the trap if they're as small as a mouse.
-					snap = FALSE
 			if(snap)
 				close_trap()
 				L.visible_message("<span class='danger'>[L] gets caught by \the [src]!</span>", \
@@ -357,7 +357,7 @@
 	playsound(src.loc,'sound/weapons/bolathrow.ogg', 75, TRUE)
 
 /obj/item/restraints/legcuffs/bola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
+	if(..() || !(iscarbon(hit_atom) || isanimal(hit_atom)))//if it gets caught or the target can't be cuffed,
 		return//abort
 	ensnare(hit_atom)
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -16,7 +16,6 @@
 	var/dreaming = 0 ///How many dream images we have left to send
 
 	var/obj/item/handcuffed = null ///Whether or not the mob is handcuffed
-	var/obj/item/legcuffed = null  ///Same as handcuffs but for legs. Bear traps use this.
 
 	var/disgust = 0
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -89,6 +89,7 @@
 	var/metabolism_efficiency = 1 ///more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..
 	var/has_limbs = 0 ///does the mob have distinct limbs?(arms,legs, chest,head)
 
+	var/obj/item/legcuffed = null  ///Same as handcuffs but for legs. Bear traps and bolas use this.
 	///How many legs does this mob have by default. This shouldn't change at runtime.
 	var/default_num_legs = 2
 	///How many legs does this mob currently have. Should only be changed through set_num_legs()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -341,6 +341,8 @@
 		approaching_target = TRUE
 	else
 		approaching_target = FALSE
+	if(legcuffed)
+		delay += legcuffed?.slowdown
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
@@ -457,6 +459,8 @@
 	if(dodging && approaching_target && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
 		return dodge(newloc,dir)
 	else
+		if(legcuffed)
+			resist_restraints()
 		return ..()
 
 /mob/living/simple_animal/hostile/proc/dodge(moving_to,move_direction)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -28,6 +28,7 @@
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
+	legcuff_resist_chance = 50
 	var/mob_trophy
 	var/achievement_type
 	var/crusher_achievement_type

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -142,6 +142,7 @@
 	var/my_z
 	///What kind of footstep this mob should have. Null if it shouldn't have any.
 	var/footstep_type
+	var/legcuff_resist_chance = 5
 
 /mob/living/simple_animal/Initialize(mapload)
 	. = ..()
@@ -566,7 +567,7 @@
 	if(legcuffed)
 		visible_message("<span class='warning'>[src] attempts to free [p_them()]self!</span>", \
 			span_notice("YYou attempt to free yourself..."))
-		if(prob(10))
+		if(prob(legcuff_resist_chance))
 			visible_message(span_warning("[src] is able free [p_them()]self!"), \
 				span_notice("You free yourself!"))
 			legcuffed.forceMove(drop_location())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple mobs now get a leg-cuff slot and some small logic to handle it
Hostile mobs will automatically try and resist on every move
Code is honestly mid but I don't want to spend a ton of time on it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More interesting hunting options
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: You can now bola and beartrap fauna!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
