### PR TITLE
Increases marine armour pricing

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -148,7 +148,7 @@
 /datum/supply_pack/spacesuit_armor/medium_marine_armor
 	name = "Medium Tactical Armor Crate"
 	desc = "One set of well-rounded medium tactical body armor. The set includes a helmet and vest."
-	cost = 3750
+	cost = 3000
 	contains = list(/obj/item/clothing/suit/armor/vest/marine/medium,
 					/obj/item/clothing/head/helmet/marine)
 	crate_name = "armor crate"

--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -139,7 +139,7 @@
 /datum/supply_pack/spacesuit_armor/marine_armor
 	name = "Tactical Armor Crate"
 	desc = "One set of well-rounded, tactical body armor. The set includes a helmet and vest."
-	cost = 1500
+	cost = 2250
 	contains = list(/obj/item/clothing/suit/armor/vest/marine,
 					/obj/item/clothing/head/helmet/marine)
 	crate_name = "armor crate"
@@ -148,7 +148,7 @@
 /datum/supply_pack/spacesuit_armor/medium_marine_armor
 	name = "Medium Tactical Armor Crate"
 	desc = "One set of well-rounded medium tactical body armor. The set includes a helmet and vest."
-	cost = 2000
+	cost = 3750
 	contains = list(/obj/item/clothing/suit/armor/vest/marine/medium,
 					/obj/item/clothing/head/helmet/marine)
 	crate_name = "armor crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the pricing for light and medium marine vests currently buyable on the outpost
## Why It's Good For The Game

Yeah uh, for what they do the price currently is REALLY fucking cheap. I would increase it by more, but anymore and odds are noone would buy them
## Changelog

:cl:
balance: Marine armour price buffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
