### PR TITLE
Gezena is no longer barefoot

### DIFF
--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -229,7 +229,7 @@
 	name = "\improper PGF Uhro-sez Boots"
 	desc = "The word “uhro-sez” translates to “steel-foot”, in reference to the steel toe protection provided by these boots. Standard issue to all members of all branches of the PGF military."
 	icon = 'icons/obj/clothing/faction/gezena/feet.dmi'
-	//mob_overlay_icon = 'icons/mob/clothing/faction/gezena/feet.dmi' todo: find out why digi breaks here
+	mob_overlay_icon = 'icons/mob/clothing/faction/gezena/feet.dmi'
 	icon_state = "pgfboots"
 	item_state = "jackboots"
 

--- a/code/modules/clothing/factions/gezena.dm
+++ b/code/modules/clothing/factions/gezena.dm
@@ -221,7 +221,6 @@
 	name = "\improper PGFN Captain's Ihuz-irra Gloves"
 	desc = "As the name, “ihuz-irra”, or “sure-grip”, suggests, the gloves employed by the PGF military are designed to ensure the highest possible grip is maintained while also providing protection from blisters in work environments. Bears the silver standard of a Gezenan captain."
 	icon_state = "captaingloves"
-	siemens_coefficient = 0.5
 
 //Boots
 


### PR DESCRIPTION
## About The Pull Request

Someone commented out something to try and see why something was broken and left it. Digi isn't broken either so I'm not sure how this happened.

Also removes partial-insulation from the Gezenan captain's gloves that Apogee happened to forget.

## Why It's Good For The Game

It's too early in the day for the marines to get silly like this.

## Changelog

:cl:
fix: Gezena has shoes again
del: Gezenan captain gloves no longer have partial insulation in parity with other captain gloves.
/:cl: