### PR TITLE
Changed growth serum so that it is directly proportional to volume in a mob, but it is clamped at 30 units for 30% growth.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1950,7 +1950,7 @@
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
 	var/newsize = current_size
-	newsize = 1 + (clamp(volume, 0, 30) / 100) * RESIZE_DEFAULT_SIZE
+	newsize = (1 + (clamp(volume, 0, 30) / 100)) * RESIZE_DEFAULT_SIZE
 
 	H.resize = newsize/current_size
 	current_size = newsize

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1943,24 +1943,14 @@
 
 /datum/reagent/growthserum
 	name = "Growth Serum"
-	description = "A commercial chemical designed to help older men in the bedroom."//not really it just makes you a giant
+	description = "A strange chemical that causes growth, but wears off over time. The growth effect is limited."
 	color = "#ff0000"//strong red. rgb 255, 0, 0
 	var/current_size = RESIZE_DEFAULT_SIZE
-	taste_description = "bitterness" // apparently what viagra tastes like
+	taste_description = "bitterness"
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
 	var/newsize = current_size
-	switch(volume)
-		if(0 to 19)
-			newsize = 1.25*RESIZE_DEFAULT_SIZE
-		if(20 to 49)
-			newsize = 1.5*RESIZE_DEFAULT_SIZE
-		if(50 to 99)
-			newsize = 2*RESIZE_DEFAULT_SIZE
-		if(100 to 199)
-			newsize = 2.5*RESIZE_DEFAULT_SIZE
-		if(200 to INFINITY)
-			newsize = 3.5*RESIZE_DEFAULT_SIZE
+	newsize = 1 + (clamp(volume, 0, 30) / 100) * RESIZE_DEFAULT_SIZE
 
 	H.resize = newsize/current_size
 	current_size = newsize


### PR DESCRIPTION
## About The Pull Request

Title. 30u gives you 30% growth. 50u is still 30%. 10u is 10%.

Also adjusts the descriptions so it's less sexual in nature.

## Why It's Good For The Game

I don't want to remove growth serum. Yeah it doesn't make sense I know, but let it have a little soul. 30% is noticeable, but not annoying or intrusive. Here's a 30% grown pori

![dreamseeker_zXXpaYrqnt](https://github.com/user-attachments/assets/b2d37eed-dc2f-4794-9db0-b12f1957245e)

Compare to this round, where I became a T-Rex with Narisi. A bunch of people laughed and had a good time with the megapori stomping around the outpost, but now it's time to be reasonable. Admins can always size edit a pori if they ever wanted such shenanigans again anyways :)

![dreamseeker_6FPaU6POQJ](https://github.com/user-attachments/assets/42f27014-8e16-4fda-ba36-8ab0c9599955)


## Changelog

:cl:
balance: growth serum now maxes out at 30% growth with 30u and has a smooth sliding scale.
/:cl:
