### PR TITLE
Legion virus feedback

### DIFF
--- a/code/datums/diseases/legionvirus.dm
+++ b/code/datums/diseases/legionvirus.dm
@@ -19,6 +19,27 @@
 	stage4 = list(span_warning("You feel something pressing against your skin!"))
 	stage5 = list(span_warning("Your skin begins to tear apart-!"))
 	new_form = /mob/living/simple_animal/hostile/asteroid/hivelord/legion
+	COOLDOWN_DECLARE(warning_timer)
+	var/cooldown_time = 1 MINUTES
+
+/datum/disease/transformation/legionvirus/infect(mob/living/infectee, make_copy = TRUE)
+	. = ..()
+	COOLDOWN_START(src, warning_timer, cooldown_time) //theos why don't you make this NOT A DISEASE if you don't plan on using ANY disease stuff??? good question:
+
+/datum/disease/transformation/legionvirus/stage_act()
+	..()
+	if(!COOLDOWN_FINISHED(src, warning_timer))
+		return
+	COOLDOWN_START(src, warning_timer, cooldown_time)
+	switch(stage)
+		if(1)
+			to_chat(affected_mob, pick(stage1))
+		if(2)
+			to_chat(affected_mob, pick(stage2))
+		if(3)
+			to_chat(affected_mob, pick(stage3))
+		if(4)
+			to_chat(affected_mob, pick(stage4))
 
 /datum/disease/transformation/legionvirus/do_disease_transformation(mob/living/H)
 	if(stage5)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -242,7 +242,8 @@
 					return //This will qdelete the legion.
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/proc/infest(mob/living/carbon/human/H)
-	visible_message(span_warning("[name] burrows into the flesh of [H]!"))
+	visible_message(span_warning("[name] burrows into [H]!"))
+	to_chat(H, span_boldwarning("You feel something digging into your body..."))
 	if(H.stat != DEAD)
 		var/obj/item/organ/legion_skull/throwyouabone = new()
 		throwyouabone.Insert(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the legion virus stage messages player-facing instead of functionally nonexistent since my dumbass somehow didn't realize they were tied to the stage increase probability. which is zero. yeah.
Also getting infected now shoves a message into chat which you will probably miss anyways since it's surrounded by getting bitten and having your bones melt. You WILL be able to tell if you have a new friend though.

## Why It's Good For The Game

I thought people were dying because the messages weren't providing enough feedback or something and it turns out they were providing a lot more than not enough feedback since they were providing NONE!

## Changelog

:cl:
code: legion virus stage messages now properly display themselves. instead of not doing that.
code: legion infesting people now give them a direct chat message. Say hello to your new friend! They might be sticking around your body longer than you will.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
