### PR TITLE
kilo shotgun fix

### DIFF
--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -662,12 +662,10 @@
 	dir = 8
 	},
 /obj/item/storage/box/ammo/a12g_rubbershot,
-/obj/item/gun/ballistic/shotgun/doublebarrel/presawn{
-	default_ammo_type = 0
-	},
 /obj/structure/cable/pink{
 	icon_state = "4-10"
 	},
+/obj/item/gun/ballistic/shotgun/doublebarrel/presawn/empty,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "gs" = (

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -353,6 +353,8 @@ EMPTY_GUN_HELPER(shotgun/doublebarrel)
 		/obj/item/ammo_box/magazine/internal/shot/dual/lethal,
 	)
 
+EMPTY_GUN_HELPER(shotgun/doublebarrel/presawn)
+
 /obj/item/gun/ballistic/shotgun/doublebarrel/roumain
 	name = "HP antique double-barreled shotgun"
 	desc = "A special-edition shotgun hand-made by Hunter's Pride with a high-quality walnut stock inlaid with brass scrollwork. Shotguns like this are very rare outside of the Saint-Roumain Militia's ranks. Otherwise functionally identical to a common double-barreled shotgun. Chambered in 12g."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hello everybody my name is market pliers and today we will be pulling the plug

## Why It's Good For The Game

fixes #3682

## Changelog

:cl:
fix: the kilo sawnoff shotgun is no longer the private domicile of The Void
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
