### PR TITLE
Minor changes to riggs lighting

### DIFF
--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -2288,6 +2288,7 @@
 /obj/effect/turf_decal/corner/opaque/blue/border{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Bp" = (
@@ -3380,11 +3381,6 @@
 /obj/item/pen/fountain/captain{
 	pixel_x = 6;
 	pixel_y = 5
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 5;
-	pixel_y = -20
 	},
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a single lightswitch in the helm because there's already one like not even a tile from it and it takes up a wall slot
Adds one light tube to the first officer's box so the switch in there actually does something outside act as a vector to annoy the captain (the room is in the same area as the helm)

## Changelog

:cl:
balance: Removes an extra lightswitch in the riggs helm and adds a light tube to the officer box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
