### PR TITLE
Makes Ration Heaters smaller.

### DIFF
--- a/code/game/objects/items/storage/ration.dm
+++ b/code/game/objects/items/storage/ration.dm
@@ -28,7 +28,9 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 7
-	STR.set_holdable(list(/obj/item/reagent_containers/food))
+	STR.set_holdable(list(
+		/obj/item/reagent_containers/food,
+		/obj/item/ration_heater))
 	STR.locked = TRUE
 	STR.locked_flavor = "sealed closed"
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -365,6 +365,7 @@
 	icon_state = "ration_heater"
 	grind_results = list(/datum/reagent/iron = 10, /datum/reagent/water = 10, /datum/reagent/consumable/sodiumchloride = 5)
 	heat = 3800
+	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/tocook = null
 	var/mutable_appearance/ration_overlay
 	var/uses = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Edits ration heaters to be able to be put back inside of ration packs.

## Why It's Good For The Game

It's really, really annoying that you can take ration heaters OUT of ration packs, but CANNOT put them back in. This fixes this by making them both the same size as the rations themselves, and adding ration heaters to the list of accepted items that can be put in ration packs.

## Changelog

:cl:
code: Changes flameless ration heaters to "small" items
code: Adds flameless ration heaters to the ration pack item whitelist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
