### PR TITLE
Angle Grinders are more Efficient than Plasmacutters

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -64,7 +64,7 @@
 			electrocute_mob(user, get_area(src), src, 1, TRUE) //zorp
 			close()
 		to_chat(user, span_notice("You start to cut [src] apart"))
-		if (W.use_tool(src, user, 15 SECONDS, volume = 75))
+		if (W.use_tool(src, user, 10 SECONDS, volume = 75))
 			deconstruct(TRUE)
 
 /obj/machinery/door/poddoor/examine(mob/user)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -78,7 +78,7 @@ FLOOR SAFES
 
 		else if(I.tool_behaviour == TOOL_DECONSTRUCT)
 			user.visible_message("<span class='warning'>[user] begin to cut through the lock of \the [src].</span>","<span class='notice'>You start cutting trough the lock of [src].</span>")
-			if(I.use_tool(src, user, 60 SECONDS))
+			if(I.use_tool(src, user, 45 SECONDS))
 				broken = TRUE
 				user.visible_message("<span class='warning'>[user] successfully cuts trough the lock of \the [src].</span>","<span class='notice'>You successfully cut trough the lock of [src].</span>")
 

--- a/code/modules/mining/equipment/angle_grinder.dm
+++ b/code/modules/mining/equipment/angle_grinder.dm
@@ -27,9 +27,9 @@
 	hitsound = 'sound/weapons/anglegrinder.ogg'
 	usesound = 'sound/weapons/anglegrinder.ogg'
 	tool_behaviour = null // is set to TOOL_DECONSTRUCT once wielded
-	toolspeed = 1
-	wall_decon_damage = 250
-	usecost = 5
+	toolspeed = 0.6
+	wall_decon_damage = 350
+	usecost = 2.5
 	pack = /obj/item/gear_pack/anglegrinder
 	var/startsound = 'sound/weapons/chainsawhit.ogg'
 	var/adv = FALSE
@@ -127,8 +127,8 @@
 	hitsound = 'sound/weapons/blade1.ogg'
 	usesound = 'sound/weapons/blade1.ogg'
 	startsound = 'sound/weapons/saberon.ogg'
-	toolspeed = 0.7
-	usecost = 10
+	toolspeed = 0.4
+	usecost = 4
 	pack = /obj/item/gear_pack/anglegrinder/energy
 	light_system = MOVABLE_LIGHT
 	light_range = 3

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -126,7 +126,7 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_DECONSTRUCT
 	wall_decon_damage = 200
-	toolspeed = 0.9 //plasmacutters can be used like angle grinders, and are a bit faster
+	toolspeed = 1 //plasmacutters can be used like angle grinders
 	internal_magazine = TRUE //so you don't cheese through the need for plasma - WS EDIT
 	var/charge_cut = 100 //amount of charge used up to start action (multiplied by amount) and per progress_flash_divisor ticks of cutting
 	var/adv = FALSE


### PR DESCRIPTION
## About The Pull Request

Makes angle grinders overall faster than plasmacutters at taking down walls and structures, and taking a fair bit less charge to boot. Slightly decreases the time to deconstruct certain objects like safes and blast doors by a negligible amount.

## Why It's Good For The Game

Bulky as hell and no better than plasmacutters other than cost (as discussed in https://github.com/shiptest-ss13/Shiptest/pull/3727). I think it'd be interesting that angle grinders being a very efficient and quick method of shipbreaking (which has little to no in game benefit, mind you) compared to the plasmacutter being a compact, specialist tool for breaching would make buying either worthwhile.

## Changelog

:cl:
balance: Angle Grinders now take less charge and are much quicker at deconstructing walls
balance: Plasmacutters are now marginally slower, hardly noticeable. 
balance: Blast doors and safes are now very slightly faster to cut open.
/:cl: