### PR TITLE
Maps Angle Grinders

### DIFF
--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -324,13 +324,14 @@
 /obj/item/circular_saw,
 /obj/item/multitool,
 /obj/item/stack/marker_beacon/thirty,
-/obj/item/gun/energy/plasmacutter,
 /obj/structure/cable{
 	icon_state = "2-10"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/item/radio/headset/alt,
+/obj/item/gear_pack/anglegrinder,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "gT" = (

--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -4468,7 +4468,8 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/welding,
-/obj/item/gun/energy/plasmacutter,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plating,
 /area/ship/engineering)
 

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -4852,8 +4852,10 @@
 /obj/item/multitool,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
-/obj/item/gun/energy/plasmacutter,
-/obj/item/gun/energy/plasmacutter,
+/obj/item/radio/headset/alt,
+/obj/item/radio/headset/alt,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/gear_pack/anglegrinder,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/electrical)
 "OU" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -686,7 +686,8 @@
 	req_access_txt = "11";
 	req_one_access = null
 	},
-/obj/item/gun/energy/plasmacutter,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "eu" = (
@@ -4900,7 +4901,8 @@
 	pixel_x = 20;
 	pixel_y = 11
 	},
-/obj/item/gun/energy/plasmacutter,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Fe" = (
@@ -6270,7 +6272,8 @@
 	req_access_txt = "11";
 	req_one_access = null
 	},
-/obj/item/gun/energy/plasmacutter,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "OK" = (
@@ -7834,7 +7837,8 @@
 	name = "honorable artificer's toolbelt"
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/item/gun/energy/plasmacutter,
+/obj/item/gear_pack/anglegrinder/energy,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/communications)
 "ZB" = (

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -2097,12 +2097,13 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/lp/engineer,
-/obj/item/gun/energy/plasmacutter,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 19;
 	pixel_y = -10
 	},
+/obj/item/radio/headset/alt,
+/obj/item/gear_pack/anglegrinder,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "pA" = (

--- a/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
@@ -3816,8 +3816,9 @@
 	},
 /obj/item/clothing/under/syndicate/hardliners,
 /obj/item/clothing/suit/hazardvest/hardliners,
-/obj/item/gun/energy/plasmacutter,
 /obj/item/clothing/gloves/color/red/insulated,
+/obj/item/gear_pack/anglegrinder,
+/obj/item/radio/headset/alt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "KL" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes plascutters from:
mudskipper
shetland
rigger
talos
komodo
ranger
replaces plascutters on those vessels with:
angle grinder
bowman headset

#3585 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using the content that got made specifically for salvaging on ships that are likely going to salvage....
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Chances are, if there was a plasma cutter on a ship, it's an angle grinder now. Rejoice. Cry in terror. Whatever honestly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
