### PR TITLE
Fixed the CLIP War Correspondent sprite for Vox

### DIFF
--- a/code/modules/clothing/factions/clip.dm
+++ b/code/modules/clothing/factions/clip.dm
@@ -331,7 +331,7 @@
 	item_state = "clip_m10_correspondant"
 
 	supports_variations = VOX_VARIATION
-	
+
 /obj/item/clothing/head/helmet/riot/clip
 	name = "\improper Minutemen riot helmet"
 	desc = "Designed to protect against close range attacks. Mainly used by the CMM-BARD against hostile xenofauna, it also sees prolific use on some Minutemen member worlds."

--- a/code/modules/clothing/factions/clip.dm
+++ b/code/modules/clothing/factions/clip.dm
@@ -330,6 +330,8 @@
 	icon_state = "clip_m10_correspondant"
 	item_state = "clip_m10_correspondant"
 
+	supports_variations = VOX_VARIATION
+	
 /obj/item/clothing/head/helmet/riot/clip
 	name = "\improper Minutemen riot helmet"
 	desc = "Designed to protect against close range attacks. Mainly used by the CMM-BARD against hostile xenofauna, it also sees prolific use on some Minutemen member worlds."


### PR DESCRIPTION
## About The Pull Request

This helmet has a Vox sprite available that used to work (but doesn't anymore for some reason), this PR makes it correctly show up now.

## Why It's Good For The Game

Fixes species support for an item that should have it.

## Changelog

:cl:
fix: War Correspondent helmet has a proper sprite for Vox. 
/:cl:
