### PR TITLE
Gives simple humans armor

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -82,8 +82,6 @@
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper
 	icon_state = "frontiersmanrangedelite"
 	icon_living = "frontiersmanrangedelite"
-	maxHealth = 100
-	health = 100
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	projectilesound = 'sound/weapons/gun/shotgun/shot.ogg'
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot
@@ -167,8 +165,6 @@
 	icon_state = "frontiersmanrangedminigun"
 	icon_living = "frontiersmanrangedminigun"
 	projectilesound = 'sound/weapons/laser4.ogg'
-	maxHealth = 100
-	health = 100
 	armor = list("melee" = 50, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 60, "bio" = 100, "fire" = 70, "acid" = 50)
 	rapid = 6
 	rapid_fire_delay = 1.5
@@ -198,8 +194,6 @@
 	name = "Frontiersman Officer"
 	icon_state = "frontiersmanofficer"
 	icon_living = "frontiersmanofficer"
-	maxHealth = 100
-	health = 100
 	rapid = 7
 	rapid_fire_delay = 1
 	projectilesound = 'sound/weapons/gun/pistol/mauler.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -82,8 +82,9 @@
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper
 	icon_state = "frontiersmanrangedelite"
 	icon_living = "frontiersmanrangedelite"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	projectilesound = 'sound/weapons/gun/shotgun/shot.ogg'
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot
 	loot = list(/obj/effect/mob_spawn/human/corpse/frontier/ranged/trooper,
@@ -166,8 +167,9 @@
 	icon_state = "frontiersmanrangedminigun"
 	icon_living = "frontiersmanrangedminigun"
 	projectilesound = 'sound/weapons/laser4.ogg'
-	maxHealth = 260
-	health = 260
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 50, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 60, "bio" = 100, "fire" = 70, "acid" = 50)
 	rapid = 6
 	rapid_fire_delay = 1.5
 	casingtype = null
@@ -196,13 +198,15 @@
 	name = "Frontiersman Officer"
 	icon_state = "frontiersmanofficer"
 	icon_living = "frontiersmanofficer"
-	maxHealth = 65
-	health = 65
-	rapid = 4
+	maxHealth = 100
+	health = 100
+	rapid = 7
+	rapid_fire_delay = 1
 	projectilesound = 'sound/weapons/gun/pistol/mauler.ogg'
 	casingtype = /obj/item/ammo_casing/c9mm
 	loot = list(/obj/effect/mob_spawn/human/corpse/frontier/ranged/officer,
 				/obj/item/gun/ballistic/automatic/pistol/mauler)
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals
 	icon_state = "frontiersmanofficer_mask"

--- a/code/modules/mob/living/simple_animal/hostile/human/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/nanotrasen.dm
@@ -11,6 +11,7 @@
 	faction = list(ROLE_DEATHSQUAD)
 	check_friendly_fire = TRUE
 	dodging = TRUE
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /mob/living/simple_animal/hostile/human/nanotrasen/screaming
 	icon_state = "nanotrasen"
@@ -55,6 +56,7 @@
 	casingtype = /obj/item/ammo_casing/c46x30mm
 	projectilesound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/nanotrasenassaultsoldier)
+	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /mob/living/simple_animal/hostile/human/nanotrasen/elite
 	name = "Nanotrasen Elite Assault Officer"
@@ -62,8 +64,8 @@
 	icon = 'icons/mob/simple_human.dmi'
 	icon_state = "nanotrasen_ert"
 	icon_living = "nanotrasen_ert"
-	maxHealth = 150
-	health = 150
+	maxHealth = 100
+	health = 100
 	melee_damage_lower = 13
 	melee_damage_upper = 18
 	ranged = TRUE
@@ -73,6 +75,7 @@
 	retreat_distance = 0
 	minimum_distance = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	armor = list("melee" = 50, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 60, "bio" = 100, "fire" = 70, "acid" = 50)
 	minbodytemp = 0
 	projectiletype = /obj/projectile/beam/laser
 	projectilesound = 'sound/weapons/laser.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/human/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/nanotrasen.dm
@@ -64,8 +64,6 @@
 	icon = 'icons/mob/simple_human.dmi'
 	icon_state = "nanotrasen_ert"
 	icon_living = "nanotrasen_ert"
-	maxHealth = 100
-	health = 100
 	melee_damage_lower = 13
 	melee_damage_upper = 18
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/human/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/pirate.dm
@@ -74,6 +74,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	speed = 1
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /mob/living/simple_animal/hostile/human/pirate/ranged/space/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/human/survivors.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/survivors.dm
@@ -4,6 +4,7 @@
 	icon_state = "survivor_base"
 	icon_living = "survivor_base"
 	atmos_requirements = list("min_oxy" = 1, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 999, "min_n2" = 0, "max_n2" = 0)
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 10, "bomb" = 20, "bio" = 100, "rad" = 20, "fire" = 50, "acid" = 30)
 	loot = list(
 		/obj/effect/mob_spawn/human/corpse/damaged/whitesands
 	)

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -28,8 +28,6 @@
 	icon_state = "syndicate_space"
 	icon_living = "syndicate_space"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -45,8 +43,6 @@
 	icon_state = "syndicate_stormtrooper"
 	icon_living = "syndicate_stormtrooper"
 	name = "Ramzi Clique Assault Trooper"
-	maxHealth = 100
-	health = 100
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/melee //dude with a knife and no shields
@@ -65,8 +61,6 @@
 	icon_state = "syndicate_space_knife"
 	icon_living = "syndicate_space_knife"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -83,8 +77,6 @@
 	icon_state = "syndicate_stormtrooper_knife"
 	icon_living = "syndicate_stormtrooper_knife"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 100
-	health = 100
 	projectile_deflect_chance = 50
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
@@ -120,8 +112,6 @@
 	icon_state = "syndicate_space_sword"
 	icon_living = "syndicate_space_sword"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -143,8 +133,6 @@
 	icon_state = "syndicate_stormtrooper_sword"
 	icon_living = "syndicate_stormtrooper_sword"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 100
-	health = 100
 	projectile_deflect_chance = 50
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
@@ -170,8 +158,6 @@
 	icon_state = "syndicate_space_pistol"
 	icon_living = "syndicate_space_pistol"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -187,8 +173,6 @@
 	icon_state = "syndicate_stormtrooper_pistol"
 	icon_living = "syndicate_stormtrooper_pistol"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 100
-	health = 100
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/smg
@@ -202,8 +186,6 @@
 	icon_state = "syndicate_space_smg"
 	icon_living = "syndicate_space_smg"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -235,8 +217,6 @@
 	icon_state = "syndicate_space_shotgun"
 	icon_living = "syndicate_space_shotgun"
 	name = "Ramzi Clique Commando"
-	maxHealth = 100
-	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
@@ -252,8 +232,6 @@
 	icon_state = "syndicate_stormtrooper_shotgun"
 	icon_living = "syndicate_stormtrooper_shotgun"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 100
-	health = 100
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 ///////////////Misc////////////

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -20,6 +20,7 @@
 	check_friendly_fire = TRUE
 	dodging = TRUE
 	rapid_melee = 2
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 ///////////////Melee////////////
 
@@ -27,12 +28,13 @@
 	icon_state = "syndicate_space"
 	icon_living = "syndicate_space"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/space/Initialize()
 	. = ..()
@@ -43,8 +45,9 @@
 	icon_state = "syndicate_stormtrooper"
 	icon_living = "syndicate_stormtrooper"
 	name = "Ramzi Clique Assault Trooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/melee //dude with a knife and no shields
 	melee_damage_lower = 15
@@ -62,13 +65,14 @@
 	icon_state = "syndicate_space_knife"
 	icon_living = "syndicate_space_knife"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
 	projectile_deflect_chance = 50
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/space/Initialize()
 	. = ..()
@@ -79,9 +83,10 @@
 	icon_state = "syndicate_stormtrooper_knife"
 	icon_living = "syndicate_stormtrooper_knife"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
 	projectile_deflect_chance = 50
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/sword
 	melee_damage_lower = 30
@@ -115,13 +120,14 @@
 	icon_state = "syndicate_space_sword"
 	icon_living = "syndicate_space_sword"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
 	projectile_deflect_chance = 50
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/sword/space/Initialize()
 	. = ..()
@@ -137,9 +143,10 @@
 	icon_state = "syndicate_stormtrooper_sword"
 	icon_living = "syndicate_stormtrooper_sword"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
 	projectile_deflect_chance = 50
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 ///////////////Guns////////////
 
@@ -163,12 +170,13 @@
 	icon_state = "syndicate_space_pistol"
 	icon_living = "syndicate_space_pistol"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/space/Initialize()
 	. = ..()
@@ -179,8 +187,9 @@
 	icon_state = "syndicate_stormtrooper_pistol"
 	icon_living = "syndicate_stormtrooper_pistol"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/smg
 	rapid = 2
@@ -193,12 +202,13 @@
 	icon_state = "syndicate_space_smg"
 	icon_living = "syndicate_space_smg"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/smg/space/Initialize()
 	. = ..()
@@ -209,8 +219,9 @@
 	icon_state = "syndicate_stormtrooper_smg"
 	icon_living = "syndicate_stormtrooper_smg"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/shotgun
 	rapid = 2
@@ -224,12 +235,13 @@
 	icon_state = "syndicate_space_shotgun"
 	icon_living = "syndicate_space_shotgun"
 	name = "Ramzi Clique Commando"
-	maxHealth = 170
-	health = 170
+	maxHealth = 100
+	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
+	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/shotgun/space/Initialize()
 	. = ..()
@@ -240,8 +252,9 @@
 	icon_state = "syndicate_stormtrooper_shotgun"
 	icon_living = "syndicate_stormtrooper_shotgun"
 	name = "Ramzi Clique Stormtrooper"
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 
 ///////////////Misc////////////
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -21,16 +21,8 @@
 	mob_size = MOB_SIZE_LARGE
 	var/icon_aggro = null
 	var/trophy_drop_mod = 25
-	var/datum/armor/armor		//WS edit - Whitesands
 
 /mob/living/simple_animal/hostile/asteroid/Initialize(mapload)
-	if (islist(armor))		//WS edit begin - Whitesands
-		armor = getArmor(arglist(armor))
-	else if (!armor)
-		armor = getArmor()
-	else if (!istype(armor, /datum/armor))
-		stack_trace("Invalid type [armor.type] found in .armor during [src.type] Initialize()")		//WS edit begin - Whitesands
-
 	. = ..()
 	apply_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
 
@@ -44,11 +36,6 @@
 	if(stat == DEAD)
 		return
 	icon_state = icon_living
-
-/mob/living/simple_animal/hostile/asteroid/getarmor(def_zone, type)		//WS edit begin - Whitesands
-	if(armor)
-		return armor.getRating(type)
-	return 0		// If no armor		//WS edit end
 
 /mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -143,7 +143,15 @@
 	///What kind of footstep this mob should have. Null if it shouldn't have any.
 	var/footstep_type
 
+	var/datum/armor/armor
+
 /mob/living/simple_animal/Initialize(mapload)
+	if (islist(armor))
+		armor = getArmor(arglist(armor))
+	else if (!armor)
+		armor = getArmor()
+	else if (!istype(armor, /datum/armor))
+		stack_trace("Invalid type [armor.type] found in .armor during [src.type] Initialize()")
 	. = ..()
 	GLOB.simple_animals[AIStatus] += src
 	if(gender == PLURAL)
@@ -187,6 +195,11 @@
 			tamed(user)
 		else
 			tame_chance += bonus_tame_chance
+
+/mob/living/simple_animal/getarmor(def_zone, type)
+	if(armor)
+		return armor.getRating(type)
+	return FALSE
 
 ///Extra effects to add when the mob is tamed, such as adding a riding component
 /mob/living/simple_animal/proc/tamed(whomst)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Give simple humans armor by grabbing the behavior from asteroid mobs and giving them to simple mobs

## Why It's Good For The Game
@Apogee-dev and I have discussed this before, simple humans, even with armor are very weak to low calibers, its "balanced" out with more health, which isn't ideal. By doing this we encourage people to use higher calibers with simplemobs, otherwise they would be reserved for pvp

Seeing as the next gun expansion is exclusively 22 lr, and 22lr is disproportinately good against simplemobs vs actual players, this is better to do now
## Changelog

:cl:
add: Gives simple humans armor!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
