### PR TITLE
Syndicate tools and soap are no longer better.

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -71,7 +71,7 @@
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
-	cleanspeed = 5 //faster than mop so it is useful for traitors who want to clean crime scenes
+	cleanspeed = 27 // ever so slightly better than NT
 
 /obj/item/soap/omega
 	name = "omega soap"

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -72,6 +72,7 @@
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
 	cleanspeed = 27 // ever so slightly better than NT
+	uses = 300
 
 /obj/item/soap/omega
 	name = "omega soap"

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -170,10 +170,8 @@
 	toolspeed = 0.5
 
 /obj/item/multitool/syndie
-	name = "suspicious-looking multitool"
 	desc = "A darkened multitool with a matte finish and an ominous glowing screen."
 	icon_state = "multitool_syndie"
-	toolspeed = 0.5
 
 /obj/item/multitool/old
 	desc = "Used for pulsing wires to test which to cut. This one looks... 'retro'. It wasn't recommended by doctors then and won't be recommended by doctors now."

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -158,11 +158,9 @@
 		new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
 
 /obj/item/storage/toolbox/syndicate
-	name = "suspicious looking toolbox"
+	name = "black and red toolbox"
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
-	force = 15
-	throwforce = 18
 	material_flags = NONE
 
 /obj/item/storage/toolbox/syndicate/ComponentInitialize()
@@ -172,11 +170,11 @@
 
 /obj/item/storage/toolbox/syndicate/PopulateContents()
 	new /obj/item/screwdriver/nuke(src)
-	new /obj/item/wrench/syndie(src) //WS Edit - Cool Syndie Tools
+	new /obj/item/wrench/syndie(src)
 	new /obj/item/weldingtool/largetank(src)
-	new /obj/item/crowbar/syndie(src) //WS Begin - Cool Syndie Tools
+	new /obj/item/crowbar/syndie(src)
 	new /obj/item/wirecutters/syndie(src)
-	new /obj/item/multitool/syndie(src) //WS End
+	new /obj/item/multitool/syndie(src)
 	new /obj/item/clothing/gloves/color/yellow(src)
 
 /obj/item/storage/toolbox/syndicate/empty

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -80,12 +80,8 @@
 
 //snowflake screwdriver, works as a key to start nuke theft, traitor only
 /obj/item/screwdriver/nuke
-	name = "screwdriver"
-	desc = "A screwdriver with an ultra thin tip that's carefully designed to boost screwing speed."
-//	icon = 'icons/obj/nuke_tools.dmi' WS edit - better tool sprites
 	icon_state = "screwdriver_nuke"
 	item_state = "screwdriver_nuke"
-	toolspeed = 0.5
 	random_color = FALSE
 
 /obj/item/paper/guides/antag/nuke_instructions

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -117,10 +117,7 @@
 	toolspeed = 0.5
 
 /obj/item/crowbar/syndie
-	name = "suspicious-looking crowbar"
-	desc = "It has special counterweights that adjust to the amount of pressure put on it by using a complex array of springs and screws."
 	icon_state = "crowbar_syndie"
-	toolspeed = 0.5
 	force = 8
 
 /obj/item/crowbar/old

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -85,10 +85,7 @@
 	random_color = FALSE
 
 /obj/item/wirecutters/syndie
-	name = "suspicious-looking wirecutters"
-	desc = "The blades of these wirecutters have suspiciously fine serrated teeth."
 	icon_state = "cutters_syndie"
-	toolspeed = 0.5
 	random_color = FALSE
 
 /obj/item/wirecutters/old

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -95,10 +95,7 @@
 	return ..()
 
 /obj/item/wrench/syndie
-	name = "suspicious-looking wrench"
-	desc = "It's one of those fancy wrenches that you turn backward without twisting the bolt for faster action."
 	icon_state = "wrench_syndie"
-	toolspeed = 0.5
 
 /obj/item/wrench/crescent
 	name = "crescent wrench"

--- a/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/tools.dm
@@ -11,17 +11,6 @@
 	stock = 1
 	availability_prob = 20
 
-/datum/blackmarket_item/tool/syndi_toolbox
-	name = "Syndicate Toolbox"
-	desc = "A set of specialized tools, built to precision perfection and certified by the GEC."
-	item = /obj/item/storage/toolbox/syndicate
-
-	price_min = 500
-	price_max = 2000
-	stock_min = 1
-	stock_max = 3
-	availability_prob = 40
-
 /datum/blackmarket_item/tool/surgery_duffel
 	name = "Cybersun Advanced Surgical Kit"
 	desc = "You might say it's morally wrong to steal. I say it's justified when it's Cybersun."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- syndicate soap clean speed swapped from 5 to 27 (1 better than NT soap, because I find that funny). Also it's uses are tripled.
- "suspicious toolbox" renamed to "black and red toolbox", lost it's damage buff.
- syndicate tools have lost the "suspicious" names, their descriptions, and their toolspeed buff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cruft. Syndi items were better on stations because of rarity. On shiptest, it feels kinda weird to map those in knowing they are just upgrades. Soap is especially awkward in that regard.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Syndicate soap is now in-line with NT soap.
del: Syndicate tools are no longer faster. They are just reskinned normal tools now.
del: Syndicate toolbox lost it's damage buff.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
