### PR TITLE
Changes the Kansatsu-class to Aspawn

### DIFF
--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -39,5 +39,5 @@
 			"slots": 2
 		}
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION

## About The Pull Request

Changes the Kansatsu-class to be aspawned. Contact an admin if you would like to have it spawned in.

## Why It's Good For The Game

Maptainer request.

## Changelog

:cl:
balance: Kansatsu has been removed from the player-accessible ship pool.
/:cl:

