### PR TITLE
Adds speedloaders to the indie viper guncase.

### DIFF
--- a/code/game/objects/items/storage/filled_guncases.dm
+++ b/code/game/objects/items/storage/filled_guncases.dm
@@ -60,6 +60,7 @@
 
 /obj/item/storage/guncase/pistol/viper
 	gun_type = /obj/item/gun/ballistic/revolver/viper/indie
+	mag_type = /obj/item/ammo_box/a357/empty
 
 /obj/item/storage/guncase/pistol/ringneck
 	gun_type = /obj/item/gun/ballistic/automatic/pistol/ringneck/indie

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -41,7 +41,7 @@
 	name = ".357 Speedloader Crate"
 	desc = "Contains a .357 speedloader for revolvers,  containing seven rounds."
 	contains = list(/obj/item/ammo_box/a357)
-	cost = 750
+	cost = 500
 
 /datum/supply_pack/ammo/mag_556mm
 	name = "5.56 Pistole C Magazine Crate"

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -41,7 +41,7 @@
 	name = ".357 Speedloader Crate"
 	desc = "Contains a .357 speedloader for revolvers,  containing seven rounds."
 	contains = list(/obj/item/ammo_box/a357)
-	cost = 500
+	cost = 750
 
 /datum/supply_pack/ammo/mag_556mm
 	name = "5.56 Pistole C Magazine Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds 357 speed loaders to the indie viper guncase.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Consistency with the syndicate viper guncase as that one got speedloaders included. Having to buy however many 750 credits speedloaders you needed tacked on a lot of extra cost to the indie viper.
## Changelog

:cl:
add: Indie Viper guncase comes with 2 speedloaders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
