### PR TITLE
Edits the name of plasma and plastitanium shards

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -371,7 +371,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 			playsound(src, 'sound/effects/glass_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 30 : 50, TRUE)
 
 /obj/item/shard/plasma
-	name = "purple shard"
+	name = "plasmaglass shard"
 	desc = "A nasty looking shard of plasma glass."
 	force = 6
 	throwforce = 11
@@ -381,7 +381,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	weld_material = /obj/item/stack/sheet/plasmaglass
 
 /obj/item/shard/plastitanium
-	name = "beige shard"
+	name = "plastitanium glass shard"
 	desc = "A nasty looking shard of plastitanium glass."
 	force = 6
 	throwforce = 11


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the name of plasmaglass shards from "purple shard" to "plasmaglass shard" and the name of plastitanium glass shards from "beige shard" to "plastitanium glass shard".

## Why It's Good For The Game

It does not fit with the current naming convention for items for these shards to be vaguely named based on their color. This change would help these shards make more sense.

## Changelog

:cl:
add: Added better names for some material shards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
