### PR TITLE
Refactors moodlets so that newline control characters don't have to be explicitly written, converts descriptions to span macros

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -73,6 +73,7 @@
 #define span_narsie(str) ("<span class='narsie'>" + str + "</span>")
 #define span_narsiesmall(str) ("<span class='narsiesmall'>" + str + "</span>")
 #define span_nicegreen(str) ("<span class='nicegreen'>" + str + "</span>")
+#define span_nicegreen_robot(str) ("<span class='nicegree robot'>" + str + "</span>")
 #define span_notice(str) ("<span class='notice'>" + str + "</span>")
 #define span_noticealien(str) ("<span class='noticealien'>" + str + "</span>")
 #define span_ooc(str) ("<span class='ooc'>" + str + "</span>")
@@ -113,6 +114,7 @@
 #define span_unconscious(str) ("<span class='unconscious'>" + str + "</span>")
 #define span_userdanger(str) ("<span class='userdanger'>" + str + "</span>")
 #define span_warning(str) ("<span class='warning'>" + str + "</span>")
+#define span_warning_robot(str) ("<span class='warning robot'>" + str + "</span>")
 #define span_yell(str) ("<span class='yell'>" + str + "</span>")
 #define span_yellowteamradio(str) ("<span class='yellowteamradio'>" + str + "</span>")
 

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -73,7 +73,7 @@
 #define span_narsie(str) ("<span class='narsie'>" + str + "</span>")
 #define span_narsiesmall(str) ("<span class='narsiesmall'>" + str + "</span>")
 #define span_nicegreen(str) ("<span class='nicegreen'>" + str + "</span>")
-#define span_nicegreen_robot(str) ("<span class='nicegree robot'>" + str + "</span>")
+#define span_nicegreen_robot(str) ("<span class='nicegreen robot'>" + str + "</span>")
 #define span_notice(str) ("<span class='notice'>" + str + "</span>")
 #define span_noticealien(str) ("<span class='noticealien'>" + str + "</span>")
 #define span_ooc(str) ("<span class='ooc'>" + str + "</span>")

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -89,7 +89,7 @@
 	if(mood_events.len)
 		for(var/i in mood_events)
 			var/datum/mood_event/event = mood_events[i]
-			msg += event.description
+			msg += "[event.description]\n"
 	else
 		msg += "<span class='nicegreen'>I don't have much of a reaction to anything right now.</span>\n"
 	to_chat(user, examine_block(msg))

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -89,7 +89,7 @@
 	if(mood_events.len)
 		for(var/i in mood_events)
 			var/datum/mood_event/event = mood_events[i]
-			msg += "[event.description]\n"
+			msg += "[event.description]\n" // now we dont have to put \n in every moodlet description
 	else
 		msg += "<span class='nicegreen'>I don't have much of a reaction to anything right now.</span>\n"
 	to_chat(user, examine_block(msg))

--- a/code/datums/mood_events/beauty_events.dm
+++ b/code/datums/mood_events/beauty_events.dm
@@ -1,19 +1,19 @@
 /datum/mood_event/horridroom
-	description = "<span class='boldwarning'>This room looks terrible!</span>\n"
+	description = span_boldwarning("This room looks terrible!")
 	mood_change = -5
 
 /datum/mood_event/badroom
-	description = "<span class='warning'>This room looks really bad.</span>\n"
+	description = span_warning("This room looks really bad.")
 	mood_change = -3
 
 /datum/mood_event/decentroom
-	description = "<span class='nicegreen'>This room looks alright.</span>\n"
+	description = span_nicegreen("This room looks alright.")
 	mood_change = 1
 
 /datum/mood_event/goodroom
-	description = "<span class='nicegreen'>This room looks really pretty!</span>\n"
+	description = span_nicegreen("This room looks really pretty!")
 	mood_change = 3
 
 /datum/mood_event/greatroom
-	description = "<span class='nicegreen'>This room is beautiful!</span>\n"
+	description = span_nicegreen("This room is beautiful!")
 	mood_change = 5

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -1,6 +1,6 @@
 /datum/mood_event/drunk
 	mood_change = 3
-	description = "<span class='nicegreen'>Everything just feels better after a drink or two.</span>\n"
+	description = span_nicegreen("Everything just feels better after a drink or two.")
 
 /datum/mood_event/drunk/add_effects(param)
 	// Display blush visual
@@ -13,26 +13,26 @@
 	owner.update_body()
 
 /datum/mood_event/quality_nice
-	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
+	description = span_nicegreen("That drink wasn't bad at all.")
 	mood_change = 2
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_good
-	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
+	description = span_nicegreen("That drink was pretty good.")
 	mood_change = 4
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_verygood
-	description = "<span class='nicegreen'>That drink was great!</span>\n"
+	description = span_nicegreen("That drink was great!")
 	mood_change = 6
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_fantastic
-	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
+	description = span_nicegreen("That drink was amazing!")
 	mood_change = 8
 	timeout = 7 MINUTES
 
 /datum/mood_event/amazingtaste
-	description = "<span class='nicegreen'>Amazing taste!</span>\n"
+	description = span_nicegreen("Amazing taste!")
 	mood_change = 50
 	timeout = 10 MINUTES

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -1,14 +1,14 @@
 /datum/mood_event/high
 	mood_change = 6
-	description = "<span class='nicegreen'>Woooow duudeeeeee...I'm tripping baaalls...</span>\n"
+	description = span_nicegreen("Woooow duudeeeeee...I'm tripping baaalls...")
 
 /datum/mood_event/smoked
-	description = "<span class='nicegreen'>I have had a smoke recently.</span>\n"
+	description = span_nicegreen("I have had a smoke recently.")
 	mood_change = 1
 	timeout = 6 MINUTES
 
 /datum/mood_event/wrong_brand
-	description = "<span class='warning'>That brand of cigarette just doesn't hit right.</span>\n"
+	description = span_warning("That brand of cigarette just doesn't hit right.")
 	mood_change = -1
 	timeout = 6 MINUTES
 
@@ -17,72 +17,72 @@
 	timeout = 5 MINUTES
 
 /datum/mood_event/overdose/add_effects(drug_name)
-	description = "<span class='warning'>I think I took a bit too much of that [drug_name]</span>\n"
+	description = span_warning("I think I took a bit too much of that [drug_name]")
 
 /datum/mood_event/withdrawal_light
 	mood_change = -2
 
 /datum/mood_event/withdrawal_light/add_effects(drug_name)
-	description = "<span class='warning'>I could use some [drug_name]</span>\n"
+	description = span_warning("I could use some [drug_name]")
 
 /datum/mood_event/withdrawal_medium
 	mood_change = -5
 
 /datum/mood_event/withdrawal_medium/add_effects(drug_name)
-	description = "<span class='warning'>I really need [drug_name]</span>\n"
+	description = span_warning("I really need [drug_name]")
 
 /datum/mood_event/withdrawal_severe
 	mood_change = -8
 
 /datum/mood_event/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some of that [drug_name]</span>\n"
+	description = span_boldwarning("Oh god I need some of that [drug_name]")
 
 /datum/mood_event/withdrawal_critical
 	mood_change = -10
 
 /datum/mood_event/withdrawal_critical/add_effects(drug_name)
-	description = "<span class='boldwarning'>[drug_name]! [drug_name]! [drug_name]!</span>\n"
+	description = span_boldwarning("[drug_name]! [drug_name]! [drug_name]!")
 
 /datum/mood_event/happiness_drug
-	description = "<span class='nicegreen'>Can't feel a thing...</span>\n"
+	description = span_nicegreen("Can't feel a thing...")
 	mood_change = 50
 
 /datum/mood_event/happiness_drug_good_od
-	description = "<span class='nicegreen'>YES! YES!! YES!!!</span>\n"
+	description = span_nicegreen("YES! YES!! YES!!!")
 	mood_change = 100
 	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_good"
 
 /datum/mood_event/happiness_drug_bad_od
-	description = "<span class='boldwarning'>NO! NO!! NO!!!</span>\n"
+	description = span_boldwarning("NO! NO!! NO!!!")
 	mood_change = -100
 	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_bad"
 
 /datum/mood_event/narcotic_medium
-	description = "<span class='nicegreen'>I feel comfortably numb.</span>\n"
+	description = span_nicegreen("I feel comfortably numb.")
 	mood_change = 4
 	timeout = 3 MINUTES
 
 /datum/mood_event/narcotic_heavy
-	description = "<span class='nicegreen'>I feel like I'm wrapped up in cotton!</span>\n"
+	description = span_nicegreen("I feel like I'm wrapped up in cotton!")
 	mood_change = 9
 	timeout = 3 MINUTES
 
 /datum/mood_event/stimulant_medium
-	description = "<span class='nicegreen'>I have so much energy! I feel like I could do anything!</span>\n"
+	description = span_nicegreen("I have so much energy! I feel like I could do anything!")
 	mood_change = 4
 	timeout = 3 MINUTES
 
 /datum/mood_event/stimulant_heavy
-	description = "<span class='nicegreen'>Eh ah AAAAH! HA HA HA HA HAA! Uuuh.</span>\n"
+	description = span_nicegreen("Eh ah AAAAH! HA HA HA HA HAA! Uuuh.")
 	mood_change = 6
 	timeout = 3 MINUTES
 
 /datum/mood_event/legion_good
 	mood_change = 20
-	description = "<span class='nicegreen'>I'm feeling great!</span>\n"
+	description = span_nicegreen("I'm feeling great!")
 
 /datum/mood_event/legion_bad
 	mood_change = -20
-	description = "<span class='warning'>That felt awful!</span>\n"
+	description = span_warning("That felt awful!")

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -1,93 +1,93 @@
 /datum/mood_event/handcuffed
-	description = "<span class='warning'>I guess my antics have finally caught up with me.</span>\n"
+	description = span_warning("I guess my antics have finally caught up with me.")
 	mood_change = -1
 
 /datum/mood_event/broken_vow //Used for when mimes break their vow of silence
-	description = "<span class='boldwarning'>I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow...</span>\n"
+	description = span_boldwarning("I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow...")
 	mood_change = -8
 
 /datum/mood_event/on_fire
-	description = "<span class='boldwarning'>I'M ON FIRE!!!</span>\n"
+	description = span_boldwarning("I'M ON FIRE!!!")
 	mood_change = -12
 
 /datum/mood_event/suffocation
-	description = "<span class='boldwarning'>CAN'T... BREATHE...</span>\n"
+	description = span_boldwarning("CAN'T... BREATHE...")
 	mood_change = -12
 
 /datum/mood_event/burnt_thumb
-	description = "<span class='warning'>I shouldn't play with lighters...</span>\n"
+	description = span_warning("I shouldn't play with lighters...")
 	mood_change = -1
 	timeout = 2 MINUTES
 
 /datum/mood_event/cold
-	description = "<span class='warning'>It's way too cold in here.</span>\n"
+	description = span_warning("It's way too cold in here.")
 	mood_change = -5
 
 /datum/mood_event/hot
-	description = "<span class='warning'>It's getting hot in here.</span>\n"
+	description = span_warning("It's getting hot in here.")
 	mood_change = -5
 
 /datum/mood_event/creampie
-	description = "<span class='warning'>I've been creamed. Tastes like pie flavor.</span>\n"
+	description = span_warning("I've been creamed. Tastes like pie flavor.")
 	mood_change = -2
 	timeout = 3 MINUTES
 
 /datum/mood_event/slipped
-	description = "<span class='warning'>I slipped. I should be more careful next time...</span>\n"
+	description = span_warning("I slipped. I should be more careful next time...")
 	mood_change = -2
 	timeout = 3 MINUTES
 
 /datum/mood_event/eye_stab
-	description = "<span class='boldwarning'>I used to be an adventurer like you, until I took a screwdriver to the eye.</span>\n"
+	description = span_boldwarning("I used to be an adventurer like you, until I took a screwdriver to the eye.")
 	mood_change = -4
 	timeout = 3 MINUTES
 
 /datum/mood_event/delam //SM delamination
-	description = "<span class='boldwarning'>Those God damn engineers can't do anything right...</span>\n"
+	description = span_boldwarning("Those God damn engineers can't do anything right...")
 	mood_change = -2
 	timeout = 4 MINUTES
 
 /datum/mood_event/depression_minimal
-	description = "<span class='warning'>I feel a bit down.</span>\n"
+	description = span_warning("I feel a bit down.")
 	mood_change = -10
 	timeout = 2 MINUTES
 
 /datum/mood_event/depression_mild
-	description = "<span class='warning'>I feel sad for no particular reason.</span>\n"
+	description = span_warning("I feel sad for no particular reason.")
 	mood_change = -12
 	timeout = 2 MINUTES
 
 /datum/mood_event/depression_moderate
-	description = "<span class='warning'>I feel miserable.</span>\n"
+	description = span_warning("I feel miserable.")
 	mood_change = -14
 	timeout = 2 MINUTES
 
 /datum/mood_event/depression_severe
-	description = "<span class='warning'>I've lost all hope.</span>\n"
+	description = span_warning("I've lost all hope.")
 	mood_change = -16
 	timeout = 2 MINUTES
 
 /datum/mood_event/dismembered
-	description = "<span class='boldwarning'>AHH! I WAS USING THAT LIMB!</span>\n"
+	description = span_boldwarning("AHH! I WAS USING THAT LIMB!")
 	mood_change = -10
 	timeout = 8 MINUTES
 
 /datum/mood_event/tased
-	description = "<span class='warning'>There's no \"z\" in \"taser\". It's in the zap.</span>\n"
+	description = span_warning("There's no \"z\" in \"taser\". It's in the zap.")
 	mood_change = -3
 	timeout = 2 MINUTES
 
 /datum/mood_event/embedded
-	description = "<span class='boldwarning'>Pull it out!</span>\n"
+	description = span_boldwarning("Pull it out!")
 	mood_change = -7
 
 /datum/mood_event/table
-	description = "<span class='warning'>Someone threw me on a table!</span>\n"
+	description = span_warning("Someone threw me on a table!")
 	mood_change = -2
 	timeout = 2 MINUTES
 
 /datum/mood_event/table_headsmash
-	description = "<span class='warning'>My fucking head, that hurts...</span>"
+	description = span_warning("My fucking head, that hurts...")
 	mood_change = -3
 	timeout = 3 MINUTES
 
@@ -96,67 +96,67 @@
 
 /datum/mood_event/brain_damage/add_effects()
 	var/damage_message = pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")
-	description = "<span class='warning'>Hurr durr... [damage_message]</span>\n"
+	description = span_warning("Hurr durr... [damage_message]")
 
 /datum/mood_event/hulk //Entire duration of having the hulk mutation
-	description = "<span class='warning'>HULK SMASH!</span>\n"
+	description = span_warning("HULK SMASH!")
 	mood_change = -4
 
 /datum/mood_event/epilepsy //Only when the mutation causes a seizure
-	description = "<span class='warning'>I should have paid attention to the epilepsy warning.</span>\n"
+	description = span_warning("I should have paid attention to the epilepsy warning.")
 	mood_change = -3
 	timeout = 5 MINUTES
 
 /datum/mood_event/nyctophobia
-	description = "<span class='warning'>It sure is dark around here...</span>\n"
+	description = span_warning("It sure is dark around here...")
 	mood_change = -3
 
 /datum/mood_event/family_heirloom_missing
-	description = "<span class='warning'>I'm missing my family heirloom...</span>\n"
+	description = span_warning("I'm missing my family heirloom...")
 	mood_change = -4
 
 /datum/mood_event/healsbadman
-	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"
+	description = span_warning("I feel like I'm held together by flimsy string, and could fall apart at any moment!")
 	mood_change = -4
 	timeout = 2 MINUTES
 
 /datum/mood_event/jittery
-	description = "<span class='warning'>I'm nervous and on edge and I can't stand still!!</span>\n"
+	description = span_warning("I'm nervous and on edge and I can't stand still!!")
 	mood_change = -2
 
 /datum/mood_event/vomit
-	description = "<span class='warning'>I just threw up. Gross.</span>\n"
+	description = span_warning("I just threw up. Gross.")
 	mood_change = -2
 	timeout = 2 MINUTES
 
 /datum/mood_event/vomitself
-	description = "<span class='warning'>I just threw up all over myself. This is disgusting.</span>\n"
+	description = span_warning("I just threw up all over myself. This is disgusting.")
 	mood_change = -4
 	timeout = 3 MINUTES
 
 /datum/mood_event/painful_medicine
-	description = "<span class='warning'>Medicine may be good for me but right now it stings like hell.</span>\n"
+	description = span_warning("Medicine may be good for me but right now it stings like hell.")
 	mood_change = -5
 	timeout = 60 SECONDS
 
 /datum/mood_event/spooked
-	description = "<span class='warning'>The rattling of those bones...It still haunts me.</span>\n"
+	description = span_warning("The rattling of those bones...It still haunts me.")
 	mood_change = -4
 	timeout = 4 MINUTES
 
 /datum/mood_event/loud_gong
-	description = "<span class='warning'>That loud gong noise really hurt my ears!</span>\n"
+	description = span_warning("That loud gong noise really hurt my ears!")
 	mood_change = -3
 	timeout = 2 MINUTES
 
 /datum/mood_event/notcreeping
-	description = "<span class='warning'>The voices are not happy, and they painfully contort my thoughts into getting back on task.</span>\n"
+	description = span_warning("The voices are not happy, and they painfully contort my thoughts into getting back on task.")
 	mood_change = -6
 	timeout = 30
 	hidden = TRUE
 
 /datum/mood_event/notcreepingsevere//not hidden since it's so severe
-	description = "<span class='boldwarning'>THEY NEEEEEEED OBSESSIONNNN!!</span>\n"
+	description = span_boldwarning("THEY NEEEEEEED OBSESSIONNNN!!")
 	mood_change = -30
 	timeout = 30
 
@@ -165,75 +165,75 @@
 	for(var/i in 1 to rand(3,5))
 		unstable += copytext_char(name, -1)
 	var/unhinged = uppertext(unstable.Join(""))//example Tinea Luxor > TINEA LUXORRRR (with randomness in how long that slur is)
-	description = "<span class='boldwarning'>THEY NEEEEEEED [unhinged]!!</span>\n"
+	description = span_boldwarning("THEY NEEEEEEED [unhinged]!!")
 
 /datum/mood_event/sapped
-	description = "<span class='boldwarning'>Some unexplainable sadness is consuming me...</span>\n"
+	description = span_boldwarning("Some unexplainable sadness is consuming me...")
 	mood_change = -15
 	timeout = 90 SECONDS
 
 /datum/mood_event/back_pain
-	description = "<span class='boldwarning'>Bags never sit right on my back, this hurts like hell!</span>\n"
+	description = span_boldwarning("Bags never sit right on my back, this hurts like hell!")
 	mood_change = -15
 
 /datum/mood_event/sad_empath
-	description = "<span class='warning'>Someone seems upset...</span>\n"
+	description = span_warning("Someone seems upset...")
 	mood_change = -2
 	timeout = 60 SECONDS
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
-	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"
+	description = span_warning("[sadtarget.name] seems upset...")
 
 /datum/mood_event/sacrifice_bad
-	description ="<span class='warning'>Those darn savages!</span>\n"
+	description =span_warning("Those darn savages!")
 	mood_change = -5
 	timeout = 2 MINUTES
 
 /datum/mood_event/artbad
-	description = "<span class='warning'>I've produced better art than that from my ass.</span>\n"
+	description = span_warning("I've produced better art than that from my ass.")
 	mood_change = -2
 	timeout = 1200
 
 /datum/mood_event/graverobbing
-	description ="<span class='boldwarning'>I just desecrated someone's grave... I can't believe I did that...</span>\n"
+	description =span_boldwarning("I just desecrated someone's grave... I can't believe I did that...")
 	mood_change = -8
 	timeout = 3 MINUTES
 
 /datum/mood_event/deaths_door
-	description = "<span class='boldwarning'>This is it... I'm really going to die.</span>\n"
+	description = span_boldwarning("This is it... I'm really going to die.")
 	mood_change = -20
 
 /datum/mood_event/gunpoint
-	description = "<span class='boldwarning'>This guy is insane! I better be careful....</span>\n"
+	description = span_boldwarning("This guy is insane! I better be careful....")
 	mood_change = -10
 
 /datum/mood_event/tripped
-	description = "<span class='boldwarning'>I can't believe I fell for the oldest trick in the book!</span>\n"
+	description = span_boldwarning("I can't believe I fell for the oldest trick in the book!")
 	mood_change = -5
 	timeout = 2 MINUTES
 
 /datum/mood_event/untied
-	description = "<span class='boldwarning'>I hate when my shoes come untied!</span>\n"
+	description = span_boldwarning("I hate when my shoes come untied!")
 	mood_change = -3
 	timeout = 1 MINUTES
 
 /datum/mood_event/high_five_alone
-	description = "<span class='boldwarning'>I tried getting a high-five with no one around, how embarassing!</span>\n"
+	description = span_boldwarning("I tried getting a high-five with no one around, how embarassing!")
 	mood_change = -2
 	timeout = 1 MINUTES
 
 /datum/mood_event/high_five_full_hand
-	description = "<span class='boldwarning'>Oh God, I don't even know how to high-five correctly...</span>\n"
+	description = span_boldwarning("Oh God, I don't even know how to high-five correctly...")
 	mood_change = -1
 	timeout = 45 SECONDS
 
 /datum/mood_event/left_hanging
-	description = "<span class='boldwarning'>But everyone loves high fives! Maybe people just... hate me?</span>\n"
+	description = span_boldwarning("But everyone loves high fives! Maybe people just... hate me?")
 	mood_change = -2
 	timeout = 1.5 MINUTES
 
 /datum/mood_event/too_slow
-	description = "<span class='boldwarning'>NO! HOW COULD I BE.... TOO SLOW???</span>\n"
+	description = span_boldwarning("NO! HOW COULD I BE.... TOO SLOW???")
 	mood_change = -2 // multiplied by how many people saw it happen, up to 8, so potentially massive. the ULTIMATE prank carries a lot of weight
 	timeout = 2 MINUTES
 
@@ -250,70 +250,70 @@
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/surgery
-	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
+	description = span_boldwarning("HE'S CUTTING ME OPEN!!")
 	mood_change = -8
 
 /datum/mood_event/nanite_sadness
-	description = "<span class='warning robot'>+++++++HAPPINESS SUPPRESSION+++++++</span>\n"
+	description = span_warning_robot("+++++++HAPPINESS SUPPRESSION+++++++")
 	mood_change = -7
 
 /datum/mood_event/nanite_sadness/add_effects(message)
-	description = "<span class='warning robot'>+++++++[message]+++++++</span>\n"
+	description = span_warning_robot("+++++++[message]+++++++")
 
 /datum/mood_event/bald
-	description ="<span class='warning'>I need something to cover my head...</span>\n"
+	description = span_warning("I need something to cover my head...")
 	mood_change = -3
 
 /datum/mood_event/bad_touch
-	description = "<span class='warning'>I don't like when people touch me.</span>\n"
+	description = span_warning("I don't like when people touch me.")
 	mood_change = -3
 	timeout = 4 MINUTES
 
 /datum/mood_event/very_bad_touch
-	description = "<span class='warning'>I really don't like when people touch me.</span>\n"
+	description = span_warning("I really don't like when people touch me.")
 	mood_change = -5
 	timeout = 4 MINUTES
 
 /datum/mood_event/noogie
-	description = "<span class='warning'>Ow! This is like space high school all over again...</span>\n"
+	description = span_warning("Ow! This is like space high school all over again...")
 	mood_change = -2
 	timeout = 1 MINUTES
 
 /datum/mood_event/noogie_harsh
-	description = "<span class='warning'>OW!! That was even worse than a regular noogie!</span>\n"
+	description = span_warning("OW!! That was even worse than a regular noogie!")
 	mood_change = -4
 	timeout = 1 MINUTES
 
 /datum/mood_event/irritate
-	description = "It feels like I'm itching all over!"
+	description = span_warning("It feels like I'm itching all over!")
 	mood_change = -2
 
 /datum/mood_event/cement
-	description = "<span class='warning'>I was forced to eat cement...</span>\n"
+	description = span_warning("I was forced to eat cement...")
 	mood_change = -6
 	timeout = 4 MINUTES
 
 /datum/mood_event/joywire_emp
-	description = span_boldwarning("IT'S GONE!! IT'S GONE!!\n")
+	description = span_boldwarning("IT'S GONE!! IT'S GONE!!")
 	mood_change = -30
 	timeout = 5 MINUTES
 
 /datum/mood_event/mindscrew
-	description = span_boldwarning("It isn't ending... it isn't ending, come on...\n")
+	description = span_boldwarning("It isn't ending... it isn't ending, come on...")
 	mood_change = -18
 	timeout = 3 MINUTES
 
 /datum/mood_event/bad_touch_bear_hug
-	description = "I just got squeezed way too hard."
+	description = span_warning("I just got squeezed way too hard.")
 	mood_change = -3
 	timeout = 2 MINUTES
 
 /datum/mood_event/rippedtail
-	description = "<span class='warning'>I ripped their tail right off, what have I done!</span>\n"
+	description = span_boldwarning("I ripped their tail right off, what have I done!")
 	mood_change = -5
 	timeout = 30 SECONDS
 
 /datum/mood_event/bad_boop
-	description = "<span class='warning'>Someone booped my nose... ACK!</span>\n"
+	description = span_warning("Someone booped my nose... ACK!")
 	mood_change = -3
 	timeout = 4 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,194 +1,194 @@
 /datum/mood_event/hug
-	description = "<span class='nicegreen'>Hugs are nice.</span>\n"
+	description = span_nicegreen("Hugs are nice.")
 	mood_change = 1
 	timeout = 2
 
 /datum/mood_event/bear_hug
-	description = "I got squeezed very tightly, but it was quite nice."
+	description = span_nicegreen("I got squeezed very tightly, but it was quite nice.")
 	mood_change = 2
 	timeout = 2 MINUTES
 
 /datum/mood_event/betterhug
-	description = "<span class='nicegreen'>Someone was very nice to me.</span>\n"
+	description = span_nicegreen("Someone was very nice to me.")
 	mood_change = 3
 	timeout = 4 MINUTES
 
 /datum/mood_event/betterhug/add_effects(mob/friend)
-	description = "<span class='nicegreen'>[friend.name] was very nice to me.</span>\n"
+	description = span_nicegreen("[friend.name] was very nice to me.")
 
 /datum/mood_event/besthug
-	description = "<span class='nicegreen'>Someone is great to be around, they make me feel so happy!</span>\n"
+	description = span_nicegreen("Someone is great to be around, they make me feel so happy!")
 	mood_change = 5
 	timeout = 4 MINUTES
 
 /datum/mood_event/besthug/add_effects(mob/friend)
-	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!</span>\n"
+	description = span_nicegreen("[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!")
 
 /datum/mood_event/best_boop
-	description = "<span class='nicegreen'>Someone booped my nose, they are silly!</span>\n"
+	description = span_nicegreen("Someone booped my nose, they are silly!")
 	mood_change = 5
 	timeout = 4 MINUTES
 
 /datum/mood_event/best_boop/add_effects(mob/friend)
-	description = "<span class='nicegreen'>[friend.name] booped my nose, [friend.p_they()] [friend.p_are()] silly!</span>\n"
+	description = span_nicegreen("[friend.name] booped my nose, [friend.p_they()] [friend.p_are()] silly!")
 
 /datum/mood_event/warmhug
-	description = "<span class='nicegreen'>Warm cozy hugs are the best!</span>\n"
+	description = span_nicegreen("Warm cozy hugs are the best!")
 	mood_change = 1
 	timeout = 2 MINUTES
 
 /datum/mood_event/arcade
-	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
+	description = span_nicegreen("I beat the arcade game!")
 	mood_change = 3
 	timeout = 8 MINUTES
 
 /datum/mood_event/blessing
-	description = "<span class='nicegreen'>I've been blessed.</span>\n"
+	description = span_nicegreen("I've been blessed.")
 	mood_change = 3
 	timeout = 8 MINUTES
 
 /datum/mood_event/book_nerd
-	description = "<span class='nicegreen'>I have recently read a book.</span>\n"
+	description = span_nicegreen("I have recently read a book.")
 	mood_change = 1
 	timeout = 5 MINUTES
 
 /datum/mood_event/exercise
-	description = "<span class='nicegreen'>Working out releases those endorphins!</span>\n"
+	description = span_nicegreen("Working out releases those endorphins!")
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal
-	description = "<span class='nicegreen'>Animals are adorable! I can't stop petting them!</span>\n"
+	description = span_nicegreen("Animals are adorable! I can't stop petting them!")
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal/add_effects(mob/animal)
-	description = "<span class='nicegreen'>\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!</span>\n"
+	description = span_nicegreen("\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!")
 
 /datum/mood_event/honk
-	description = "<span class='nicegreen'>I've been honked!</span>\n"
+	description = span_nicegreen("I've been honked!")
 	mood_change = 2
 	timeout = 4 MINUTES
 	special_screen_obj = "honked_nose"
 	special_screen_replace = FALSE
 
 /datum/mood_event/perform_cpr
-	description = "<span class='nicegreen'>It feels good to save a life.</span>\n"
+	description = span_nicegreen("It feels good to save a life.")
 	mood_change = 6
 	timeout = 8 MINUTES
 
 /datum/mood_event/oblivious
-	description = "<span class='nicegreen'>What a lovely day.</span>\n"
+	description = span_nicegreen("What a lovely day.")
 	mood_change = 3
 
 /datum/mood_event/jolly
-	description = "<span class='nicegreen'>I feel happy for no particular reason.</span>\n"
+	description = span_nicegreen("I feel happy for no particular reason.")
 	mood_change = 6
 	timeout = 2 MINUTES
 
 /datum/mood_event/focused
-	description = "<span class='nicegreen'>I have a goal, and I will reach it, whatever it takes!</span>\n" //Used for syndies, nukeops etc so they can focus on their goals
+	description = span_nicegreen("I have a goal, and I will reach it, whatever it takes!") //Used for syndies, nukeops etc so they can focus on their goals
 	mood_change = 4
 	hidden = TRUE
 
 /datum/mood_event/badass_antag
-	description = "<span class='greentext'>I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of having me around.</span>\n"
+	description = span_greentext("I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of having me around.")
 	mood_change = 7
 	hidden = TRUE
 	special_screen_obj = "badass_sun"
 	special_screen_replace = FALSE
 
 /datum/mood_event/creeping
-	description = "<span class='greentext'>The voices have released their hooks on my mind! I feel free again!</span>\n" //creeps get it when they are around their obsession
+	description = span_greentext("The voices have released their hooks on my mind! I feel free again!") //creeps get it when they are around their obsession
 	mood_change = 18
 	timeout = 3 SECONDS
 	hidden = TRUE
 
 /datum/mood_event/revolution
-	description = "<span class='nicegreen'>VIVA LA REVOLUTION!</span>\n"
+	description = span_nicegreen("VIVA LA REVOLUTION!")
 	mood_change = 3
 	hidden = TRUE
 
 /datum/mood_event/family_heirloom
-	description = "<span class='nicegreen'>My family heirloom is safe with me.</span>\n"
+	description = span_nicegreen("My family heirloom is safe with me.")
 	mood_change = 1
 
 /datum/mood_event/rilena_fan
-	description = "<span class='nicegreen'>I love my RILENA merch!</span>\n"
+	description = span_nicegreen("I love my RILENA merch!")
 	mood_change = 1
 
 /datum/mood_event/rilena_super_fan
-	description = "<span class='nicegreen'>I love my RILENA hoodie!</span>\n"
+	description = span_nicegreen("I love my RILENA hoodie!")
 	mood_change = 1
 
 /datum/mood_event/goodmusic
-	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"
+	description = span_nicegreen("There is something soothing about this music.")
 	mood_change = 3
 	timeout = 60 SECONDS
 
 /datum/mood_event/chemical_euphoria
-	description = "<span class='nicegreen'>Heh...hehehe...hehe...</span>\n"
+	description = span_nicegreen("Heh...hehehe...hehe...")
 	mood_change = 4
 
 /datum/mood_event/chemical_laughter
-	description = "<span class='nicegreen'>Laughter really is the best medicine! Or is it?</span>\n"
+	description = span_nicegreen("Laughter really is the best medicine! Or is it?")
 	mood_change = 4
 	timeout = 3 MINUTES
 
 /datum/mood_event/chemical_superlaughter
-	description = "<span class='nicegreen'>*WHEEZE*</span>\n"
+	description = span_nicegreen("*WHEEZE*")
 	mood_change = 12
 	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
-	description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>\n"
+	description = span_nicegreen("You are comforted by the presence of a holy person.")
 	mood_change = 3
 	timeout = 5 MINUTES
 
 /datum/mood_event/clownshoes
-	description = "<span class='nicegreen'>The shoes are a clown's legacy, I never want to take them off!</span>\n"
+	description = span_nicegreen("The shoes are a clown's legacy, I never want to take them off!")
 	mood_change = 5
 
 /datum/mood_event/sacrifice_good
-	description ="<span class='nicegreen'>The gods are pleased with this offering!</span>\n"
+	description =span_nicegreen("The gods are pleased with this offering!")
 	mood_change = 5
 	timeout = 3 MINUTES
 
 /datum/mood_event/artok
-	description = "<span class='nicegreen'>It's nice to see people are making art around here.</span>\n"
+	description = span_nicegreen("It's nice to see people are making art around here.")
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/artgood
-	description = "<span class='nicegreen'>What a thought-provoking piece of art. I'll remember that for a while.</span>\n"
+	description = span_nicegreen("What a thought-provoking piece of art. I'll remember that for a while.")
 	mood_change = 4
 	timeout = 5 MINUTES
 
 /datum/mood_event/artgreat
-	description = "<span class='nicegreen'>That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.</span>\n"
+	description = span_nicegreen("That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.")
 	mood_change = 6
 	timeout = 5 MINUTES
 
 /datum/mood_event/pet_borg
-	description = "<span class='nicegreen'>I just love my robotic friends!</span>\n"
+	description = span_nicegreen("I just love my robotic friends!")
 	mood_change = 3
 	timeout = 5 MINUTES
 
 /datum/mood_event/bottle_flip
-	description = "<span class='nicegreen'>The bottle landing like that was satisfying.</span>\n"
+	description = span_nicegreen("The bottle landing like that was satisfying.")
 	mood_change = 2
 	timeout = 3 MINUTES
 
 /datum/mood_event/hope_lavaland
-	description = "<span class='nicegreen'>What a peculiar emblem.  It makes me feel hopeful for my future.</span>\n"
+	description = span_nicegreen("What a peculiar emblem.  It makes me feel hopeful for my future.")
 	mood_change = 5
 
 /datum/mood_event/nanite_happiness
-	description = "<span class='nicegreen robot'>+++++++HAPPINESS ENHANCEMENT+++++++</span>\n"
+	description = span_nicegreen_robot("+++++++HAPPINESS ENHANCEMENT+++++++")
 	mood_change = 7
 
 /datum/mood_event/nanite_happiness/add_effects(message)
-	description = "<span class='nicegreen robot'>+++++++[message]+++++++</span>\n"
+	description = span_nicegreen_robot("+++++++[message]+++++++")
 
 /datum/mood_event/area
 	description = "" //Fill this out in the area
@@ -199,31 +199,31 @@
 	description = _description
 
 /datum/mood_event/confident_mane
-	description = "<span class='nicegreen'>I'm feeling confident with a head full of hair.</span>\n"
+	description = span_nicegreen("I'm feeling confident with a head full of hair.")
 	mood_change = 2
 
 /datum/mood_event/dkickflip
-	description = "<span class='nicegreen'>I just witnessed the most RAD thing ever.</span>\n"
+	description = span_nicegreen("I just witnessed the most RAD thing ever.")
 	mood_change = 5
 	timeout = 2 MINUTES
 
 /datum/mood_event/high_five
-	description = "<span class='nicegreen'>I love getting high fives!</span>\n"
+	description = span_nicegreen("I love getting high fives!")
 	mood_change = 2
 	timeout = 45 SECONDS
 
 /datum/mood_event/high_ten
-	description = "<span class='nicegreen'>AMAZING! A HIGH-TEN!</span>\n"
+	description = span_nicegreen("AMAZING! A HIGH-TEN!")
 	mood_change = 3
 	timeout = 45 SECONDS
 
 /datum/mood_event/down_low
-	description = "<span class='nicegreen'>HA! What a rube, they never stood a chance...</span>\n"
+	description = span_nicegreen("HA! What a rube, they never stood a chance...")
 	mood_change = 4
 	timeout = 1.5 MINUTES
 
 /datum/mood_event/kiss
-	description = "Someone blew a kiss at me, I must be a real catch!"
+	description = span_nicegreen("Someone blew a kiss at me, I must be a real catch!")
 	mood_change = 1.5
 	timeout = 2 MINUTES
 
@@ -231,21 +231,21 @@
 	if(!beau)
 		return
 	if(direct)
-		description = "[beau.name] gave me a kiss, ahh!!"
+		description = span_nicegreen("[beau.name] gave me a kiss, ahh!!")
 	else
-		description = "[beau.name] blew a kiss at me, I must be a real catch!"
+		description = span_nicegreen("[beau.name] blew a kiss at me, I must be a real catch!")
 
 /datum/mood_event/fishing
-	description = "Fishing is relaxing"
+	description = span_nicegreen("Fishing is relaxing")
 	mood_change = 5
 	timeout = 3 MINUTES
 
 /datum/mood_event/joywire
-	description = span_boldnicegreen("I feel so joyous! Oh, so joyous!\n")
+	description = span_boldnicegreen("I feel so joyous! Oh, so joyous!")
 	mood_change = 8
 	timeout = 10 SECONDS
 
 /datum/mood_event/root
-	description = span_nicegreen("I rooted recently, it feels good to charge naturally.\n")
+	description = span_nicegreen("I rooted recently, it feels good to charge naturally.")
 	mood_change = 5
 	timeout = 5 MINUTES

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -1,89 +1,89 @@
 //nutrition
 /datum/mood_event/wellfed
-	description = "<span class='nicegreen'>I'm stuffed!</span>\n"
+	description = span_nicegreen("I'm stuffed!")
 	mood_change = 8
 
 /datum/mood_event/fed
-	description = "<span class='nicegreen'>I have recently had some food.</span>\n"
+	description = span_nicegreen("I have recently had some food.")
 	mood_change = 5
 
 /datum/mood_event/hungry
-	description = "<span class='warning'>I'm getting a bit hungry.</span>\n"
+	description = span_warning("I'm getting a bit hungry.")
 	mood_change = -6
 
 /datum/mood_event/starving
-	description = "<span class='boldwarning'>I'm starving!</span>\n"
+	description = span_boldwarning("I'm starving!")
 	mood_change = -10
 
 //charge
 /datum/mood_event/supercharged
-	description = "<span class='boldwarning'>I can't possibly keep all this power inside, I need to release some quick!</span>\n"
+	description = span_boldwarning("I can't possibly keep all this power inside, I need to release some quick!")
 	mood_change = -10
 
 /datum/mood_event/overcharged
-	description = "<span class='warning'>I feel dangerously overcharged, perhaps I should release some power.</span>\n"
+	description = span_warning("I feel dangerously overcharged, perhaps I should release some power.")
 	mood_change = -4
 
 /datum/mood_event/charged
-	description = "<span class='nicegreen'>I feel the power in my veins!</span>\n"
+	description = span_nicegreen("I feel the power in my veins!")
 	mood_change = 6
 
 /datum/mood_event/lowpower
-	description = "<span class='warning'>My power is running low, I should go charge up somewhere.</span>\n"
+	description = span_warning("My power is running low, I should go charge up somewhere.")
 	mood_change = -6
 
 /datum/mood_event/decharged
-	description = "<span class='boldwarning'>I'm in desperate need of some electricity!</span>\n"
+	description = span_boldwarning("I'm in desperate need of some electricity!")
 	mood_change = -10
 
 //Disgust
 /datum/mood_event/gross
-	description = "<span class='warning'>I saw something gross.</span>\n"
+	description = span_warning("I saw something gross.")
 	mood_change = -4
 
 /datum/mood_event/verygross
-	description = "<span class='warning'>I think I'm going to puke...</span>\n"
+	description = span_warning("I think I'm going to puke...")
 	mood_change = -6
 
 /datum/mood_event/disgusted
-	description = "<span class='boldwarning'>Oh god that's disgusting...</span>\n"
+	description = span_boldwarning("Oh god that's disgusting...")
 	mood_change = -8
 
 /datum/mood_event/disgust/bad_smell
-	description = "<span class='warning'>You smell something horribly decayed inside this room.</span>\n"
+	description = span_warning("You smell something horribly decayed inside this room.")
 	mood_change = -6
 
 /datum/mood_event/disgust/nauseating_stench
-	description = "<span class='warning'>The stench of rotting carcasses is unbearable!</span>\n"
+	description = span_warning("The stench of rotting carcasses is unbearable!")
 	mood_change = -12
 
 //Generic needs events
 /datum/mood_event/favorite_food
-	description = "<span class='nicegreen'>I really enjoyed eating that.</span>\n"
+	description = span_nicegreen("I really enjoyed eating that.")
 	mood_change = 5
 	timeout = 4 MINUTES
 
 /datum/mood_event/gross_food
-	description = "<span class='warning'>I really didn't like that food.</span>\n"
+	description = span_warning("I really didn't like that food.")
 	mood_change = -2
 	timeout = 4 MINUTES
 
 /datum/mood_event/disgusting_food
-	description = "<span class='warning'>That food was disgusting!</span>\n"
+	description = span_warning("That food was disgusting!")
 	mood_change = -6
 	timeout = 4 MINUTES
 
 /datum/mood_event/breakfast
-	description = "<span class='nicegreen'>Nothing like a hearty breakfast to start the shift.</span>\n"
+	description = span_nicegreen("Nothing like a hearty breakfast to start the shift.")
 	mood_change = 2
 	timeout = 10 MINUTES
 
 /datum/mood_event/nice_shower
-	description = "<span class='nicegreen'>I have recently had a nice shower.</span>\n"
+	description = span_nicegreen("I have recently had a nice shower.")
 	mood_change = 4
 	timeout = 5 MINUTES
 
 /datum/mood_event/fresh_laundry
-	description = "<span class='nicegreen'>There's nothing like the feeling of a freshly laundered jumpsuit.</span>\n"
+	description = span_nicegreen("There's nothing like the feeling of a freshly laundered jumpsuit.")
 	mood_change = 2
 	timeout = 10 MINUTES


### PR DESCRIPTION
## About The Pull Request

Refactors moodlets to use span macros, changes how they print so explicit newlines are not required in descriptions. Added span macros to a couple descriptions that had no coloring

Tested locally and moodlets display properly

![image](https://github.com/user-attachments/assets/5c186a1e-2d11-44a6-9d27-8fd83b4e375e)


## Why It's Good For The Game

Refactor good

## Changelog

:cl:
refactor: Refactored moods so explicit newlines are not required in descriptions. None of this changes player facing stuff.
/:cl:
