### PR TITLE
Reinforces the windows on the Mudskipper

### DIFF
--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -1016,6 +1016,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"xR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "mudskipper_window"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/aft)
 "xU" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1051,7 +1059,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "yB" = (
@@ -1431,7 +1439,7 @@
 	dir = 4;
 	id = "mudskipper_bridge"
 	},
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "Gq" = (
@@ -1811,7 +1819,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
@@ -1823,10 +1831,10 @@
 "Qt" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
-/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Qu" = (
@@ -2224,7 +2232,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "XI" = (
@@ -2278,7 +2286,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/ship/crew)
 "Yi" = (
@@ -2566,7 +2574,7 @@ cs
 hX
 cs
 cs
-Xm
+xR
 yg
 XK
 Ni


### PR DESCRIPTION
## About The Pull Request

Compared to all the other ships of it's manufacturing company (the Kilo, the Shetland...) the mudskipper oddly lacks reinforced windows. This brings it up to par with the rest of the dubiously well constructed ships adjacent to it.
Shetland:
![image](https://github.com/user-attachments/assets/935c2ff1-d90a-41c6-9afe-1a7278490dc1)
Kilo:
![image](https://github.com/user-attachments/assets/7dc153af-c149-4494-a538-059f5438b5d5)

## Why It's Good For The Game

https://github.com/user-attachments/assets/481c70a8-f2d1-460d-b2b6-947b3c18e1ea

You can also do this with a single screwdriver.

## Changelog

:cl:
fix: Mudskipper windows are correctly reinforced, like other ships by the same manufacturer. 
/:cl: