### PR TITLE
Removes the extra turret from the crying sun and slightly re-organizes the armory

### DIFF
--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -225,16 +225,13 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "bT" = (
-/obj/item/storage/box/flashbangs{
-	pixel_x = -7;
-	pixel_y = 7
-	},
 /obj/item/storage/box/zipties{
 	pixel_y = 7;
-	pixel_x = 8
+	pixel_x = 4
 	},
 /obj/item/storage/box/flashes{
-	pixel_y = -1
+	pixel_y = -1;
+	pixel_x = -7
 	},
 /obj/item/screwdriver{
 	pixel_x = -5;
@@ -2373,6 +2370,19 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "uo" = (
+/obj/structure/closet/secure_closet/wall/directional/west{
+	icon_state = "sec_wall";
+	name = "ordnance locker"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/purple{
+	dir = 10
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_y = 7
+	},
 /obj/item/grenade/frag{
 	pixel_x = -8;
 	pixel_y = -1
@@ -2382,10 +2392,6 @@
 	pixel_y = -8
 	},
 /obj/item/grenade/smokebomb{
-	pixel_y = 3;
-	pixel_x = 13
-	},
-/obj/item/grenade/smokebomb{
 	pixel_y = 1;
 	pixel_x = 7
 	},
@@ -2393,15 +2399,9 @@
 	pixel_x = 11;
 	pixel_y = -5
 	},
-/obj/structure/closet/secure_closet/wall/directional/west{
-	icon_state = "sec_wall";
-	name = "equipment locker"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/purple{
-	dir = 10
+/obj/item/grenade/smokebomb{
+	pixel_y = 3;
+	pixel_x = 13
 	},
 /turf/open/floor/vault,
 /area/ship/security/armory)
@@ -3612,17 +3612,6 @@
 /obj/item/clothing/head/helmet/space/gezena,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"DG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/porta_turret/ship/pgf/light{
-	dir = 5;
-	mode = 1;
-	id = "crying_sun_grid"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "DJ" = (
 /obj/effect/turf_decal/industrial/traffic,
 /obj/structure/sign/flag/gezena{
@@ -7431,7 +7420,7 @@ xz
 xz
 xz
 Si
-DG
+KB
 KM
 Te
 EM

--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -2380,9 +2380,16 @@
 /obj/effect/turf_decal/corner/opaque/purple{
 	dir = 10
 	},
+/obj/item/storage/box/flashbangs{
+	pixel_y = 6
+	},
 /obj/item/grenade/frag{
 	pixel_x = -10;
 	pixel_y = -1
+	},
+/obj/item/grenade/frag{
+	pixel_x = -5;
+	pixel_y = -6
 	},
 /obj/item/grenade/smokebomb{
 	pixel_y = 2;
@@ -2395,13 +2402,6 @@
 /obj/item/grenade/smokebomb{
 	pixel_x = 11;
 	pixel_y = -5
-	},
-/obj/item/grenade/frag{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_y = 6
 	},
 /turf/open/floor/vault,
 /area/ship/security/armory)

--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -2380,28 +2380,28 @@
 /obj/effect/turf_decal/corner/opaque/purple{
 	dir = 10
 	},
-/obj/item/storage/box/flashbangs{
-	pixel_y = 7
-	},
 /obj/item/grenade/frag{
-	pixel_x = -8;
+	pixel_x = -10;
 	pixel_y = -1
 	},
-/obj/item/grenade/frag{
-	pixel_x = -3;
-	pixel_y = -8
+/obj/item/grenade/smokebomb{
+	pixel_y = 2;
+	pixel_x = 13
 	},
 /obj/item/grenade/smokebomb{
-	pixel_y = 1;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = -2
 	},
 /obj/item/grenade/smokebomb{
 	pixel_x = 11;
 	pixel_y = -5
 	},
-/obj/item/grenade/smokebomb{
-	pixel_y = 3;
-	pixel_x = 13
+/obj/item/grenade/frag{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_y = 6
 	},
 /turf/open/floor/vault,
 /area/ship/security/armory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes an extra turret that found it's way onto the hull of the PGF Crying Sun, likely in the recent PGF turret overhaul. Additionally, a locker in the armory has been renamed and the flashbangs have been moved from the Marine equipment locker to the Lieutenant's ordnance locker. I've attached an image below to show how it's now organized.

![Screenshot 2024-10-03 172121](https://github.com/user-attachments/assets/c8c123e3-0c39-4fc6-b7e1-d2c545ac0631)
![Screenshot 2024-10-04 015626](https://github.com/user-attachments/assets/9440b65f-ff3e-48f2-8a35-05ae0f442ad6)
![Screenshot 2024-10-17 131256](https://github.com/user-attachments/assets/d2fe5685-ffb8-487a-9d2f-c7228a8ea099)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ships having automated turrets that they weren't meant to have is generally a bad thing for balance and being able to enjoy the ship's lovingly labored over design. As for the flashbangs, the ship's fragmentation and smoke grenades were already being controlled by the lieutenant so it seems logical to do the same with grenades that can blind and deafen someone.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Removed extra turret that wasn't supposed to be on the ship
fix: Moved armory flashbangs to a more secure location
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
