### PR TITLE
Removes marine armor from cargo

### DIFF
--- a/code/modules/cargo/packs/spacesuit_armor.dm
+++ b/code/modules/cargo/packs/spacesuit_armor.dm
@@ -135,21 +135,3 @@
 	contains = list(/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-
-/datum/supply_pack/spacesuit_armor/marine_armor
-	name = "Tactical Armor Crate"
-	desc = "One set of well-rounded, tactical body armor. The set includes a helmet and vest."
-	cost = 1500
-	contains = list(/obj/item/clothing/suit/armor/vest/marine,
-					/obj/item/clothing/head/helmet/marine)
-	crate_name = "armor crate"
-	crate_type = /obj/structure/closet/crate/secure/plasma
-
-/datum/supply_pack/spacesuit_armor/medium_marine_armor
-	name = "Medium Tactical Armor Crate"
-	desc = "One set of well-rounded medium tactical body armor. The set includes a helmet and vest."
-	cost = 2000
-	contains = list(/obj/item/clothing/suit/armor/vest/marine/medium,
-					/obj/item/clothing/head/helmet/marine)
-	crate_name = "armor crate"
-	crate_type = /obj/structure/closet/crate/secure/plasma

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -234,12 +234,11 @@
 	desc = "A tactical black helmet, sealed from outside hazards with a reinforced visor."
 	icon_state = "marine_command"
 	item_state = "helmetalt"
-	armor = list("melee" = 35, "bullet" = 55, "laser" = 45, "energy" = 25, "bomb" = 30, "bio" = 75, "fire" = 40, "acid" = 50)
-	slowdown = 0.1
-	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
-	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT | BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	armor = list("melee" = 50, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 60, "bio" = 100, "fire" = 70, "acid" = 50)
+	slowdown = 0.3
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	clothing_flags = STOPSPRESSUREDAMAGE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF | SEALS_EYES
 	can_flashlight = TRUE
 	dog_fashion = null
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -47,32 +47,22 @@
 	icon_state = "marine_light"
 	item_state = "armor"
 	clothing_flags = THICKMATERIAL
-	body_parts_covered = CHEST|GROIN
-	armor = list("melee" = 20, "bullet" = 45, "laser" = 45, "energy" = 25, "bomb" = 30, "bio" = 65, "fire" = 40, "acid" = 50)
-	cold_protection = CHEST|GROIN
+	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	armor = list("melee" = 50, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 60, "bio" = 100, "fire" = 70, "acid" = 50)
+	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
-	heat_protection = CHEST|GROIN
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	supports_variations = VOX_VARIATION | DIGITIGRADE_VARIATION_NO_NEW_ICON
-	slowdown = 0 //one day...
+	slowdown = 0.5
 
 /obj/item/clothing/suit/armor/vest/marine/medium
 	name = "medium tactical armor vest"
 	icon_state = "marine_medium"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	cold_protection = CHEST|GROIN|LEGS|ARMS
-	heat_protection = CHEST|GROIN|LEGS|ARMS
-	armor = list("melee" = 35, "bullet" = 55, "laser" = 45, "energy" = 25, "bomb" = 30, "bio" = 75, "fire" = 40, "acid" = 50)
-	slowdown = 0.1
 
 /obj/item/clothing/suit/armor/vest/marine/heavy
-	name = "heavy tactical armor vest"
+	name = "large tactical armor vest"
 	icon_state = "marine_heavy"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	cold_protection = CHEST|GROIN|LEGS|ARMS
-	heat_protection = CHEST|GROIN|LEGS|ARMS
-	armor = list("melee" = 60, "bullet" = 75, "laser" = 55, "energy" = 25, "bomb" = 50, "bio" = 75, "fire" = 40, "acid" = 50)
-	slowdown = 0.5
 
 /obj/item/clothing/suit/armor/vest/old
 	name = "degrading armor vest"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes marine armor from cargo and reverts the nerfs

## Why It's Good For The Game

For the record, i'm **_not_** against limb armor at all or even the niche of marine armor in cargo, I just do not like the sprite and it I especially don't like seeing people with it, for aesthetics and gameplay reasons

I do like the idea of the marine armor. Just moving the marine into cargo instead of making a new, well balanced and sprited armor doesn't help

This isn't a kneejerk revert, I've been watching the past 3 uptimes closely.

It being the "meta" for the past week of uptime doesn't do much favors. I understand there's a price increase, but I suspsect it will still be the "goal" even if it costs a hundred thousand credits per unit

While I could just make it so no indies can aquire it with the factional cargo PR, I still liked the visual diversity of factions before this armor was added.

If you (assuming you are a dev or a maint) want a replacement please to merge this please ask me and ill see if I can draw/make one, for now I think this is for the best.

If you still want more time to test the marine armor experiment, i'm willing to wait a week for it

## Changelog

:cl:
del: Marine armor from cargo. ERTs may still aquire it
/:cl:
