### PR TITLE
Fixes shotgun calibers

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -27,7 +27,6 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "beanbag"
-	caliber = "12ga beanbag"
 	custom_materials = list(/datum/material/iron=250)
 	projectile_type = /obj/projectile/bullet/slug/beanbag
 
@@ -35,7 +34,6 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "rubber"
-	caliber = "12ga rubber"
 	projectile_type = /obj/projectile/bullet/pellet/rubbershot
 	pellets = 8
 	variance = 25
@@ -45,7 +43,6 @@
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "incendiary"
-	caliber = "12ga incendiary"
 	projectile_type = /obj/projectile/bullet/incendiary/shotgun
 
 /obj/item/ammo_casing/shotgun/blank
@@ -59,7 +56,6 @@
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvised"
-	caliber = "improvised 12ga"
 	projectile_type = /obj/projectile/bullet/pellet/improvised
 	custom_materials = list(/datum/material/iron=250)
 	pellets = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes the caliber strings on the beanbag, rubber, improvised and incendiary shotgun rounds and shotguns being unable to load them as a consequence.

Magazines check for an exact caliber match, so having unique strings like "12ga beanbag" means the round gets rejected.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes are good
## Changelog

:cl:
fix: Shotgun calibers and shotguns being unable to load certain rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
