### PR TITLE
Icemoon Ruin - Server Array

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -167,9 +167,14 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"el" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "eu" = (
 /obj/effect/spawner/bunk_bed,
 /turf/open/floor/plating/airless,
@@ -195,7 +200,6 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -293,6 +297,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
+"iL" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "iN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -314,6 +322,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "jn" = (
@@ -363,6 +372,12 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"kE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "lb" = (
 /obj/structure/table,
 /obj/structure/sign/warning/xeno_mining{
@@ -402,13 +417,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"lO" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "lT" = (
 /obj/structure/flora/rock/pile/icy{
 	icon_state = "icemoonrock1"
@@ -425,7 +441,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/flora/ash/puce,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
@@ -594,19 +609,10 @@
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"vN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "vV" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
-"wA" = (
-/obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "wE" = (
@@ -622,6 +628,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"wT" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -648,10 +658,6 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"zc" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "zG" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -706,14 +712,13 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "BD" = (
-/obj/machinery/power/smes,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/techfloor/orange,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
-	icon_state = "0-5"
+	icon_state = "5-8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
@@ -726,10 +731,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"Cv" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -802,6 +803,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
+"Fk" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Fr" = (
 /obj/effect/turf_decal/techfloor/orange,
 /turf/open/floor/plating/airless,
@@ -861,10 +867,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
-"Is" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
 "Iu" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = -32
@@ -908,11 +910,10 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"Kb" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
+"KE" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -997,7 +998,6 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/structure/spider/spiderling/viper,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
 "OM" = (
@@ -1013,8 +1013,10 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1114,8 +1116,6 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -1224,10 +1224,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Ze" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Zx" = (
 /turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -1250,10 +1246,10 @@
 (1,1,1) = {"
 Qa
 Qa
-Pa
-Pa
-Cv
-Pa
+mH
+mH
+el
+mH
 Qa
 tq
 tq
@@ -1276,11 +1272,11 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
+mH
+mH
+mH
+mH
+mH
 lT
 tq
 tq
@@ -1303,11 +1299,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1330,11 +1326,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-Pa
-Pa
-Pa
+mH
+mH
+mH
 Bw
-Pa
+mH
 tq
 tq
 tq
@@ -1357,10 +1353,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1384,8 +1380,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-Pa
-Pa
+mH
+mH
 OQ
 tq
 tq
@@ -1400,9 +1396,9 @@ Zx
 tq
 tq
 tq
-Pa
-Pa
-Pa
+mH
+mH
+mH
 OQ
 tq
 tq
@@ -1411,8 +1407,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-Pa
-Pa
+mH
+mH
 tq
 tq
 tq
@@ -1424,22 +1420,22 @@ aH
 Aa
 gz
 Zx
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+mH
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-Pa
-Pa
+mH
+mH
 tq
 tq
 tq
@@ -1452,13 +1448,13 @@ jw
 gz
 Zx
 pw
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1466,7 +1462,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-Pa
+mH
 tq
 tq
 tq
@@ -1483,17 +1479,17 @@ Zx
 wE
 IK
 ub
-Pa
-Pa
-Pa
+mH
+mH
+mH
 dJ
-Pa
-Pa
+mH
+mH
 "}
 (10,1,1) = {"
 Qa
 Qa
-Pa
+mH
 tq
 tq
 tq
@@ -1510,12 +1506,12 @@ sO
 IK
 IK
 tq
-Pa
-Pa
-Pa
+mH
+mH
+mH
 lw
-Pa
-Pa
+mH
+mH
 "}
 (11,1,1) = {"
 Qa
@@ -1538,11 +1534,11 @@ qi
 IK
 tq
 tq
-Pa
-Pa
+mH
+mH
 dJ
-Pa
-Pa
+mH
+mH
 "}
 (12,1,1) = {"
 Qa
@@ -1568,8 +1564,8 @@ Wm
 hR
 aO
 EX
-Pa
-Pa
+mH
+mH
 "}
 (13,1,1) = {"
 Qa
@@ -1594,9 +1590,9 @@ mT
 jh
 Wm
 vV
-Pa
-Pa
-Pa
+mH
+mH
+mH
 "}
 (14,1,1) = {"
 Qa
@@ -1622,8 +1618,8 @@ Ge
 fB
 tq
 lT
-Pa
-Pa
+mH
+mH
 "}
 (15,1,1) = {"
 tq
@@ -1649,7 +1645,7 @@ xN
 fB
 tq
 tq
-Pa
+mH
 Qa
 "}
 (16,1,1) = {"
@@ -1780,7 +1776,7 @@ gZ
 JV
 qA
 fB
-Ze
+Ss
 Wm
 kp
 kp
@@ -1821,10 +1817,10 @@ tq
 tq
 tq
 kp
-zc
-Pa
+iL
+mH
 ah
-ee
+Pa
 fB
 PW
 kz
@@ -1834,7 +1830,7 @@ Jc
 Ce
 IJ
 fB
-Ze
+Ss
 fB
 kp
 tq
@@ -1848,10 +1844,10 @@ tq
 tq
 tq
 Vh
-Pa
-wA
+mH
+lO
 Wm
-vN
+fR
 fB
 ZO
 Ng
@@ -1886,9 +1882,9 @@ fB
 fB
 al
 Dc
-Ze
+Ss
 Xo
-Ze
+Ss
 Wm
 kp
 tq
@@ -1907,14 +1903,14 @@ tq
 Wm
 Lu
 QM
-vN
+fR
 CA
 Yy
 KZ
 Do
 fB
 jn
-Kb
+Fk
 Xo
 Wm
 tq
@@ -1933,10 +1929,10 @@ tq
 tq
 Wm
 dL
-fR
-Ze
-aE
+kE
 Ss
+aE
+ee
 fB
 fB
 fB
@@ -1990,9 +1986,9 @@ tq
 tq
 qp
 fm
-Pa
-Pa
-Is
+mH
+mH
+KE
 tq
 tq
 tq
@@ -2016,8 +2012,8 @@ tq
 tq
 tq
 tq
+wT
 mH
-Pa
 tq
 tq
 tq
@@ -2043,7 +2039,7 @@ tq
 tq
 tq
 tq
-Pa
+mH
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -167,14 +167,9 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"el" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "eu" = (
 /obj/effect/spawner/bunk_bed,
 /turf/open/floor/plating/airless,
@@ -200,6 +195,7 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -297,10 +293,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
-"iL" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "iN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -372,12 +364,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"kE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "lb" = (
 /obj/structure/table,
 /obj/structure/sign/warning/xeno_mining{
@@ -421,10 +407,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"lO" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "lT" = (
 /obj/structure/flora/rock/pile/icy{
 	icon_state = "icemoonrock1"
@@ -559,6 +541,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"rK" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -578,6 +564,10 @@
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"tp" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "tq" = (
 /turf/closed/mineral/random/snow,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -601,9 +591,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/pet/mothroach,
-/obj/item/reagent_containers/food/snacks/meat/slab/mothroach,
-/obj/structure/closet/crate/critter,
+/obj/structure/table,
+/obj/item/t_scanner,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
 "vj" = (
@@ -628,10 +617,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"wT" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -665,6 +650,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
+"zT" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
 "Aa" = (
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/opaque/red,
@@ -778,6 +767,12 @@
 "Ey" = (
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"EK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "EN" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -802,11 +797,6 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/unpowered/server_array)
-"Fk" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "Fr" = (
 /obj/effect/turf_decal/techfloor/orange,
@@ -910,15 +900,15 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"KE" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"Lf" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "Lu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
@@ -1013,10 +1003,9 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1142,10 +1131,15 @@
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
+"Vt" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
 "Xo" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1194,7 +1188,8 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/obj/item/t_scanner,
+/obj/structure/closet/crate/critter,
+/mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Yy" = (
@@ -1242,13 +1237,18 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"ZY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 
 (1,1,1) = {"
 Qa
 Qa
 mH
 mH
-el
+Pa
 mH
 Qa
 tq
@@ -1722,7 +1722,7 @@ Hr
 Hr
 gB
 fB
-Xo
+Vt
 Wm
 tq
 tq
@@ -1749,7 +1749,7 @@ DC
 dh
 tv
 fB
-Xo
+Vt
 Wm
 kp
 tq
@@ -1817,10 +1817,10 @@ tq
 tq
 tq
 kp
-iL
+Lf
 mH
 ah
-Pa
+ee
 fB
 PW
 kz
@@ -1845,9 +1845,9 @@ tq
 tq
 Vh
 mH
-lO
+tp
 Wm
-fR
+ZY
 fB
 ZO
 Ng
@@ -1857,7 +1857,7 @@ fB
 Gf
 fB
 fB
-Xo
+Vt
 Wm
 kp
 tq
@@ -1883,7 +1883,7 @@ fB
 al
 Dc
 Ss
-Xo
+Vt
 Ss
 Wm
 kp
@@ -1903,15 +1903,15 @@ tq
 Wm
 Lu
 QM
-fR
+ZY
 CA
 Yy
 KZ
 Do
 fB
 jn
-Fk
 Xo
+Vt
 Wm
 tq
 tq
@@ -1929,10 +1929,10 @@ tq
 tq
 Wm
 dL
-kE
+fR
 Ss
 aE
-ee
+EK
 fB
 fB
 fB
@@ -1988,7 +1988,7 @@ qp
 fm
 mH
 mH
-KE
+zT
 tq
 tq
 tq
@@ -2012,7 +2012,7 @@ tq
 tq
 tq
 tq
-wT
+rK
 mH
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -167,7 +167,6 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -196,7 +195,6 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -220,10 +218,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"gA" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "gB" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/techfloor/orange{
@@ -357,7 +351,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/obj/structure/flora/ash/puce,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
@@ -416,8 +410,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -429,6 +422,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
@@ -452,6 +448,10 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
+"nF" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "ov" = (
 /obj/machinery/door/airlock/security{
 	dir = 4
@@ -549,6 +549,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"qM" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -559,10 +563,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
-"sT" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "tb" = (
 /turf/open/floor/plasteel/mono/dark{
 	initial_gas_mix = "ICEMOON_ATMOS"
@@ -581,6 +581,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"tz" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "ub" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -600,12 +604,6 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
-"uo" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
@@ -663,6 +661,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
+"zS" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Aa" = (
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/opaque/red,
@@ -721,6 +724,12 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"BS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Ce" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
@@ -729,11 +738,6 @@
 /turf/open/floor/plasteel/mono/dark{
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
-/area/ruin/unpowered/server_array)
-"Cs" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -807,11 +811,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"Fj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Fr" = (
 /obj/effect/turf_decal/techfloor/orange,
 /turf/open/floor/plating/airless,
@@ -829,9 +828,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
 "Ge" = (
-/obj/effect/decal/cleanable/blood/hitsplatter{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4;
 	pixel_x = 11
@@ -917,6 +913,12 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
+"KV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -934,11 +936,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Nb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Ng" = (
 /obj/machinery/light/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1022,9 +1019,8 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1123,13 +1119,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
-"Sm" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
 "Ss" = (
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1255,14 +1248,18 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"ZW" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 
 (1,1,1) = {"
 Qa
 Qa
-mH
-mH
-sT
-mH
+Pa
+Pa
+nF
+Pa
 Qa
 tq
 tq
@@ -1285,12 +1282,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
+Pa
+Pa
+Pa
+Pa
+Pa
 mH
-mH
-mH
-mH
-mH
-uo
 tq
 tq
 tq
@@ -1312,11 +1309,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1339,11 +1336,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-mH
-mH
-mH
+Pa
+Pa
+Pa
 Bw
-mH
+Pa
 tq
 tq
 tq
@@ -1366,10 +1363,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1393,8 +1390,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 OQ
 tq
 tq
@@ -1409,9 +1406,9 @@ Zx
 tq
 tq
 tq
-Ss
-Ss
-mH
+lT
+lT
+Pa
 OQ
 tq
 tq
@@ -1420,8 +1417,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1437,18 +1434,18 @@ Zx
 Zx
 Zx
 Zx
-Ss
-Ss
-mH
-mH
+lT
+lT
+Pa
+Pa
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1464,10 +1461,10 @@ pw
 Zx
 Zx
 Zx
-Ss
-Ss
-mH
-mH
+lT
+lT
+Pa
+Pa
 tq
 tq
 tq
@@ -1475,7 +1472,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1492,17 +1489,17 @@ Zx
 wE
 IK
 ub
-Ss
-mH
-mH
+lT
+Pa
+Pa
 dJ
-Ss
-mH
+lT
+Pa
 "}
 (10,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1519,17 +1516,17 @@ sO
 IK
 IK
 tq
-Ss
-Ss
-mH
+lT
+lT
+Pa
 lw
-Ss
-mH
+lT
+Pa
 "}
 (11,1,1) = {"
 Qa
 Qa
-uo
+mH
 tq
 tq
 tq
@@ -1547,11 +1544,11 @@ qi
 IK
 tq
 tq
-Ss
-Ss
+lT
+lT
 dJ
-Ss
-mH
+lT
+Pa
 "}
 (12,1,1) = {"
 Qa
@@ -1559,7 +1556,7 @@ Qa
 tq
 tq
 tq
-Ss
+lT
 pS
 PT
 by
@@ -1577,8 +1574,8 @@ Wm
 hR
 aO
 EX
-Ss
-mH
+lT
+Pa
 "}
 (13,1,1) = {"
 Qa
@@ -1586,7 +1583,7 @@ Qa
 tq
 tq
 tq
-Ss
+lT
 pS
 wG
 GV
@@ -1603,9 +1600,9 @@ mT
 jh
 Wm
 vV
-mH
-mH
-mH
+Pa
+Pa
+Pa
 "}
 (14,1,1) = {"
 Qa
@@ -1613,7 +1610,7 @@ Qa
 tq
 tq
 tq
-Ss
+lT
 pS
 pS
 IK
@@ -1630,9 +1627,9 @@ oO
 Ge
 fB
 tq
-uo
 mH
-mH
+Pa
+Pa
 "}
 (15,1,1) = {"
 tq
@@ -1658,7 +1655,7 @@ xN
 fB
 tq
 tq
-mH
+Pa
 Qa
 "}
 (16,1,1) = {"
@@ -1764,7 +1761,7 @@ tv
 fB
 Xo
 Wm
-Ss
+lT
 tq
 tq
 tq
@@ -1774,7 +1771,7 @@ tq
 tq
 tq
 tq
-Ss
+lT
 Wm
 cm
 Rv
@@ -1789,10 +1786,10 @@ gZ
 JV
 qA
 fB
-Pa
+Ss
 Wm
-Ss
-Ss
+lT
+lT
 tq
 tq
 "}
@@ -1801,7 +1798,7 @@ tq
 tq
 tq
 tq
-Ss
+lT
 Wm
 Wm
 Wm
@@ -1818,7 +1815,7 @@ jX
 fB
 Ey
 fB
-Ss
+lT
 tq
 tq
 tq
@@ -1829,11 +1826,11 @@ tq
 tq
 tq
 tq
-Ss
-gA
-mH
+lT
+kp
+Pa
 ah
-Fj
+ee
 fB
 PW
 kz
@@ -1843,9 +1840,9 @@ Jc
 Ce
 IJ
 fB
-Pa
-fB
 Ss
+fB
+lT
 tq
 tq
 tq
@@ -1857,10 +1854,10 @@ tq
 tq
 tq
 Vh
-mH
-lT
+Pa
+ZW
 Wm
-Nb
+fR
 fB
 ZO
 Ng
@@ -1872,7 +1869,7 @@ fB
 fB
 Xo
 Wm
-Ss
+lT
 tq
 tq
 tq
@@ -1895,11 +1892,11 @@ fB
 fB
 al
 Dc
-Pa
-Xo
-Pa
-Wm
 Ss
+Xo
+Ss
+Wm
+lT
 tq
 tq
 tq
@@ -1916,14 +1913,14 @@ tq
 Wm
 Lu
 QM
-Nb
+fR
 CA
 Yy
 KZ
 Do
 fB
 jn
-Cs
+zS
 Xo
 Wm
 tq
@@ -1942,10 +1939,10 @@ tq
 tq
 Wm
 dL
-fR
-Pa
+BS
+Ss
 aE
-ee
+KV
 fB
 fB
 fB
@@ -1974,9 +1971,9 @@ Wm
 FR
 Wm
 fB
-Ss
-Ss
-Ss
+lT
+lT
+lT
 tq
 tq
 tq
@@ -1999,9 +1996,9 @@ tq
 tq
 qp
 fm
-mH
-mH
-Sm
+Pa
+Pa
+qM
 tq
 tq
 tq
@@ -2025,8 +2022,8 @@ tq
 tq
 tq
 tq
-kp
-mH
+tz
+Pa
 tq
 tq
 tq
@@ -2052,7 +2049,7 @@ tq
 tq
 tq
 tq
-mH
+Pa
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -15,6 +15,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "aH" = (
@@ -34,7 +35,7 @@
 /area/ruin/unpowered/server_array/crew)
 "aO" = (
 /obj/structure/fence,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "aS" = (
 /obj/effect/turf_decal/siding/wood/end{
@@ -59,10 +60,6 @@
 "by" = (
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array/crew)
-"bP" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "bQ" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -119,6 +116,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
+/obj/item/organ/cyberimp/arm/power_cord,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "cB" = (
@@ -157,7 +155,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "dL" = (
 /obj/machinery/portable_atmospherics/canister/bz{
@@ -168,6 +166,8 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "eu" = (
@@ -181,11 +181,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"eY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "fB" = (
 /turf/closed/wall/r_wall,
@@ -195,6 +200,13 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"fY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "gd" = (
@@ -258,7 +270,7 @@
 "hq" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/laborer,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "hB" = (
 /obj/machinery/door/airlock/maintenance{
@@ -350,7 +362,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -381,9 +393,14 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
+"lo" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "lw" = (
 /obj/structure/fence/door,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "lD" = (
 /obj/structure/cable{
@@ -408,8 +425,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -421,8 +440,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/flora/grass/green,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
@@ -449,10 +467,10 @@
 /obj/machinery/door/airlock/security{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
@@ -531,7 +549,8 @@
 /area/ruin/unpowered/server_array/crew)
 "qp" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "qA" = (
 /obj/structure/window/reinforced{
@@ -541,6 +560,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"rm" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -573,8 +596,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "uf" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -593,7 +618,7 @@
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "wE" = (
 /obj/structure/marker_beacon,
@@ -687,7 +712,7 @@
 /area/ruin/unpowered/server_array/crew)
 "Bw" = (
 /obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "BD" = (
 /obj/machinery/power/smes,
@@ -775,7 +800,7 @@
 /area/ruin/unpowered/server_array/crew)
 "EX" = (
 /obj/structure/fence/corner,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "EZ" = (
 /obj/machinery/door/window/brigdoor/eastright,
@@ -829,10 +854,6 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"Ha" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Hr" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -891,6 +912,10 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
+"KY" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -899,6 +924,7 @@
 "Lu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "LI" = (
@@ -907,6 +933,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Mv" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
 "Ng" = (
 /obj/machinery/light/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -974,6 +1004,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
+/obj/structure/spider/spiderling/viper,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
 "OM" = (
@@ -983,12 +1014,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "OQ" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock2"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/flora/grass/brown,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "PS" = (
 /obj/machinery/door/airlock{
@@ -1037,6 +1070,7 @@
 "QM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mob_spawn/human/skeleton,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Ro" = (
@@ -1088,8 +1122,8 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/structure/flora/stump,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
@@ -1112,12 +1146,17 @@
 "Vh" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/skeleton,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
+"VX" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
 "Xo" = (
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "Xt" = (
@@ -1170,6 +1209,7 @@
 /area/ruin/unpowered/server_array)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "YJ" = (
@@ -1220,14 +1260,14 @@ Qa
 Qa
 kp
 kp
+rm
 kp
-kp
 Qa
 tq
 tq
 tq
-Qa
-Qa
+tq
+tq
 Qa
 Qa
 Qa
@@ -1249,7 +1289,11 @@ kp
 kp
 kp
 kp
-kp
+lT
+tq
+tq
+tq
+tq
 tq
 tq
 tq
@@ -1258,14 +1302,10 @@ Qa
 Qa
 Qa
 Qa
-Qa
-Qa
-Qa
-Qa
-Qa
-Qa
-Qa
-Qa
+tq
+tq
+tq
+tq
 Qa
 Qa
 "}
@@ -1275,7 +1315,7 @@ kp
 kp
 kp
 kp
-Pa
+kp
 tq
 tq
 tq
@@ -1284,17 +1324,17 @@ tq
 tq
 tq
 tq
-Qa
-Qa
-Qa
-Qa
-Qa
 tq
 tq
 tq
-Qa
-Qa
-Qa
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
 "}
 (4,1,1) = {"
 Qa
@@ -1319,16 +1359,16 @@ tq
 tq
 tq
 tq
-Qa
-Qa
-Qa
+tq
+tq
+tq
 "}
 (5,1,1) = {"
 Qa
 kp
-Ss
 kp
-mH
+kp
+kp
 tq
 tq
 tq
@@ -1347,13 +1387,13 @@ tq
 tq
 tq
 tq
-Qa
-Qa
+tq
+tq
 "}
 (6,1,1) = {"
 Qa
 kp
-Pa
+kp
 OQ
 tq
 tq
@@ -1368,14 +1408,14 @@ Zx
 tq
 tq
 tq
-lT
+mH
 mH
 kp
-kp
+OQ
 tq
 tq
-Qa
-Qa
+tq
+tq
 "}
 (7,1,1) = {"
 Qa
@@ -1396,13 +1436,13 @@ Zx
 Zx
 Zx
 Zx
+mH
+mH
 kp
-Ss
 kp
-Pa
 tq
-Qa
-Qa
+tq
+tq
 "}
 (8,1,1) = {"
 Qa
@@ -1423,13 +1463,13 @@ pw
 Zx
 Zx
 Zx
-kp
-kp
+mH
+mH
 kp
 kp
 tq
-kp
-Qa
+tq
+tq
 "}
 (9,1,1) = {"
 Qa
@@ -1451,17 +1491,17 @@ Zx
 wE
 IK
 ub
-kp
+mH
 kp
 kp
 dJ
-kp
+mH
 kp
 "}
 (10,1,1) = {"
 Qa
 Qa
-Pa
+kp
 tq
 tq
 tq
@@ -1478,17 +1518,17 @@ sO
 IK
 IK
 tq
-kp
-kp
+mH
+mH
 kp
 lw
-kp
+mH
 kp
 "}
 (11,1,1) = {"
 Qa
 Qa
-kp
+lT
 tq
 tq
 tq
@@ -1506,19 +1546,19 @@ qi
 IK
 tq
 tq
-Pa
-kp
+mH
+mH
 dJ
-kp
+mH
 kp
 "}
 (12,1,1) = {"
 Qa
 Qa
-Qa
 tq
 tq
-kp
+tq
+mH
 pS
 PT
 by
@@ -1536,7 +1576,7 @@ Wm
 hR
 aO
 EX
-kp
+mH
 kp
 "}
 (13,1,1) = {"
@@ -1545,7 +1585,7 @@ Qa
 tq
 tq
 tq
-kp
+mH
 pS
 wG
 GV
@@ -1572,7 +1612,7 @@ Qa
 tq
 tq
 tq
-kp
+mH
 pS
 pS
 IK
@@ -1594,8 +1634,8 @@ kp
 kp
 "}
 (15,1,1) = {"
-Qa
-Qa
+tq
+tq
 tq
 tq
 tq
@@ -1617,11 +1657,11 @@ xN
 fB
 tq
 tq
-Ss
+kp
 Qa
 "}
 (16,1,1) = {"
-Qa
+tq
 tq
 tq
 tq
@@ -1648,7 +1688,7 @@ tq
 Qa
 "}
 (17,1,1) = {"
-Qa
+tq
 tq
 tq
 tq
@@ -1672,7 +1712,7 @@ Wm
 tq
 tq
 tq
-Qa
+tq
 "}
 (18,1,1) = {"
 tq
@@ -1699,7 +1739,7 @@ Wm
 tq
 tq
 tq
-Qa
+tq
 "}
 (19,1,1) = {"
 tq
@@ -1723,17 +1763,17 @@ tv
 fB
 Xo
 Wm
-kp
+mH
 tq
 tq
-Qa
+tq
 "}
 (20,1,1) = {"
 tq
 tq
 tq
 tq
-kp
+mH
 Wm
 cm
 Rv
@@ -1748,10 +1788,10 @@ gZ
 JV
 qA
 fB
-Ey
+VX
 Wm
-kp
-kp
+mH
+mH
 tq
 tq
 "}
@@ -1760,7 +1800,7 @@ tq
 tq
 tq
 tq
-kp
+mH
 Wm
 Wm
 Wm
@@ -1777,7 +1817,7 @@ jX
 fB
 Ey
 fB
-kp
+mH
 tq
 tq
 tq
@@ -1788,11 +1828,11 @@ tq
 tq
 tq
 tq
-kp
-bP
+mH
+KY
 kp
 ah
-ee
+eY
 fB
 PW
 kz
@@ -1802,22 +1842,22 @@ Jc
 Ce
 IJ
 fB
-Ey
+VX
 fB
-kp
+mH
 tq
 tq
 tq
 "}
 (23,1,1) = {"
-Qa
+tq
 tq
 tq
 tq
 tq
 Vh
 kp
-lT
+Pa
 Wm
 fR
 fB
@@ -1831,13 +1871,13 @@ fB
 fB
 Xo
 Wm
-kp
+mH
 tq
 tq
 tq
 "}
 (24,1,1) = {"
-Qa
+tq
 tq
 tq
 tq
@@ -1854,17 +1894,17 @@ fB
 fB
 al
 Dc
-Ey
+VX
 Xo
-Ey
+VX
 Wm
-kp
+mH
 tq
 tq
-Qa
+tq
 "}
 (25,1,1) = {"
-Qa
+tq
 tq
 tq
 tq
@@ -1882,17 +1922,17 @@ KZ
 Do
 fB
 jn
-Ha
+lo
 Xo
 Wm
 tq
 tq
 tq
-Qa
+tq
 "}
 (26,1,1) = {"
 Qa
-Qa
+tq
 tq
 tq
 tq
@@ -1901,8 +1941,8 @@ tq
 tq
 Wm
 dL
-fR
-Ey
+fY
+VX
 aE
 ee
 fB
@@ -1914,12 +1954,12 @@ Wm
 Wm
 tq
 tq
-Qa
+tq
 Qa
 "}
 (27,1,1) = {"
 Qa
-Qa
+tq
 tq
 tq
 tq
@@ -1933,21 +1973,21 @@ Wm
 FR
 Wm
 fB
-kp
-kp
-kp
+mH
+mH
+mH
 tq
 tq
 tq
 tq
 tq
-Qa
+tq
 Qa
 "}
 (28,1,1) = {"
 Qa
 Qa
-Qa
+tq
 tq
 tq
 tq
@@ -1958,16 +1998,16 @@ tq
 tq
 qp
 fm
-lT
 kp
 kp
+Mv
 tq
 tq
 tq
 tq
 tq
 tq
-Qa
+tq
 Qa
 Qa
 "}
@@ -1984,8 +2024,8 @@ tq
 tq
 tq
 tq
+Ss
 kp
-kp
 tq
 tq
 tq
@@ -1993,7 +2033,7 @@ tq
 tq
 tq
 tq
-Qa
+tq
 Qa
 Qa
 Qa
@@ -2002,9 +2042,9 @@ Qa
 Qa
 Qa
 Qa
-Qa
-Qa
-Qa
+tq
+tq
+tq
 tq
 tq
 tq
@@ -2015,11 +2055,11 @@ kp
 tq
 tq
 tq
-Qa
 tq
 tq
 tq
-Qa
+tq
+tq
 Qa
 Qa
 Qa

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -55,6 +55,14 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
+"bj" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
 "bm" = (
 /obj/effect/spawner/structure/window,
 /obj/effect/decal/cleanable/glass,
@@ -157,6 +165,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"dE" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9;
+	mode = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "dJ" = (
 /obj/structure/fence{
 	dir = 8
@@ -201,6 +216,7 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -292,14 +308,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"hY" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/door/poddoor/shutters{
-	id = "server_lockdown"
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array/crew)
 "iK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -336,10 +344,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"jv" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "jw" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -374,10 +378,6 @@
 "kp" = (
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
-"ks" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -411,6 +411,10 @@
 /obj/structure/fence/door,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
+"lx" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "lD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -431,10 +435,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -446,6 +448,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
@@ -455,6 +460,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"nc" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "nl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -528,6 +537,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"pf" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "pw" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32;
@@ -565,12 +578,15 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"rX" = (
+"rv" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
+"rM" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
@@ -589,9 +605,10 @@
 /area/ruin/unpowered/server_array)
 "tg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "tq" = (
 /turf/closed/mineral/random/snow,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -619,10 +636,6 @@
 /obj/item/t_scanner,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
-"vf" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
@@ -645,10 +658,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"xw" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -728,6 +737,11 @@
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Bl" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Bw" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/icerock,
@@ -770,21 +784,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
-"CX" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "Dc" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
-"Dg" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "Do" = (
@@ -803,13 +808,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"DJ" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "DY" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/tech/grid,
@@ -833,18 +831,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"ET" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9;
-	mode = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
-"EV" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "EX" = (
 /obj/structure/fence/corner,
 /turf/open/floor/plating/asteroid/icerock,
@@ -870,6 +856,10 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
+"FZ" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "Ge" = (
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4;
@@ -956,12 +946,6 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"KX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1026,8 +1010,12 @@
 "NC" = (
 /turf/closed/wall,
 /area/ruin/unpowered/server_array/crew)
-"NM" = (
-/turf/open/floor/plating/rust,
+"NE" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "NV" = (
 /obj/structure/mirror{
@@ -1065,10 +1053,12 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
+"PI" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1170,9 +1160,15 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"SI" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1200,7 +1196,12 @@
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
+"WM" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Xo" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1282,7 +1283,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Zx" = (
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
@@ -1304,10 +1304,10 @@
 (1,1,1) = {"
 Qa
 Qa
-mH
-mH
-CX
-mH
+Pa
+Pa
+rv
+Pa
 Qa
 tq
 tq
@@ -1330,12 +1330,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
+Pa
+Pa
+Pa
+Pa
+Pa
 mH
-mH
-mH
-mH
-mH
-lT
 tq
 tq
 tq
@@ -1357,11 +1357,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1384,11 +1384,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-mH
-mH
-mH
+Pa
+Pa
+Pa
 Bw
-mH
+Pa
 tq
 tq
 tq
@@ -1411,10 +1411,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1438,8 +1438,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 OQ
 tq
 tq
@@ -1450,13 +1450,13 @@ IK
 An
 pb
 gz
-NM
+Zx
 tq
 tq
 tq
-mH
-mH
-mH
+Pa
+Pa
+Pa
 OQ
 tq
 tq
@@ -1465,8 +1465,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1476,24 +1476,24 @@ Oc
 IK
 aH
 Aa
-hY
-Zx
-mH
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+bj
+PI
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1504,15 +1504,15 @@ IK
 Xt
 jw
 gz
-Zx
+PI
 pw
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1520,7 +1520,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1533,21 +1533,21 @@ ov
 IK
 IK
 wE
-NM
+Zx
 wE
 IK
 ub
-mH
-mH
-mH
+Pa
+Pa
+Pa
 dJ
-mH
-mH
+Pa
+Pa
 "}
 (10,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1564,17 +1564,17 @@ sO
 IK
 IK
 tq
-mH
-mH
-mH
+Pa
+Pa
+Pa
 lw
-mH
-mH
+Pa
+Pa
 "}
 (11,1,1) = {"
 Qa
 Qa
-lT
+mH
 tq
 tq
 tq
@@ -1592,11 +1592,11 @@ qi
 IK
 tq
 tq
-mH
-mH
+Pa
+Pa
 dJ
-mH
-mH
+Pa
+Pa
 "}
 (12,1,1) = {"
 Qa
@@ -1622,8 +1622,8 @@ Wm
 hR
 aO
 EX
-mH
-mH
+Pa
+Pa
 "}
 (13,1,1) = {"
 Qa
@@ -1648,9 +1648,9 @@ mT
 jh
 Wm
 vV
-mH
-mH
-mH
+Pa
+Pa
+Pa
 "}
 (14,1,1) = {"
 Qa
@@ -1675,9 +1675,9 @@ oO
 Ge
 fB
 tq
-lT
 mH
-mH
+Pa
+Pa
 "}
 (15,1,1) = {"
 tq
@@ -1703,7 +1703,7 @@ xN
 fB
 tq
 tq
-mH
+Pa
 Qa
 "}
 (16,1,1) = {"
@@ -1723,7 +1723,7 @@ vj
 vj
 Qn
 iN
-tg
+rM
 fL
 NX
 Nl
@@ -1747,7 +1747,7 @@ IK
 hQ
 uf
 QC
-ET
+dE
 cB
 jY
 jY
@@ -1780,7 +1780,7 @@ Hr
 Hr
 gB
 fB
-Xo
+lx
 Wm
 tq
 tq
@@ -1806,8 +1806,8 @@ FF
 DC
 dh
 tv
-xw
-Xo
+WM
+lx
 Wm
 kp
 tq
@@ -1819,7 +1819,7 @@ tq
 tq
 tq
 tq
-DJ
+NE
 Wm
 cm
 Rv
@@ -1834,7 +1834,7 @@ gZ
 JV
 qA
 fB
-ks
+nc
 Wm
 kp
 kp
@@ -1875,10 +1875,10 @@ tq
 tq
 kp
 kp
-Ss
+FZ
 kp
 ah
-KX
+tg
 fB
 PW
 kz
@@ -1888,7 +1888,7 @@ Jc
 Ce
 IJ
 fB
-ks
+nc
 fB
 kp
 tq
@@ -1903,9 +1903,9 @@ tq
 tq
 Vh
 kp
-vf
+lT
 Wm
-fR
+Ss
 fB
 ZO
 Ng
@@ -1915,7 +1915,7 @@ fB
 Gf
 fB
 fB
-Xo
+lx
 Wm
 kp
 tq
@@ -1940,9 +1940,9 @@ fB
 fB
 al
 Dc
-EV
-Xo
-ks
+Bl
+lx
+nc
 Wm
 kp
 tq
@@ -1961,15 +1961,15 @@ tq
 Wm
 Lu
 QM
-fR
+Ss
 CA
 Yy
 KZ
 Do
 fB
 jn
-Dg
 Xo
+lx
 Wm
 tq
 tq
@@ -1987,8 +1987,8 @@ tq
 tq
 Wm
 dL
-rX
-Pa
+fR
+SI
 aE
 ee
 fB
@@ -2019,9 +2019,9 @@ Wm
 FR
 Wm
 fB
-mH
-mH
-mH
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -2044,9 +2044,9 @@ tq
 tq
 qp
 fm
-mH
-mH
-jv
+Pa
+Pa
+pf
 tq
 tq
 tq
@@ -2070,8 +2070,8 @@ tq
 tq
 tq
 tq
-jv
-mH
+pf
+Pa
 tq
 tq
 tq
@@ -2097,7 +2097,7 @@ tq
 tq
 tq
 tq
-mH
+Pa
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1,8 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"af" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "ah" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/welded,
@@ -98,11 +94,6 @@
 /obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
-"ch" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "cm" = (
 /obj/structure/closet/emcloset/empty,
 /obj/item/bodypart/chest,
@@ -321,11 +312,6 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"iZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
 "jh" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -429,14 +415,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
 /turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
-"mw" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -448,9 +427,11 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -531,6 +512,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"pn" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
+"pt" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "pw" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32;
@@ -541,7 +530,7 @@
 "pS" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array/crew)
-"qc" = (
+"qa" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/door/poddoor/shutters{
@@ -593,6 +582,7 @@
 	},
 /area/ruin/unpowered/server_array)
 "tg" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -604,6 +594,11 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"tS" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "ub" = (
 /obj/structure/sign/warning/securearea{
@@ -626,10 +621,6 @@
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"vL" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "vV" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -675,9 +666,9 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"yW" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
+"zi" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "zG" = (
 /obj/structure/sink{
@@ -798,6 +789,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"DQ" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "DY" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/tech/grid,
@@ -846,6 +844,11 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
+"FZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "Ge" = (
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4;
@@ -874,6 +877,18 @@
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"Hf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"Hi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Hr" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -889,12 +904,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
-"Id" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Iu" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = -32
@@ -956,12 +965,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"MM" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/greenglow,
@@ -1044,8 +1047,19 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
+/obj/structure/flora/ash/puce,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
+"Pu" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"PH" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1079,11 +1093,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"Qx" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "QC" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -1152,15 +1161,14 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/cave/explored)
-"TU" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Tz" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1188,12 +1196,7 @@
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
-"Wx" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "Xo" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1244,6 +1247,10 @@
 /mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"Yw" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/spider/stickyweb,
@@ -1272,14 +1279,7 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Zc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Zx" = (
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
@@ -1301,10 +1301,10 @@
 (1,1,1) = {"
 Qa
 Qa
-Pa
-Pa
-yW
-Pa
+lT
+lT
+pt
+lT
 Qa
 tq
 tq
@@ -1327,12 +1327,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
 lT
+lT
+lT
+lT
+lT
+mH
 tq
 tq
 tq
@@ -1354,11 +1354,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
+lT
+lT
+lT
+lT
+lT
 tq
 tq
 tq
@@ -1381,11 +1381,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-Pa
-Pa
-Pa
+lT
+lT
+lT
 Bw
-Pa
+lT
 tq
 tq
 tq
@@ -1408,10 +1408,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
+lT
+lT
+lT
+lT
 tq
 tq
 tq
@@ -1435,8 +1435,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-Pa
-Pa
+lT
+lT
 OQ
 tq
 tq
@@ -1447,13 +1447,13 @@ IK
 An
 pb
 gz
-Ss
+Zx
 tq
 tq
 tq
-Pa
-Pa
-Pa
+lT
+lT
+lT
 OQ
 tq
 tq
@@ -1462,8 +1462,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-Pa
-Pa
+lT
+lT
 tq
 tq
 tq
@@ -1473,24 +1473,24 @@ Oc
 IK
 aH
 Aa
-qc
-Zx
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+qa
+pn
+lT
+lT
+lT
+lT
+lT
+lT
+lT
+lT
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-Pa
-Pa
+lT
+lT
 tq
 tq
 tq
@@ -1501,15 +1501,15 @@ IK
 Xt
 jw
 gz
-Zx
+pn
 pw
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+lT
+lT
+lT
+lT
+lT
+lT
+lT
 tq
 tq
 tq
@@ -1517,7 +1517,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-Pa
+lT
 tq
 tq
 tq
@@ -1530,21 +1530,21 @@ ov
 IK
 IK
 wE
-Ss
+Zx
 wE
 IK
 ub
-Pa
-Pa
-Pa
+lT
+lT
+lT
 dJ
-Pa
-Pa
+lT
+lT
 "}
 (10,1,1) = {"
 Qa
 Qa
-Pa
+lT
 tq
 tq
 tq
@@ -1561,17 +1561,17 @@ sO
 IK
 IK
 tq
-Pa
-Pa
-Pa
+lT
+lT
+lT
 lw
-Pa
-Pa
+lT
+lT
 "}
 (11,1,1) = {"
 Qa
 Qa
-lT
+mH
 tq
 tq
 tq
@@ -1589,11 +1589,11 @@ qi
 IK
 tq
 tq
-Pa
-Pa
+lT
+lT
 dJ
-Pa
-Pa
+lT
+lT
 "}
 (12,1,1) = {"
 Qa
@@ -1619,8 +1619,8 @@ Wm
 hR
 aO
 EX
-Pa
-Pa
+lT
+lT
 "}
 (13,1,1) = {"
 Qa
@@ -1645,9 +1645,9 @@ mT
 jh
 Wm
 vV
-Pa
-Pa
-Pa
+lT
+lT
+lT
 "}
 (14,1,1) = {"
 Qa
@@ -1672,9 +1672,9 @@ oO
 Ge
 fB
 tq
+mH
 lT
-Pa
-Pa
+lT
 "}
 (15,1,1) = {"
 tq
@@ -1700,7 +1700,7 @@ xN
 fB
 tq
 tq
-Pa
+lT
 Qa
 "}
 (16,1,1) = {"
@@ -1720,7 +1720,7 @@ vj
 vj
 Qn
 iN
-iZ
+FZ
 fL
 NX
 Nl
@@ -1744,7 +1744,7 @@ IK
 hQ
 uf
 QC
-MM
+PH
 cB
 jY
 jY
@@ -1777,7 +1777,7 @@ Hr
 Hr
 gB
 fB
-tg
+Xo
 Wm
 tq
 tq
@@ -1803,8 +1803,8 @@ FF
 DC
 dh
 tv
-mH
-tg
+Ss
+Xo
 Wm
 kp
 tq
@@ -1816,7 +1816,7 @@ tq
 tq
 tq
 tq
-TU
+DQ
 Wm
 cm
 Rv
@@ -1831,7 +1831,7 @@ gZ
 JV
 qA
 fB
-vL
+Pu
 Wm
 kp
 kp
@@ -1857,7 +1857,7 @@ fB
 Jc
 tb
 jX
-mH
+fB
 Ey
 fB
 kp
@@ -1872,10 +1872,10 @@ tq
 tq
 kp
 kp
-Wx
+zi
 kp
 ah
-Id
+Hi
 fB
 PW
 kz
@@ -1884,8 +1884,8 @@ fB
 Jc
 Ce
 IJ
-mH
-vL
+fB
+Pu
 fB
 kp
 tq
@@ -1900,7 +1900,7 @@ tq
 tq
 Vh
 kp
-mw
+Yw
 Wm
 fR
 fB
@@ -1912,7 +1912,7 @@ fB
 Gf
 fB
 fB
-tg
+Xo
 Wm
 kp
 tq
@@ -1931,15 +1931,15 @@ tq
 fB
 YO
 fB
-mH
+Ss
 Gf
 fB
 fB
 al
 Dc
-ch
-tg
-vL
+Tz
+Xo
+Pu
 Wm
 kp
 tq
@@ -1965,8 +1965,8 @@ KZ
 Do
 fB
 jn
-Xo
 tg
+Xo
 Wm
 tq
 tq
@@ -1984,8 +1984,8 @@ tq
 tq
 Wm
 dL
-Zc
-Qx
+Hf
+tS
 aE
 ee
 fB
@@ -2016,9 +2016,9 @@ Wm
 FR
 Wm
 fB
-Pa
-Pa
-Pa
+lT
+lT
+lT
 tq
 tq
 tq
@@ -2041,9 +2041,9 @@ tq
 tq
 qp
 fm
+lT
+lT
 Pa
-Pa
-af
 tq
 tq
 tq
@@ -2067,8 +2067,8 @@ tq
 tq
 tq
 tq
-af
 Pa
+lT
 tq
 tq
 tq
@@ -2094,7 +2094,7 @@ tq
 tq
 tq
 tq
-Pa
+lT
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -146,11 +146,20 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
+"dg" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "dh" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"dA" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "dJ" = (
 /obj/structure/fence{
@@ -167,6 +176,7 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -260,7 +270,8 @@
 "hq" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/laborer,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "hB" = (
 /obj/machinery/door/airlock/maintenance{
@@ -278,6 +289,7 @@
 	},
 /obj/item/circular_saw/augment,
 /obj/item/ammo_casing/a44roum/hp,
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
 "hR" = (
@@ -353,7 +365,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -408,10 +421,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -423,8 +434,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "mT" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -541,10 +553,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"rK" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+"ru" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -561,12 +575,7 @@
 	},
 /area/ruin/unpowered/server_array)
 "tg" = (
-/obj/machinery/light/dim/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
-"tp" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "tq" = (
 /turf/closed/mineral/random/snow,
@@ -617,6 +626,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"wN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -630,6 +644,11 @@
 	pixel_x = 9
 	},
 /obj/effect/mob_spawn/human/laborer,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"yp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "yt" = (
@@ -650,9 +669,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
-"zT" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+"zW" = (
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Aa" = (
 /obj/effect/turf_decal/techfloor,
@@ -694,6 +715,7 @@
 /obj/structure/table,
 /obj/item/weldingtool,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Bw" = (
@@ -767,12 +789,6 @@
 "Ey" = (
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"EK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "EN" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -837,9 +853,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "GV" = (
-/obj/machinery/light/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/light/broken/directional/east,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
 "Hr" = (
@@ -900,15 +916,15 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
+"KL" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"Lf" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "Lu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
@@ -922,12 +938,12 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Ng" = (
-/obj/machinery/light/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/greenglow,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 4
 	},
+/obj/machinery/light/broken/directional/east,
 /turf/open/floor/plasteel/mono/dark{
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
@@ -1003,9 +1019,10 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1083,6 +1100,7 @@
 	pixel_x = -1
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "RQ" = (
@@ -1105,9 +1123,8 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1129,17 +1146,13 @@
 "Vh" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/skeleton,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
-"Vt" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
 "Xo" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1237,19 +1250,14 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"ZY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 
 (1,1,1) = {"
 Qa
 Qa
-mH
-mH
-Pa
-mH
+Ss
+Ss
+KL
+Ss
 Qa
 tq
 tq
@@ -1272,12 +1280,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
-lT
+Ss
+Ss
+Ss
+Ss
+Ss
+zW
 tq
 tq
 tq
@@ -1299,11 +1307,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1326,11 +1334,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-mH
-mH
-mH
+Ss
+Ss
+Ss
 Bw
-mH
+Ss
 tq
 tq
 tq
@@ -1353,10 +1361,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1380,8 +1388,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-mH
-mH
+Ss
+Ss
 OQ
 tq
 tq
@@ -1396,9 +1404,9 @@ Zx
 tq
 tq
 tq
-mH
-mH
-mH
+Ss
+Ss
+Ss
 OQ
 tq
 tq
@@ -1407,8 +1415,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-mH
-mH
+Ss
+Ss
 tq
 tq
 tq
@@ -1420,22 +1428,22 @@ aH
 Aa
 gz
 Zx
-mH
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-mH
-mH
+Ss
+Ss
 tq
 tq
 tq
@@ -1448,13 +1456,13 @@ jw
 gz
 Zx
 pw
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1462,7 +1470,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-mH
+Ss
 tq
 tq
 tq
@@ -1479,17 +1487,17 @@ Zx
 wE
 IK
 ub
-mH
-mH
-mH
+Ss
+Ss
+Ss
 dJ
-mH
-mH
+Ss
+Ss
 "}
 (10,1,1) = {"
 Qa
 Qa
-mH
+Ss
 tq
 tq
 tq
@@ -1506,17 +1514,17 @@ sO
 IK
 IK
 tq
-mH
-mH
-mH
+Ss
+Ss
+Ss
 lw
-mH
-mH
+Ss
+Ss
 "}
 (11,1,1) = {"
 Qa
 Qa
-lT
+zW
 tq
 tq
 tq
@@ -1534,11 +1542,11 @@ qi
 IK
 tq
 tq
-mH
-mH
+Ss
+Ss
 dJ
-mH
-mH
+Ss
+Ss
 "}
 (12,1,1) = {"
 Qa
@@ -1546,7 +1554,7 @@ Qa
 tq
 tq
 tq
-kp
+tg
 pS
 PT
 by
@@ -1564,8 +1572,8 @@ Wm
 hR
 aO
 EX
-mH
-mH
+Ss
+Ss
 "}
 (13,1,1) = {"
 Qa
@@ -1573,7 +1581,7 @@ Qa
 tq
 tq
 tq
-kp
+tg
 pS
 wG
 GV
@@ -1590,9 +1598,9 @@ mT
 jh
 Wm
 vV
-mH
-mH
-mH
+Ss
+Ss
+Ss
 "}
 (14,1,1) = {"
 Qa
@@ -1600,7 +1608,7 @@ Qa
 tq
 tq
 tq
-kp
+tg
 pS
 pS
 IK
@@ -1617,9 +1625,9 @@ oO
 Ge
 fB
 tq
-lT
-mH
-mH
+zW
+Ss
+Ss
 "}
 (15,1,1) = {"
 tq
@@ -1645,7 +1653,7 @@ xN
 fB
 tq
 tq
-mH
+Ss
 Qa
 "}
 (16,1,1) = {"
@@ -1662,10 +1670,10 @@ DY
 vj
 vj
 vj
-tg
+vj
 Qn
 iN
-Qn
+wN
 fL
 NX
 Nl
@@ -1689,7 +1697,7 @@ IK
 hQ
 uf
 QC
-fB
+ru
 cB
 jY
 jY
@@ -1722,7 +1730,7 @@ Hr
 Hr
 gB
 fB
-Vt
+Xo
 Wm
 tq
 tq
@@ -1749,9 +1757,9 @@ DC
 dh
 tv
 fB
-Vt
+Xo
 Wm
-kp
+tg
 tq
 tq
 tq
@@ -1761,7 +1769,7 @@ tq
 tq
 tq
 tq
-kp
+tg
 Wm
 cm
 Rv
@@ -1776,10 +1784,10 @@ gZ
 JV
 qA
 fB
-Ss
+mH
 Wm
-kp
-kp
+tg
+tg
 tq
 tq
 "}
@@ -1788,7 +1796,7 @@ tq
 tq
 tq
 tq
-kp
+tg
 Wm
 Wm
 Wm
@@ -1805,7 +1813,7 @@ jX
 fB
 Ey
 fB
-kp
+tg
 tq
 tq
 tq
@@ -1815,12 +1823,12 @@ tq
 tq
 tq
 tq
-tq
-kp
-Lf
-mH
+tg
+tg
+dg
+tg
 ah
-ee
+yp
 fB
 PW
 kz
@@ -1830,9 +1838,9 @@ Jc
 Ce
 IJ
 fB
-Ss
+mH
 fB
-kp
+tg
 tq
 tq
 tq
@@ -1844,10 +1852,10 @@ tq
 tq
 tq
 Vh
-mH
-tp
+tg
+lT
 Wm
-ZY
+Pa
 fB
 ZO
 Ng
@@ -1857,9 +1865,9 @@ fB
 Gf
 fB
 fB
-Vt
+Xo
 Wm
-kp
+tg
 tq
 tq
 tq
@@ -1882,11 +1890,11 @@ fB
 fB
 al
 Dc
-Ss
-Vt
-Ss
+mH
+Xo
+mH
 Wm
-kp
+tg
 tq
 tq
 tq
@@ -1903,15 +1911,15 @@ tq
 Wm
 Lu
 QM
-ZY
+Pa
 CA
 Yy
 KZ
 Do
 fB
 jn
+dA
 Xo
-Vt
 Wm
 tq
 tq
@@ -1930,9 +1938,9 @@ tq
 Wm
 dL
 fR
-Ss
+mH
 aE
-EK
+ee
 fB
 fB
 fB
@@ -1961,9 +1969,9 @@ Wm
 FR
 Wm
 fB
-kp
-kp
-kp
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1986,9 +1994,9 @@ tq
 tq
 qp
 fm
-mH
-mH
-zT
+Ss
+Ss
+kp
 tq
 tq
 tq
@@ -2012,8 +2020,8 @@ tq
 tq
 tq
 tq
-rK
-mH
+kp
+Ss
 tq
 tq
 tq
@@ -2039,7 +2047,7 @@ tq
 tq
 tq
 tq
-mH
+Ss
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -59,6 +59,10 @@
 "by" = (
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array/crew)
+"bP" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "bQ" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -124,6 +128,10 @@
 /obj/structure/cable{
 	icon_state = "4-10"
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown";
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "cH" = (
@@ -179,10 +187,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
-"fw" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "fB" = (
 /turf/closed/wall/r_wall,
 /area/ruin/unpowered/server_array)
@@ -208,6 +212,9 @@
 /area/ruin/unpowered/server_array/crew)
 "gz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
 "gB" = (
@@ -334,6 +341,10 @@
 /area/ruin/unpowered/server_array)
 "jY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -656,6 +667,11 @@
 /obj/structure/sign/poster/official{
 	pixel_y = 32
 	},
+/obj/machinery/button/door{
+	pixel_y = 25;
+	name = "lockdown control";
+	id = "server_lockdown"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Av" = (
@@ -663,10 +679,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"Aw" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -817,6 +829,10 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"Ha" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Hr" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -1773,7 +1789,7 @@ tq
 tq
 tq
 kp
-Aw
+bP
 kp
 ah
 ee
@@ -1866,7 +1882,7 @@ KZ
 Do
 fB
 jn
-fw
+Ha
 Xo
 Wm
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -303,6 +303,12 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"ie" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = -24
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "iK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -613,7 +619,7 @@
 /area/ruin/unpowered/server_array)
 "ub" = (
 /obj/structure/sign/warning/securearea{
-	pixel_y = 32
+	pixel_y = 24
 	},
 /obj/structure/flora/rock/pile/icy{
 	icon_state = "icemoonrock1"
@@ -1879,7 +1885,7 @@ tq
 kp
 kp
 ow
-kp
+ie
 ah
 ee
 fB

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -88,6 +88,7 @@
 "cg" = (
 /obj/structure/chair/sofa/grey/corpo/left/directional/south,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
 "cm" = (
@@ -181,11 +182,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"eY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -199,11 +195,6 @@
 /turf/closed/wall,
 /area/ruin/unpowered/server_array)
 "fR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
-"fY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
@@ -229,6 +220,10 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"gA" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "gB" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/techfloor/orange{
@@ -362,6 +357,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
+/obj/structure/flora/ash/puce,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
@@ -393,11 +389,6 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
-"lo" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "lw" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/asteroid/icerock/cracked,
@@ -425,9 +416,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
+/obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
@@ -440,7 +429,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
@@ -560,10 +549,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"rm" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -574,6 +559,10 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
+"sT" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "tb" = (
 /turf/open/floor/plasteel/mono/dark{
 	initial_gas_mix = "ICEMOON_ATMOS"
@@ -611,6 +600,12 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
+"uo" = (
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
@@ -735,6 +730,11 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"Cs" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -806,6 +806,11 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array)
+"Fj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Fr" = (
 /obj/effect/turf_decal/techfloor/orange,
@@ -912,10 +917,6 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"KY" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -933,10 +934,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Mv" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
+"Nb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Ng" = (
 /obj/machinery/light/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1008,9 +1010,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
 "OM" = (
-/obj/machinery/portable_atmospherics/canister/fuel,
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "OQ" = (
@@ -1020,9 +1022,9 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1121,9 +1123,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
-"Ss" = (
+"Sm" = (
 /obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ss" = (
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
@@ -1148,10 +1153,6 @@
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
-"VX" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
@@ -1258,10 +1259,10 @@
 (1,1,1) = {"
 Qa
 Qa
-kp
-kp
-rm
-kp
+mH
+mH
+sT
+mH
 Qa
 tq
 tq
@@ -1284,12 +1285,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-kp
-kp
-kp
-kp
-kp
-lT
+mH
+mH
+mH
+mH
+mH
+uo
 tq
 tq
 tq
@@ -1311,11 +1312,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-kp
-kp
-kp
-kp
-kp
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1338,11 +1339,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-kp
-kp
-kp
+mH
+mH
+mH
 Bw
-kp
+mH
 tq
 tq
 tq
@@ -1365,10 +1366,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-kp
-kp
-kp
-kp
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1392,8 +1393,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-kp
-kp
+mH
+mH
 OQ
 tq
 tq
@@ -1408,9 +1409,9 @@ Zx
 tq
 tq
 tq
+Ss
+Ss
 mH
-mH
-kp
 OQ
 tq
 tq
@@ -1419,8 +1420,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-kp
-kp
+mH
+mH
 tq
 tq
 tq
@@ -1436,18 +1437,18 @@ Zx
 Zx
 Zx
 Zx
+Ss
+Ss
 mH
 mH
-kp
-kp
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-kp
-kp
+mH
+mH
 tq
 tq
 tq
@@ -1463,10 +1464,10 @@ pw
 Zx
 Zx
 Zx
+Ss
+Ss
 mH
 mH
-kp
-kp
 tq
 tq
 tq
@@ -1474,7 +1475,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-kp
+mH
 tq
 tq
 tq
@@ -1491,17 +1492,17 @@ Zx
 wE
 IK
 ub
+Ss
 mH
-kp
-kp
+mH
 dJ
+Ss
 mH
-kp
 "}
 (10,1,1) = {"
 Qa
 Qa
-kp
+mH
 tq
 tq
 tq
@@ -1518,17 +1519,17 @@ sO
 IK
 IK
 tq
+Ss
+Ss
 mH
-mH
-kp
 lw
+Ss
 mH
-kp
 "}
 (11,1,1) = {"
 Qa
 Qa
-lT
+uo
 tq
 tq
 tq
@@ -1546,11 +1547,11 @@ qi
 IK
 tq
 tq
-mH
-mH
+Ss
+Ss
 dJ
+Ss
 mH
-kp
 "}
 (12,1,1) = {"
 Qa
@@ -1558,7 +1559,7 @@ Qa
 tq
 tq
 tq
-mH
+Ss
 pS
 PT
 by
@@ -1576,8 +1577,8 @@ Wm
 hR
 aO
 EX
+Ss
 mH
-kp
 "}
 (13,1,1) = {"
 Qa
@@ -1585,7 +1586,7 @@ Qa
 tq
 tq
 tq
-mH
+Ss
 pS
 wG
 GV
@@ -1602,9 +1603,9 @@ mT
 jh
 Wm
 vV
-kp
-kp
-kp
+mH
+mH
+mH
 "}
 (14,1,1) = {"
 Qa
@@ -1612,7 +1613,7 @@ Qa
 tq
 tq
 tq
-mH
+Ss
 pS
 pS
 IK
@@ -1629,9 +1630,9 @@ oO
 Ge
 fB
 tq
-lT
-kp
-kp
+uo
+mH
+mH
 "}
 (15,1,1) = {"
 tq
@@ -1657,7 +1658,7 @@ xN
 fB
 tq
 tq
-kp
+mH
 Qa
 "}
 (16,1,1) = {"
@@ -1763,7 +1764,7 @@ tv
 fB
 Xo
 Wm
-mH
+Ss
 tq
 tq
 tq
@@ -1773,7 +1774,7 @@ tq
 tq
 tq
 tq
-mH
+Ss
 Wm
 cm
 Rv
@@ -1788,10 +1789,10 @@ gZ
 JV
 qA
 fB
-VX
+Pa
 Wm
-mH
-mH
+Ss
+Ss
 tq
 tq
 "}
@@ -1800,7 +1801,7 @@ tq
 tq
 tq
 tq
-mH
+Ss
 Wm
 Wm
 Wm
@@ -1817,7 +1818,7 @@ jX
 fB
 Ey
 fB
-mH
+Ss
 tq
 tq
 tq
@@ -1828,11 +1829,11 @@ tq
 tq
 tq
 tq
+Ss
+gA
 mH
-KY
-kp
 ah
-eY
+Fj
 fB
 PW
 kz
@@ -1842,9 +1843,9 @@ Jc
 Ce
 IJ
 fB
-VX
+Pa
 fB
-mH
+Ss
 tq
 tq
 tq
@@ -1856,10 +1857,10 @@ tq
 tq
 tq
 Vh
-kp
-Pa
+mH
+lT
 Wm
-fR
+Nb
 fB
 ZO
 Ng
@@ -1871,7 +1872,7 @@ fB
 fB
 Xo
 Wm
-mH
+Ss
 tq
 tq
 tq
@@ -1894,11 +1895,11 @@ fB
 fB
 al
 Dc
-VX
+Pa
 Xo
-VX
+Pa
 Wm
-mH
+Ss
 tq
 tq
 tq
@@ -1915,14 +1916,14 @@ tq
 Wm
 Lu
 QM
-fR
+Nb
 CA
 Yy
 KZ
 Do
 fB
 jn
-lo
+Cs
 Xo
 Wm
 tq
@@ -1941,8 +1942,8 @@ tq
 tq
 Wm
 dL
-fY
-VX
+fR
+Pa
 aE
 ee
 fB
@@ -1973,9 +1974,9 @@ Wm
 FR
 Wm
 fB
-mH
-mH
-mH
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1998,9 +1999,9 @@ tq
 tq
 qp
 fm
-kp
-kp
-Mv
+mH
+mH
+Sm
 tq
 tq
 tq
@@ -2024,8 +2025,8 @@ tq
 tq
 tq
 tq
-Ss
 kp
+mH
 tq
 tq
 tq
@@ -2051,7 +2052,7 @@ tq
 tq
 tq
 tq
-kp
+mH
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -147,6 +147,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"cN" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "dd" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/carpet/black,
@@ -180,6 +184,11 @@
 /obj/effect/spawner/bunk_bed,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array/crew)
+"eH" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "eO" = (
 /obj/machinery/computer/station_alert/retro{
 	dir = 1
@@ -187,6 +196,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"eW" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -201,6 +214,7 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -212,6 +226,11 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
+"gl" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "gs" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/cobweb,
@@ -292,6 +311,11 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"ie" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "iK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -360,7 +384,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/turf/open/floor/plating/ice/icemoon,
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -427,10 +452,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
@@ -512,14 +534,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"pn" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/cave/explored)
-"pt" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "pw" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32;
@@ -529,14 +543,6 @@
 /area/overmap_encounter/planetoid/cave/explored)
 "pS" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/unpowered/server_array/crew)
-"qa" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/door/poddoor/shutters{
-	id = "server_lockdown"
-	},
-/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
 "qi" = (
 /obj/structure/sign/warning/coldtemp{
@@ -582,7 +588,7 @@
 	},
 /area/ruin/unpowered/server_array)
 "tg" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -594,11 +600,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/unpowered/server_array)
-"tS" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "ub" = (
 /obj/structure/sign/warning/securearea{
@@ -660,16 +661,33 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"yL" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
 "yP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"zi" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+"zl" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
+"zo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "zG" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -716,6 +734,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"AK" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9;
+	mode = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -773,6 +798,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
+"Dd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -789,13 +819,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"DQ" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "DY" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/tech/grid,
@@ -844,11 +867,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
-"FZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
 "Ge" = (
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4;
@@ -877,18 +895,6 @@
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"Hf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
-"Hi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Hr" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -947,6 +953,10 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
+"Kp" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1047,19 +1057,11 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/flora/ash/puce,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
-"Pu" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
-"PH" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1114,6 +1116,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Rs" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "Rv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -1164,11 +1170,6 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"Tz" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1212,6 +1213,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/box/ammo/a44roum_hp,
 /obj/structure/spider/stickyweb,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/glasses/hud/security/sunglasses,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Xw" = (
@@ -1247,10 +1250,6 @@
 /mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"Yw" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/spider/stickyweb,
@@ -1297,13 +1296,17 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"ZX" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 
 (1,1,1) = {"
 Qa
 Qa
 lT
 lT
-pt
+kp
 lT
 Qa
 tq
@@ -1332,7 +1335,7 @@ lT
 lT
 lT
 lT
-mH
+Pa
 tq
 tq
 tq
@@ -1473,8 +1476,8 @@ Oc
 IK
 aH
 Aa
-qa
-pn
+yL
+Kp
 lT
 lT
 lT
@@ -1501,7 +1504,7 @@ IK
 Xt
 jw
 gz
-pn
+Kp
 pw
 lT
 lT
@@ -1571,7 +1574,7 @@ lT
 (11,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1601,7 +1604,7 @@ Qa
 tq
 tq
 tq
-kp
+mH
 pS
 PT
 by
@@ -1628,7 +1631,7 @@ Qa
 tq
 tq
 tq
-kp
+mH
 pS
 wG
 GV
@@ -1655,7 +1658,7 @@ Qa
 tq
 tq
 tq
-kp
+mH
 pS
 pS
 IK
@@ -1672,7 +1675,7 @@ oO
 Ge
 fB
 tq
-mH
+Pa
 lT
 lT
 "}
@@ -1720,7 +1723,7 @@ vj
 vj
 Qn
 iN
-FZ
+Dd
 fL
 NX
 Nl
@@ -1744,7 +1747,7 @@ IK
 hQ
 uf
 QC
-PH
+AK
 cB
 jY
 jY
@@ -1806,7 +1809,7 @@ tv
 Ss
 Xo
 Wm
-kp
+mH
 tq
 tq
 tq
@@ -1816,7 +1819,7 @@ tq
 tq
 tq
 tq
-DQ
+zl
 Wm
 cm
 Rv
@@ -1831,10 +1834,10 @@ gZ
 JV
 qA
 fB
-Pu
+eW
 Wm
-kp
-kp
+mH
+mH
 tq
 tq
 "}
@@ -1843,7 +1846,7 @@ tq
 tq
 tq
 tq
-kp
+mH
 Wm
 Wm
 Wm
@@ -1860,7 +1863,7 @@ jX
 fB
 Ey
 fB
-kp
+mH
 tq
 tq
 tq
@@ -1870,12 +1873,12 @@ tq
 tq
 tq
 tq
-kp
-kp
-zi
-kp
+mH
+mH
+ZX
+mH
 ah
-Hi
+zo
 fB
 PW
 kz
@@ -1885,9 +1888,9 @@ Jc
 Ce
 IJ
 fB
-Pu
+eW
 fB
-kp
+mH
 tq
 tq
 tq
@@ -1899,10 +1902,10 @@ tq
 tq
 tq
 Vh
-kp
-Yw
+mH
+Rs
 Wm
-fR
+tg
 fB
 ZO
 Ng
@@ -1914,7 +1917,7 @@ fB
 fB
 Xo
 Wm
-kp
+mH
 tq
 tq
 tq
@@ -1937,11 +1940,11 @@ fB
 fB
 al
 Dc
-Tz
+eH
 Xo
-Pu
+eW
 Wm
-kp
+mH
 tq
 tq
 tq
@@ -1958,14 +1961,14 @@ tq
 Wm
 Lu
 QM
-fR
+tg
 CA
 Yy
 KZ
 Do
 fB
 jn
-tg
+gl
 Xo
 Wm
 tq
@@ -1984,8 +1987,8 @@ tq
 tq
 Wm
 dL
-Hf
-tS
+fR
+ie
 aE
 ee
 fB
@@ -2043,7 +2046,7 @@ qp
 fm
 lT
 lT
-Pa
+cN
 tq
 tq
 tq
@@ -2067,7 +2070,7 @@ tq
 tq
 tq
 tq
-Pa
+cN
 lT
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -29,6 +29,7 @@
 	icon_state = "6-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "aO" = (
@@ -114,7 +115,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "cB" = (
@@ -179,6 +179,10 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
+"fw" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "fB" = (
 /turf/closed/wall/r_wall,
 /area/ruin/unpowered/server_array)
@@ -241,6 +245,7 @@
 /area/ruin/unpowered/server_array)
 "he" = (
 /obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array)
 "hq" = (
@@ -305,7 +310,6 @@
 "jn" = (
 /obj/structure/closet/firecloset/empty,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "jw" = (
@@ -524,7 +528,6 @@
 	},
 /obj/effect/turf_decal/techfloor/orange,
 /obj/structure/table,
-/obj/effect/landmark/mission_poi/main,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "sh" = (
@@ -567,7 +570,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/large,
+/mob/living/simple_animal/pet/mothroach,
+/obj/item/reagent_containers/food/snacks/meat/slab/mothroach,
+/obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
 "vj" = (
@@ -658,6 +663,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"Aw" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -750,7 +759,6 @@
 "EP" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/mission_poi,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "EX" = (
@@ -1041,6 +1049,7 @@
 	pixel_y = 4;
 	pixel_x = -1
 	},
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "RQ" = (
@@ -1086,7 +1095,6 @@
 /area/ruin/unpowered/server_array/crew)
 "Vh" = (
 /obj/structure/closet/body_bag,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -1104,13 +1112,12 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet,
-/obj/item/ammo_box/a44roum/hp,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
 	brute_damage = 200
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/item/storage/box/ammo/a44roum_hp,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Xw" = (
@@ -1766,7 +1773,7 @@ tq
 tq
 tq
 kp
-kp
+Aw
 kp
 ah
 ee
@@ -1859,7 +1866,7 @@ KZ
 Do
 fB
 jn
-Xo
+fw
 Xo
 Wm
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"af" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "ah" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/welded,
@@ -94,6 +98,11 @@
 /obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
+"ch" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "cm" = (
 /obj/structure/closet/emcloset/empty,
 /obj/item/bodypart/chest,
@@ -312,6 +321,11 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"iZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "jh" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -395,10 +409,6 @@
 /obj/structure/fence/door,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
-"lB" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/cave/explored)
 "lD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -424,6 +434,10 @@
 	},
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
+"mw" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -434,8 +448,9 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "mT" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -526,12 +541,14 @@
 "pS" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array/crew)
-"pX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
+"qc" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
 /turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
+/area/ruin/unpowered/server_array/crew)
 "qi" = (
 /obj/structure/sign/warning/coldtemp{
 	pixel_x = -32
@@ -564,10 +581,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"su" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "sO" = (
 /obj/machinery/door/airlock/external/glass{
 	dir = 4
@@ -581,7 +594,7 @@
 /area/ruin/unpowered/server_array)
 "tg" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "tq" = (
 /turf/closed/mineral/random/snow,
@@ -613,6 +626,10 @@
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"vL" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "vV" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -658,6 +675,10 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"yW" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "zG" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -669,6 +690,7 @@
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/opaque/red,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
@@ -703,10 +725,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"Bb" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -718,11 +736,6 @@
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
-"By" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "BD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -734,11 +747,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"BW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
 "Ce" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
@@ -860,12 +868,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"GR" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "GV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
@@ -887,6 +889,12 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
+"Id" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Iu" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = -32
@@ -948,6 +956,12 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"MM" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/greenglow,
@@ -1030,10 +1044,8 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1067,10 +1079,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"QA" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+"Qx" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "QC" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -1092,12 +1105,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Ru" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Rv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -1125,10 +1132,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"RM" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "RQ" = (
 /obj/structure/salvageable/server,
 /obj/effect/turf_decal/techfloor/orange,
@@ -1149,13 +1152,15 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/door/poddoor/shutters{
-	id = "server_lockdown"
-	},
 /turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array/crew)
+/area/overmap_encounter/planetoid/cave/explored)
+"TU" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1183,7 +1188,12 @@
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
+"Wx" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "Xo" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1196,9 +1206,6 @@
 	},
 /obj/structure/closet/secure_closet,
 /obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/box/ammo/a44roum_hp,
 /obj/structure/spider/stickyweb,
@@ -1237,11 +1244,6 @@
 /mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"Yo" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/spider/stickyweb,
@@ -1270,7 +1272,14 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Zc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Zx" = (
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
@@ -1292,10 +1301,10 @@
 (1,1,1) = {"
 Qa
 Qa
-mH
-mH
-Bb
-mH
+Pa
+Pa
+yW
+Pa
 Qa
 tq
 tq
@@ -1318,11 +1327,11 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
 lT
 tq
 tq
@@ -1345,11 +1354,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1372,11 +1381,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-mH
-mH
-mH
+Pa
+Pa
+Pa
 Bw
-mH
+Pa
 tq
 tq
 tq
@@ -1399,10 +1408,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1426,8 +1435,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 OQ
 tq
 tq
@@ -1438,13 +1447,13 @@ IK
 An
 pb
 gz
-Zx
+Ss
 tq
 tq
 tq
-mH
-mH
-mH
+Pa
+Pa
+Pa
 OQ
 tq
 tq
@@ -1453,8 +1462,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1464,24 +1473,24 @@ Oc
 IK
 aH
 Aa
-Ss
-lB
-mH
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+qc
+Zx
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-mH
-mH
+Pa
+Pa
 tq
 tq
 tq
@@ -1492,15 +1501,15 @@ IK
 Xt
 jw
 gz
-lB
+Zx
 pw
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -1508,7 +1517,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1521,21 +1530,21 @@ ov
 IK
 IK
 wE
-Zx
+Ss
 wE
 IK
 ub
-mH
-mH
-mH
+Pa
+Pa
+Pa
 dJ
-mH
-mH
+Pa
+Pa
 "}
 (10,1,1) = {"
 Qa
 Qa
-mH
+Pa
 tq
 tq
 tq
@@ -1552,12 +1561,12 @@ sO
 IK
 IK
 tq
-mH
-mH
-mH
+Pa
+Pa
+Pa
 lw
-mH
-mH
+Pa
+Pa
 "}
 (11,1,1) = {"
 Qa
@@ -1580,11 +1589,11 @@ qi
 IK
 tq
 tq
-mH
-mH
+Pa
+Pa
 dJ
-mH
-mH
+Pa
+Pa
 "}
 (12,1,1) = {"
 Qa
@@ -1610,8 +1619,8 @@ Wm
 hR
 aO
 EX
-mH
-mH
+Pa
+Pa
 "}
 (13,1,1) = {"
 Qa
@@ -1636,9 +1645,9 @@ mT
 jh
 Wm
 vV
-mH
-mH
-mH
+Pa
+Pa
+Pa
 "}
 (14,1,1) = {"
 Qa
@@ -1664,8 +1673,8 @@ Ge
 fB
 tq
 lT
-mH
-mH
+Pa
+Pa
 "}
 (15,1,1) = {"
 tq
@@ -1691,7 +1700,7 @@ xN
 fB
 tq
 tq
-mH
+Pa
 Qa
 "}
 (16,1,1) = {"
@@ -1711,7 +1720,7 @@ vj
 vj
 Qn
 iN
-BW
+iZ
 fL
 NX
 Nl
@@ -1735,7 +1744,7 @@ IK
 hQ
 uf
 QC
-GR
+MM
 cB
 jY
 jY
@@ -1768,7 +1777,7 @@ Hr
 Hr
 gB
 fB
-Xo
+tg
 Wm
 tq
 tq
@@ -1794,8 +1803,8 @@ FF
 DC
 dh
 tv
-fB
-Xo
+mH
+tg
 Wm
 kp
 tq
@@ -1807,7 +1816,7 @@ tq
 tq
 tq
 tq
-kp
+TU
 Wm
 cm
 Rv
@@ -1822,7 +1831,7 @@ gZ
 JV
 qA
 fB
-tg
+vL
 Wm
 kp
 kp
@@ -1848,7 +1857,7 @@ fB
 Jc
 tb
 jX
-fB
+mH
 Ey
 fB
 kp
@@ -1863,10 +1872,10 @@ tq
 tq
 kp
 kp
-RM
+Wx
 kp
 ah
-Ru
+Id
 fB
 PW
 kz
@@ -1875,8 +1884,8 @@ fB
 Jc
 Ce
 IJ
-fB
-tg
+mH
+vL
 fB
 kp
 tq
@@ -1891,7 +1900,7 @@ tq
 tq
 Vh
 kp
-su
+mw
 Wm
 fR
 fB
@@ -1903,7 +1912,7 @@ fB
 Gf
 fB
 fB
-Xo
+tg
 Wm
 kp
 tq
@@ -1922,15 +1931,15 @@ tq
 fB
 YO
 fB
-fB
+mH
 Gf
 fB
 fB
 al
 Dc
-By
-Xo
+ch
 tg
+vL
 Wm
 kp
 tq
@@ -1956,8 +1965,8 @@ KZ
 Do
 fB
 jn
-Pa
 Xo
+tg
 Wm
 tq
 tq
@@ -1975,8 +1984,8 @@ tq
 tq
 Wm
 dL
-pX
-Yo
+Zc
+Qx
 aE
 ee
 fB
@@ -2007,9 +2016,9 @@ Wm
 FR
 Wm
 fB
-mH
-mH
-mH
+Pa
+Pa
+Pa
 tq
 tq
 tq
@@ -2032,9 +2041,9 @@ tq
 tq
 qp
 fm
-mH
-mH
-QA
+Pa
+Pa
+af
 tq
 tq
 tq
@@ -2058,8 +2067,8 @@ tq
 tq
 tq
 tq
-QA
-mH
+af
+Pa
 tq
 tq
 tq
@@ -2085,7 +2094,7 @@ tq
 tq
 tq
 tq
-mH
+Pa
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -35,7 +35,7 @@
 /area/ruin/unpowered/server_array/crew)
 "aO" = (
 /obj/structure/fence,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "aS" = (
 /obj/effect/turf_decal/siding/wood/end{
@@ -156,7 +156,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "dL" = (
 /obj/machinery/portable_atmospherics/canister/bz{
@@ -195,6 +195,7 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -351,8 +352,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/asteroid/icerock/cracked,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -385,7 +385,7 @@
 /area/ruin/unpowered/server_array/crew)
 "lw" = (
 /obj/structure/fence/door,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "lD" = (
 /obj/structure/cable{
@@ -410,7 +410,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -422,9 +425,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
+/obj/structure/flora/ash/puce,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
@@ -448,10 +449,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
-"nF" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "ov" = (
 /obj/machinery/door/airlock/security{
 	dir = 4
@@ -515,9 +512,7 @@
 	pixel_y = 32;
 	pixel_x = 32
 	},
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "pS" = (
 /turf/closed/wall/r_wall/rust,
@@ -549,10 +544,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"qM" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/overmap_encounter/planetoid/cave/explored)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -581,10 +572,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"tz" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "ub" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -592,7 +579,7 @@
 /obj/structure/flora/rock/pile/icy{
 	icon_state = "icemoonrock1"
 	},
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "uf" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -607,17 +594,24 @@
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"vN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "vV" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
+"wA" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "wE" = (
 /obj/structure/marker_beacon,
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "wG" = (
 /obj/structure/bed/bunk,
@@ -654,6 +648,10 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"zc" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "zG" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -661,11 +659,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
-"zS" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Aa" = (
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/opaque/red,
@@ -724,12 +717,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"BS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "Ce" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
@@ -739,6 +726,10 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"Cv" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -804,7 +795,7 @@
 /area/ruin/unpowered/server_array/crew)
 "EX" = (
 /obj/structure/fence/corner,
-/turf/open/floor/plating/asteroid/icerock/cracked,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "EZ" = (
 /obj/machinery/door/window/brigdoor/eastright,
@@ -870,6 +861,10 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
+"Is" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/overmap_encounter/planetoid/cave/explored)
 "Iu" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = -32
@@ -913,11 +908,10 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"KV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
+"Kb" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
@@ -1120,6 +1114,8 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -1228,10 +1224,12 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Ze" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Zx" = (
-/turf/open/floor/plating/snowed/temperatre{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
 /obj/structure/salvageable/safe_server,
@@ -1248,17 +1246,13 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"ZW" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 
 (1,1,1) = {"
 Qa
 Qa
 Pa
 Pa
-nF
+Cv
 Pa
 Qa
 tq
@@ -1287,7 +1281,7 @@ Pa
 Pa
 Pa
 Pa
-mH
+lT
 tq
 tq
 tq
@@ -1375,7 +1369,7 @@ IK
 IK
 IK
 IK
-tq
+IK
 tq
 tq
 tq
@@ -1406,8 +1400,8 @@ Zx
 tq
 tq
 tq
-lT
-lT
+Pa
+Pa
 Pa
 OQ
 tq
@@ -1430,12 +1424,12 @@ aH
 Aa
 gz
 Zx
-Zx
-Zx
-Zx
-Zx
-lT
-lT
+Pa
+Pa
+Pa
+Pa
+Pa
+Pa
 Pa
 Pa
 tq
@@ -1458,11 +1452,11 @@ jw
 gz
 Zx
 pw
-Zx
-Zx
-Zx
-lT
-lT
+Pa
+Pa
+Pa
+Pa
+Pa
 Pa
 Pa
 tq
@@ -1489,11 +1483,11 @@ Zx
 wE
 IK
 ub
-lT
+Pa
 Pa
 Pa
 dJ
-lT
+Pa
 Pa
 "}
 (10,1,1) = {"
@@ -1516,17 +1510,17 @@ sO
 IK
 IK
 tq
-lT
-lT
+Pa
+Pa
 Pa
 lw
-lT
+Pa
 Pa
 "}
 (11,1,1) = {"
 Qa
 Qa
-mH
+lT
 tq
 tq
 tq
@@ -1544,10 +1538,10 @@ qi
 IK
 tq
 tq
-lT
-lT
+Pa
+Pa
 dJ
-lT
+Pa
 Pa
 "}
 (12,1,1) = {"
@@ -1556,7 +1550,7 @@ Qa
 tq
 tq
 tq
-lT
+kp
 pS
 PT
 by
@@ -1574,7 +1568,7 @@ Wm
 hR
 aO
 EX
-lT
+Pa
 Pa
 "}
 (13,1,1) = {"
@@ -1583,7 +1577,7 @@ Qa
 tq
 tq
 tq
-lT
+kp
 pS
 wG
 GV
@@ -1610,7 +1604,7 @@ Qa
 tq
 tq
 tq
-lT
+kp
 pS
 pS
 IK
@@ -1627,7 +1621,7 @@ oO
 Ge
 fB
 tq
-mH
+lT
 Pa
 Pa
 "}
@@ -1761,7 +1755,7 @@ tv
 fB
 Xo
 Wm
-lT
+kp
 tq
 tq
 tq
@@ -1771,7 +1765,7 @@ tq
 tq
 tq
 tq
-lT
+kp
 Wm
 cm
 Rv
@@ -1786,10 +1780,10 @@ gZ
 JV
 qA
 fB
-Ss
+Ze
 Wm
-lT
-lT
+kp
+kp
 tq
 tq
 "}
@@ -1798,7 +1792,7 @@ tq
 tq
 tq
 tq
-lT
+kp
 Wm
 Wm
 Wm
@@ -1815,7 +1809,7 @@ jX
 fB
 Ey
 fB
-lT
+kp
 tq
 tq
 tq
@@ -1826,8 +1820,8 @@ tq
 tq
 tq
 tq
-lT
 kp
+zc
 Pa
 ah
 ee
@@ -1840,9 +1834,9 @@ Jc
 Ce
 IJ
 fB
-Ss
+Ze
 fB
-lT
+kp
 tq
 tq
 tq
@@ -1855,9 +1849,9 @@ tq
 tq
 Vh
 Pa
-ZW
+wA
 Wm
-fR
+vN
 fB
 ZO
 Ng
@@ -1869,7 +1863,7 @@ fB
 fB
 Xo
 Wm
-lT
+kp
 tq
 tq
 tq
@@ -1892,11 +1886,11 @@ fB
 fB
 al
 Dc
-Ss
+Ze
 Xo
-Ss
+Ze
 Wm
-lT
+kp
 tq
 tq
 tq
@@ -1913,14 +1907,14 @@ tq
 Wm
 Lu
 QM
-fR
+vN
 CA
 Yy
 KZ
 Do
 fB
 jn
-zS
+Kb
 Xo
 Wm
 tq
@@ -1939,10 +1933,10 @@ tq
 tq
 Wm
 dL
-BS
-Ss
+fR
+Ze
 aE
-KV
+Ss
 fB
 fB
 fB
@@ -1971,9 +1965,9 @@ Wm
 FR
 Wm
 fB
-lT
-lT
-lT
+kp
+kp
+kp
 tq
 tq
 tq
@@ -1998,7 +1992,7 @@ qp
 fm
 Pa
 Pa
-qM
+Is
 tq
 tq
 tq
@@ -2022,7 +2016,7 @@ tq
 tq
 tq
 tq
-tz
+mH
 Pa
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
 /obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/welded,
 /obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -9,6 +9,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "aE" = (
@@ -16,6 +17,7 @@
 	dir = 8
 	},
 /obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "aH" = (
@@ -31,6 +33,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "aO" = (
@@ -118,6 +121,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
 /obj/item/organ/cyberimp/arm/power_cord,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "cB" = (
@@ -140,26 +144,18 @@
 	pixel_x = 5
 	},
 /obj/item/clothing/glasses/welding,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "dd" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/carpet/black,
 /area/ruin/unpowered/server_array/crew)
-"dg" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "dh" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/unpowered/server_array)
-"dA" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
 "dJ" = (
 /obj/structure/fence{
@@ -205,7 +201,6 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -277,7 +272,6 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -345,6 +339,7 @@
 	icon_state = "4-9"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "jX" = (
@@ -365,8 +360,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -401,6 +395,10 @@
 /obj/structure/fence/door,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
+"lB" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
 "lD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -421,8 +419,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -434,9 +434,8 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -514,6 +513,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "pw" = (
@@ -526,6 +526,12 @@
 "pS" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array/crew)
+"pX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "qi" = (
 /obj/structure/sign/warning/coldtemp{
 	pixel_x = -32
@@ -553,16 +559,15 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"ru" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"su" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "sO" = (
 /obj/machinery/door/airlock/external/glass{
 	dir = 4
@@ -575,8 +580,9 @@
 	},
 /area/ruin/unpowered/server_array)
 "tg" = (
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "tq" = (
 /turf/closed/mineral/random/snow,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -626,11 +632,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
-"wN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -644,11 +645,6 @@
 	pixel_x = 9
 	},
 /obj/effect/mob_spawn/human/laborer,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
-"yp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "yt" = (
@@ -669,16 +665,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered/server_array/crew)
-"zW" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "Aa" = (
 /obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/spline/fancy/opaque/red,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "An" = (
@@ -704,6 +695,7 @@
 	name = "lockdown control";
 	id = "server_lockdown"
 	},
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Av" = (
@@ -711,6 +703,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"Bb" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -722,6 +718,11 @@
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
+"By" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "BD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -733,6 +734,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"BW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "Ce" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
@@ -747,6 +753,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "CW" = (
@@ -760,7 +768,6 @@
 /area/ruin/unpowered/server_array/crew)
 "Dc" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -771,6 +778,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "DC" = (
@@ -852,6 +860,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"GR" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "GV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
@@ -916,13 +930,10 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"KL" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Lu" = (
@@ -1019,7 +1030,7 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1056,6 +1067,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
+"QA" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "QC" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -1077,6 +1092,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"Ru" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Rv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -1101,8 +1122,13 @@
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/machinery/light/small/broken/directional/east,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"RM" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "RQ" = (
 /obj/structure/salvageable/server,
 /obj/effect/turf_decal/techfloor/orange,
@@ -1123,8 +1149,13 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1170,6 +1201,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/box/ammo/a44roum_hp,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Xw" = (
@@ -1205,6 +1237,11 @@
 /mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"Yo" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/spider/stickyweb,
@@ -1212,6 +1249,7 @@
 /area/ruin/unpowered/server_array)
 "YJ" = (
 /obj/machinery/vending/engineering,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "YO" = (
@@ -1254,10 +1292,10 @@
 (1,1,1) = {"
 Qa
 Qa
-Ss
-Ss
-KL
-Ss
+mH
+mH
+Bb
+mH
 Qa
 tq
 tq
@@ -1280,12 +1318,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-Ss
-Ss
-Ss
-Ss
-Ss
-zW
+mH
+mH
+mH
+mH
+mH
+lT
 tq
 tq
 tq
@@ -1307,11 +1345,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-Ss
-Ss
-Ss
-Ss
-Ss
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1334,11 +1372,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-Ss
-Ss
-Ss
+mH
+mH
+mH
 Bw
-Ss
+mH
 tq
 tq
 tq
@@ -1361,10 +1399,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-Ss
-Ss
-Ss
-Ss
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1388,8 +1426,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-Ss
-Ss
+mH
+mH
 OQ
 tq
 tq
@@ -1404,9 +1442,9 @@ Zx
 tq
 tq
 tq
-Ss
-Ss
-Ss
+mH
+mH
+mH
 OQ
 tq
 tq
@@ -1415,8 +1453,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-Ss
-Ss
+mH
+mH
 tq
 tq
 tq
@@ -1426,24 +1464,24 @@ Oc
 IK
 aH
 Aa
-gz
-Zx
 Ss
-Ss
-Ss
-Ss
-Ss
-Ss
-Ss
-Ss
+lB
+mH
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-Ss
-Ss
+mH
+mH
 tq
 tq
 tq
@@ -1454,15 +1492,15 @@ IK
 Xt
 jw
 gz
-Zx
+lB
 pw
-Ss
-Ss
-Ss
-Ss
-Ss
-Ss
-Ss
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1470,7 +1508,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-Ss
+mH
 tq
 tq
 tq
@@ -1487,17 +1525,17 @@ Zx
 wE
 IK
 ub
-Ss
-Ss
-Ss
+mH
+mH
+mH
 dJ
-Ss
-Ss
+mH
+mH
 "}
 (10,1,1) = {"
 Qa
 Qa
-Ss
+mH
 tq
 tq
 tq
@@ -1514,17 +1552,17 @@ sO
 IK
 IK
 tq
-Ss
-Ss
-Ss
+mH
+mH
+mH
 lw
-Ss
-Ss
+mH
+mH
 "}
 (11,1,1) = {"
 Qa
 Qa
-zW
+lT
 tq
 tq
 tq
@@ -1542,11 +1580,11 @@ qi
 IK
 tq
 tq
-Ss
-Ss
+mH
+mH
 dJ
-Ss
-Ss
+mH
+mH
 "}
 (12,1,1) = {"
 Qa
@@ -1554,7 +1592,7 @@ Qa
 tq
 tq
 tq
-tg
+kp
 pS
 PT
 by
@@ -1572,8 +1610,8 @@ Wm
 hR
 aO
 EX
-Ss
-Ss
+mH
+mH
 "}
 (13,1,1) = {"
 Qa
@@ -1581,7 +1619,7 @@ Qa
 tq
 tq
 tq
-tg
+kp
 pS
 wG
 GV
@@ -1598,9 +1636,9 @@ mT
 jh
 Wm
 vV
-Ss
-Ss
-Ss
+mH
+mH
+mH
 "}
 (14,1,1) = {"
 Qa
@@ -1608,7 +1646,7 @@ Qa
 tq
 tq
 tq
-tg
+kp
 pS
 pS
 IK
@@ -1625,9 +1663,9 @@ oO
 Ge
 fB
 tq
-zW
-Ss
-Ss
+lT
+mH
+mH
 "}
 (15,1,1) = {"
 tq
@@ -1653,7 +1691,7 @@ xN
 fB
 tq
 tq
-Ss
+mH
 Qa
 "}
 (16,1,1) = {"
@@ -1673,7 +1711,7 @@ vj
 vj
 Qn
 iN
-wN
+BW
 fL
 NX
 Nl
@@ -1697,7 +1735,7 @@ IK
 hQ
 uf
 QC
-ru
+GR
 cB
 jY
 jY
@@ -1759,7 +1797,7 @@ tv
 fB
 Xo
 Wm
-tg
+kp
 tq
 tq
 tq
@@ -1769,7 +1807,7 @@ tq
 tq
 tq
 tq
-tg
+kp
 Wm
 cm
 Rv
@@ -1784,10 +1822,10 @@ gZ
 JV
 qA
 fB
-mH
+tg
 Wm
-tg
-tg
+kp
+kp
 tq
 tq
 "}
@@ -1796,7 +1834,7 @@ tq
 tq
 tq
 tq
-tg
+kp
 Wm
 Wm
 Wm
@@ -1813,7 +1851,7 @@ jX
 fB
 Ey
 fB
-tg
+kp
 tq
 tq
 tq
@@ -1823,12 +1861,12 @@ tq
 tq
 tq
 tq
-tg
-tg
-dg
-tg
+kp
+kp
+RM
+kp
 ah
-yp
+Ru
 fB
 PW
 kz
@@ -1838,9 +1876,9 @@ Jc
 Ce
 IJ
 fB
-mH
-fB
 tg
+fB
+kp
 tq
 tq
 tq
@@ -1852,10 +1890,10 @@ tq
 tq
 tq
 Vh
-tg
-lT
+kp
+su
 Wm
-Pa
+fR
 fB
 ZO
 Ng
@@ -1867,7 +1905,7 @@ fB
 fB
 Xo
 Wm
-tg
+kp
 tq
 tq
 tq
@@ -1890,11 +1928,11 @@ fB
 fB
 al
 Dc
-mH
+By
 Xo
-mH
-Wm
 tg
+Wm
+kp
 tq
 tq
 tq
@@ -1911,14 +1949,14 @@ tq
 Wm
 Lu
 QM
-Pa
+fR
 CA
 Yy
 KZ
 Do
 fB
 jn
-dA
+Pa
 Xo
 Wm
 tq
@@ -1937,8 +1975,8 @@ tq
 tq
 Wm
 dL
-fR
-mH
+pX
+Yo
 aE
 ee
 fB
@@ -1969,9 +2007,9 @@ Wm
 FR
 Wm
 fB
-Ss
-Ss
-Ss
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1994,9 +2032,9 @@ tq
 tq
 qp
 fm
-Ss
-Ss
-kp
+mH
+mH
+QA
 tq
 tq
 tq
@@ -2020,8 +2058,8 @@ tq
 tq
 tq
 tq
-kp
-Ss
+QA
+mH
 tq
 tq
 tq
@@ -2047,7 +2085,7 @@ tq
 tq
 tq
 tq
-Ss
+mH
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1269,8 +1269,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "YJ" = (
-/obj/machinery/vending/engineering,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/salvageable/circuit_imprinter,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "YO" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1,0 +1,2004 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/machinery/door/airlock/maintenance/external,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"aE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"aH" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/red{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/north,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"aO" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"aS" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered/server_array/crew)
+"ba" = (
+/obj/structure/chair/sofa/grey/corpo/right/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/carpet/black,
+/area/ruin/unpowered/server_array/crew)
+"bm" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array/crew)
+"by" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array/crew)
+"bQ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_y = -3;
+	pixel_x = -13
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 15;
+	pixel_x = 20
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array)
+"ca" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array/crew)
+"cg" = (
+/obj/structure/chair/sofa/grey/corpo/left/directional/south,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/carpet/black,
+/area/ruin/unpowered/server_array/crew)
+"cm" = (
+/obj/structure/closet/emcloset/empty,
+/obj/item/bodypart/chest,
+/obj/item/bodypart/head/ipc{
+	pixel_y = -5
+	},
+/obj/item/bodypart/l_arm/ipc,
+/obj/item/bodypart/r_arm{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/bodypart/leg/left{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/bodypart/leg/right/ipc{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/organ/heart/cybernetic,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"cB" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"cH" = (
+/obj/structure/table,
+/obj/item/clothing/head/hardhat{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"dd" = (
+/obj/machinery/vending/sustenance,
+/turf/open/floor/carpet/black,
+/area/ruin/unpowered/server_array/crew)
+"dh" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"dJ" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"dL" = (
+/obj/machinery/portable_atmospherics/canister/bz{
+	gas_type = null
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"ee" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"eu" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array/crew)
+"eO" = (
+/obj/machinery/computer/station_alert/retro{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"fm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"fB" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
+"fL" = (
+/turf/closed/wall,
+/area/ruin/unpowered/server_array)
+"fR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"gd" = (
+/obj/machinery/suit_storage_unit/independent/engineering,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array/crew)
+"gs" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array/crew)
+"gz" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
+"gB" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"gV" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array)
+"gZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/machinery/computer/monitor/retro{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"he" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array)
+"hq" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/laborer,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"hB" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"hQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/item/circular_saw/augment,
+/obj/item/ammo_casing/a44roum/hp,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array/crew)
+"hR" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"iK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"iN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"iR" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"jh" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"jn" = (
+/obj/structure/closet/firecloset/empty,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"jw" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/red{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"jX" = (
+/obj/structure/salvageable/safe_server,
+/obj/effect/turf_decal/techfloor/orange,
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"jY" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"kp" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"kz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"lb" = (
+/obj/structure/table,
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scrapuranium{
+	pixel_y = 2;
+	pixel_x = -4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 6
+	},
+/obj/item/screwdriver{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"lw" = (
+/obj/structure/fence/door,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"lD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"lH" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"lT" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"mA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/incident{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"mH" = (
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"mT" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"nl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered/server_array/crew)
+"ov" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ruin/unpowered/server_array/crew)
+"oO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/missing_gloves{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"oU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"pb" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/item/shard{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/shard{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/red{
+	dir = 10
+	},
+/obj/structure/frame/computer/retro{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"pw" = (
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"pS" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered/server_array/crew)
+"qi" = (
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"qj" = (
+/obj/structure/salvageable/autolathe,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"qp" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"qA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/structure/table,
+/obj/effect/landmark/mission_poi/main,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"sh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"sO" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"tb" = (
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"tg" = (
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"tq" = (
+/turf/closed/mineral/random/snow,
+/area/overmap_encounter/planetoid/cave/explored)
+"tv" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"ub" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"uf" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array/crew)
+"vj" = (
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"vV" = (
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"wE" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"wG" = (
+/obj/structure/bed/bunk,
+/obj/item/stack/sheet/metal,
+/obj/structure/sign/poster/contraband/engis_unite{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
+"xN" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/item/gun/ballistic/revolver/shadow/no_mag,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/innards,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ammo_casing/a44roum/hp{
+	pixel_x = 9
+	},
+/obj/effect/mob_spawn/human/laborer,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"yt" = (
+/obj/effect/turf_decal/techfloor/orange/corner,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"yP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"zG" = (
+/obj/structure/sink{
+	pixel_y = 18
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/unpowered/server_array/crew)
+"Aa" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/opaque/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"An" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/red{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Av" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"Bc" = (
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Bw" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"BD" = (
+/obj/machinery/power/smes,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"Ce" = (
+/obj/machinery/light/dim/directional/east,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"CA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"CW" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered/server_array/crew)
+"Dc" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"Do" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"DC" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"DY" = (
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"Ey" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"EN" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"EP" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/mission_poi,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"EX" = (
+/obj/structure/fence/corner,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"EZ" = (
+/obj/machinery/door/window/brigdoor/eastright,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array)
+"Fr" = (
+/obj/effect/turf_decal/techfloor/orange,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"FF" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"FR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered/server_array)
+"Ge" = (
+/obj/effect/decal/cleanable/blood/hitsplatter{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/squirt{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"Gf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
+"GQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"GV" = (
+/obj/machinery/light/dim/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
+"Hr" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Ht" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"Iu" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"IJ" = (
+/obj/structure/salvageable/server,
+/obj/effect/turf_decal/techfloor/orange,
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"IK" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array/crew)
+"Jb" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"Jc" = (
+/obj/structure/salvageable/server,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"Jt" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"JF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
+"JV" = (
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array)
+"KZ" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Lu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"LI" = (
+/obj/structure/salvageable/computer{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Ng" = (
+/obj/machinery/light/dim/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"Nl" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/fingerless{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/paper/crumpled/bloody/fluff/ruins/serverarray,
+/obj/item/pen,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Ns" = (
+/obj/structure/sign/poster/contraband/tools{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Nw" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"NC" = (
+/turf/closed/wall,
+/area/ruin/unpowered/server_array/crew)
+"NV" = (
+/obj/structure/mirror{
+	broken = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array/crew)
+"NX" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Oc" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/unpowered/server_array/crew)
+"OM" = (
+/obj/machinery/portable_atmospherics/canister/fuel,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"OQ" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Pa" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"PS" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"PT" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
+"PW" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/telecomms/server,
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 1;
+	pixel_y = -2;
+	amount = 2
+	},
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"Qa" = (
+/turf/template_noop,
+/area/template_noop)
+"Qn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"QC" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/unpowered/server_array/crew)
+"QM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Ro" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Rv" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8;
+	pixel_x = -22
+	},
+/obj/effect/decal/cleanable/blood/splatter{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/blood/innards{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/melee/knife/shiv{
+	pixel_y = -6;
+	pixel_x = 7
+	},
+/obj/item/wirecutters{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array)
+"RQ" = (
+/obj/structure/salvageable/server,
+/obj/effect/turf_decal/techfloor/orange,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+"Sl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/unpowered/server_array/crew)
+"Ss" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"UJ" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"Vd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/light/dim/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/unpowered/server_array/crew)
+"Vh" = (
+/obj/structure/closet/body_bag,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Wm" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered/server_array)
+"Xo" = (
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
+"Xt" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/red{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet,
+/obj/item/ammo_box/a44roum/hp,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Xw" = (
+/obj/item/wallframe/camera{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 1;
+	pixel_y = -2;
+	amount = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/unpowered/server_array/crew)
+"XD" = (
+/obj/structure/closet/toolcloset/empty,
+/obj/item/wrench,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"XJ" = (
+/obj/effect/turf_decal/techfloor/orange/corner,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/item/t_scanner,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Yy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"YJ" = (
+/obj/machinery/vending/engineering,
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"YO" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"YQ" = (
+/obj/item/storage/firstaid/regular{
+	pixel_y = 17;
+	pixel_x = -5
+	},
+/obj/structure/table,
+/obj/item/organ/eyes/robotic,
+/obj/item/organ/tongue/robot{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"Zx" = (
+/turf/open/floor/plating/snowed/temperatre{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"ZO" = (
+/obj/structure/salvageable/safe_server,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/cable{
+	icon_state = "0-10"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plasteel/tech{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/ruin/unpowered/server_array)
+
+(1,1,1) = {"
+Qa
+Qa
+kp
+kp
+kp
+kp
+Qa
+tq
+tq
+tq
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+"}
+(2,1,1) = {"
+Qa
+kp
+kp
+kp
+kp
+kp
+kp
+tq
+tq
+tq
+tq
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+"}
+(3,1,1) = {"
+Qa
+kp
+kp
+kp
+kp
+Pa
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+Qa
+Qa
+Qa
+tq
+tq
+tq
+Qa
+Qa
+Qa
+"}
+(4,1,1) = {"
+Qa
+kp
+kp
+kp
+Bw
+kp
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+Qa
+"}
+(5,1,1) = {"
+Qa
+kp
+Ss
+kp
+mH
+tq
+tq
+tq
+tq
+IK
+IK
+IK
+IK
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+"}
+(6,1,1) = {"
+Qa
+kp
+Pa
+OQ
+tq
+tq
+tq
+IK
+IK
+IK
+An
+pb
+gz
+Zx
+tq
+tq
+tq
+lT
+mH
+kp
+kp
+tq
+tq
+Qa
+Qa
+"}
+(7,1,1) = {"
+Qa
+kp
+kp
+tq
+tq
+tq
+tq
+IK
+Oc
+IK
+aH
+Aa
+gz
+Zx
+Zx
+Zx
+Zx
+Zx
+kp
+Ss
+kp
+Pa
+tq
+Qa
+Qa
+"}
+(8,1,1) = {"
+Qa
+kp
+kp
+tq
+tq
+tq
+tq
+NV
+zG
+IK
+Xt
+jw
+gz
+Zx
+pw
+Zx
+Zx
+Zx
+kp
+kp
+kp
+kp
+tq
+kp
+Qa
+"}
+(9,1,1) = {"
+Qa
+Qa
+kp
+tq
+tq
+tq
+IK
+IK
+PS
+IK
+IK
+ov
+IK
+IK
+wE
+Zx
+wE
+IK
+ub
+kp
+kp
+kp
+dJ
+kp
+kp
+"}
+(10,1,1) = {"
+Qa
+Qa
+Pa
+tq
+tq
+tq
+IK
+gs
+Qn
+Qn
+Iu
+CW
+nl
+IK
+IK
+sO
+IK
+IK
+tq
+kp
+kp
+kp
+lw
+kp
+kp
+"}
+(11,1,1) = {"
+Qa
+Qa
+kp
+tq
+tq
+tq
+pS
+XD
+JF
+qj
+NC
+dd
+Vd
+NC
+lb
+Qn
+qi
+IK
+tq
+tq
+Pa
+kp
+dJ
+kp
+kp
+"}
+(12,1,1) = {"
+Qa
+Qa
+Qa
+tq
+tq
+kp
+pS
+PT
+by
+eu
+NC
+ba
+Sl
+NC
+Xw
+vj
+EN
+fB
+Wm
+Wm
+hR
+aO
+EX
+kp
+kp
+"}
+(13,1,1) = {"
+Qa
+Qa
+tq
+tq
+tq
+kp
+pS
+wG
+GV
+Jt
+NC
+cg
+aS
+NC
+NC
+UJ
+NC
+fL
+mT
+jh
+Wm
+vV
+kp
+kp
+kp
+"}
+(14,1,1) = {"
+Qa
+Qa
+tq
+tq
+tq
+kp
+pS
+pS
+IK
+IK
+NC
+bm
+Ht
+NC
+gd
+vj
+ca
+fL
+oO
+Ge
+fB
+tq
+lT
+kp
+kp
+"}
+(15,1,1) = {"
+Qa
+Qa
+tq
+tq
+tq
+pS
+pS
+cH
+OM
+IK
+Qn
+Av
+iR
+mA
+yP
+GQ
+lD
+gV
+iK
+xN
+fB
+tq
+tq
+Ss
+Qa
+"}
+(16,1,1) = {"
+Qa
+tq
+tq
+tq
+tq
+IK
+YQ
+Nw
+Ro
+DY
+vj
+vj
+vj
+tg
+Qn
+iN
+Qn
+fL
+NX
+Nl
+Wm
+tq
+tq
+tq
+Qa
+"}
+(17,1,1) = {"
+Qa
+tq
+tq
+tq
+tq
+IK
+Bc
+EP
+eO
+IK
+hQ
+uf
+QC
+fB
+cB
+jY
+jY
+fB
+fB
+hB
+Wm
+tq
+tq
+tq
+Qa
+"}
+(18,1,1) = {"
+tq
+tq
+tq
+tq
+tq
+pS
+YJ
+Ro
+LI
+fB
+jY
+jY
+jY
+fB
+XJ
+Hr
+Hr
+gB
+fB
+Xo
+Wm
+tq
+tq
+tq
+Qa
+"}
+(19,1,1) = {"
+tq
+tq
+tq
+tq
+tq
+Wm
+Wm
+bQ
+fB
+fB
+yt
+Hr
+Hr
+Ns
+FF
+DC
+dh
+tv
+fB
+Xo
+Wm
+kp
+tq
+tq
+Qa
+"}
+(20,1,1) = {"
+tq
+tq
+tq
+tq
+kp
+Wm
+cm
+Rv
+sh
+he
+Fr
+Jb
+dh
+lH
+fB
+gZ
+JV
+qA
+fB
+Ey
+Wm
+kp
+kp
+tq
+tq
+"}
+(21,1,1) = {"
+tq
+tq
+tq
+tq
+kp
+Wm
+Wm
+Wm
+fB
+fB
+fB
+oU
+EZ
+BD
+fB
+Jc
+tb
+jX
+fB
+Ey
+fB
+kp
+tq
+tq
+tq
+"}
+(22,1,1) = {"
+tq
+tq
+tq
+tq
+tq
+kp
+kp
+kp
+ah
+ee
+fB
+PW
+kz
+RQ
+fB
+Jc
+Ce
+IJ
+fB
+Ey
+fB
+kp
+tq
+tq
+tq
+"}
+(23,1,1) = {"
+Qa
+tq
+tq
+tq
+tq
+Vh
+kp
+lT
+Wm
+fR
+fB
+ZO
+Ng
+RQ
+fB
+fB
+Gf
+fB
+fB
+Xo
+Wm
+kp
+tq
+tq
+tq
+"}
+(24,1,1) = {"
+Qa
+tq
+tq
+tq
+tq
+tq
+hq
+tq
+fB
+YO
+fB
+fB
+Gf
+fB
+fB
+al
+Dc
+Ey
+Xo
+Ey
+Wm
+kp
+tq
+tq
+Qa
+"}
+(25,1,1) = {"
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+Wm
+Lu
+QM
+fR
+CA
+Yy
+KZ
+Do
+fB
+jn
+Xo
+Xo
+Wm
+tq
+tq
+tq
+Qa
+"}
+(26,1,1) = {"
+Qa
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+Wm
+dL
+fR
+Ey
+aE
+ee
+fB
+fB
+fB
+fB
+fB
+Wm
+Wm
+tq
+tq
+Qa
+Qa
+"}
+(27,1,1) = {"
+Qa
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+Wm
+Wm
+fB
+Wm
+FR
+Wm
+fB
+kp
+kp
+kp
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+"}
+(28,1,1) = {"
+Qa
+Qa
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+qp
+fm
+lT
+kp
+kp
+tq
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+Qa
+"}
+(29,1,1) = {"
+Qa
+Qa
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+kp
+kp
+tq
+tq
+tq
+tq
+tq
+tq
+tq
+Qa
+Qa
+Qa
+Qa
+"}
+(30,1,1) = {"
+Qa
+Qa
+Qa
+Qa
+Qa
+Qa
+tq
+tq
+tq
+tq
+tq
+tq
+kp
+tq
+tq
+tq
+Qa
+tq
+tq
+tq
+Qa
+Qa
+Qa
+Qa
+Qa
+"}

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -147,10 +147,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"cN" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
 "dd" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/carpet/black,
@@ -184,11 +180,6 @@
 /obj/effect/spawner/bunk_bed,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array/crew)
-"eH" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "eO" = (
 /obj/machinery/computer/station_alert/retro{
 	dir = 1
@@ -196,10 +187,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"eW" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -214,7 +201,6 @@
 /area/ruin/unpowered/server_array)
 "fR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -226,11 +212,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
-"gl" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "gs" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/cobweb,
@@ -311,11 +292,14 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"ie" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+"hY" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array/crew)
 "iK" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -352,6 +336,10 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"jv" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "jw" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -384,9 +372,12 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "kp" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
+/turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
+"ks" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "kz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -440,6 +431,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
@@ -452,7 +446,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/turf/open/floor/plating/ice/icemoon,
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mT" = (
 /obj/machinery/power/smes,
@@ -571,6 +565,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"rX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/eggcluster,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
@@ -589,9 +589,9 @@
 /area/ruin/unpowered/server_array)
 "tg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
 "tq" = (
 /turf/closed/mineral/random/snow,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -619,6 +619,10 @@
 /obj/item/t_scanner,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array/crew)
+"vf" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "vj" = (
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
@@ -641,6 +645,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"xw" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -661,33 +669,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
-"yL" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/door/poddoor/shutters{
-	id = "server_lockdown"
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array/crew)
 "yP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"zl" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
-"zo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "zG" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -734,13 +721,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
-"AK" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9;
-	mode = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "Bc" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -790,6 +770,10 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
+"CX" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "Dc" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden/crude,
@@ -798,11 +782,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
-"Dd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
+"Dg" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -819,6 +803,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"DJ" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "DY" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/tech/grid,
@@ -842,6 +833,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
+"ET" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9;
+	mode = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
+"EV" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "EX" = (
 /obj/structure/fence/corner,
 /turf/open/floor/plating/asteroid/icerock,
@@ -953,10 +956,12 @@
 /obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/unpowered/server_array)
-"Kp" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/cave/explored)
+"KX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "KZ" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1021,6 +1026,9 @@
 "NC" = (
 /turf/closed/wall,
 /area/ruin/unpowered/server_array/crew)
+"NM" = (
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
 "NV" = (
 /obj/structure/mirror{
 	broken = 1
@@ -1057,11 +1065,10 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1116,10 +1123,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Rs" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "Rv" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -1167,9 +1170,9 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1279,6 +1282,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
 "Zx" = (
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
@@ -1296,18 +1300,14 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
-"ZX" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 
 (1,1,1) = {"
 Qa
 Qa
-lT
-lT
-kp
-lT
+mH
+mH
+CX
+mH
 Qa
 tq
 tq
@@ -1330,12 +1330,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
+mH
+mH
+mH
+mH
+mH
 lT
-lT
-lT
-lT
-lT
-Pa
 tq
 tq
 tq
@@ -1357,11 +1357,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-lT
-lT
-lT
-lT
-lT
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1384,11 +1384,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-lT
-lT
-lT
+mH
+mH
+mH
 Bw
-lT
+mH
 tq
 tq
 tq
@@ -1411,10 +1411,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-lT
-lT
-lT
-lT
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1438,8 +1438,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-lT
-lT
+mH
+mH
 OQ
 tq
 tq
@@ -1450,13 +1450,13 @@ IK
 An
 pb
 gz
-Zx
+NM
 tq
 tq
 tq
-lT
-lT
-lT
+mH
+mH
+mH
 OQ
 tq
 tq
@@ -1465,8 +1465,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-lT
-lT
+mH
+mH
 tq
 tq
 tq
@@ -1476,24 +1476,24 @@ Oc
 IK
 aH
 Aa
-yL
-Kp
-lT
-lT
-lT
-lT
-lT
-lT
-lT
-lT
+hY
+Zx
+mH
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-lT
-lT
+mH
+mH
 tq
 tq
 tq
@@ -1504,15 +1504,15 @@ IK
 Xt
 jw
 gz
-Kp
+Zx
 pw
-lT
-lT
-lT
-lT
-lT
-lT
-lT
+mH
+mH
+mH
+mH
+mH
+mH
+mH
 tq
 tq
 tq
@@ -1520,7 +1520,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-lT
+mH
 tq
 tq
 tq
@@ -1533,21 +1533,21 @@ ov
 IK
 IK
 wE
-Zx
+NM
 wE
 IK
 ub
-lT
-lT
-lT
+mH
+mH
+mH
 dJ
-lT
-lT
+mH
+mH
 "}
 (10,1,1) = {"
 Qa
 Qa
-lT
+mH
 tq
 tq
 tq
@@ -1564,17 +1564,17 @@ sO
 IK
 IK
 tq
-lT
-lT
-lT
+mH
+mH
+mH
 lw
-lT
-lT
+mH
+mH
 "}
 (11,1,1) = {"
 Qa
 Qa
-Pa
+lT
 tq
 tq
 tq
@@ -1592,11 +1592,11 @@ qi
 IK
 tq
 tq
-lT
-lT
+mH
+mH
 dJ
-lT
-lT
+mH
+mH
 "}
 (12,1,1) = {"
 Qa
@@ -1604,7 +1604,7 @@ Qa
 tq
 tq
 tq
-mH
+kp
 pS
 PT
 by
@@ -1622,8 +1622,8 @@ Wm
 hR
 aO
 EX
-lT
-lT
+mH
+mH
 "}
 (13,1,1) = {"
 Qa
@@ -1631,7 +1631,7 @@ Qa
 tq
 tq
 tq
-mH
+kp
 pS
 wG
 GV
@@ -1648,9 +1648,9 @@ mT
 jh
 Wm
 vV
-lT
-lT
-lT
+mH
+mH
+mH
 "}
 (14,1,1) = {"
 Qa
@@ -1658,7 +1658,7 @@ Qa
 tq
 tq
 tq
-mH
+kp
 pS
 pS
 IK
@@ -1675,9 +1675,9 @@ oO
 Ge
 fB
 tq
-Pa
 lT
-lT
+mH
+mH
 "}
 (15,1,1) = {"
 tq
@@ -1703,7 +1703,7 @@ xN
 fB
 tq
 tq
-lT
+mH
 Qa
 "}
 (16,1,1) = {"
@@ -1723,7 +1723,7 @@ vj
 vj
 Qn
 iN
-Dd
+tg
 fL
 NX
 Nl
@@ -1747,7 +1747,7 @@ IK
 hQ
 uf
 QC
-AK
+ET
 cB
 jY
 jY
@@ -1806,10 +1806,10 @@ FF
 DC
 dh
 tv
-Ss
+xw
 Xo
 Wm
-mH
+kp
 tq
 tq
 tq
@@ -1819,7 +1819,7 @@ tq
 tq
 tq
 tq
-zl
+DJ
 Wm
 cm
 Rv
@@ -1834,10 +1834,10 @@ gZ
 JV
 qA
 fB
-eW
+ks
 Wm
-mH
-mH
+kp
+kp
 tq
 tq
 "}
@@ -1846,7 +1846,7 @@ tq
 tq
 tq
 tq
-mH
+kp
 Wm
 Wm
 Wm
@@ -1863,7 +1863,7 @@ jX
 fB
 Ey
 fB
-mH
+kp
 tq
 tq
 tq
@@ -1873,12 +1873,12 @@ tq
 tq
 tq
 tq
-mH
-mH
-ZX
-mH
+kp
+kp
+Ss
+kp
 ah
-zo
+KX
 fB
 PW
 kz
@@ -1888,9 +1888,9 @@ Jc
 Ce
 IJ
 fB
-eW
+ks
 fB
-mH
+kp
 tq
 tq
 tq
@@ -1902,10 +1902,10 @@ tq
 tq
 tq
 Vh
-mH
-Rs
+kp
+vf
 Wm
-tg
+fR
 fB
 ZO
 Ng
@@ -1917,7 +1917,7 @@ fB
 fB
 Xo
 Wm
-mH
+kp
 tq
 tq
 tq
@@ -1934,17 +1934,17 @@ tq
 fB
 YO
 fB
-Ss
+fB
 Gf
 fB
 fB
 al
 Dc
-eH
+EV
 Xo
-eW
+ks
 Wm
-mH
+kp
 tq
 tq
 tq
@@ -1961,14 +1961,14 @@ tq
 Wm
 Lu
 QM
-tg
+fR
 CA
 Yy
 KZ
 Do
 fB
 jn
-gl
+Dg
 Xo
 Wm
 tq
@@ -1987,8 +1987,8 @@ tq
 tq
 Wm
 dL
-fR
-ie
+rX
+Pa
 aE
 ee
 fB
@@ -2019,9 +2019,9 @@ Wm
 FR
 Wm
 fB
-lT
-lT
-lT
+mH
+mH
+mH
 tq
 tq
 tq
@@ -2044,9 +2044,9 @@ tq
 tq
 qp
 fm
-lT
-lT
-cN
+mH
+mH
+jv
 tq
 tq
 tq
@@ -2070,8 +2070,8 @@ tq
 tq
 tq
 tq
-cN
-lT
+jv
+mH
 tq
 tq
 tq
@@ -2097,7 +2097,7 @@ tq
 tq
 tq
 tq
-lT
+mH
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -49,19 +49,15 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
+"aU" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "ba" = (
 /obj/structure/chair/sofa/grey/corpo/right/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/carpet/black,
-/area/ruin/unpowered/server_array/crew)
-"bj" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/door/poddoor/shutters{
-	id = "server_lockdown"
-	},
-/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
 "bm" = (
 /obj/effect/spawner/structure/window,
@@ -132,6 +128,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
+"cu" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "cB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -165,13 +166,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"dE" = (
-/obj/machinery/porta_turret/ship/nt{
-	dir = 9;
-	mode = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/server_array)
 "dJ" = (
 /obj/structure/fence{
 	dir = 8
@@ -187,7 +181,7 @@
 /area/ruin/unpowered/server_array)
 "ee" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/eggcluster,
+/obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -234,7 +228,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array/crew)
 "gz" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
 /obj/machinery/door/poddoor/shutters{
 	id = "server_lockdown"
 	},
@@ -280,8 +275,8 @@
 /area/ruin/unpowered/server_array)
 "hq" = (
 /obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/laborer,
 /obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/mob_spawn/human/engineer,
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "hB" = (
@@ -411,10 +406,6 @@
 /obj/structure/fence/door,
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
-"lx" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
 "lD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -423,6 +414,13 @@
 	icon_state = "2-5"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/unpowered/server_array/crew)
+"lF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/machinery/door/poddoor/shutters{
+	id = "server_lockdown"
+	},
+/turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
 "lH" = (
 /obj/effect/turf_decal/techfloor/orange{
@@ -435,8 +433,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
 "lT" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/ice/icemoon,
+/obj/structure/flora/rock/pile/icy{
+	icon_state = "icemoonrock1"
+	},
+/turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "mA" = (
 /obj/structure/cable{
@@ -448,11 +448,10 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "mH" = (
-/obj/structure/flora/rock/pile/icy{
-	icon_state = "icemoonrock1"
-	},
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered/server_array)
 "mT" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -460,10 +459,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
-"nc" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "nl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -490,6 +485,10 @@
 	dir = 4
 	},
 /area/ruin/unpowered/server_array/crew)
+"ow" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "oO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -537,10 +536,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"pf" = (
-/obj/structure/flora/ash/puce,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
+"pp" = (
+/obj/machinery/porta_turret/ship/nt{
+	dir = 9;
+	mode = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/server_array)
 "pw" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32;
@@ -578,15 +580,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array)
-"rv" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
-"rM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/unpowered/server_array/crew)
 "sh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
@@ -605,7 +598,7 @@
 /area/ruin/unpowered/server_array)
 "tg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/cocoon,
+/obj/structure/spider/eggcluster,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
@@ -658,6 +651,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array/crew)
+"xE" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
+	brute_damage = 200
+	},
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "xN" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -670,7 +670,7 @@
 /obj/item/ammo_casing/a44roum/hp{
 	pixel_x = 9
 	},
-/obj/effect/mob_spawn/human/laborer,
+/obj/effect/mob_spawn/human/engineer,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "yt" = (
@@ -737,11 +737,6 @@
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ruin/unpowered/server_array/crew)
-"Bl" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Bw" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/icerock,
@@ -766,6 +761,10 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/server_array)
+"Cj" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ice/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
 "CA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -856,10 +855,11 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
-"FZ" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
+"Gc" = (
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "Ge" = (
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4;
@@ -958,11 +958,20 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
+"LE" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "LI" = (
 /obj/structure/salvageable/computer{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
+/area/ruin/unpowered/server_array/crew)
+"MK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/unpowered/server_array/crew)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1010,13 +1019,6 @@
 "NC" = (
 /turf/closed/wall,
 /area/ruin/unpowered/server_array/crew)
-"NE" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	brute_damage = 200
-	},
-/turf/open/floor/plating/ice/icemoon,
-/area/overmap_encounter/planetoid/cave/explored)
 "NV" = (
 /obj/structure/mirror{
 	broken = 1
@@ -1053,12 +1055,9 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "Pa" = (
-/turf/open/floor/plating/asteroid/icerock,
-/area/overmap_encounter/planetoid/cave/explored)
-"PI" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/cave/explored)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
 "PS" = (
 /obj/machinery/door/airlock{
 	dir = 4
@@ -1107,6 +1106,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mob_spawn/human/skeleton,
 /obj/structure/spider/stickyweb,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/server_array)
+"Rn" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Ro" = (
@@ -1160,15 +1164,8 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Ss" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/rust,
-/area/ruin/unpowered/server_array)
-"SI" = (
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "UJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -1196,12 +1193,7 @@
 "Wm" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/unpowered/server_array)
-"WM" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/server_array)
 "Xo" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/ruin/unpowered/server_array)
@@ -1235,6 +1227,10 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/server_array/crew)
+"Xy" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/icerock,
+/area/overmap_encounter/planetoid/cave/explored)
 "XD" = (
 /obj/structure/closet/toolcloset/empty,
 /obj/item/wrench,
@@ -1254,6 +1250,10 @@
 /mob/living/simple_animal/pet/mothroach,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
+"Yu" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/overmap_encounter/planetoid/cave/explored)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/spider/stickyweb,
@@ -1304,10 +1304,10 @@
 (1,1,1) = {"
 Qa
 Qa
-Pa
-Pa
-rv
-Pa
+Ss
+Ss
+aU
+Ss
 Qa
 tq
 tq
@@ -1330,12 +1330,12 @@ Qa
 "}
 (2,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
-mH
+Ss
+Ss
+Ss
+Ss
+Ss
+lT
 tq
 tq
 tq
@@ -1357,11 +1357,11 @@ Qa
 "}
 (3,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1384,11 +1384,11 @@ tq
 "}
 (4,1,1) = {"
 Qa
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 Bw
-Pa
+Ss
 tq
 tq
 tq
@@ -1411,10 +1411,10 @@ tq
 "}
 (5,1,1) = {"
 Qa
-Pa
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1438,8 +1438,8 @@ tq
 "}
 (6,1,1) = {"
 Qa
-Pa
-Pa
+Ss
+Ss
 OQ
 tq
 tq
@@ -1449,14 +1449,14 @@ IK
 IK
 An
 pb
-gz
+lF
 Zx
 tq
 tq
 tq
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 OQ
 tq
 tq
@@ -1465,8 +1465,8 @@ tq
 "}
 (7,1,1) = {"
 Qa
-Pa
-Pa
+Ss
+Ss
 tq
 tq
 tq
@@ -1476,24 +1476,24 @@ Oc
 IK
 aH
 Aa
-bj
-PI
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+gz
+Yu
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
 "}
 (8,1,1) = {"
 Qa
-Pa
-Pa
+Ss
+Ss
 tq
 tq
 tq
@@ -1503,16 +1503,16 @@ zG
 IK
 Xt
 jw
-gz
-PI
+lF
+Yu
 pw
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -1520,7 +1520,7 @@ tq
 (9,1,1) = {"
 Qa
 Qa
-Pa
+Ss
 tq
 tq
 tq
@@ -1537,17 +1537,17 @@ Zx
 wE
 IK
 ub
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 dJ
-Pa
-Pa
+Ss
+Ss
 "}
 (10,1,1) = {"
 Qa
 Qa
-Pa
+Ss
 tq
 tq
 tq
@@ -1564,17 +1564,17 @@ sO
 IK
 IK
 tq
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 lw
-Pa
-Pa
+Ss
+Ss
 "}
 (11,1,1) = {"
 Qa
 Qa
-mH
+lT
 tq
 tq
 tq
@@ -1592,11 +1592,11 @@ qi
 IK
 tq
 tq
-Pa
-Pa
+Ss
+Ss
 dJ
-Pa
-Pa
+Ss
+Ss
 "}
 (12,1,1) = {"
 Qa
@@ -1622,8 +1622,8 @@ Wm
 hR
 aO
 EX
-Pa
-Pa
+Ss
+Ss
 "}
 (13,1,1) = {"
 Qa
@@ -1648,9 +1648,9 @@ mT
 jh
 Wm
 vV
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 "}
 (14,1,1) = {"
 Qa
@@ -1675,9 +1675,9 @@ oO
 Ge
 fB
 tq
-mH
-Pa
-Pa
+lT
+Ss
+Ss
 "}
 (15,1,1) = {"
 tq
@@ -1703,7 +1703,7 @@ xN
 fB
 tq
 tq
-Pa
+Ss
 Qa
 "}
 (16,1,1) = {"
@@ -1723,7 +1723,7 @@ vj
 vj
 Qn
 iN
-rM
+MK
 fL
 NX
 Nl
@@ -1747,7 +1747,7 @@ IK
 hQ
 uf
 QC
-dE
+pp
 cB
 jY
 jY
@@ -1780,7 +1780,7 @@ Hr
 Hr
 gB
 fB
-lx
+Xo
 Wm
 tq
 tq
@@ -1806,8 +1806,8 @@ FF
 DC
 dh
 tv
-WM
-lx
+LE
+Xo
 Wm
 kp
 tq
@@ -1819,7 +1819,7 @@ tq
 tq
 tq
 tq
-NE
+xE
 Wm
 cm
 Rv
@@ -1834,7 +1834,7 @@ gZ
 JV
 qA
 fB
-nc
+Pa
 Wm
 kp
 kp
@@ -1875,10 +1875,10 @@ tq
 tq
 kp
 kp
-FZ
+ow
 kp
 ah
-tg
+ee
 fB
 PW
 kz
@@ -1888,7 +1888,7 @@ Jc
 Ce
 IJ
 fB
-nc
+Pa
 fB
 kp
 tq
@@ -1903,9 +1903,9 @@ tq
 tq
 Vh
 kp
-lT
+Cj
 Wm
-Ss
+mH
 fB
 ZO
 Ng
@@ -1915,7 +1915,7 @@ fB
 Gf
 fB
 fB
-lx
+Xo
 Wm
 kp
 tq
@@ -1940,9 +1940,9 @@ fB
 fB
 al
 Dc
-Bl
-lx
-nc
+Rn
+Xo
+Pa
 Wm
 kp
 tq
@@ -1961,15 +1961,15 @@ tq
 Wm
 Lu
 QM
-Ss
+mH
 CA
 Yy
 KZ
 Do
 fB
 jn
+cu
 Xo
-lx
 Wm
 tq
 tq
@@ -1988,9 +1988,9 @@ tq
 Wm
 dL
 fR
-SI
+Gc
 aE
-ee
+tg
 fB
 fB
 fB
@@ -2019,9 +2019,9 @@ Wm
 FR
 Wm
 fB
-Pa
-Pa
-Pa
+Ss
+Ss
+Ss
 tq
 tq
 tq
@@ -2044,9 +2044,9 @@ tq
 tq
 qp
 fm
-Pa
-Pa
-pf
+Ss
+Ss
+Xy
 tq
 tq
 tq
@@ -2070,8 +2070,8 @@ tq
 tq
 tq
 tq
-pf
-Pa
+Xy
+Ss
 tq
 tq
 tq
@@ -2097,7 +2097,7 @@ tq
 tq
 tq
 tq
-Pa
+Ss
 tq
 tq
 tq

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_server_array.dmm
@@ -1104,8 +1104,8 @@
 /area/ruin/unpowered/server_array/crew)
 "QM" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mob_spawn/human/skeleton,
 /obj/structure/spider/stickyweb,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/server_array)
 "Rn" = (
@@ -1185,9 +1185,12 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/server_array/crew)
 "Vh" = (
-/obj/structure/closet/body_bag,
-/obj/effect/mob_spawn/human/skeleton,
 /obj/effect/decal/cleanable/blood/gibs/old,
+/obj/item/bodybag{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating/ice/icemoon,
 /area/overmap_encounter/planetoid/cave/explored)
 "Wm" = (

--- a/_maps/map_catalogue.txt
+++ b/_maps/map_catalogue.txt
@@ -38,6 +38,10 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 		Size = (x = 47)(y = 37)(z = 1)
 		Tags = "Medium Combat Challenge", "Minor Loot", "Shelter"
 
+		File Name = _maps\RandomRuins\IceRuins\icemoon_underground_server_array.dmm
+		Size = (x = 30)(y = 25)(z = 1)
+		Tags = "Medium Combat Challenge", "Minor Loot", "Shelter"
+
 
 
 	JungleRuins:

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -39,3 +39,9 @@
 	suffix = "icemoon_ice_lodge.dmm"
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
 
+/datum/map_template/ruin/icemoon/server_array
+	name = "Server Array"
+	id = "server_array"
+	description = "A long abandoned server array, using the icemoons atmosphere to cool down the large amount of heat produced by the machinery."
+	suffix = "icemoon_underground_server_array.dmm"
+	ruin_tags = list(RUIN_TAG_MINOR_LOOT, RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_SHELTER)

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -44,4 +44,4 @@
 	id = "server_array"
 	description = "A long abandoned server array, using the icemoons atmosphere to cool down the large amount of heat produced by the machinery."
 	suffix = "icemoon_underground_server_array.dmm"
-	ruin_tags = list(RUIN_TAG_MINOR_LOOT, RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_SHELTER)
+	ruin_tags = list(RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_SHELTER)

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -46,3 +46,12 @@
 /area/ruin/powered/icemoon/lodge/gear_room
 	name = "Gear Room"
 	icon_state = "security"
+
+// Server Array
+/area/ruin/unpowered/server_array
+	name = "Server Array"
+	icon_state = "away4"
+
+/area/ruin/unpowered/server_array/crew
+	name = "Crew Quarters"
+	icon_state = "away2"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -187,6 +187,15 @@
 	poison_type = /datum/reagent/toxin/venom //all in venom, glass cannon. you bite 5 times and they are DEFINITELY dead, but 40 health and you are extremely obvious. Ambush, maybe?
 	speed = 1
 
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper/ice //spiders dont usually like tempatures of 140 kelvin who knew
+	name = "ice viper"
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	minbodytemp = 0
+	maxbodytemp = 1500
+	poison_per_bite = 8
+	poison_type = /datum/reagent/toxin/mindbreaker // not deadly, but leads to interesting scenarios! Might need to modify the poison per bite though...
+	color = rgb(114,228,250)
+
 //tarantulas are really tanky, regenerating (maybe), hulky monster but are also extremely slow, so.
 /mob/living/simple_animal/hostile/poison/giant_spider/tarantula
 	name = "tarantula"

--- a/code/modules/ruins/icemoonruin_code/serverarray.dm
+++ b/code/modules/ruins/icemoonruin_code/serverarray.dm
@@ -1,7 +1,7 @@
 ///////////	things made for the server array icemoon ruin
 
 /obj/item/paper/crumpled/bloody/fluff/ruins/serverarray
-	default_raw_text = "my last words<BR><BR>ive killed<BR>i didnt sign up to kill<BR>im so sorry i have one bullet left<BR>i hope its enough"
+	default_raw_text = "my last words<BR><BR>ive killed<BR>i can still hear them even without tongues<BR>im so sorry,,, i have one bullet left<BR>they wont have my body too"
 	name = "bloody note"
 
 /datum/outfit/laborer

--- a/code/modules/ruins/icemoonruin_code/serverarray.dm
+++ b/code/modules/ruins/icemoonruin_code/serverarray.dm
@@ -3,21 +3,3 @@
 /obj/item/paper/crumpled/bloody/fluff/ruins/serverarray
 	default_raw_text = "my last words<BR><BR>ive killed<BR>i can still hear them even without tongues<BR>im so sorry,,, i have one bullet left<BR>they wont have my body too"
 	name = "bloody note"
-
-/datum/outfit/laborer
-	name = "Laborer"
-
-	belt = /obj/item/storage/belt/utility/full
-	ears = /obj/item/radio/headset/headset_eng
-	uniform = /obj/item/clothing/under/nanotrasen
-	suit = /obj/item/clothing/suit/hooded/wintercoat/engineering
-	shoes = /obj/item/clothing/shoes/workboots
-	head = /obj/item/clothing/head/hardhat
-	r_pocket = /obj/item/t_scanner
-	back = /obj/item/storage/backpack/industrial
-	id = /obj/item/card/id
-
-/obj/effect/mob_spawn/human/laborer
-	name = "Laborer"
-	outfit = /datum/outfit/laborer
-	icon_state = "corpseengineer"

--- a/code/modules/ruins/icemoonruin_code/serverarray.dm
+++ b/code/modules/ruins/icemoonruin_code/serverarray.dm
@@ -1,0 +1,23 @@
+///////////	things made for the server array icemoon ruin
+
+/obj/item/paper/crumpled/bloody/fluff/ruins/serverarray
+	default_raw_text = "my last words<BR><BR>ive killed<BR>i didnt sign up to kill<BR>im so sorry i have one bullet left<BR>i hope its enough"
+	name = "bloody note"
+
+/datum/outfit/laborer
+	name = "Laborer"
+
+	belt = /obj/item/storage/belt/utility/full
+	ears = /obj/item/radio/headset/headset_eng
+	uniform = /obj/item/clothing/under/color/khaki
+	suit = /obj/item/clothing/suit/hooded/wintercoat/engineering
+	shoes = /obj/item/clothing/shoes/workboots
+	head = /obj/item/clothing/head/hardhat
+	r_pocket = /obj/item/t_scanner
+	back = /obj/item/storage/backpack/industrial
+	id = /obj/item/card/id
+
+/obj/effect/mob_spawn/human/laborer
+	name = "Laborer"
+	outfit = /datum/outfit/laborer
+	icon_state = "corpseengineer"

--- a/code/modules/ruins/icemoonruin_code/serverarray.dm
+++ b/code/modules/ruins/icemoonruin_code/serverarray.dm
@@ -9,7 +9,7 @@
 
 	belt = /obj/item/storage/belt/utility/full
 	ears = /obj/item/radio/headset/headset_eng
-	uniform = /obj/item/clothing/under/color/khaki
+	uniform = /obj/item/clothing/under/nanotrasen
 	suit = /obj/item/clothing/suit/hooded/wintercoat/engineering
 	shoes = /obj/item/clothing/shoes/workboots
 	head = /obj/item/clothing/head/hardhat

--- a/code/modules/ruins/icemoonruin_code/serverarray.dm
+++ b/code/modules/ruins/icemoonruin_code/serverarray.dm
@@ -3,3 +3,5 @@
 /obj/item/paper/crumpled/bloody/fluff/ruins/serverarray
 	default_raw_text = "my last words<BR><BR>ive killed<BR>i can still hear them even without tongues<BR>im so sorry,,, i have one bullet left<BR>they wont have my body too"
 	name = "bloody note"
+
+// Ice Vipers in giant_spider.dm were also made for server array.

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3238,6 +3238,7 @@
 #include "code\modules\ruins\rockplanet_ruin_code.dm"
 #include "code\modules\ruins\icemoonruin_code\hydroponicslab.dm"
 #include "code\modules\ruins\icemoonruin_code\library.dm"
+#include "code\modules\ruins\icemoonruin_code\serverarray.dm"
 #include "code\modules\ruins\icemoonruin_code\wrath.dm"
 #include "code\modules\ruins\lavalandruin_code\biodome_winter.dm"
 #include "code\modules\ruins\lavalandruin_code\puzzle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a **Server Array** ruin to Ice moons.

The ruin offers an engineering challenge to be fully explored, but in case a team is lacking the tools, they can scrounge around for everything they need to get past the obstacles.

The available loot is wide in variety, allowing any job to hopefully gain something from the time spent to explore it.

There are plenty of spiders, but their venom is replaced with **Mindbreaker Toxin**, not posing a threat to the body but instead the victims mind. Spiders already have many ice variants, so these new ones are the ice variant of the viper spider.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There need to be more ice ruins! The variety is lacking, and if I had to invest in a structure on an ice moon it would definitely be a bunch of machinery being cooled down by the chilly air.

![mapimage](https://github.com/user-attachments/assets/86c0532c-c7a1-4a6d-a371-0794d341c6e0)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: server array ice ruin
add: ice vipers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
