### PR TITLE
Fix to turn mob spawning off when a drill incurs a malfunction

### DIFF
--- a/code/modules/mining/drill.dm
+++ b/code/modules/mining/drill.dm
@@ -344,7 +344,7 @@
 
 //Overly long proc to handle the unique properties for each malfunction type
 /obj/machinery/drill/proc/malfunction(malfunction_type)
-	if(!active)
+	if(active)
 		mining.toggle_spawning() //turns mob spawning off after a malfunction
 	switch(malfunction_type)
 		if(MALF_LASER)

--- a/code/modules/mining/drill.dm
+++ b/code/modules/mining/drill.dm
@@ -344,6 +344,7 @@
 
 //Overly long proc to handle the unique properties for each malfunction type
 /obj/machinery/drill/proc/malfunction(malfunction_type)
+	mining.toggle_spawning() //turns mob spawning off after a malfunction
 	switch(malfunction_type)
 		if(MALF_LASER)
 			say("Malfunction: Laser array damaged, please replace before continuing mining operations.")

--- a/code/modules/mining/drill.dm
+++ b/code/modules/mining/drill.dm
@@ -344,7 +344,8 @@
 
 //Overly long proc to handle the unique properties for each malfunction type
 /obj/machinery/drill/proc/malfunction(malfunction_type)
-	mining.toggle_spawning() //turns mob spawning off after a malfunction
+	if(!active)
+		mining.toggle_spawning() //turns mob spawning off after a malfunction
 	switch(malfunction_type)
 		if(MALF_LASER)
 			say("Malfunction: Laser array damaged, please replace before continuing mining operations.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fix toggles fauna spawning off after a drill is beset by a malfunction.

## Why It's Good For The Game

I've seen several instances of runaway spawning occurring after a drill suffers a malfunction. When this happens, it cannot be toggled off by alt-clicking on it, and it _must_ be unwrenched. This should fix that behavior. 

## Changelog

:cl:
fix: fixed fauna spawning after drill malfunctions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
