### PR TITLE
Alters Abandoned Airlock Functionality

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -167,16 +167,7 @@
 	if(abandoned)
 		var/outcome = rand(1,100)
 		switch(outcome)
-			if(1 to 9)
-				var/turf/here = get_turf(src)
-				for(var/turf/closed/T in range(2, src))
-					here.PlaceOnTop(T.type)
-					qdel(src)
-					return
-				here.PlaceOnTop(/turf/closed/wall)
-				qdel(src)
-				return
-			if(9 to 11)
+			if(1 to 11)
 				lights = FALSE
 				locked = TRUE
 			if(12 to 15)
@@ -185,6 +176,19 @@
 				welded = TRUE
 			if(24 to 30)
 				panel_open = TRUE
+			if(31 to 40)
+				panel_open = TRUE
+				set_electrified(MACHINE_ELECTRIFIED_PERMANENT)
+			if(41 to 50)
+				seal = new /obj/item/door_seal(src)
+				modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
+			if(51 to 60)
+				new previous_airlock(loc)
+				QDEL(src)
+			if(69)
+				new /obj/effect/decal/cleanable/oil/slippery(loc)
+
+
 	update_appearance()
 
 /obj/machinery/door/airlock/ComponentInitialize()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -184,7 +184,7 @@
 				modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
 			if(51 to 60)
 				new previous_airlock(loc)
-				QDEL(src)
+				qdel(src)
 			if(69)
 				new /obj/effect/decal/cleanable/oil/slippery(loc)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes some effects from the abandoned airlock var 
-no more wall
adds new effects
-electroshock
-sealed
-airlock assembly
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: abandoned airlocks now have more effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
