### PR TITLE
Suspicious Duffel Bags now incur movement slowdown

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -483,7 +483,6 @@
 	desc = "A large duffel bag for holding extra tactical supplies."
 	icon_state = "duffel-syndie"
 	item_state = "duffel-syndieammo"
-	slowdown = 0
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffelbag/syndie/ComponentInitialize()


### PR DESCRIPTION
## About The Pull Request

Suspicious duffel bags now incur movement slowdown like any other duffel bag.

## Why It's Good For The Game

The amount of times I've seen this used to powergame storage is more times than I'd like to see.

## Changelog

:cl:
balance: Suspicious Duffel Bags now incur movement slowdown
/:cl: