### PR TITLE
E-11 ruin fix

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_e11_manufactory.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_e11_manufactory.dmm
@@ -260,7 +260,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 10
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "bB" = (
 /obj/structure/chair,
@@ -354,7 +354,7 @@
 "ch" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/human/hermit/ranged/e11,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "cm" = (
 /obj/effect/decal/remains/xeno/larva{
@@ -402,7 +402,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -455,7 +455,7 @@
 	id = "e11_manufactory_warehouse_holofield"
 	},
 /obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/ruin/whitesands/e11manufactory/warehouse)
 "cN" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -480,11 +480,11 @@
 "cR" = (
 /obj/effect/turf_decal/industrial/warning/corner,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dc" = (
 /obj/item/shard,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dg" = (
 /obj/structure/chair/stool{
@@ -513,7 +513,7 @@
 /area/ruin/whitesands/e11manufactory)
 "do" = (
 /obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dw" = (
 /obj/structure/chair{
@@ -525,7 +525,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "dz" = (
 /obj/structure/railing,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dA" = (
 /obj/structure/flora/tree/dead/barren,
@@ -553,7 +553,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -569,7 +569,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 9
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "dX" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -634,7 +634,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "et" = (
 /obj/structure/table,
@@ -668,7 +668,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 9
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -695,14 +695,14 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "eV" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -710,7 +710,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fs" = (
 /obj/structure/closet{
@@ -773,7 +773,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -825,7 +825,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gt" = (
 /obj/effect/turf_decal/road{
@@ -850,7 +850,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gG" = (
 /obj/effect/spawner/random/maintenance,
@@ -862,7 +862,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gM" = (
 /turf/closed/wall/concrete,
@@ -884,12 +884,12 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "gV" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hb" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/e11,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "he" = (
 /obj/machinery/conveyor{
@@ -906,7 +906,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hk" = (
 /obj/machinery/door/airlock/external{
@@ -941,7 +941,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -984,7 +984,7 @@
 /area/ruin/whitesands/e11manufactory/office)
 "hw" = (
 /obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hz" = (
 /obj/structure/table/reinforced,
@@ -1045,7 +1045,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hY" = (
 /turf/open/floor/concrete/slab_4{
@@ -1093,13 +1093,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ir" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "is" = (
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -1113,7 +1113,7 @@
 /area/ruin/whitesands/e11manufactory/mats)
 "iu" = (
 /obj/effect/turf_decal/weather/whitesands/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ix" = (
 /obj/structure/flora/ash/garden/arid,
@@ -1148,7 +1148,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "iM" = (
 /obj/structure/closet/crate/secure/plasma{
@@ -1241,7 +1241,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "jD" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
@@ -1380,7 +1380,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "kt" = (
 /obj/machinery/conveyor,
@@ -1391,7 +1391,7 @@
 	max_integrity = 70;
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "kA" = (
 /obj/effect/turf_decal/road{
@@ -1461,7 +1461,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "le" = (
 /obj/structure/cable/yellow{
@@ -1470,7 +1470,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "lh" = (
 /obj/item/solar_assembly,
@@ -1558,7 +1558,7 @@
 	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "lT" = (
 /obj/structure/fence{
@@ -1567,7 +1567,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 6
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "lV" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -1585,13 +1585,13 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 9
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ma" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "mc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1613,7 +1613,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "mk" = (
 /obj/structure/table,
@@ -1629,7 +1629,7 @@
 	pixel_x = 7;
 	pixel_y = -1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "mm" = (
 /obj/effect/turf_decal/box/corners,
@@ -1817,7 +1817,7 @@
 /obj/structure/cable/orange{
 	icon_state = "0-10"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "nE" = (
 /obj/structure/fence{
@@ -1826,7 +1826,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "nG" = (
 /obj/effect/turf_decal/road{
@@ -1900,7 +1900,7 @@
 "on" = (
 /obj/effect/decal/cleanable/molten_object,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "op" = (
 /obj/structure/chair/stool/bar{
@@ -1926,7 +1926,7 @@
 "ox" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "oy" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1949,7 +1949,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "oE" = (
 /obj/structure/fence{
@@ -1958,7 +1958,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 6
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "oJ" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2004,7 +2004,7 @@
 /area/ruin/whitesands/e11manufactory)
 "oS" = (
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "oX" = (
 /obj/effect/turf_decal/corner/opaque/purple/diagonal,
@@ -2051,7 +2051,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "pE" = (
 /turf/closed/wall/rust/yesdiag,
@@ -2161,7 +2161,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qu" = (
 /obj/structure/cable/yellow{
@@ -2173,7 +2173,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-10"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qx" = (
 /turf/open/floor/plasteel/mono,
@@ -2209,7 +2209,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qH" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2227,7 +2227,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 10
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qN" = (
 /obj/machinery/door/airlock/external{
@@ -2262,7 +2262,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rg" = (
 /obj/machinery/power/solar,
@@ -2297,7 +2297,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/weather/whitesands/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2322,7 +2322,7 @@
 /obj/effect/turf_decal/industrial/caution{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rP" = (
 /obj/effect/turf_decal/road{
@@ -2370,7 +2370,7 @@
 	pixel_x = -3;
 	layer = 2.99
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rU" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -2458,7 +2458,7 @@
 "sB" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "sG" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2514,7 +2514,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "sY" = (
 /obj/structure/salvageable/server,
@@ -2554,7 +2554,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "tw" = (
 /obj/machinery/door/poddoor/shutters{
@@ -2580,14 +2580,14 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/ruin/whitesands/e11manufactory/warehouse)
 "tF" = (
 /obj/structure/railing{
 	dir = 10;
 	layer = 4.1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "tG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2615,7 +2615,7 @@
 "tN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "tO" = (
 /obj/machinery/vending/cigarette,
@@ -2644,7 +2644,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "uq" = (
 /obj/effect/turf_decal/road{
@@ -2686,7 +2686,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "uC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2761,7 +2761,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "vg" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2939,7 +2939,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/ruin/whitesands/e11manufactory/office)
 "wQ" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -3061,7 +3061,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "xG" = (
 /obj/machinery/door/airlock/grunge{
@@ -3120,7 +3120,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "xY" = (
 /obj/structure/closet/firecloset/full,
@@ -3148,7 +3148,7 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "yl" = (
 /obj/machinery/conveyor{
@@ -3173,7 +3173,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "yK" = (
 /obj/machinery/door/airlock/grunge{
@@ -3191,7 +3191,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "yO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3261,12 +3261,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "zE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "zK" = (
 /turf/open/floor/plasteel/mono,
@@ -3344,7 +3344,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "AB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -3409,7 +3409,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "AU" = (
 /obj/structure/fence{
@@ -3418,7 +3418,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "AW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3486,7 +3486,7 @@
 	dir = 9
 	},
 /obj/structure/railing/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Bl" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -3570,7 +3570,7 @@
 /obj/structure/fence{
 	dir = 2
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "BZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -3623,7 +3623,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CH" = (
 /obj/effect/turf_decal/box/corners{
@@ -3640,7 +3640,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 6
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CL" = (
 /obj/effect/turf_decal/road{
@@ -3666,7 +3666,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CQ" = (
 /obj/structure/chair{
@@ -3694,7 +3694,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CY" = (
 /mob/living/simple_animal/hostile/human/hermit/survivor/random,
@@ -3735,7 +3735,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "DC" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "DD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3771,7 +3771,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "DM" = (
 /obj/structure/window/unanchored,
@@ -3781,7 +3781,7 @@
 	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "DN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -3951,13 +3951,13 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "EZ" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ff" = (
 /obj/structure/chair/stool/bar{
@@ -3975,7 +3975,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Fp" = (
 /obj/effect/turf_decal/corner/opaque/red/diagonal,
@@ -4016,7 +4016,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "FL" = (
 /obj/structure/table/reinforced,
@@ -4029,7 +4029,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "FR" = (
 /obj/structure/sink/kitchen{
@@ -4052,7 +4052,7 @@
 "FV" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/turf_decal/weather/whitesands/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "FY" = (
 /obj/effect/turf_decal/road{
@@ -4090,7 +4090,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Gp" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
@@ -4112,7 +4112,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Gw" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -4169,7 +4169,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4193,7 +4193,7 @@
 /obj/machinery/conveyor{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Hd" = (
 /obj/effect/spawner/random/maintenance,
@@ -4206,7 +4206,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Hi" = (
 /obj/effect/turf_decal/weather/whitesands{
@@ -4216,7 +4216,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Hp" = (
 /obj/structure/chair{
@@ -4252,7 +4252,7 @@
 /obj/structure/railing{
 	dir = 9
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "HD" = (
 /obj/item/restraints/legcuffs/beartrap{
@@ -4261,7 +4261,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "HE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -4273,7 +4273,7 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "HV" = (
 /obj/structure/cable/orange{
@@ -4281,7 +4281,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4,
 /obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "HX" = (
 /obj/item/restraints/legcuffs/beartrap{
@@ -4295,7 +4295,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "Ie" = (
 /obj/structure/mecha_wreckage/ripley,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ii" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -4341,7 +4341,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "It" = (
 /obj/structure/table,
@@ -4386,7 +4386,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ID" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -4457,7 +4457,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ju" = (
 /obj/effect/decal/cleanable/oil,
@@ -4492,7 +4492,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "JP" = (
 /obj/effect/turf_decal/rechargefloor,
@@ -4546,7 +4546,7 @@
 	armed = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Km" = (
 /turf/closed/wall/rust,
@@ -4575,7 +4575,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4601,7 +4601,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/can/food/beans,
 /obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4609,7 +4609,7 @@
 /obj/item/trash/plate{
 	pixel_x = 3
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KO" = (
 /obj/effect/turf_decal/solarpanel,
@@ -4632,7 +4632,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KR" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -4671,7 +4671,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Lo" = (
 /obj/item/solar_assembly,
@@ -4743,7 +4743,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "LH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
@@ -4766,7 +4766,7 @@
 	max_integrity = 70;
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "LV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4785,7 +4785,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "LZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4816,7 +4816,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "Mi" = (
 /obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Mm" = (
 /obj/structure/closet{
@@ -4937,7 +4937,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ni" = (
 /obj/effect/turf_decal/road{
@@ -5013,7 +5013,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "NH" = (
 /turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
@@ -5043,7 +5043,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "NW" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -5097,7 +5097,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Oq" = (
 /obj/structure/guncloset{
@@ -5131,7 +5131,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "OF" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -5146,7 +5146,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ON" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -5182,7 +5182,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "OV" = (
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -5210,7 +5210,7 @@
 /turf/open/floor/concrete/reinforced/whitesands,
 /area/overmap_encounter/planetoid/sand/explored)
 "Pg" = (
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Pi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5301,7 +5301,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "PQ" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -5310,7 +5310,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "PR" = (
 /obj/structure/closet/crate/secure/engineering{
@@ -5364,7 +5364,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Qi" = (
 /obj/machinery/door/airlock/external{
@@ -5400,7 +5400,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Qq" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5417,7 +5417,7 @@
 	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/human/hermit/ranged/e11,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Qu" = (
 /obj/structure/flora/ash/garden/arid,
@@ -5430,7 +5430,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "QE" = (
 /obj/structure/table,
@@ -5461,7 +5461,7 @@
 	dir = 9
 	},
 /obj/structure/railing/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "QU" = (
 /obj/structure/closet{
@@ -5514,7 +5514,7 @@
 /obj/structure/cable/orange{
 	icon_state = "0-1"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Rl" = (
 /obj/machinery/airalarm/directional/east,
@@ -5541,7 +5541,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Rv" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -5594,7 +5594,7 @@
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "RQ" = (
 /obj/machinery/conveyor,
@@ -5606,7 +5606,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "RS" = (
 /obj/structure/salvageable/server,
@@ -5634,7 +5634,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "RZ" = (
 /obj/structure/table,
@@ -5703,14 +5703,14 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Sy" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/orange{
 	icon_state = "0-8"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "SA" = (
 /obj/effect/turf_decal/solarpanel,
@@ -5761,7 +5761,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "SH" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -5778,7 +5778,7 @@
 	pixel_y = -15;
 	pixel_x = -9
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "SO" = (
 /turf/closed/wall/r_wall/rust/yesdiag,
@@ -5836,7 +5836,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5856,7 +5856,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "To" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -5880,7 +5880,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "TN" = (
 /obj/machinery/door/airlock/external,
@@ -5898,7 +5898,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "TU" = (
 /obj/effect/turf_decal/weather/whitesands{
@@ -5929,7 +5929,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Uj" = (
 /turf/open/floor/concrete/slab_2{
@@ -6006,7 +6006,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "UR" = (
 /obj/effect/turf_decal/road{
@@ -6067,7 +6067,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Vx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6108,7 +6108,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "VH" = (
 /obj/structure/railing/corner,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "VL" = (
 /obj/structure/bed,
@@ -6122,14 +6122,14 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "We" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Wi" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -6147,7 +6147,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Wn" = (
 /obj/structure/table/reinforced,
@@ -6171,7 +6171,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 10
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Wu" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -6188,7 +6188,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "WC" = (
 /obj/structure/table/reinforced,
@@ -6243,7 +6243,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "WS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6289,7 +6289,7 @@
 /area/ruin/whitesands/e11manufactory/warehouse)
 "Xi" = (
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Xj" = (
 /obj/item/solar_assembly,
@@ -6419,7 +6419,7 @@
 /obj/effect/turf_decal/industrial/caution{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "XX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -6494,7 +6494,7 @@
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "YR" = (
 /obj/machinery/door/airlock/external,
@@ -6512,7 +6512,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Zd" = (
 /obj/machinery/conveyor{
@@ -6522,11 +6522,11 @@
 /area/ruin/whitesands/e11manufactory)
 "Ze" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Zg" = (
 /obj/machinery/conveyor,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Zi" = (
 /obj/structure/cable/yellow{
@@ -6535,7 +6535,7 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Zj" = (
 /turf/open/floor/plating/asteroid/whitesands/dried{
@@ -6546,7 +6546,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ZB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6583,7 +6583,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ZO" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -6617,7 +6617,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/whitesands,
+/turf/open/floor/concrete/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ZZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_e11_manufactory.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_e11_manufactory.dmm
@@ -31,7 +31,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "av" = (
 /obj/machinery/door/airlock/external,
@@ -75,7 +75,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "aF" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -133,7 +133,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "aU" = (
 /obj/structure/marker_beacon{
@@ -165,13 +165,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "bd" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -196,7 +196,7 @@
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "bk" = (
 /obj/machinery/door/airlock/external{
@@ -287,7 +287,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "bM" = (
 /obj/structure/bed,
@@ -426,7 +426,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "cK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -601,7 +601,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "eg" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -659,7 +659,7 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "eG" = (
 /obj/structure/fence{
@@ -739,7 +739,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fu" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -753,7 +753,7 @@
 /obj/structure/marker_beacon{
 	picked_color = "Cerulean"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fA" = (
 /obj/machinery/power/tracker,
@@ -764,7 +764,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fJ" = (
 /obj/structure/fence/cut/large{
@@ -783,7 +783,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "fY" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -805,7 +805,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "gc" = (
 /obj/structure/mecha_wreckage/ripley,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gi" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -835,7 +835,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -880,7 +880,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ruin/whitesands/e11manufactory/barracks)
 "gU" = (
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "gV" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1028,11 +1028,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "hS" = (
 /obj/structure/flora/ash/puce,
@@ -1065,7 +1065,7 @@
 	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ie" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1142,7 +1142,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "iL" = (
 /obj/effect/turf_decal/weather/whitesands{
@@ -1371,7 +1371,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "kr" = (
 /turf/closed/wall/rust/yesdiag,
@@ -1404,7 +1404,7 @@
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "kB" = (
 /obj/effect/turf_decal/corner/opaque/purple/diagonal,
@@ -1482,7 +1482,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-6"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ln" = (
 /obj/structure/table/glass,
@@ -1542,7 +1542,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "lF" = (
 /obj/effect/turf_decal/industrial/loading{
@@ -1693,7 +1693,7 @@
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "mM" = (
 /turf/template_noop,
@@ -1702,7 +1702,7 @@
 /obj/effect/turf_decal/road/slow{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "mV" = (
 /obj/structure/table/reinforced,
@@ -1798,7 +1798,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "nw" = (
 /obj/effect/turf_decal/road{
@@ -1810,7 +1810,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "nA" = (
 /obj/machinery/power/smes/engineering,
@@ -1875,7 +1875,7 @@
 	color = "#FFFFFF"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "og" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2021,7 +2021,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "pb" = (
 /obj/structure/fence/end,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "pf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2034,7 +2034,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "pu" = (
 /obj/structure/table,
@@ -2121,7 +2121,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "qi" = (
 /obj/effect/turf_decal/weather/whitesands/corner,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qj" = (
 /obj/machinery/power/solar,
@@ -2132,7 +2132,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-10"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "qm" = (
 /obj/structure/filingcabinet{
@@ -2252,7 +2252,7 @@
 /mob/living/simple_animal/hostile/human/hermit/ranged/hunter{
 	faction = list("eoehoma")
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rb" = (
 /turf/closed/wall/rust/yesdiag,
@@ -2273,7 +2273,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2290,7 +2290,7 @@
 /area/ruin/whitesands/e11manufactory)
 "rx" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ry" = (
 /obj/structure/cable/yellow{
@@ -2329,7 +2329,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "rQ" = (
 /obj/structure/closet/crate{
@@ -2396,7 +2396,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "sc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2476,7 +2476,7 @@
 	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "sI" = (
 /obj/structure/closet{
@@ -2610,7 +2610,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-1"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "tN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2657,7 +2657,7 @@
 	picked_color = "Cerulean"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ut" = (
 /obj/machinery/door/airlock/external{
@@ -2723,7 +2723,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "uS" = (
 /obj/structure/cable/yellow{
@@ -2735,11 +2735,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "uT" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "uW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -2803,7 +2803,7 @@
 /obj/effect/turf_decal/road{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "vA" = (
 /obj/structure/flora/ash/cap_shroom,
@@ -2852,7 +2852,7 @@
 	icon_state = "0-2"
 	},
 /obj/item/shard,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "wd" = (
 /obj/structure/statue/snow/snowman{
@@ -2932,7 +2932,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "wL" = (
 /obj/machinery/power/solar_control,
@@ -2989,7 +2989,7 @@
 /obj/effect/turf_decal/industrial/warning/cee{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "xi" = (
 /obj/effect/turf_decal/industrial/caution,
@@ -3142,7 +3142,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "yi" = (
 /obj/structure/cable/orange{
@@ -3210,7 +3210,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "zd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -3249,7 +3249,7 @@
 /obj/effect/turf_decal/industrial/stand_clear/white{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "zz" = (
 /turf/open/floor/concrete/slab_3{
@@ -3287,7 +3287,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-1"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "zZ" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -3393,7 +3393,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 8
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "AK" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -3507,7 +3507,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Bq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -3527,7 +3527,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "BL" = (
 /obj/machinery/door/airlock/grunge{
@@ -3557,7 +3557,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "BX" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3634,7 +3634,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/foamtank,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CI" = (
 /obj/effect/turf_decal/weather/whitesands{
@@ -3653,7 +3653,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "CN" = (
 /obj/machinery/conveyor{
@@ -3704,7 +3704,7 @@
 /obj/effect/turf_decal/road{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Db" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
@@ -3762,7 +3762,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "DL" = (
 /obj/structure/fence/cut/large{
@@ -3836,7 +3836,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Eb" = (
 /obj/machinery/door/airlock/external{
@@ -3892,7 +3892,7 @@
 	color = "#FFFFFF"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ep" = (
 /obj/effect/turf_decal/road{
@@ -3901,7 +3901,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ex" = (
 /obj/structure/fence{
@@ -4047,7 +4047,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "FV" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -4064,7 +4064,7 @@
 /obj/structure/marker_beacon{
 	picked_color = "Cerulean"
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ge" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -4103,7 +4103,7 @@
 /obj/effect/turf_decal/industrial/warning/cee{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Gs" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -4287,7 +4287,7 @@
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ia" = (
 /obj/effect/spawner/structure/window,
@@ -4307,7 +4307,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "Ik" = (
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Il" = (
 /obj/machinery/conveyor/inverted{
@@ -4377,7 +4377,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "IC" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -4451,7 +4451,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Jn" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -4482,7 +4482,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "JM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4509,7 +4509,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "JX" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal,
@@ -4619,7 +4619,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KP" = (
 /obj/structure/rack,
@@ -4653,7 +4653,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "KZ" = (
 /obj/structure/sink{
@@ -4681,7 +4681,7 @@
 	icon_state = "0-1"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Lq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4727,7 +4727,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 5
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "LB" = (
 /obj/structure/cable/yellow{
@@ -4749,7 +4749,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
 	dir = 5
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "LN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -4812,7 +4812,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Mi" = (
 /obj/effect/turf_decal/industrial/warning/corner,
@@ -4860,7 +4860,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-1"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Mz" = (
 /obj/effect/turf_decal/road{
@@ -4872,7 +4872,7 @@
 /obj/structure/marker_beacon{
 	picked_color = "Cerulean"
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "MB" = (
 /obj/effect/turf_decal/corner/opaque/red/diagonal,
@@ -4919,7 +4919,7 @@
 /obj/effect/turf_decal/trimline/opaque/white/arrow_ccw{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "MR" = (
 /turf/closed/wall/rust,
@@ -4943,7 +4943,7 @@
 /obj/effect/turf_decal/road{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Nj" = (
 /obj/effect/turf_decal/road{
@@ -4955,7 +4955,7 @@
 /obj/effect/turf_decal/weather/whitesands/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Nr" = (
 /obj/structure/fence/door{
@@ -5053,7 +5053,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "NX" = (
 /turf/closed/wall/rust,
@@ -5084,7 +5084,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Oo" = (
 /obj/machinery/conveyor{
@@ -5110,14 +5110,14 @@
 /obj/effect/turf_decal/trimline/opaque/white/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ov" = (
 /obj/effect/turf_decal/road{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Oy" = (
 /obj/machinery/door/airlock/grunge{
@@ -5163,14 +5163,14 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "OT" = (
 /obj/effect/turf_decal/road{
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "OU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5207,7 +5207,7 @@
 	picked_color = "Cerulean"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Pg" = (
 /turf/open/floor/concrete/whitesands/lit,
@@ -5222,7 +5222,7 @@
 /area/ruin/whitesands/e11manufactory/office)
 "Pj" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Pl" = (
 /obj/structure/chair{
@@ -5484,7 +5484,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ra" = (
 /obj/effect/turf_decal/road{
@@ -5494,7 +5494,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Rb" = (
 /obj/structure/bed,
@@ -5507,7 +5507,7 @@
 /obj/effect/turf_decal/trimline/opaque/white/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ri" = (
 /obj/machinery/power/smes/engineering,
@@ -5617,7 +5617,7 @@
 /obj/structure/fence/end{
 	dir = 1
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "RV" = (
 /obj/structure/flora/rock,
@@ -5723,7 +5723,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "SB" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -5799,7 +5799,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "SX" = (
 /obj/structure/closet{
@@ -5904,7 +5904,7 @@
 /obj/effect/turf_decal/weather/whitesands{
 	dir = 6
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "TX" = (
 /obj/structure/fence{
@@ -5943,7 +5943,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Un" = (
 /obj/effect/turf_decal/road{
@@ -5952,7 +5952,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -5994,13 +5994,13 @@
 /obj/effect/turf_decal/trimline/opaque/white/arrow_cw{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "UM" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "UN" = (
 /obj/structure/railing/corner{
@@ -6025,7 +6025,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/whitesands,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Vc" = (
 /obj/machinery/power/solar,
@@ -6033,7 +6033,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Vd" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger{
@@ -6092,7 +6092,7 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "VG" = (
 /obj/machinery/door/airlock/grunge{
@@ -6175,7 +6175,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "Wu" = (
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Wx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6274,7 +6274,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Xf" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -6296,7 +6296,7 @@
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow,
 /obj/item/shard,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Xl" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -6327,7 +6327,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Xr" = (
 /obj/machinery/conveyor,
@@ -6349,7 +6349,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Xz" = (
 /obj/machinery/conveyor,
@@ -6372,7 +6372,7 @@
 /area/ruin/whitesands/e11manufactory/barracks)
 "XF" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "XI" = (
 /obj/machinery/door/window/eastleft,
@@ -6438,7 +6438,7 @@
 /obj/effect/turf_decal/trimline/opaque/white/line{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Ye" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6457,7 +6457,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "Yx" = (
 /obj/effect/turf_decal/road{
@@ -6469,7 +6469,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/whitesands,
+/turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "YE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6593,7 +6593,7 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ruin/whitesands/e11manufactory/warehouse)
 "ZR" = (
-/turf/open/floor/concrete/reinforced/whitesands,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "ZS" = (
 /obj/effect/decal/cleanable/confetti,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It shouldn't be dark anymore. ~~I'll test tomorrow if it actually isn't.~~ It is not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
fix: E-11 Manufactory ruin is no longer dark.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
