### PR TITLE
Replaces the red insulated gloves in syndicate toolboxes with normal insulated gloves

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -177,7 +177,7 @@
 	new /obj/item/crowbar/syndie(src) //WS Begin - Cool Syndie Tools
 	new /obj/item/wirecutters/syndie(src)
 	new /obj/item/multitool/syndie(src) //WS End
-	new /obj/item/clothing/gloves/color/red/insulated(src)
+	new /obj/item/clothing/gloves/color/yellow(src)
 
 /obj/item/storage/toolbox/syndicate/empty
 


### PR DESCRIPTION
## About The Pull Request

Says in the title

## Why It's Good For The Game

Red insuls look like Shit

## Changelog

:cl:
balance: Replace red insuls with yellow insuls in syndicate toolboxes
/:cl: