### PR TITLE
Scarborough attachment stuff.

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -1,3 +1,6 @@
+#define SCARBOROUGH_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet)
+#define SCARBOROUGH_ATTACH_SLOTS list(ATTACHMENT_SLOT_MUZZLE = 1, ATTACHMENT_SLOT_SCOPE = 1, ATTACHMENT_SLOT_RAIL = 1)
+
 //########### PISTOLS ###########//
 /obj/item/gun/ballistic/automatic/pistol/ringneck
 	name = "PC-76 \"Ringneck\""
@@ -28,17 +31,8 @@
 	manufacturer = MANUFACTURER_SCARBOROUGH
 	show_magazine_on_sprite = TRUE
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 27,
@@ -117,17 +111,8 @@ EMPTY_GUN_HELPER(automatic/pistol/ringneck/indie)
 	manufacturer = MANUFACTURER_SCARBOROUGH
 	show_magazine_on_sprite = TRUE
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 32,
@@ -239,17 +224,8 @@ EMPTY_GUN_HELPER(revolver/viper/indie)
 
 	show_magazine_on_sprite = TRUE
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 40,
@@ -385,12 +361,7 @@ EMPTY_GUN_HELPER(automatic/pistol/himehabu)
 	show_ammo_capacity_on_magazine_sprite = TRUE
 	manufacturer = MANUFACTURER_SCARBOROUGH
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1
@@ -547,12 +518,7 @@ EMPTY_GUN_HELPER(automatic/smg/sidewinder)
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
 	zoom_out_amt = 5
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1
@@ -685,17 +651,8 @@ EMPTY_GUN_HELPER(automatic/marksman/taipan)
 	spread_unwielded = 8
 	wield_slowdown = 0.4
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 42,
@@ -751,17 +708,8 @@ EMPTY_GUN_HELPER(automatic/assault/hydra)
 	wield_slowdown = 0.85 //better than the lmgs since it doesnt have a bipod, still not ideal
 	wield_delay = 0.9 SECONDS //ditto
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 48,
@@ -970,17 +918,8 @@ EMPTY_GUN_HELPER(automatic/assault/hydra/dmr)
 	wield_slowdown = 0.6
 	wield_delay = 0.65 SECONDS
 
-	valid_attachments = list(
-		/obj/item/attachment/silencer,
-		/obj/item/attachment/laser_sight,
-		/obj/item/attachment/rail_light,
-		/obj/item/attachment/bayonet
-	)
-	slot_available = list(
-		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1,
-		ATTACHMENT_SLOT_RAIL = 1
-	)
+	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 44,
@@ -1092,3 +1031,6 @@ EMPTY_GUN_HELPER(shotgun/bulldog)
 	caliber = "70mm"
 	icon_state = "84mm-hedp"
 	projectile_type = /obj/projectile/bullet/a84mm
+
+#undef SCARBOROUGH_ATTACHMENTS
+#undef SCARBOROUGH_ATTACH_SLOTS

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -401,8 +401,8 @@ EMPTY_GUN_HELPER(automatic/pistol/himehabu)
 			"y" = 23,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 38,
-			"y" = 18,
+			"x" = 28,
+			"y" = 16,
 		)
 	)
 
@@ -972,10 +972,14 @@ EMPTY_GUN_HELPER(automatic/assault/hydra/dmr)
 
 	valid_attachments = list(
 		/obj/item/attachment/silencer,
+		/obj/item/attachment/laser_sight,
+		/obj/item/attachment/rail_light,
+		/obj/item/attachment/bayonet
 	)
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
-		ATTACHMENT_SLOT_SCOPE = 1
+		ATTACHMENT_SLOT_SCOPE = 1,
+		ATTACHMENT_SLOT_RAIL = 1
 	)
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
@@ -985,6 +989,10 @@ EMPTY_GUN_HELPER(automatic/assault/hydra/dmr)
 		ATTACHMENT_SLOT_SCOPE = list(
 			"x" = 25,
 			"y" = 24,
+		),
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 30,
+			"y" = 18,
 		)
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Cobra offset is fixed.
- Bulldog and Mastiff can now have rail attachments.
- Makes the common attachment lineup a define (requested by erika)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
SA is all tactical and stuff, their shotguns should prolly be allowed to have a knife on them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Bulldogs and Mastiffs can now have rail attachments.
fix: Fixes the Cobra rail attachment offset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
