### PR TITLE
You can no longer see clothes through Blood Red Hardsuits (& others)

### DIFF
--- a/code/modules/clothing/factions/hardliners.dm
+++ b/code/modules/clothing/factions/hardliners.dm
@@ -125,7 +125,6 @@
 	icon = 'icons/obj/clothing/faction/hardliners/suits.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/hardliners/suits.dmi'
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/hl
-	lightweight = 1
 	jetpack = null
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite/hl
@@ -147,7 +146,6 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite/hl
 	icon = 'icons/obj/clothing/faction/hardliners/suits.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/hardliners/suits.dmi'
-	lightweight = 1
 	jetpack = null
 
 /////////

--- a/code/modules/clothing/factions/ngr.dm
+++ b/code/modules/clothing/factions/ngr.dm
@@ -135,7 +135,6 @@
 	icon = 'icons/obj/clothing/faction/ngr/suits.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/ngr/suits.dmi'
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ngr
-	lightweight = 1
 	jetpack = null
 	greyscale_colors = list("#33353a", "#d9ad82", "#8c1a34")
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -436,7 +436,6 @@
 	item_state = "hardsuit1-ramzi"
 	hardsuit_type = "ramzi"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
-	lightweight = 1
 	jetpack = null
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 20,"energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
 	slowdown = 0.7


### PR DESCRIPTION
## About The Pull Request

Used to be able to see what someone was wearing underneath their hardsuit 

## Why It's Good For The Game

Oversight probably. I don't think the NGR / Hardliner / Ramzi hardsuits are supposed to have this var applied to them to begin with

## Changelog

:cl:
fix: You can no longer see through Marauder hardsuits
/:cl: