### PR TITLE
Changes Ramzi mobs to use rusted red instead of blood red as a reference

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -160,7 +160,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/space/Initialize()
 	. = ..()
@@ -188,7 +188,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/smg/space/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -31,7 +31,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/space/Initialize()
 	. = ..()
@@ -42,7 +42,7 @@
 	icon_state = "syndicate_stormtrooper"
 	icon_living = "syndicate_stormtrooper"
 	name = "Ramzi Clique Assault Trooper"
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
 
 /mob/living/simple_animal/hostile/human/syndicate/melee //dude with a knife and no shields
 	melee_damage_lower = 15
@@ -64,7 +64,7 @@
 	maxbodytemp = 1000
 	speed = 1
 	projectile_deflect_chance = 50
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/space/Initialize()
 	. = ..()
@@ -76,7 +76,7 @@
 	icon_living = "syndicate_stormtrooper_knife"
 	name = "Ramzi Clique Stormtrooper"
 	projectile_deflect_chance = 50
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/sword
 	melee_damage_lower = 30
@@ -115,7 +115,7 @@
 	maxbodytemp = 1000
 	speed = 1
 	projectile_deflect_chance = 50
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/melee/sword/space/Initialize()
 	. = ..()
@@ -171,7 +171,7 @@
 	icon_state = "syndicate_stormtrooper_pistol"
 	icon_living = "syndicate_stormtrooper_pistol"
 	name = "Ramzi Clique Stormtrooper"
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/smg
 	rapid = 2
@@ -199,7 +199,7 @@
 	icon_state = "syndicate_stormtrooper_smg"
 	icon_living = "syndicate_stormtrooper_smg"
 	name = "Ramzi Clique Stormtrooper"
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/shotgun
 	rapid = 2
@@ -217,7 +217,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1000
 	speed = 1
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged/shotgun/space/Initialize()
 	. = ..()
@@ -228,7 +228,7 @@
 	icon_state = "syndicate_stormtrooper_shotgun"
 	icon_living = "syndicate_stormtrooper_shotgun"
 	name = "Ramzi Clique Stormtrooper"
-	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi
 
 ///////////////Misc////////////
 


### PR DESCRIPTION
## About The Pull Request

Used to be like this

## Why It's Good For The Game

Most Ramzi operatives use rusted reds instead of all blood reds, and having them all have cracked ass armour when they should have rusted-red is probably better.

## Changelog

:cl:
balance: Ramzi mobs now use the rusted-red as a reference item instead of blood-reds to have lower armour.
/:cl: