### PR TITLE
Bandage lifespan no longer scales with bleeding speed

### DIFF
--- a/code/datums/components/bandage.dm
+++ b/code/datums/components/bandage.dm
@@ -41,7 +41,7 @@
 	SIGNAL_HANDLER
 
 	var/obj/item/bodypart/heal_target = parent
-	lifespan -= 1 + heal_target.bleeding // particularly nasty bleeding can burn through dressing faster
+	lifespan--
 	heal_target.adjust_bleeding(-bleed_reduction)
 	if(lifespan <= 0 || !heal_target.bleeding) //remove treatment once it's no longer able to treat
 		drop_bandage(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bandage lifespan is now a flat 1 point = 1 tick of bleed staunching instead of also being reduced by the current bloodloss speed

## Why It's Good For The Game

Didn't scale well with higher speeds of bleeding, effectively making them unmanageable since the rate of bleed healing is balanced around casual bloodloss and not ranked and competitive bloodloss

## Changelog

:cl:
balance: bandages will no longer fall off faster with more bleeding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
