### PR TITLE
Resolves issue #3487 -- Throwing bug fix

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -160,8 +160,6 @@ SUBSYSTEM_DEF(throwing)
 				finalize()
 			return
 
-		dist_travelled++
-
 		if(actual_target && !(actual_target.pass_flags_self & LETPASSTHROW) && actual_target.loc == AM.loc) // we crossed a movable with no density (e.g. a mouse or APC) we intend to hit anyway.
 			finalize(TRUE, actual_target)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fix removes a second increment to the dist_travelled variable. This line appears to have caused the throwing range of items to be halved, effectively. This fix should make it so that thrown objects go as far as they are intended to.

## Why It's Good For The Game

Resolves the issue linked here: https://github.com/shiptest-ss13/Shiptest/issues/3487

## Changelog

:cl:
fix: fixed halved throw range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
