### PR TITLE
Severely Reduces Fishing Missions

### DIFF
--- a/code/modules/overmap/missions.dm
+++ b/code/modules/overmap/missions.dm
@@ -1,9 +1,12 @@
 /datum/mission
 	var/name = "Mission"
 	var/desc = "Do something for me."
-	var/value = 1000 /// The mission's payout.
-	var/duration = 30 MINUTES /// The amount of time in which to complete the mission.
-	var/weight = 0 /// The relative probability of this mission being selected. 0-weight missions are never selected.
+	/// The mission's payout.
+	var/value = 1000
+	/// The amount of time in which to complete the mission.
+	var/duration = 30 MINUTES
+	/// The relative probability of this mission being selected. 0-weight missions are never selected.
+	var/weight = 0
 
 	/// Should mission value scale proportionally to the deviation from the mission's base duration?
 	var/dur_value_scaling = TRUE
@@ -64,12 +67,16 @@
 	return ..()
 
 /datum/mission/proc/turn_in()
+	if(QDELING(src))
+		return
 	SSblackbox.record_feedback("nested tally", "mission", 1, list(name, "succeeded"))
 	SSblackbox.record_feedback("nested tally", "mission", value, list(name, "payout"))
 	servant.ship_account.adjust_money(value, CREDIT_LOG_MISSION)
 	qdel(src)
 
 /datum/mission/proc/give_up()
+	if(QDELING(src))
+		return
 	SSblackbox.record_feedback("nested tally", "mission", 1, list(name, "abandoned"))
 	qdel(src)
 

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -223,70 +223,18 @@ Acquire: Anomaly
 		Acquire: Fishing
 */
 
-/datum/mission/acquire/aquarium
-	name = "Fish needed for my aquarium"
-	weight = 6
-	value = 750
+/datum/mission/acquire/fish
+	name = "Fish needed for my meal"
+	weight = 2
 	duration = 60 MINUTES
 	val_mod_range = 0.2
+	objective_type = /obj/item/fish
 	container_type = /obj/item/storage/fish_case/mission
 
-/datum/mission/acquire/aquarium/New(...)
-	objective_type = pick(/obj/item/fish/clownfish,
-						/obj/item/fish/pufferfish,
-						/obj/item/fish/cardinal,
-						/obj/item/fish/greenchromis,
-						/obj/item/fish/trout,
-						/obj/item/fish/salmon,
-						/obj/item/fish/dwarf_moonfish,
-						/obj/item/fish/gunner_jellyfish,
-						/obj/item/fish/plasmatetra,
-						/obj/item/fish/catfish,
-						/obj/item/fish/bass,
-						/obj/item/fish/armorfish,
-						/obj/item/fish/needlefish)
-	desc = "My aquarium is sorely lacking in [initial(objective_type.name)], can you please bring one to me? \
-			Don't worry about if it's alive or dead, I have methods."
-	. = ..()
-
-/datum/mission/acquire/aquarium/rare
-	name = "Rare fish needed for my aquarium!"
-	weight = 1
-	value = 1500
-	val_mod_range = 0.3
-
-/datum/mission/acquire/aquarium/rare/New(...)
-	. = ..()
-	objective_type = pick(/obj/item/fish/lanternfish,
-						/obj/item/fish/firefish,
-						/obj/item/fish/donkfish)
-	desc = "I seek to make my beloved aquarium truly spectacular, and to do this I need only the finest fish! \
-			Bring me a [initial(objective_type.name)] and I will reward you handsomely."
-
-/datum/mission/acquire/aquarium/sabatoge
-	name = "That bastard has had it good for too long!"
-	weight = 1
-	value = 3000
-	duration = 100 MINUTES
-
-/datum/mission/acquire/aquarium/sabatoge/New(...)
-	. = ..()
-	desc = "My arch-nemesis [pick("Rutherford","Baldwin","Anderson","Percival")] thinks his aquarium is so much better than mine, I'll show him! \
-			Bring me an emulsijack, and make sure it's alive!"
-	objective_type = pick(/obj/item/fish/emulsijack)
-
-/datum/mission/acquire/fish_cook
-	name = "Fish needed for my meal"
-	weight = 3
-	duration = 40 MINUTES
-	val_mod_range = 0.2
-	objective_type = /obj/item/fish
-	container_type = /obj/item/storage/fish_case/mission/big
-
-/datum/mission/acquire/fish_cook/New(...)
+/datum/mission/acquire/fish/New(...)
 	num_wanted = rand(1,3)
 	desc = "I am a chef in need of [num_wanted] fish for my latest dish. Any fish will do, just make sure they're not filleted!"
-	value = (250*num_wanted)
+	value = (500*num_wanted)
 	. = ..()
 
 /datum/mission/acquire/fish/alive/atom_effective_count(atom/movable/target)
@@ -338,13 +286,9 @@ Acquire: Anomaly
 
 /obj/item/storage/fish_case/mission
 	name = "fish delivery case"
-	desc = "A stasis case that keeps fish alive during transportation, or at least stops them from becoming more dead."
-
-/obj/item/storage/fish_case/mission/big
-	name = "large fish delivery case"
 	desc = "A specialized container for the delivering of large quatities of fish. Guarantees they stay fresh during delivery!."
 
-/obj/item/storage/fish_case/mission/big/ComponentInitialize()
+/obj/item/storage/fish_case/mission/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Judging by the stats, nobody seems to think fishing missions are terribly worthwhile as they are now for multiple reasons. They're extremely common and don't pay that well, despite the setup and time required to do them. I feel like leaving a rarer, better-paid one would be fine, so that's what I did. I drastically reduced the total weight of all fishing missions from 11 to 2, so they should take up a lot less slots now. I also only kept the non-specific fish mission, as the specific fish ones seemed to be mostly based on RNG, let alone the rarer ones.

## Why It's Good For The Game

It's still not a very interesting mission objective, but it might inspire people to go try out fishing when they're bored, or something. Getting rid of annoying, rarely-done missions means people have to sift through less to get to missions they actually want.

## Changelog

:cl:
del: Most fishing missions. Now only the cooking one, that takes 1-3 of any fish, has been left.
tweak: The fish cooking mission now pays twice as much as it used to, 500 credits per fish. It's also less likely to appear as a mission.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
