### PR TITLE
Nanotrasen Turrets

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_delta.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_delta.dmm
@@ -1371,9 +1371,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "jH" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 9;
-	id = "delta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "delta_grid";
+	dir = 9
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -2891,9 +2891,9 @@
 /turf/open/floor/plasteel/white,
 /area/ship/science/robotics)
 "WG" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 4;
-	id = "delta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "delta_grid";
+	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -3018,9 +3018,9 @@
 /turf/open/floor/plasteel/white,
 /area/ship/science/robotics)
 "YZ" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 10;
-	id = "delta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "delta_grid";
+	dir = 10
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)

--- a/_maps/shuttles/nanotrasen/nanotrasen_meta.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_meta.dmm
@@ -1680,9 +1680,10 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "jo" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 4;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew)
@@ -2206,9 +2207,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "uT" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 4;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/canteen/kitchen)
@@ -2399,9 +2401,10 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "yF" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 1;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 5
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
@@ -3079,9 +3082,10 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Lo" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 2;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 6
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
@@ -3480,16 +3484,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "TR" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 2;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 10
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/canteen)
 "TV" = (
-/obj/machinery/porta_turret/ship/weak{
-	dir = 1;
-	id = "meta_grid"
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "meta_grid";
+	pixel_y = 0;
+	dir = 9
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -842,6 +842,44 @@ DEFINE_BITFIELD(turret_flags, list(
 	stun_projectile_sound = 'sound/weapons/gun/smg/shot.ogg'
 	desc = "A ballistic machine gun auto-turret."
 
+//high rof, range, faster projectile speed
+/* 'Nanotrasen' turrets */
+
+/obj/machinery/porta_turret/ship/nt
+	name = "Sharplite Defense Turret"
+	desc = "A cheap and effective turret designed by Sharplite and purchased and installed on most Nanotrasen Vessels."
+	faction = list(FACTION_PLAYER_NANOTRASEN, "turret")
+	icon_state = "standard_lethal"
+	base_icon_state = "standard"
+	stun_projectile = /obj/projectile/beam/disabler/sharplite
+	lethal_projectile = /obj/projectile/beam/laser/sharplite
+	lethal_projectile_sound = 'sound/weapons/gun/laser/nt-fire.ogg'
+	stun_projectile_sound = 'sound/weapons/taser2.ogg'
+	shot_delay = 10
+	scan_range = 10
+
+/obj/machinery/porta_turret/ship/nt/light
+	name = "Sharplite LDS"
+	desc = "A cheap and effective 'defensive system' designed by Sharplite for installation on Nanotrasen vessels."
+	stun_projectile = /obj/projectile/beam/disabler/weak/sharplite
+	lethal_projectile = /obj/projectile/beam/laser/light/sharplite
+	lethal_projectile_sound = 'sound/weapons/gun/laser/nt-fire.ogg'
+	stun_projectile_sound = 'sound/weapons/taser2.ogg'
+
+
+/obj/machinery/porta_turret/ship/nt/heavy
+	name = "Sharplite Defense Cannon"
+	desc = "A heavy laser mounting designed by Sharplite for usage on Nanotrasen vessels."
+	lethal_projectile = /obj/projectile/beam/laser/heavylaser/sharplite
+	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
+
+/obj/machinery/porta_turret/ship/nt/pulse
+	name = "Sharplite Pulse Cannon"
+	desc = "A pulse cannon mounting designed by Sharplite. Not sold to any purchasers and exclusively used on Nanotrasen Vessels."
+	lethal_projectile = /obj/projectile/beam/pulse/sharplite_turret
+	lethal_projectile_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'
+
+
 
 /* Syndicate Turrets */
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,6 +37,15 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
+/obj/projectile/beam/laser/sharplite
+	speed = 0.4
+
+/obj/projectile/beam/laser/light
+	damage = 15
+
+/obj/projectile/beam/laser/light/sharplite
+	speed = 0.4
+
 /obj/projectile/beam/laser/eoehoma
 	damage = 25
 	armour_penetration = -10
@@ -53,6 +62,9 @@
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
+
+/obj/projectile/beam/laser/heavylaser/sharplite
+	speed = 0.4
 
 /obj/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -119,8 +131,14 @@
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
 
+/obj/projectile/beam/disabler/sharplite
+	speed = 0.4
+
 /obj/projectile/beam/disabler/weak
 	damage = 15
+
+/obj/projectile/beam/disabler/weak/sharplite
+	speed = 0.4
 
 /obj/projectile/beam/disabler/weak/negative_ap
 	armour_penetration = -30
@@ -147,6 +165,11 @@
 	if(!isopenturf(targets_turf))
 		return
 	targets_turf.IgniteTurf(rand(8,22), "blue")
+
+/obj/projectile/beam/pulse/sharplite_turret
+	wall_damage_flags = null
+	wall_damage_override = 0
+	speed = 0.4
 
 /obj/projectile/beam/pulse/shotgun
 	damage = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Nanotrasen ship turrets.

Nanotrasen ship turrets are higher rof, higher range, less damage, somewhat slower projectiles (not a major amount, but still slower). 
The only turret mapped in currently is the /light turret, on the Meta and Delta. A medium turret, heavy turret, and pulse turret are also defined for mapper usage. 

Note: They will not actually be higher ROF until #3407 is resolved. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Continud turretification.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Sharplite has produced a line of turrets for Nanotrasen, which is now mounting them on relevant vessels. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
