### PR TITLE
Carpentry Tweaks -- Allows easels and cabinets to be crafted, and fixes various bugs with painting frames

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -127,6 +127,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("dresser", /obj/structure/dresser, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("picture frame", /obj/item/wallframe/picture, 1, time = 10),\
 	new/datum/stack_recipe("painting frame", /obj/item/wallframe/painting, 1, time = 10),\
+	new/datum/stack_recipe("easel", /obj/structure/easel, 4, time = 10),\
 	new/datum/stack_recipe("display case chassis", /obj/structure/displaycase_chassis, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("wooden buckler", /obj/item/shield/riot/buckler, 20, time = 40), \
 	new/datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50),\
@@ -136,6 +137,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("rake", /obj/item/cultivator/rake, 5, time = 10),\
 	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 4, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
 	new/datum/stack_recipe("wooden crate", /obj/structure/closet/crate/wooden, 6, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
+	new/datum/stack_recipe("wooden cabinet", /obj/structure/closet/cabinet, 10, time = 50, one_per_turf = TRUE, on_floor = TRUE),\
 	new/datum/stack_recipe("baseball bat", /obj/item/melee/baseball_bat, 5, time = 15),\
 	new/datum/stack_recipe("loom", /obj/structure/loom, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("mortar", /obj/item/reagent_containers/glass/mortar, 3), \

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -241,8 +241,8 @@
 	if(dir)
 		setDir(dir)
 	if(building)
-		pixel_x = (dir & 3)? 0 : (dir == 4 ? -30 : 30)
-		pixel_y = (dir & 3)? (dir ==1 ? -30 : 30) : 0
+		pixel_x = (dir & 3)? 0 : (dir == 4 ? 30 : -30)
+		pixel_y = (dir & 3)? (dir ==1 ? 30 : -30) : 0
 	//The painting is being loaded by the maploader and SSpersistence has already run. Load a painting ourselves.
 	if(mapload && SSpersistence.initialized)
 		load_persistent()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -224,7 +224,7 @@
 	custom_materials = null
 	flags_1 = 0
 	icon_state = "frame-empty"
-	result_path = /obj/structure/sign/painting
+	result_path = /obj/structure/sign/painting/library
 
 /obj/structure/sign/painting
 	name = "Painting"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the ability to craft easels and cabinets, and it fixes the spawned structure type when painting frames are used from being the generic type to the library type. This PR also fixes a bug when placing painting frames, as shown below.

| before | after |
|--------|-------|
|![dreamseeker_tpNvZO4I62](https://github.com/user-attachments/assets/95a26ded-9c47-4e75-9b79-9b5f5f82250f)|![dreamseeker_Yep9pLj1oV](https://github.com/user-attachments/assets/39b9cc72-a4d9-4517-a14f-a92204faf117)|

## Why It's Good For The Game

Cabinets and easels _should_ be craftable, so as to keep parity with other materials. It also provides an avenue to pursue more low-tech solutions when one is going for a more rustic aesthetic. 

Additionally, crafted painting frames have had a minor problem with not displaying saved paintings when one is placed in them because the type of frame that typically gets mapped is not the same type that can be crafted. This should fix that, _and_ a bug associated with pixel shifts for the frame structure when it's initialized.

## Changelog

:cl:
add: Added ability to make cabinets and easels
fix: fixed painting frame persistence and initialization bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
