### PR TITLE
Removes Drunkslurring at low drunkenness

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -472,7 +472,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 	if(drunkenness)
 		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
-		if(drunkenness >= 15)
+		if(drunkenness >= 11)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
 			jitteriness = max(jitteriness - 3, 0)
 			throw_alert("drunk", /atom/movable/screen/alert/drunk)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -474,8 +474,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
 		if(drunkenness >= 6)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
-			if(prob(25))
-				slurring += 2
 			jitteriness = max(jitteriness - 3, 0)
 			throw_alert("drunk", /atom/movable/screen/alert/drunk)
 			sound_environment_override = SOUND_ENVIRONMENT_PSYCHOTIC
@@ -484,8 +482,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			clear_alert("drunk")
 			sound_environment_override = SOUND_ENVIRONMENT_NONE
 
-		if(drunkenness >= 11 && slurring < 5)
-			slurring += 1.2
+		if(drunkenness >= 30 && slurring < 5)
+			slurring += 2
 
 		if(drunkenness >= 41)
 			if(prob(25))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -472,7 +472,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 	if(drunkenness)
 		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
-		if(drunkenness >= 6)
+		if(drunkenness >= 15)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
 			jitteriness = max(jitteriness - 3, 0)
 			throw_alert("drunk", /atom/movable/screen/alert/drunk)
@@ -482,8 +482,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			clear_alert("drunk")
 			sound_environment_override = SOUND_ENVIRONMENT_NONE
 
-		if(drunkenness >= 30 && slurring < 5)
-			slurring += 2
+		if(drunkenness >= 31 && slurring < 5)
+			slurring += 0.5
 
 		if(drunkenness >= 41)
 			if(prob(25))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -134,11 +134,6 @@
 				newletter = "oo"
 			else if(lowerletter == "c")
 				newletter = "k"
-		if(rand(1, 20) == 20)
-			if(newletter == " ")
-				newletter = "...huuuhhh..."
-			else if(newletter == ".")
-				newletter = " *BURP*."
 		switch(rand(1, 20))
 			if(1)
 				newletter += "'"


### PR DESCRIPTION
## About The Pull Request

You no longer slur your speech randomly at >6 drunkenness and no longer get guaranteed speech slurring at >11 drunkenness, which was raised to 31.

Getting "drunk" itself is raised to 11 from 6.

If you do get your speech slurred, its lessened, and "huuughhhhh" and burping was removed from your speech entirely.

## Why It's Good For The Game

(takes one sip of whiskey) Huuuughhhhh.....h hurhhghhhhhhh...... C'aph'tian said't a getm back,.. ... .hurheuhghhhhh.... the ship.... *BURP* *BURP* hurhghhhhhhh......


## Changelog

:cl:
del: You no longer slur your speech at low drunkenness.
balance: Thresholds for slurred speech increased as well as the threshold for getting drunk.
del: Making weird groaning sounds and burping loudly at random was removed from slurred speech.
/:cl: