### PR TITLE
Reduces 357 Hollowpoint negative AP

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -111,7 +111,7 @@
 /obj/projectile/bullet/a357/hp
 	name = ".357 hollow point bullet"
 	damage = 45
-	armour_penetration = -50
+	armour_penetration = -20
 	ricochet_chance = 0 //mushroom on impact, no bounces
 
 // .45-70 Gov't (Hunting Revolver)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Reduces 357 hollowpoint negative AP to -20 from -50

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Since the hollowpoint nerf, 357 hollowpoint is no longer a nasty 2 shot crit. I think it's fine for it to have a more typical hollowpoint AP modifier on par with .44 now.

## Changelog

:cl:
add: Increases 357 hollowpoint AP to -20 from -50
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
