### PR TITLE
inteq valor and haste changes

### DIFF
--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -2459,10 +2459,10 @@
 /obj/effect/turf_decal/box/white,
 /obj/machinery/light/directional/west,
 /obj/item/paper{
-	default_raw_text = <head><table bgcolor="gold" width="100%" height="15%" frame ="below">    <th>        <div align="left"><font size="1" color="black">        <h1>Inteq</h1> Risk Management        </font></div>    </th>    <th>        <div align="right"><font color="black">         <br>         <br>        IRMV Memo<br>        Mothership <br>        <br>    </th></table></head><br>Apologies  for the trouble, we were meant to get a chemistry machine hauled in here from the stores, after we shuffled the stasis bed onto the haste-class, but something's gone awry, terribly sorry.<br><br><table bgcolor="gold" width="100%">    <th>        <font color="black"><font size="0.25"><center><i>Have a safe and secure day <center></i></font>    </th></table>;
 	name = "IRMG Memo";
 	pixel_x = -2;
-	pixel_y = 0
+	pixel_y = 0;
+	text = <head><tablebgcolor="gold"width="100%"height="15%"frame="below"><th><divalign="left"><fontsize="1"color="black"><h1>Inteq</h1>RiskManagement</font></div></th><th><divalign="right"><fontcolor="black"><br><br>IRMVMemo<br>Mothership<br><br></th></table></head><br>Apologiesforthetrouble,weweremeanttogetachemistrymachinehauledinherefromthestores,afterweshuffledthestasisbedontothehaste-class,butsomething'sgoneawry,terriblysorry.<br><br><tablebgcolor="gold"width="100%"><th><fontcolor="black"><fontsize="0.25"><center><i>Haveasafeandsecureday<center></i></font></th></table>
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/mono/white,

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -83,6 +83,10 @@
 "aW" = (
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/port)
+"bd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "bh" = (
 /obj/structure/railing{
 	dir = 6
@@ -283,8 +287,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/industrial/traffic/corner{
-	dir = 1
+/obj/structure/platform/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -560,6 +564,9 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
 "eV" = (
@@ -756,6 +763,9 @@
 	pixel_x = -3;
 	pixel_y = -20
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "gt" = (
@@ -776,11 +786,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical/surgery)
@@ -893,6 +903,12 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical/surgery)
+"ic" = (
+/obj/item/radio/intercom/directional{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/medical)
 "id" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -983,12 +999,12 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1072,6 +1088,11 @@
 	},
 /obj/item/clothing/head/helmet/inteq{
 	pixel_x = -7
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
@@ -1185,12 +1206,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "kH" = (
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/obj/effect/turf_decal/industrial/traffic/corner{
+/obj/structure/platform{
 	dir = 8
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "kK" = (
@@ -1474,6 +1493,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm)
 "mI" = (
@@ -1573,6 +1597,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
 "nU" = (
@@ -1638,10 +1664,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical/surgery)
 "oz" = (
+/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable{
-	icon_state = "6-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "oC" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -1874,6 +1908,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "qA" = (
@@ -1901,6 +1938,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/floor,
+/obj/structure/platform/corner,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "qL" = (
@@ -2247,8 +2286,18 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "tj" = (
-/obj/effect/turf_decal/industrial/traffic,
-/turf/open/floor/plasteel/patterned,
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "tk" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -2373,6 +2422,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/platform/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "vd" = (
@@ -2404,11 +2456,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "vn" = (
-/obj/machinery/stasis{
-	dir = 1
-	},
 /obj/effect/turf_decal/box/white,
 /obj/machinery/light/directional/west,
+/obj/item/paper{
+	default_raw_text = <head><table bgcolor="gold" width="100%" height="15%" frame ="below">    <th>        <div align="left"><font size="1" color="black">        <h1>Inteq</h1> Risk Management        </font></div>    </th>    <th>        <div align="right"><font color="black">         <br>         <br>        IRMV Memo<br>        Mothership <br>        <br>    </th></table></head><br>Apologies  for the trouble, we were meant to get a chemistry machine hauled in here from the stores, after we shuffled the stasis bed onto the haste-class, but something's gone awry, terribly sorry.<br><br><table bgcolor="gold" width="100%">    <th>        <font color="black"><font size="0.25"><center><i>Have a safe and secure day <center></i></font>    </th></table>;
+	name = "IRMG Memo";
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
 "vx" = (
@@ -2427,8 +2483,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/industrial/traffic{
+/obj/structure/platform{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -2642,8 +2697,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/industrial/traffic/corner{
-	dir = 4
+/obj/machinery/light/floor,
+/obj/structure/platform/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2724,7 +2780,9 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/traffic/corner,
+/obj/structure/platform{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "yN" = (
@@ -2904,6 +2962,10 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -20
+	},
+/obj/structure/sink{
+	pixel_x = 0;
+	pixel_y = 19
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -3093,12 +3155,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "BB" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20
-	},
-/turf/template_noop,
-/area/template_noop)
+/obj/machinery/airalarm/directional,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/cargo)
 "BC" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = 32
@@ -3117,10 +3176,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "BV" = (
@@ -3131,13 +3186,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Cb" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "Cc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3148,6 +3201,9 @@
 /area/ship/cargo)
 "Ch" = (
 /obj/structure/punching_bag,
+/obj/structure/sign/warning/incident{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Cr" = (
@@ -3314,10 +3370,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "DG" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
 	},
@@ -3377,16 +3429,9 @@
 /turf/open/floor/plating,
 /area/ship/hallway/port)
 "Ea" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/stand_clear{
+/turf/open/floor/plasteel/stairs/mid{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ed" = (
 /obj/effect/turf_decal/corner/opaque/yellow{
@@ -3555,7 +3600,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/floor,
+/obj/structure/platform,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "FJ" = (
@@ -3697,6 +3742,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "HA" = (
@@ -3933,6 +3980,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "JT" = (
@@ -4007,23 +4057,14 @@
 "Kp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
-"Kz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -4141,23 +4182,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ls" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/stand_clear{
+/turf/open/floor/plasteel/stairs/left{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
-"LH" = (
-/obj/machinery/light/floor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "LI" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -4232,10 +4259,12 @@
 	},
 /area/ship/cargo)
 "Mn" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
 /area/ship/cargo)
 "Mq" = (
 /obj/structure/table,
@@ -4587,6 +4616,10 @@
 	pixel_x = -20;
 	pixel_y = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
 "Pk" = (
@@ -4597,7 +4630,8 @@
 /obj/machinery/washing_machine,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 20
+	pixel_x = 20;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
@@ -5033,6 +5067,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
+"Uu" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
 "Uz" = (
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
@@ -5419,6 +5462,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "Yi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical/surgery)
 "Yn" = (
@@ -5548,12 +5594,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
-"Zf" = (
-/obj/structure/sign/warning/incident{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "Zu" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security)
@@ -5694,15 +5734,15 @@ cu
 Td
 Td
 Td
-BB
+Td
 Nh
 xj
 qG
 yK
-Cb
-Cb
-Cb
-Cb
+yK
+yK
+yK
+yK
 xz
 xj
 Nh
@@ -5731,12 +5771,12 @@ Td
 xj
 og
 FI
-tj
+OM
 OM
 OM
 OM
 UO
-LH
+vy
 tf
 xj
 Td
@@ -5763,13 +5803,13 @@ Td
 Td
 xj
 rL
-uS
-tj
+FI
 OM
 OM
 OM
 OM
-Kz
+OM
+vy
 RI
 xj
 Td
@@ -5796,13 +5836,13 @@ Td
 Td
 xj
 sZ
-uS
-tj
+FI
 OM
 OM
 OM
 OM
-Kz
+OM
+vy
 kL
 xj
 Td
@@ -5829,13 +5869,13 @@ Td
 Td
 xj
 GF
-uS
-tj
+FI
 OM
 OM
 OM
 OM
-Kz
+OM
+vy
 cE
 xj
 Td
@@ -5863,14 +5903,14 @@ Td
 xj
 Ch
 FI
-tj
+OM
 OM
 OM
 OM
 OM
 vy
 fG
-xj
+BB
 Td
 Td
 Td
@@ -5894,14 +5934,14 @@ DU
 DU
 DU
 HC
-Zf
-oz
-tj
+ZF
+FI
 OM
 OM
 OM
 OM
-Kz
+OM
+vy
 ZF
 SL
 jL
@@ -5928,12 +5968,12 @@ aW
 aW
 DR
 ZF
-ZF
+uS
 kH
 Mn
 Ea
 Ls
-Mn
+kH
 de
 KU
 zI
@@ -6005,7 +6045,7 @@ Md
 LI
 LI
 LI
-LI
+ic
 LI
 EE
 oy
@@ -6026,7 +6066,7 @@ ss
 bx
 mt
 xj
-nX
+tj
 Jd
 qA
 UQ
@@ -6034,7 +6074,7 @@ hm
 Cc
 JJ
 zT
-nX
+oz
 LI
 jG
 ml
@@ -6056,10 +6096,10 @@ Qc
 AP
 HC
 ou
-ou
-ou
+bd
+Cb
 Hw
-nX
+Uu
 ct
 TB
 AM

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -287,8 +287,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/platform/corner{
-	dir = 4
+/obj/effect/turf_decal/industrial/traffic/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1206,10 +1209,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "kH" = (
-/obj/structure/platform{
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/traffic{
 	dir = 8
 	},
-/obj/machinery/light/floor,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "kK" = (
@@ -1939,7 +1945,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/floor,
-/obj/structure/platform/corner,
+/obj/effect/turf_decal/industrial/traffic/corner{
+	dir = 2
+	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "qL" = (
@@ -2422,8 +2431,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/platform/corner{
-	dir = 1
+/obj/effect/turf_decal/industrial/traffic/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2458,13 +2470,9 @@
 "vn" = (
 /obj/effect/turf_decal/box/white,
 /obj/machinery/light/directional/west,
-/obj/item/paper{
-	name = "IRMG Memo";
-	pixel_x = -2;
-	pixel_y = 0;
-	text = <head><tablebgcolor="gold"width="100%"height="15%"frame="below"><th><divalign="left"><fontsize="1"color="black"><h1>Inteq</h1>RiskManagement</font></div></th><th><divalign="right"><fontcolor="black"><br><br>IRMVMemo<br>Mothership<br><br></th></table></head><br>Apologiesforthetrouble,weweremeanttogetachemistrymachinehauledinherefromthestores,afterweshuffledthestasisbedontothehaste-class,butsomething'sgoneawry,terriblysorry.<br><br><tablebgcolor="gold"width="100%"><th><fontcolor="black"><fontsize="0.25"><center><i>Haveasafeandsecureday<center></i></font></th></table>
+/obj/machinery/stasis{
+	dir = 1
 	},
-/obj/structure/frame/machine,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/medical)
 "vx" = (
@@ -2483,8 +2491,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/platform{
+/obj/effect/turf_decal/industrial/traffic{
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2680,6 +2692,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"xv" = (
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "xy" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2698,8 +2722,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/floor,
-/obj/structure/platform/corner{
-	dir = 8
+/obj/effect/turf_decal/industrial/traffic/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2780,9 +2807,10 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
 	},
-/obj/structure/platform{
+/obj/effect/turf_decal/industrial/traffic{
 	dir = 4
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "yN" = (
@@ -3430,7 +3458,7 @@
 /area/ship/hallway/port)
 "Ea" = (
 /turf/open/floor/plasteel/stairs/mid{
-	dir = 4
+	dir = 8
 	},
 /area/ship/cargo)
 "Ed" = (
@@ -3600,7 +3628,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/platform,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 2
+	},
+/obj/structure/railing,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "FJ" = (
@@ -4182,8 +4213,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ls" = (
-/turf/open/floor/plasteel/stairs/left{
-	dir = 4
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
 	},
 /area/ship/cargo)
 "LI" = (
@@ -4262,8 +4293,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/stairs/right{
-	dir = 4
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
 	},
 /area/ship/cargo)
 "Mq" = (
@@ -4445,6 +4476,15 @@
 /obj/effect/turf_decal/trimline/opaque/brown/line,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
+"Oa" = (
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "Oc" = (
 /obj/item/clothing/mask/balaclava/inteq,
 /obj/item/clothing/gloves/tackler/combat/insulated,
@@ -5738,10 +5778,10 @@ Td
 Nh
 xj
 qG
-yK
-yK
-yK
-yK
+xv
+Oa
+Oa
+Oa
 yK
 xz
 xj

--- a/_maps/shuttles/subshuttles/inteq_haste.dmm
+++ b/_maps/shuttles/subshuttles/inteq_haste.dmm
@@ -2,20 +2,59 @@
 "a" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
-"f" = (
-/obj/machinery/power/terminal{
-	dir = 1
+"b" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/railing,
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_x = -2;
+	pixel_y = 26
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = 11
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_y = 21;
+	pixel_x = -14;
+	id = "haste_holo"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"c" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	pixel_y = 7
 	},
 /obj/effect/turf_decal/techfloor{
-	dir = 1
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"d" = (
+/turf/closed/wall/mineral/plastitanium{
+	icon_state = "plastitanium_wall-6-d"
+	},
+/area/ship/bridge)
+"f" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"i" = (
+/turf/closed/wall/mineral/plastitanium{
+	icon_state = "plastitanium_wall-21-d"
+	},
 /area/ship/bridge)
 "s" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -34,34 +73,75 @@
 	},
 /turf/open/floor/engine/hull/interior,
 /area/ship/bridge)
+"v" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "haste_window"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"w" = (
+/obj/machinery/computer/helm{
+	dir = 4;
+	layer = 3
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	pixel_x = 6;
+	pixel_y = 23;
+	id = "haste_door"
+	},
+/obj/machinery/button/door{
+	pixel_x = -6;
+	pixel_y = 23;
+	id = "haste_window";
+	name = "window shutters"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "B" = (
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-1"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/bridge)
+"D" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 5
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/bridge)
+"E" = (
+/obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-5"
-	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/bridge)
-"D" = (
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/obj/structure/chair/handrail{
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
@@ -79,34 +159,24 @@
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "haste_window"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "I" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/structure/rack,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/medical{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/defibrillator/loaded{
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-5"
-	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/stasis{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "J" = (
 /obj/structure/window/reinforced{
@@ -124,25 +194,41 @@
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 2
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "haste_window"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "K" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "haste_window"
+	},
 /turf/open/floor/plating,
 /area/ship/bridge)
-"M" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
-	dir = 1
+"L" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "haste_door"
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/bridge)
+"M" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
 	},
 /obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "O" = (
 /obj/machinery/power/shieldwallgen/atmos{
@@ -170,16 +256,13 @@
 /area/ship/bridge)
 "R" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/techfloor,
+/obj/structure/cable/yellow{
+	icon_state = "0-1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "T" = (
@@ -192,69 +275,64 @@
 /turf/open/floor/engine/hull/interior,
 /area/ship/bridge)
 "X" = (
-/obj/machinery/computer/helm{
-	dir = 4;
-	layer = 3
+/obj/item/storage/firstaid/regular{
+	pixel_x = 8;
+	pixel_y = 5
 	},
-/obj/structure/railing{
-	dir = 10
+/obj/item/storage/firstaid/medical{
+	pixel_x = -8;
+	pixel_y = 5
 	},
-/obj/machinery/button/shieldwallgen{
-	pixel_y = 21;
-	pixel_x = 9;
-	id = "haste_holo"
-	},
-/obj/machinery/button/door{
-	pixel_x = -2;
-	pixel_y = 23;
-	id = "haste_door"
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/bridge)
-"Z" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/structure/railing,
-/obj/item/radio/intercom/wideband/directional/north{
-	pixel_x = -9
+/obj/effect/turf_decal/techfloor{
+	dir = 9
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-10"
+	icon_state = "2-4"
 	},
-/obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = 10
+/obj/structure/table,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/bridge)
+"Z" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 
 (1,1,1) = {"
-a
+d
 K
+v
 K
-a
+i
 "}
 (2,1,1) = {"
 a
+w
 X
 B
 a
 "}
 (3,1,1) = {"
 a
+b
 Z
 I
 a
 "}
 (4,1,1) = {"
 a
+c
 D
 M
 a
 "}
 (5,1,1) = {"
 J
+E
 f
 R
 F
@@ -262,6 +340,7 @@ F
 (6,1,1) = {"
 T
 s
+L
 O
 T
 "}

--- a/_maps/shuttles/subshuttles/inteq_haste.dmm
+++ b/_maps/shuttles/subshuttles/inteq_haste.dmm
@@ -173,9 +173,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/stasis{
-	dir = 1
-	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/bridge)
 "J" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few things regarding the Valor-Class that were unintentionally overwrote by #3508 and fixes, finally, the fact the landing pad was never centered. Alongside a few QoL Fixes to boot on the Valor and Haste.
On-top of this, the Haste-Class has been made bigger, given window shutters and we've taken a stasis bed from the Valor itself, and moved it onto the Haste; this was required to make the shuttle centered, and will make transporting patients easier with a larger shuttle.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

### **Check the drop-downs below for change comparisons.**
<details><summary>Changes to the Landing Pad</summary>
<p>

![image](https://github.com/user-attachments/assets/d2d9e557-57fd-4658-bab4-a3341a79d92d)

![image](https://github.com/user-attachments/assets/d30b7570-4a3f-41d7-a8bf-03e8009a2d2e)
</p>
</details> 

<details><summary>Changes to the Haste</summary>
<p>

![image](https://github.com/user-attachments/assets/3e848227-d815-4cea-8b5c-58b5c7935c8a)

As you can see, the Haste has been made larger, and a stasis bed has been dragged from the medical area to here. 
But, as a cost, the Fourth Defib has been taken from the ship- a tragedy, i'm sure. However, there are still 3 on the Valor itself.

Furthermore, blast-doors have been added to the windows, alongside a button to open and close them, a welcome change i'm sure.

</p>
</details> 

<details><summary>Uncategorized Changes</summary>
<p>

![image](https://github.com/user-attachments/assets/2fea1d53-d052-413d-a386-f35f52b04240)

Removed a second privacy shutters button in the surgery room (was where red circle was)
Added an intercom outside the surgery room for patient use (blue circle)
The keen eye will also notice how the surgery room has a vent and scrubber, that's been added alongside a vent and scrubber in the EVA room.

![image](https://github.com/user-attachments/assets/6ff08c06-1071-4bbf-b316-dea88c344711)

Removed- this light switch, idk how it got here; it can never spawn naturally because it spawns on a null tile, but. It's gone now I suppose???

Alongside this lightswitch, a few lights have been moved around to ensure they still light up the entire hangar.

![image](https://github.com/user-attachments/assets/745cb010-69ae-4881-88dd-8e7dda7418c6)

Finally, the Hangar will have an Air Alarm!!! Rejoice.

</p>
</details> 


## Why It's Good For The Game
Small cleanup, and QoL for the Valor is *good*.

As for the Haste changes, making is symetrical has given it a great time to be remapped to be bigger and more specialised for moving patients, as it is right now it can barely hold a response team, let alone bringing them back. With the extra room no longer will we have to lay on-top of eachother on the floor. Mostly.

Moving the stasis bed helps this, too, and sells the Haste as a shitty box ambulance more than it was.
And as for the windows? It would be nice to not die instantly to one carp chewing the engines as much, bringing it in line with every other shuttle as to having shuttered windows.

Final question you may ask:

> Since you moved stuff from the Valor to the Haste, why not move the Holopad from the mess, too?

Now, this one is a deeply personal feeling of mine, that, when you fuck up as the Haste, saying it into Wideband is infinitely funnier. This is all.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Air Alarms and Vents to the Valor
change: New Landing Pad, it's now symettrical 
change: Made the haste class bigger, and given it window shutters
change: Moved a stasis bed from the Valor-class to the Haste-class
change: Removed a defibrillator from the Haste-class (valor still spawns with 3 round-start, we don't need more)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
