### PR TITLE
Vomiting Is Now Nicer And Less Profuse

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -438,7 +438,7 @@
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing in your stomach!</span>")
 		if(stun)
-			Paralyze(50)
+			Immobilize(30)
 		return TRUE
 
 	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
@@ -454,7 +454,7 @@
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "vomit", /datum/mood_event/vomit)
 
 	if(stun)
-		Paralyze(20)
+		Immobilize(10)
 
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 	var/turf/T = get_turf(src)
@@ -476,6 +476,7 @@
 		T = get_step(T, dir)
 		if (T?.is_blocked_turf())
 			break
+	adjust_disgust(-(lost_nutrition*rand(0.5, 2)))
 	return TRUE
 
 /mob/living/carbon/proc/spew_organ(power = 5, amt = 1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -917,7 +917,7 @@
 			visible_message(span_warning("[src] dry heaves!"), \
 							span_userdanger("You try to throw up, but there's nothing in your stomach!"))
 		if(stun)
-			Paralyze(30)
+			Immobilize(30)
 		return 1
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -581,7 +581,7 @@
 
 /datum/reagent/medicine/anti_rad/on_mob_life(mob/living/carbon/M)
 	M.radiation -= M.radiation - rand(50,150)
-	M.adjust_disgust(3*REM)
+	M.adjust_disgust(4*REM)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -581,7 +581,7 @@
 
 /datum/reagent/medicine/anti_rad/on_mob_life(mob/living/carbon/M)
 	M.radiation -= M.radiation - rand(50,150)
-	M.adjust_disgust(4*REM, 0)
+	M.adjust_disgust(3*REM)
 	..()
 	. = 1
 

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -78,7 +78,8 @@
 
 				if(prob(pukeprob))
 					H.blur_eyes(3)
-					H.manual_emote(pick("tears up!", "whimpers!", "chokes!"))
+					if(prob(25))
+						H.manual_emote(pick("tears up!", "whimpers!", "chokes!"))
 					H.vomit(20, 0, 1, 1, 1, 0)
 					H.confused += 2.5
 					H.stuttering += 1
@@ -87,8 +88,8 @@
 				SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "disgust", /datum/mood_event/disgusted)
 
 				//profusely vomiting.
-				H.force_scream()
-				H.vomit(40, 0, 1, 1, 1, 0)
+				if(prob(pukeprob))
+					H.vomit(40, 0, 1, 1, 1, 0)
 
 		H.adjust_disgust(-0.5 * disgust_metabolism)
 


### PR DESCRIPTION
:cl:
add: vomiting now removes a random amount of disgust.
balance: vomiting should no longer trigger 12000 times in one minute on that one person. im so sorry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
