### PR TITLE
Fixes searching with the orbit menu

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -96,8 +96,8 @@ export const searchFor = (searchText) =>
 export const compareString = (a, b) => (a < b ? -1 : a > b);
 
 export const compareNumberedText = (a, b) => {
-  const aName = a.real_name;
-  const bName = b.real_name;
+  const aName = a.name;
+  const bName = b.name;
 
   // Check if aName and bName are the same except for a number at the end
   // e.g. Medibot (2) and Medibot (3)

--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -81,10 +81,10 @@ export const isJobOrNameMatch = (
 ): boolean => {
   if (!searchQuery) return true;
 
-  const { full_name, job } = observable;
+  const { name, job } = observable;
 
   return (
-    full_name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
+    name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     job?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     false
   );
@@ -96,8 +96,8 @@ export const searchFor = (searchText) =>
 export const compareString = (a, b) => (a < b ? -1 : a > b);
 
 export const compareNumberedText = (a, b) => {
-  const aName = a.name;
-  const bName = b.name;
+  const aName = a.real_name;
+  const bName = b.real_name;
 
   // Check if aName and bName are the same except for a number at the end
   // e.g. Medibot (2) and Medibot (3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR modifies the search algorithm for points of interests so that the real name of a character, e.g. "Kristina Dryden" is what gets passed to the search function, instead of a character's "full name", e.g. "calm human woman". 

![vf7sJJ034D](https://github.com/user-attachments/assets/59b9381b-f49d-4564-a8b7-e33653706693)

The sorting algorithm seems to take jobs as the sorting parameter, instead of real names. As of right now, the portion of code that causes this to occur still eludes me.

## Why It's Good For The Game

This felt like a minor oversight to me. It feels clunky to search for a character's name and have the search return no results because the search function had been looking for a character's _attributes_ instead. 

## Changelog

:cl:
fix: fixed the orbit menu search function so that names work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
