### PR TITLE
Fixes a number of issues revolving around guns not taking certain magazines

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -57,7 +57,10 @@
 //BALLISTIC
 	///Compatible magazines with the gun
 	var/default_ammo_type
+	///Allowed base types of magazines with the gun
 	var/allowed_ammo_types
+	///Incompatible magazines with the gun
+	var/blacklisted_ammo_types
 	///Whether the gun alarms when empty or not.
 	var/empty_alarm = FALSE
 	///Do we eject the magazine upon runing out of ammo?

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -42,6 +42,9 @@
 
 /obj/item/gun/ballistic/Initialize(mapload, spawn_empty)
 	. = ..()
+
+	allowed_ammo_types = typecacheof(allowed_ammo_types) - blacklisted_ammo_types
+
 	if(spawn_empty)
 		if(internal_magazine)
 			spawn_no_ammo = TRUE

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -46,8 +46,6 @@
 	default_ammo_type = /obj/item/ammo_box/magazine/skm_762_40
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/skm_762_40,
-		/obj/item/ammo_box/magazine/skm_762_40/extended,
-		/obj/item/ammo_box/magazine/skm_762_40/drum,
 	)
 
 	spread = 1

--- a/code/modules/projectiles/guns/ballistic/hmg.dm
+++ b/code/modules/projectiles/guns/ballistic/hmg.dm
@@ -184,8 +184,6 @@
 	default_ammo_type = /obj/item/ammo_box/magazine/skm_762_40
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/skm_762_40,
-		/obj/item/ammo_box/magazine/skm_762_40/extended,
-		/obj/item/ammo_box/magazine/skm_762_40/drum
 	)
 
 	fire_delay = 0.13 SECONDS

--- a/code/modules/projectiles/guns/ballistic/smg.dm
+++ b/code/modules/projectiles/guns/ballistic/smg.dm
@@ -79,7 +79,6 @@
 	default_ammo_type = /obj/item/ammo_box/magazine/c45_firestorm_mag
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/c45_firestorm_mag,
-		/obj/item/ammo_box/magazine/c45_firestorm_mag/pan
 	)
 	unique_mag_sprites_for_variants = TRUE
 	burst_size = 1
@@ -118,7 +117,6 @@
 	default_ammo_type = /obj/item/ammo_box/magazine/skm_46_30
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/skm_46_30,
-		/obj/item/ammo_box/magazine/skm_46_30/recycled,
 	)
 
 	recoil = 2
@@ -210,10 +208,6 @@
 	default_ammo_type = /obj/item/ammo_box/magazine/smgm9mm
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/smgm9mm,
-		/obj/item/ammo_box/magazine/smgm9mm/ap,
-		/obj/item/ammo_box/magazine/smgm9mm/inc,
-		/obj/item/ammo_box/magazine/smgm9mm/rubber,
-
 	)
 
 	fire_sound = 'sound/weapons/gun/smg/vector_fire.ogg'

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -45,9 +45,6 @@
 
 /obj/item/gun/ballistic/automatic/toy/pistol/riot
 	default_ammo_type = /obj/item/ammo_box/magazine/toy/pistol/riot
-	allowed_ammo_types = list(
-		/obj/item/ammo_box/magazine/toy/pistol/riot,
-	)
 
 /obj/item/gun/ballistic/automatic/toy/pistol/riot/Initialize()
 	magazine = new /obj/item/ammo_box/magazine/toy/pistol/riot(src)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -125,7 +125,7 @@
 		update_appearance()
 
 /obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
-	if (!internal_magazine && (A.type in allowed_ammo_types - blacklisted_ammo_types))
+	if (!internal_magazine && (A.type in (allowed_ammo_types - blacklisted_ammo_types)))
 		var/obj/item/stock_parts/cell/gun/C = A
 		if (!cell)
 			insert_cell(user, C)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -125,7 +125,7 @@
 		update_appearance()
 
 /obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
-	if (!internal_magazine && (A.type in allowed_ammo_types))
+	if (!internal_magazine && (A.type in allowed_ammo_types - blacklisted_ammo_types))
 		var/obj/item/stock_parts/cell/gun/C = A
 		if (!cell)
 			insert_cell(user, C)

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -146,7 +146,6 @@ NO_MAG_GUN_HELPER(automatic/pistol/cm357)
 	default_ammo_type = /obj/item/ammo_box/magazine/cm5_9mm
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/cm5_9mm,
-		/obj/item/ammo_box/magazine/cm5_9mm/rubber,
 	)
 	bolt_type = BOLT_TYPE_CLIP
 	weapon_weight = WEAPON_LIGHT
@@ -527,7 +526,6 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 	default_ammo_type = /obj/item/ammo_box/magazine/cm15_12g
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/cm15_12g,
-		/obj/item/ammo_box/magazine/cm15_12g/incendiary
 	)
 
 	empty_indicator = FALSE

--- a/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
@@ -19,6 +19,7 @@
 	default_ammo_type = /obj/item/stock_parts/cell/gun/kalix
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix, /obj/item/ammo_casing/energy/disabler/hitscan)
 
@@ -60,6 +61,7 @@
 	default_ammo_type = /obj/item/stock_parts/cell/gun/pgf
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/pgf , /obj/item/ammo_casing/energy/disabler/hitscan)
 
@@ -95,6 +97,7 @@
 	default_ammo_type = /obj/item/stock_parts/cell/gun/kalix
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/pistol)
 

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -525,7 +525,6 @@ NO_MAG_GUN_HELPER(automatic/smg/sidewinder)
 	default_ammo_type = /obj/item/ammo_box/magazine/boomslang
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/boomslang,
-		/obj/item/ammo_box/magazine/boomslang/short,
 	)
 	w_class = WEIGHT_CLASS_BULKY
 
@@ -657,9 +656,6 @@ NO_MAG_GUN_HELPER(automatic/marksman/taipan)
 	default_ammo_type = /obj/item/ammo_box/magazine/m556_42_hydra
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m556_42_hydra,
-		/obj/item/ammo_box/magazine/m556_42_hydra/extended,
-		/obj/item/ammo_box/magazine/m556_42_hydra/casket,
-		/obj/item/ammo_box/magazine/m556_42_hydra/small
 	)
 	gun_firenames = list(FIREMODE_SEMIAUTO = "single", FIREMODE_BURST = "burst fire", FIREMODE_FULLAUTO = "full auto", FIREMODE_OTHER = "underbarrel grenade launcher")
 	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
@@ -913,12 +909,6 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 	default_ammo_type = /obj/item/ammo_box/magazine/m12g_bulldog
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m12g_bulldog,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum/stun,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum/slug,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum/dragon,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum/bioterror,
-		/obj/item/ammo_box/magazine/m12g_bulldog/drum/meteor,
 	)
 	fire_delay = 0.4 SECONDS // this NEEDS the old delay.
 	fire_sound = 'sound/weapons/gun/shotgun/bulldog.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the strict type-check for allowed ammo lists (in ballistics, im not touching cells. yet.) with a typecache of any allowed magazine & an available list of blacklisted specific ammo types.
Etherbor guns can now take both civilian and military etherbor cells, mirroring sharplite weapons which can accept both standard and upgraded cells. Behind every blade of grass.

## Why It's Good For The Game

The shredder can now take slug boxes again
Any gun where you can find or make empty magazines can now take those empty magazines. Guncrates conveniently avoided this by emptying non-subtyped magazines.
Guns with alternate ammunition in magazines no longer require those alternate ammunition magazine types to be added to their allowed types despite only really changing the ammunition the magazine starts with


## Changelog

:cl:
fix: guns with magazines can no longer sometimes refuse to accept those magazines
balance: etherbor military and civilian weapon cells are interchangeable between military and civilian arms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
