### PR TITLE
Map Frontiersmen Turrets Onto Ruins

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
@@ -7,7 +7,8 @@
 "bl" = (
 /obj/machinery/light/floor,
 /obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 6
+	dir = 6;
+	faction = list("Frontiersmen","Turret")
 	},
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach)
@@ -147,7 +148,8 @@
 "hd" = (
 /obj/machinery/light/floor,
 /obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 10
+	dir = 10;
+	faction = list("Frontiersmen","Turret")
 	},
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach)
@@ -265,7 +267,8 @@
 "lT" = (
 /obj/machinery/light/floor,
 /obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 5
+	dir = 5;
+	faction = list("Frontiersmen","Turret")
 	},
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach)
@@ -396,7 +399,8 @@
 "pd" = (
 /obj/machinery/light/floor,
 /obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 9
+	dir = 9;
+	faction = list("Frontiersmen","Turret")
 	},
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach)

--- a/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_fishing_hut.dmm
@@ -4,6 +4,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ruin/beach)
+"bl" = (
+/obj/machinery/light/floor,
+/obj/machinery/porta_turret/ship/frontiersmen{
+	dir = 6
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/beach)
 "bs" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -139,12 +146,8 @@
 /area/ruin/beach)
 "hd" = (
 /obj/machinery/light/floor,
-/obj/machinery/porta_turret/syndicate/energy{
-	active_power_usage = 0;
-	faction = list("Frontiersmen","beach");
-	idle_power_usage = 0;
-	reqpower = 0;
-	name = "Point defense anti-carp turret"
+/obj/machinery/porta_turret/ship/frontiersmen{
+	dir = 10
 	},
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach)
@@ -259,6 +262,13 @@
 	},
 /turf/open/water/beach/deep,
 /area/overmap_encounter/planetoid/beachplanet/explored)
+"lT" = (
+/obj/machinery/light/floor,
+/obj/machinery/porta_turret/ship/frontiersmen{
+	dir = 5
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/beach)
 "lX" = (
 /obj/effect/turf_decal/weather/sand{
 	dir = 1
@@ -383,6 +393,13 @@
 	},
 /turf/open/water/beach,
 /area/overmap_encounter/planetoid/beachplanet/explored)
+"pd" = (
+/obj/machinery/light/floor,
+/obj/machinery/porta_turret/ship/frontiersmen{
+	dir = 9
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/beach)
 "pe" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/siding/wood{
@@ -478,6 +495,7 @@
 /obj/machinery/light/small/directional/north{
 	light_color = "#694c12"
 	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
 /turf/open/floor/carpet,
 /area/ruin/beach)
 "tj" = (
@@ -657,9 +675,7 @@
 /area/overmap_encounter/planetoid/beachplanet/explored)
 "Bg" = (
 /obj/effect/turf_decal/corner/opaque/pink/diagonal,
-/mob/living/simple_animal/hostile/human/frontier{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier,
 /turf/open/floor/plastic,
 /area/ruin/beach)
 "Bo" = (
@@ -840,9 +856,7 @@
 "GP" = (
 /obj/structure/chair/sofa/brown/right/directional/south,
 /obj/effect/decal/cleanable/cobweb,
-/mob/living/simple_animal/hostile/human/frontier{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier,
 /turf/open/floor/carpet,
 /area/ruin/beach)
 "Hb" = (
@@ -1032,9 +1046,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
 /turf/open/floor/wood/ebony,
 /area/overmap_encounter/planetoid/beachplanet/explored)
 "Os" = (
@@ -1108,9 +1120,7 @@
 /area/ruin/beach)
 "Rh" = (
 /obj/structure/chair/sofa/brown/corner/directional/south,
-/mob/living/simple_animal/hostile/human/frontier{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier,
 /turf/open/floor/carpet,
 /area/ruin/beach)
 "RE" = (
@@ -1223,9 +1233,7 @@
 	pixel_x = 4;
 	layer = 2.9
 	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
 /turf/open/floor/wood/ebony,
 /area/overmap_encounter/planetoid/beachplanet/explored)
 "Vm" = (
@@ -1305,9 +1313,7 @@
 /turf/open/water/beach,
 /area/overmap_encounter/planetoid/beachplanet/explored)
 "ZJ" = (
-/mob/living/simple_animal/hostile/human/frontier{
-	faction = list("Frontiersmen","beach")
-	},
+/mob/living/simple_animal/hostile/human/frontier,
 /turf/open/floor/wood,
 /area/ruin/beach)
 "ZV" = (
@@ -1673,7 +1679,7 @@ Fr
 Fr
 Fr
 sG
-hd
+pd
 Fq
 Fr
 QQ
@@ -2260,7 +2266,7 @@ Fr
 Fr
 Fr
 sG
-hd
+lT
 Fq
 QQ
 ut
@@ -2356,7 +2362,7 @@ YL
 ID
 Fr
 sG
-hd
+bl
 Fq
 Fr
 Fr

--- a/_maps/RandomRuins/BeachRuins/beach_pirate_crash.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_pirate_crash.dmm
@@ -1365,16 +1365,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small/directional/east,
-/obj/machinery/porta_turret/syndicate/pod{
-	desc = "A turret built with substandard parts and run down further with age. Still capable of delivering lethal lasers to the odd space carp, but not much else.";
-	dir = 8;
-	faction = list("Frontiersmen");
-	lethal_projectile = /obj/projectile/beam/weak/penetrator;
-	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg';
-	name = "laser turret"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/porta_turret/ship/frontiersmen/light{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/beach/piratecrash)
 "PH" = (

--- a/_maps/RandomRuins/BeachRuins/beach_pirate_crash.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_pirate_crash.dmm
@@ -1368,7 +1368,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/porta_turret/ship/frontiersmen/light{
-	dir = 10
+	dir = 10;
+	faction = list("Frontiersmen","Turret")
 	},
 /turf/open/floor/plating,
 /area/ruin/beach/piratecrash)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the frontiersmen turrets onto the 2 beach frontiersmen ruins with turrets
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Content that is fitting for the factions used in places where you'd expect it to be used
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Some frontiersmen ruins have been updated to have frontiersmen turrets

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
