### PR TITLE
Increases the moles in the plasma belt tank cargo pack

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -24,8 +24,8 @@
 	name = "Plasmaman Internals Crate"
 	desc = "Contains two plasmaman belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
 	cost = 100
-	contains = list(/obj/item/tank/internals/plasmaman/belt,
-					/obj/item/tank/internals/plasmaman/belt)
+	contains = list(/obj/item/tank/internals/plasmaman/belt/full,
+					/obj/item/tank/internals/plasmaman/belt/full)
 	crate_name = "plasmaman internals crate"
 
 /datum/supply_pack/emergency/plasmaman_suit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change swaps the type of plasma belt tank sold in the crate from tanks filled only to 303 kPa, to tanks filled to 1013 kPa.

## Why It's Good For The Game

The amount of plasma offered in these tanks is only 0.75 moles. It would benefit gameplay to increase this to 2.2 moles.

## Changelog

:cl:
balance: increased amount of plasma in plasma internals cargo crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
