### PR TITLE
The airlock abandoner helper can no longer randomly turn doors into walls.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -167,23 +167,14 @@
 	if(abandoned)
 		var/outcome = rand(1,100)
 		switch(outcome)
-			if(1 to 9)
-				var/turf/here = get_turf(src)
-				for(var/turf/closed/T in range(2, src))
-					here.PlaceOnTop(T.type)
-					qdel(src)
-					return
-				here.PlaceOnTop(/turf/closed/wall)
-				qdel(src)
-				return
-			if(9 to 11)
+			if(1 to 5)
 				lights = FALSE
 				locked = TRUE
-			if(12 to 15)
+			if(6 to 11)
 				locked = TRUE
-			if(16 to 23)
+			if(12 to 21)
 				welded = TRUE
-			if(24 to 30)
+			if(22 to 30)
 				panel_open = TRUE
 	update_appearance()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
It's 9% of happening has been redistributed to other effects.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I assume it's an old feature for maintenance tunnels. Ima be real, doors randomly disapearing really isn't fun when mapping ruins and such, and the rest of the effects are fitting.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Abandoned airlocks can no longer randomly turn into walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
