### PR TITLE
Disables the Komodo

### DIFF
--- a/_maps/configs/syndicate_gorlex_komodo.json
+++ b/_maps/configs/syndicate_gorlex_komodo.json
@@ -51,5 +51,5 @@
 			"slots": 2
 		}
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the Komodo adminspawn. This is a temporary measure until the Komodo's replacement is finished.

## Why It's Good For The Game

the komodo has a downright rancid reputation and is pending a replacement anyway. Putting access to it under admin control helps at least a little, letting admins allow players with a proven record to run it without completely locking it away.

## Changelog

:cl:
balance: Made Komodo aspawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
