### PR TITLE
Un-nerfs Kepori

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -17,7 +17,7 @@
 	species_clothing_path = 'icons/mob/clothing/species/kepori.dmi'
 	species_eye_path = 'icons/mob/species/kepori/kepori_eyes.dmi'
 	heatmod = 0.67
-	// coldmod = 1.5
+	coldmod = 1.5
 	// brutemod = 1.5
 	// burnmod = 1.5
 	speedmod = -0.10

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -17,10 +17,10 @@
 	species_clothing_path = 'icons/mob/clothing/species/kepori.dmi'
 	species_eye_path = 'icons/mob/species/kepori/kepori_eyes.dmi'
 	heatmod = 0.67
-	coldmod = 1.5
-	brutemod = 1.5
-	burnmod = 1.5
-	speedmod = -0.25
+	// coldmod = 1.5
+	// brutemod = 1.5
+	// burnmod = 1.5
+	speedmod = -0.10
 	bodytemp_normal = HUMAN_BODYTEMP_NORMAL + 30
 	bodytemp_heat_damage_limit = HUMAN_BODYTEMP_HEAT_DAMAGE_LIMIT + 30
 	bodytemp_cold_damage_limit = HUMAN_BODYTEMP_COLD_DAMAGE_LIMIT + 30


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gonna try this out to see if it improves how Kepori actually feel. I don't really think straight up taking more damage is an interesting downside, considering their only upside was being a little faster. This also greatly lowers the movespeed modifier. 

Personally I don't really think it's a good idea to have a straight numbers modifier as a nerf like this, considering we balance things without even thinking about this. Projectiles and mob attacks do a high amount of damage, and it's all but guaranteed to break or completely disable a limb in one hit. With limb armor being fairly rare to come by, and the area a projectile/melee targets having RNG on where they actually hit, it's not actually that interesting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
balance: Removed Kepori damage modifiers.
balance: Decreased Kepori move speed modifier. (They are still a bit faster than average)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
