### PR TITLE
Allows fire extinguishers to be refilled with sinks

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -20,7 +20,7 @@
 	var/chem = /datum/reagent/water
 	var/safety = TRUE
 	var/refilling = FALSE
-	var/tanktype = /obj/structure/reagent_dispensers/watertank
+	var/tanktype = /obj/structure/ //A simple tanktype change won't do it
 	var/sprite_name = "fire_extinguisher"
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -116,6 +116,19 @@
 			to_chat(user, "<span class='warning'>\The [W] is empty!</span>")
 		safety = safety_save
 		return 1
+	if(istype(target, /obj/structure/sink) && target.Adjacent(user))
+		var/safety_save = safety
+		safety = TRUE
+		if(reagents.total_volume == reagents.maximum_volume)
+			to_chat(user, "<span class='warning'>\The [src] is already full!</span>")
+			safety = safety_save
+			return 1
+		else
+			refill()
+			to_chat(user, "<span class='notice'>\The [src] has been refilled.</span>")
+			playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+			for(var/datum/reagent/water/R in reagents.reagent_list)
+				R.cooling_temperature = cooling_power
 	else
 		return 0
 

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -20,7 +20,7 @@
 	var/chem = /datum/reagent/water
 	var/safety = TRUE
 	var/refilling = FALSE
-	var/tanktype = /obj/structure/ //A simple tanktype change won't do it
+	var/tanktype = /obj/structure/reagent_dispensers/watertank
 	var/sprite_name = "fire_extinguisher"
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -345,6 +345,9 @@
 		O.use(1)
 		return
 
+	if(istype(O, /obj/item/extinguisher))
+		return ..()
+
 	if(!istype(O))
 		return
 	if(O.item_flags & ABSTRACT) //Abstract items like grabs won't wash. No-drop items will though because it's still technically an item in your hand.

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -346,7 +346,17 @@
 		return
 
 	if(istype(O, /obj/item/extinguisher))
-		return ..()
+		var/obj/item/extinguisher/EX = O
+		var/safety_save = EX.safety
+		EX.safety = TRUE
+		if(!(EX.reagents.total_volume == EX.reagents.maximum_volume))
+			EX.refill()
+			to_chat(user, "<span class='notice'>\The [EX] has been refilled.</span>")
+			playsound(EX.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+			EX.safety = safety_save
+			return 1
+		else
+			return ..()
 
 	if(!istype(O))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change adds the ability to refill a fire extinguisher with a sink.

## Why It's Good For The Game

I've always found it a little inconsistent how a water dispenser is required in order to refill a fire extinguisher. My hope is that this change will give more options for players to refill their extinguishers.

## Changelog

:cl:
add: Added ability to refill fire extinguishers with sinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
