### PR TITLE
Rock Planet Shipping Dock has the correct gun

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_shippingdock.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_shippingdock.dmm
@@ -2002,7 +2002,7 @@
 	},
 /obj/item/ammo_box/magazine/m9mm_rattlesnake,
 /obj/item/ammo_box/magazine/m9mm_rattlesnake,
-/obj/item/storage/pistolcase/ringneck,
+/obj/item/gun/ballistic/automatic/pistol/rattlesnake/no_mag,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/rockplanet/shippingdocksecure)
 "rK" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Rock Planet shipping dock ruin has a rattlesnake instead of the ringneck case.
![image](https://github.com/user-attachments/assets/24637f48-0658-4efd-9a57-446cb3b48e22)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Seems like the ringneck got mapped in by mistake, since the crate had two rattlesnake mags, and the gun there before was the TEC-9, which the rattlesnake was supposed to replace.

## Changelog

:cl:
fix: Shipping dock ruin correctly has a rattlesnake instead of a ringneck case
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
