### PR TITLE
Sound Enabling: Vox Screaming

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -67,6 +67,8 @@
 			return pick('sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg')
 	else if(ismoth(H))
 		return 'sound/voice/moth/scream_moth.ogg'
+	else if(isvox(H))
+		return 'sound/voice/vox/vox_scream_1.ogg'
 	else if(islizard(H))
 		return pick('sound/voice/lizard/lizard_scream_1.ogg', 'sound/voice/lizard/lizard_scream_2.ogg', 'sound/voice/lizard/lizard_scream_3.ogg', 'sound/voice/lizard/lizard_scream_4.ogg')
 


### PR DESCRIPTION
## About The Pull Request

Within the files there existed a sound effect for Vox screaming, but for one reason or another it was never actually enabled for them. This fixes that.

## Why It's Good For The Game

More species being able to scream in pain after getting an arm torn off is good.

## Changelog

:cl:
add: Enabled thee screaming audio emote for Vox.
/:cl:
