### PR TITLE
Fixes the Listening Post Server Monitor + Replaces a Frontier Suit with a Softsuit

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
@@ -1232,7 +1232,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/listening_post/commons)
 "vJ" = (
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/syndicate,
+/obj/item/clothing/head/helmet/space/syndicate,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/listening_post)
 "vR" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
@@ -1232,7 +1232,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/listening_post/commons)
 "vJ" = (
-/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/listening_post)
 "vR" = (
@@ -1762,11 +1763,11 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered/listening_post/engineering)
 "Gy" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
+	},
+/obj/machinery/computer/telecomms/server{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/listening_post/operations)

--- a/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
@@ -1232,8 +1232,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/listening_post/commons)
 "vJ" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
+/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/listening_post)
 "vR" = (


### PR DESCRIPTION
## About The Pull Request

The Telecomms Monitor board on the listening post doesn't actually work. It's just a maintenance computer. The intended thing to properly use the listening setup is a Server Monitor, that lets you see the contents of the server.

Replaced the singular suit on the ruin with a Soft suit

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
add: Added a soft suit to the Listening Post
fix: Fixed the Listening Post Comms Monitor to be the right type
/:cl: