### PR TITLE
Minor Pubby ruin fix.

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
@@ -1447,7 +1447,7 @@
 /obj/machinery/door/airlock/hatch{
 	welded = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/ruin/whitesands/pubbycrash/split)
 "ET" = (
 /obj/structure/cable/yellow{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This airlock had a turf passthrough under it. Acid spawning randomly is NOT fun.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixing oversights good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Pubby ruin can no longer randomly have acid in airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
