### PR TITLE
Puts the correct revolver type in the Abandoned Miskilamo Shipbreaking Yard

### DIFF
--- a/_maps/RandomRuins/WasteRuins/wasteplanet_yard.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_yard.dmm
@@ -3042,10 +3042,10 @@
 	icon_state = "0-2"
 	},
 /obj/structure/closet/wall/directional/west,
-/obj/item/gun/ballistic/revolver,
 /obj/item/clothing/suit/hooded/wintercoat/captain,
 /obj/item/storage/firstaid/o2,
 /obj/machinery/light/small/broken/directional/north,
+/obj/item/gun/ballistic/revolver/viper/indie,
 /turf/open/floor/plasteel/wasteplanet,
 /area/ruin/wasteplanet/wasteplanet_shipbreaking/ship)
 "Mf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The ruin had the base revolver type mapped. Replaces it with a Viper.

![image](https://github.com/user-attachments/assets/0c153e7b-df5b-4973-ba1d-6c2bb72772bb)



## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I DEMAND-

## Changelog

:cl:
fix: Abandoned Miskilamo Shipbreaking Yard ruin has the correct revolver subtype.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
