### PR TITLE
Minor Miskilamo Redecaling + Other Stuff

### DIFF
--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -39,7 +39,7 @@
 /obj/structure/table_frame,
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ay" = (
 /obj/effect/decal/cleanable/glass,
@@ -71,7 +71,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/turf_decal/corner/opaque/grey/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "aS" = (
@@ -97,7 +97,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "aZ" = (
 /obj/machinery/airalarm/directional/south,
@@ -123,7 +123,7 @@
 /turf/open/floor/plating,
 /area/ship/hallway/port)
 "bm" = (
-/obj/effect/spawner/random/maintenance,
+/obj/item/toy/plush/moth/punished,
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "bn" = (
@@ -151,8 +151,10 @@
 	pixel_x = -14;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "bF" = (
 /turf/closed/wall,
@@ -179,7 +181,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "bL" = (
 /obj/structure/cable/pink{
@@ -403,7 +408,7 @@
 	icon_state = "0-10"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "cw" = (
 /obj/structure/table/wood,
@@ -441,10 +446,10 @@
 /obj/item/clothing/shoes/workboots/mining,
 /obj/item/clothing/under/rank/cargo/miner/hazard,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/armor/vest/old,
 /obj/item/clothing/gloves/explorer,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/head/hardhat/mining,
+/obj/item/clothing/suit/armor/vest,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "cC" = (
@@ -487,7 +492,7 @@
 	pixel_y = 13
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance/fore)
 "cK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -506,7 +511,7 @@
 /obj/structure/cable/pink{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "cP" = (
 /obj/structure/grille,
@@ -541,6 +546,7 @@
 	},
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "cY" = (
@@ -559,7 +565,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "da" = (
 /turf/open/floor/plasteel/patterned,
@@ -598,9 +604,11 @@
 "dt" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "dF" = (
 /obj/effect/turf_decal/miskilamo_small/right{
@@ -618,7 +626,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "eN" = (
 /obj/machinery/light/directional/west,
@@ -632,7 +640,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "fu" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -645,7 +653,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "gp" = (
 /obj/structure/closet/wall/blue/directional/north{
@@ -666,7 +674,7 @@
 	icon_state = "4-10"
 	},
 /obj/item/gun/ballistic/shotgun/doublebarrel/presawn/empty,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "gs" = (
 /obj/structure/cable/pink{
@@ -701,12 +709,12 @@
 	pixel_x = 5;
 	pixel_y = -9
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "hh" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "hN" = (
 /obj/machinery/mineral/processing_unit{
@@ -792,7 +800,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/turf_decal/corner/opaque/grey/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "iT" = (
@@ -803,6 +811,7 @@
 /mob/living/simple_animal/hostile/cockroach,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "jl" = (
@@ -847,6 +856,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "jU" = (
@@ -872,7 +882,8 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance/fore)
 "kA" = (
 /turf/closed/wall/r_wall,
@@ -924,6 +935,7 @@
 /obj/structure/cable/pink{
 	icon_state = "1-5"
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ng" = (
@@ -985,7 +997,7 @@
 	pixel_x = -13;
 	pixel_y = 11
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -1096,11 +1108,10 @@
 /obj/machinery/computer/cargo/retro{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 10
 	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "tb" = (
 /turf/closed/wall/rust,
@@ -1175,6 +1186,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "yd" = (
@@ -1286,6 +1300,9 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "AP" = (
@@ -1295,7 +1312,7 @@
 	target_pressure = 500
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "AQ" = (
 /turf/closed/wall,
@@ -1317,7 +1334,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Bu" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1329,7 +1346,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner_techfloor_grid/full{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "BS" = (
 /obj/structure/grille,
@@ -1389,11 +1409,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1423,6 +1439,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel,
 /area/ship/crew)
 "EU" = (
@@ -1469,10 +1486,8 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
-/obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "HP" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -1519,10 +1534,10 @@
 /turf/closed/wall,
 /area/ship/maintenance/fore)
 "KM" = (
-/obj/machinery/atmospherics/components/binary/valve/layer4,
 /obj/effect/decal/cleanable/oil/streak,
 /obj/item/cigbutt,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "KR" = (
@@ -1563,7 +1578,7 @@
 /obj/structure/cable/pink{
 	icon_state = "2-5"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Mj" = (
 /obj/machinery/mineral/unloading_machine,
@@ -1662,7 +1677,10 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew)
 "NT" = (
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 3
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "NU" = (
 /obj/structure/table/wood,
@@ -1707,12 +1725,8 @@
 /obj/machinery/computer/helm/retro{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "PJ" = (
 /turf/closed/wall/r_wall/rust,
@@ -1762,7 +1776,7 @@
 /obj/structure/cable/pink{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/hangar/plasteel,
 /area/ship/bridge)
 "Sx" = (
 /obj/structure/table/reinforced,
@@ -1818,10 +1832,7 @@
 	pixel_x = -17;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "TG" = (
 /turf/closed/wall,
@@ -1898,7 +1909,7 @@
 	name = "Thruster Lockdown";
 	pixel_x = 21
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Vh" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -1908,7 +1919,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Vq" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1965,11 +1976,8 @@
 	pixel_x = 10;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "XQ" = (
 /obj/machinery/cryopod{

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -610,6 +610,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"dE" = (
+/obj/structure/sign/number/random,
+/turf/closed/wall/r_wall,
+/area/ship/engineering)
 "dF" = (
 /obj/effect/turf_decal/miskilamo_small/right{
 	dir = 1
@@ -1510,6 +1514,10 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"IJ" = (
+/obj/structure/sign/number/random,
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew/dorm)
 "Jf" = (
 /turf/closed/wall/r_wall,
 /area/ship/hallway/port)
@@ -2092,7 +2100,7 @@ Ng
 cM
 hh
 oP
-Ua
+dE
 aa
 aa
 "}
@@ -2107,7 +2115,7 @@ Vd
 fs
 ZG
 AP
-kA
+dE
 aa
 aa
 "}
@@ -2122,7 +2130,7 @@ AQ
 Vh
 cZ
 Bm
-kA
+dE
 aa
 aa
 "}
@@ -2137,7 +2145,7 @@ cq
 cq
 cq
 cq
-wh
+IJ
 aa
 aa
 "}

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -1545,7 +1545,9 @@
 /obj/effect/decal/cleanable/oil/streak,
 /obj/item/cigbutt,
 /obj/effect/turf_decal/corner/opaque/grey/half,
-/obj/machinery/atmospherics/components/binary/volume_pump/layer4,
+/obj/machinery/atmospherics/components/binary/volume_pump/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "KR" = (

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -859,7 +859,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/bridge)

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -25,7 +25,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -184,7 +184,7 @@
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 10
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "bL" = (
 /obj/structure/cable/pink{
@@ -678,7 +678,7 @@
 	icon_state = "4-10"
 	},
 /obj/item/gun/ballistic/shotgun/doublebarrel/presawn/empty,
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "gs" = (
 /obj/structure/cable/pink{
@@ -1114,7 +1114,7 @@
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 10
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "tb" = (
 /turf/closed/wall/rust,
@@ -1352,7 +1352,7 @@
 /obj/effect/turf_decal/corner_techfloor_grid/full{
 	dir = 4
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "BS" = (
 /obj/structure/grille,
@@ -1412,7 +1412,7 @@
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1490,7 +1490,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "HP" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -1689,7 +1689,7 @@
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 3
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "NU" = (
 /obj/structure/table/wood,
@@ -1785,7 +1785,7 @@
 /obj/structure/cable/pink{
 	icon_state = "2-8"
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/bridge)
 "Sx" = (
 /obj/structure/table/reinforced,

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -2258,10 +2258,6 @@
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	name = "Air to Distro";
-	target_pressure = 1000
-	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer2{
 	dir = 1;
 	name = "Scrubbers to External"
@@ -2269,6 +2265,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/binary/pump/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Yu" = (

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -76,14 +76,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch{
 	pixel_x = -3;
 	pixel_y = 23
 	},
 /obj/structure/chair/handrail,
 /turf/open/floor/plasteel/patterned,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "cs" = (
 /turf/template_noop,
 /area/template_noop)
@@ -108,9 +107,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-9"
 	},
 /turf/open/floor/carpet,
 /area/ship/crew)
@@ -139,10 +135,10 @@
 	pixel_x = -3;
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/box,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "dQ" = (
@@ -174,9 +170,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 6
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "dZ" = (
@@ -204,6 +197,9 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ec" = (
@@ -228,6 +224,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "eu" = (
@@ -245,9 +242,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
-"ev" = (
-/turf/closed/wall,
-/area/ship/crew/cryo)
 "eL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -413,6 +407,7 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "js" = (
@@ -425,13 +420,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/light_switch{
 	pixel_x = 3;
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "kV" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -441,8 +435,10 @@
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "kX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4{
@@ -462,7 +458,7 @@
 /area/ship/cargo)
 "lg" = (
 /turf/closed/wall/r_wall/rust,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "lj" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -482,25 +478,19 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock{
 	dir = 1;
 	name = "Restroom"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "mC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
@@ -592,6 +582,9 @@
 /obj/item/gun/energy/laser/e10,
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ot" = (
@@ -653,9 +646,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
-"oU" = (
-/turf/closed/wall,
-/area/ship/crew/toilet)
 "po" = (
 /obj/structure/catwalk,
 /obj/machinery/door/poddoor{
@@ -681,7 +671,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
 /turf/open/floor/plasteel/patterned,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -697,14 +687,14 @@
 	pixel_x = -6;
 	pixel_y = -21
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/computer/crew/retro{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "qE" = (
@@ -714,6 +704,7 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "qN" = (
@@ -727,7 +718,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "rr" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -743,7 +734,7 @@
 /area/ship/bridge)
 "rG" = (
 /turf/closed/wall/r_wall,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "rO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -773,12 +764,12 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "sf" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/computer/helm/retro{
 	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -826,7 +817,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/corner/opaque/neutral{
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -866,15 +857,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uz" = (
@@ -921,7 +911,7 @@
 	pixel_x = 32
 	},
 /obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/corner/opaque/neutral/half{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -952,12 +942,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "wj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
@@ -965,6 +951,7 @@
 /obj/structure/cable{
 	icon_state = "4-5"
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ws" = (
@@ -985,10 +972,8 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "xo" = (
 /obj/structure/dresser,
@@ -1008,7 +993,7 @@
 /obj/machinery/light/dim/directional/south,
 /obj/structure/curtain,
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "xH" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -1052,7 +1037,7 @@
 	pixel_x = -22;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "yv" = (
@@ -1126,9 +1111,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "zW" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -1139,10 +1121,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/cryo)
-"zX" = (
-/turf/closed/wall/r_wall/rust,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "Ag" = (
 /turf/closed/wall/r_wall,
 /area/ship/hallway/aft)
@@ -1248,11 +1227,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "Cr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1264,9 +1240,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
-"Cv" = (
-/turf/closed/wall/r_wall,
-/area/ship/maintenance)
 "CG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/suit/space/eva,
@@ -1313,10 +1286,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "6-8"
+	icon_state = "2-6"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
@@ -1330,17 +1300,17 @@
 	pixel_x = -3;
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
-"DU" = (
-/turf/closed/wall/r_wall,
-/area/ship/crew/cryo)
 "Ed" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1365,9 +1335,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-9"
 	},
 /turf/open/floor/carpet,
 /area/ship/crew)
@@ -1430,9 +1397,6 @@
 	},
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gk" = (
@@ -1451,14 +1415,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "GW" = (
-/obj/structure/cable{
-	icon_state = "6-10"
-	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Hk" = (
@@ -1471,6 +1431,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Id" = (
@@ -1520,7 +1481,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "IU" = (
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
@@ -1587,13 +1548,9 @@
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "KU" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -1602,7 +1559,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 4
@@ -1623,7 +1580,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "LV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1635,10 +1592,15 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "LY" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
@@ -1652,9 +1614,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "6-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-10"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
@@ -1687,9 +1646,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"MK" = (
-/turf/closed/wall,
-/area/ship/maintenance)
 "Ne" = (
 /turf/closed/wall/rust,
 /area/ship/crew)
@@ -1759,6 +1715,9 @@
 /area/ship/hallway/aft)
 "NU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Oc" = (
@@ -1807,10 +1766,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
@@ -1824,6 +1784,9 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Qp" = (
@@ -1852,8 +1815,9 @@
 /obj/structure/cable{
 	icon_state = "1-9"
 	},
-/obj/structure/cable{
-	icon_state = "2-5"
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
@@ -1882,7 +1846,7 @@
 	bulb_power = 0.6;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -1914,15 +1878,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
 	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "Rv" = (
 /obj/item/gps/mining{
 	gpstag = "SCAV0";
@@ -1959,8 +1920,10 @@
 	bulb_power = 0.6;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "So" = (
@@ -1988,7 +1951,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "ST" = (
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -1998,8 +1961,8 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "Ti" = (
@@ -2073,7 +2036,7 @@
 /area/ship/bridge)
 "Uo" = (
 /turf/closed/wall/r_wall/yesdiag,
-/area/ship/crew/cryo)
+/area/ship/crew)
 "UF" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -2103,9 +2066,6 @@
 /obj/machinery/light/directional/west,
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
@@ -2116,9 +2076,6 @@
 /obj/item/flashlight/lamp/green{
 	pixel_y = 4
 	},
-/obj/structure/cable{
-	icon_state = "5-6"
-	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Vn" = (
@@ -2126,8 +2083,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/wrapping,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "Vo" = (
 /obj/machinery/power/terminal{
@@ -2153,23 +2112,26 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "VW" = (
 /turf/closed/wall,
 /area/ship/external/dark)
 "Wk" = (
 /turf/closed/wall/rust,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "Wm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock{
@@ -2192,7 +2154,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
+/area/ship/hallway/central)
 "Xc" = (
 /obj/machinery/blackbox_recorder,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2208,10 +2170,8 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "Xk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2223,6 +2183,7 @@
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
+/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -2292,7 +2253,7 @@
 /area/ship/crew)
 "Yi" = (
 /turf/closed/wall/r_wall/yesdiag,
-/area/ship/maintenance)
+/area/ship/hallway/central)
 "Yq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
@@ -2320,8 +2281,10 @@
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "YK" = (
 /obj/structure/cable{
@@ -2378,6 +2341,7 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 
@@ -2639,8 +2603,8 @@ Gq
 dc
 Pr
 dc
-oU
-oU
+dc
+dc
 rG
 rG
 IU
@@ -2658,7 +2622,7 @@ Gq
 kV
 gf
 Xh
-oU
+dc
 kB
 xp
 rG
@@ -2696,7 +2660,7 @@ Ne
 DS
 Mi
 ZJ
-oU
+dc
 tK
 Sq
 lg
@@ -2715,10 +2679,10 @@ Ne
 LY
 mC
 iY
-MK
-MK
+dc
+dc
 Wk
-Cv
+rG
 cs
 hX
 cs
@@ -2726,18 +2690,18 @@ cs
 (19,1,1) = {"
 hX
 cs
-zX
+Zx
 KU
 zW
 Lw
-ev
+Gq
 Vn
 DC
 PO
 Rn
 wi
 pF
-Cv
+rG
 cs
 hX
 cs
@@ -2745,18 +2709,18 @@ cs
 (20,1,1) = {"
 hX
 IU
-DU
+OR
 qN
 IP
 GI
-ev
+Gq
 Yv
 LV
 xk
-MK
+dc
 cn
 KT
-Cv
+rG
 IU
 hX
 cs
@@ -2765,16 +2729,16 @@ cs
 cs
 cs
 Uo
-DU
-ev
-ev
-ev
+OR
+Gq
+Gq
+Gq
 dc
 TV
 dc
-MK
-MK
-Cv
+dc
+dc
+rG
 Yi
 cs
 cs

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -30,6 +30,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ao" = (
@@ -393,6 +396,9 @@
 	icon_state = "0-6"
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "iy" = (
@@ -413,8 +419,8 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/grey/half{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -623,6 +629,9 @@
 	icon_state = "4-10"
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "oG" = (
@@ -733,6 +742,9 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "rG" = (
@@ -973,8 +985,8 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
-/obj/effect/turf_decal/corner/opaque/grey/half{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -2141,8 +2153,8 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/effect/turf_decal/corner/opaque/grey/half{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -2312,8 +2324,8 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/grey/half{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -578,22 +578,15 @@
 	locked = 1;
 	secure = 1
 	},
-/obj/item/gun/energy/laser/scatter,
-/obj/item/stock_parts/cell/gun/upgraded,
-/obj/machinery/holopad/emergency/command,
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/head/caphat,
 /obj/item/megaphone/command,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser/e10,
-/obj/item/gun/energy/laser/e10,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/machinery/holopad/emergency/command,
+/obj/item/gun/energy/laser/scatter,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ot" = (
@@ -1011,10 +1004,22 @@
 /area/ship/hallway/central)
 "xH" = (
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 4;
+	pixel_x = -8
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/gun/upgraded{
+	pixel_x = 5;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "xR" = (
@@ -1746,9 +1751,11 @@
 /area/ship/bridge)
 "OD" = (
 /obj/machinery/airalarm/directional/east,
-/obj/structure/chair/plastic{
-	dir = 8
-	},
+/obj/structure/guncloset,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser/e10,
+/obj/item/gun/energy/laser/e10,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "OR" = (
@@ -2214,18 +2221,26 @@
 	gpstag = "SCAV1"
 	},
 /obj/item/gps/mining{
-	gpstag = "SCAV1"
+	gpstag = "SCAV1";
+	pixel_y = 10
 	},
 /obj/item/gps/mining{
-	gpstag = "SCAV1"
+	gpstag = "SCAV1";
+	pixel_x = -8
 	},
 /obj/item/gps/mining{
-	gpstag = "SCAV1"
+	gpstag = "SCAV1";
+	pixel_x = -8;
+	pixel_y = 10
 	},
 /obj/item/melee/knife/survival,
-/obj/item/melee/knife/survival,
+/obj/item/melee/knife/survival{
+	pixel_x = 6
+	},
 /obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite{
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Yd" = (

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -318,7 +318,6 @@
 /obj/item/pickaxe/mini,
 /obj/item/reagent_containers/pill/patch/styptic,
 /obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/item/circular_saw,
 /obj/item/multitool,
 /obj/item/stack/marker_beacon/thirty,
 /obj/structure/cable{
@@ -329,6 +328,7 @@
 	},
 /obj/item/radio/headset/alt,
 /obj/item/gear_pack/anglegrinder,
+/obj/item/gun/energy/plasmacutter,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "gT" = (
@@ -475,12 +475,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engine)
-"ma" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -551,7 +545,6 @@
 /area/ship/hallway/aft)
 "nx" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
@@ -1183,11 +1176,13 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Bn" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "Bw" = (
@@ -1200,16 +1195,16 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "BA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
 /obj/structure/chair/handrail,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "BW" = (
@@ -1243,24 +1238,27 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Cr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "CG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Dj" = (
@@ -1377,15 +1375,15 @@
 	},
 /area/ship/cargo)
 "EQ" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Ft" = (
@@ -1499,16 +1497,16 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "JN" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/chair/handrail,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "JS" = (
@@ -1775,15 +1773,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"PR" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/shutters{
-	id = "mudskipper_window"
-	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/ship/hallway/aft)
 "PU" = (
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
@@ -1959,13 +1948,6 @@
 /obj/effect/turf_decal/spline/fancy/opaque/grey,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
-"Ti" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	name = "airlock waste injector"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "Tn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2446,7 +2428,7 @@ js
 Qp
 Ag
 Ag
-Ti
+IU
 hX
 cs
 "}
@@ -2464,8 +2446,8 @@ Rc
 OB
 EQ
 Cr
-PR
-ma
+Xm
+IU
 cs
 cs
 "}

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -416,7 +416,7 @@
 /obj/effect/turf_decal/corner/opaque/grey/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "js" = (
 /turf/closed/wall/rust,
@@ -448,7 +448,7 @@
 	},
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/corner/opaque/grey/three_quarters,
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "kX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4{
@@ -983,7 +983,7 @@
 /obj/effect/turf_decal/corner/opaque/grey/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "xo" = (
 /obj/structure/dresser,
@@ -1316,7 +1316,7 @@
 /obj/effect/turf_decal/corner/opaque/grey/three_quarters{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ed" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -1608,7 +1608,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/corner/opaque/grey/half,
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
@@ -2081,7 +2081,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/wrapping,
 /obj/effect/turf_decal/corner/opaque/grey/half,
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Vo" = (
 /obj/machinery/power/terminal{
@@ -2107,7 +2107,7 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "VW" = (
 /turf/closed/wall,
@@ -2162,7 +2162,7 @@
 /obj/effect/turf_decal/corner/opaque/grey/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Xk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2270,7 +2270,7 @@
 	},
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/corner/opaque/grey/half,
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "YK" = (
 /obj/structure/cable{
@@ -2333,7 +2333,7 @@
 /obj/effect/turf_decal/corner/opaque/grey/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 
 (1,1,1) = {"

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -424,6 +424,10 @@
 "jz" = (
 /turf/closed/wall/rust,
 /area/ship/engineering/engine)
+"kw" = (
+/obj/structure/sign/number/random,
+/turf/closed/wall/r_wall,
+/area/ship/engineering/engine)
 "kB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2364,7 +2368,7 @@ MF
 zx
 MF
 xZ
-Yu
+kw
 IU
 hX
 cs
@@ -2383,7 +2387,7 @@ Vo
 qE
 ao
 yY
-Yu
+kw
 cs
 hX
 cs
@@ -2402,7 +2406,7 @@ KA
 eu
 hY
 sI
-Yu
+kw
 IU
 hX
 hX
@@ -2421,7 +2425,7 @@ dw
 hr
 xU
 YL
-Yu
+kw
 cs
 cs
 hX

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -170,6 +170,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "dZ" = (
@@ -196,9 +199,6 @@
 	},
 /obj/structure/chair/handrail{
 	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -240,6 +240,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "eL" = (
@@ -346,6 +349,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "hH" = (
@@ -407,8 +413,10 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "js" = (
 /turf/closed/wall/rust,
@@ -435,10 +443,8 @@
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "kX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4{
@@ -808,6 +814,7 @@
 	icon_state = "0-1"
 	},
 /obj/machinery/power/ship_gravity,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "sT" = (
@@ -862,9 +869,6 @@
 /area/ship/hallway/central)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uz" = (
@@ -972,8 +976,10 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "xo" = (
 /obj/structure/dresser,
@@ -1019,6 +1025,9 @@
 	},
 /obj/machinery/light/small/directional/east{
 	bulb_power = 0.2
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
@@ -1300,17 +1309,12 @@
 	pixel_x = -3;
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "Ed" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1397,6 +1401,9 @@
 	},
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gk" = (
@@ -1594,13 +1601,8 @@
 "LY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
@@ -1715,9 +1717,6 @@
 /area/ship/hallway/aft)
 "NU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Oc" = (
@@ -1768,10 +1767,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "PR" = (
@@ -1784,9 +1779,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Qp" = (
@@ -1814,10 +1806,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-9"
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
@@ -2067,6 +2055,9 @@
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "UZ" = (
@@ -2083,10 +2074,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/wrapping,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "Vo" = (
 /obj/machinery/power/terminal{
@@ -2111,12 +2100,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-10"
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
 	},
 /turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
@@ -2170,8 +2153,10 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "Xk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2278,10 +2263,8 @@
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/hangar/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half,
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "YK" = (
 /obj/structure/cable{
@@ -2301,6 +2284,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/robot_debris,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "Zi" = (
@@ -2338,8 +2324,10 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 
 (1,1,1) = {"

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -419,8 +419,8 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -985,8 +985,8 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
-/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -2324,8 +2324,8 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/grey/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -443,7 +443,7 @@
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/corner/opaque/grey/half,
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters,
 /turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "kX" = (
@@ -1309,7 +1309,9 @@
 	pixel_x = -3;
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/corner/opaque/grey/half,
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters{
+	dir = 1
+	},
 /turf/open/floor/hangar/plasteel/dark,
 /area/ship/hallway/central)
 "Ed" = (

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -71,22 +71,24 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/janitor)
 "aH" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "aI" = (
 /turf/closed/wall,
 /area/ship/crew/toilet)
 "aR" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/item/cutting_board,
 /obj/item/melee/knife/kitchen,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "aS" = (
 /turf/closed/wall/r_wall/rust,
@@ -183,6 +185,9 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 7
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "bM" = (
@@ -443,15 +448,13 @@
 /area/ship/external/dark)
 "ea" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half,
+/turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "ec" = (
 /obj/structure/chair/sofa/brown/left/directional/south,
@@ -590,15 +593,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "ft" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/structure/table/reinforced,
 /obj/item/megaphone/command{
 	pixel_x = 10
 	},
 /obj/machinery/recharger,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "fu" = (
@@ -736,10 +739,12 @@
 /area/ship/crew/janitor)
 "gd" = (
 /obj/effect/spawner/random/vending/snack,
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 4
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "gk" = (
 /obj/machinery/door/airlock/public/glass{
@@ -783,6 +788,7 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "gF" = (
@@ -822,6 +828,9 @@
 "gK" = (
 /obj/structure/cable{
 	icon_state = "8-10"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
@@ -973,11 +982,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "ib" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/fax/indie,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "if" = (
@@ -1237,6 +1246,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "kf" = (
@@ -1405,6 +1416,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
+"lM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "lU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
@@ -1528,7 +1543,6 @@
 /area/ship/hallway/aft)
 "mZ" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
@@ -1537,7 +1551,10 @@
 /obj/structure/cable{
 	icon_state = "0-10"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1588,7 +1605,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/janitor)
 "nU" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/item/kirbyplants/fullysynthetic,
 /obj/machinery/firealarm/directional/north,
 /obj/item/cigbutt{
@@ -1628,11 +1644,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "Air to Distro"
-	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	name = "Air To Distro"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
@@ -1670,12 +1686,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "oB" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/machinery/computer/crew/retro{
 	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -1718,7 +1734,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "oV" = (
 /turf/closed/wall/r_wall/rust/yesdiag,
@@ -1779,6 +1795,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "pr" = (
@@ -1852,13 +1869,13 @@
 	req_access_txt = "1";
 	req_ship_access = 1
 	},
-/obj/item/clothing/suit/armor/vest/old,
-/obj/item/clothing/suit/armor/vest/old,
 /obj/item/clothing/head/helmet,
 /obj/effect/turf_decal/box,
 /obj/item/clothing/glasses/cheapsuns,
 /obj/item/melee/classic_baton,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "pX" = (
@@ -1889,6 +1906,7 @@
 /obj/structure/crate_shelf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "qg" = (
@@ -1948,14 +1966,14 @@
 /area/ship/engineering/engine)
 "ql" = (
 /obj/item/kirbyplants/fullysynthetic,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "qB" = (
 /obj/structure/bed,
@@ -2034,10 +2052,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "rc" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -2201,12 +2219,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "sb" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/machinery/computer/helm/retro{
 	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -2233,7 +2251,6 @@
 /area/ship/hallway/starboard)
 "sq" = (
 /obj/effect/turf_decal/industrial/warning,
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/box,
 /obj/structure/cable{
 	icon_state = "2-9"
@@ -2241,6 +2258,10 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 9
 	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/item/pickaxe,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "su" = (
@@ -2519,6 +2540,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "vk" = (
@@ -2528,11 +2555,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "vt" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/structure/closet/emcloset,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "vw" = (
@@ -2647,6 +2676,9 @@
 /obj/structure/cable{
 	icon_state = "6-10"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "wt" = (
@@ -2657,7 +2689,6 @@
 	pixel_x = -15;
 	pixel_y = 21
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/item/radio/intercom/directional/north,
 /obj/item/spacecash/bundle/c1000{
 	pixel_x = 4;
@@ -2666,14 +2697,14 @@
 /obj/item/phone{
 	pixel_y = -4
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "wz" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/drinks/bottle/tequila{
 	pixel_x = 10;
 	pixel_y = 11
@@ -2685,13 +2716,15 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "wK" = (
 /obj/structure/chair/plastic{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -2699,7 +2732,10 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "wM" = (
 /obj/structure/railing,
@@ -2726,7 +2762,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "wQ" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2734,9 +2769,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "wT" = (
@@ -2813,13 +2849,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "xs" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
 /obj/item/kirbyplants/fullysynthetic,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "xu" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
@@ -2836,6 +2874,9 @@
 	pixel_x = 20;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 7
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "xx" = (
@@ -2850,7 +2891,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
 "xz" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -4;
@@ -2860,17 +2900,25 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "xO" = (
 /obj/machinery/microwave,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "xT" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
@@ -2893,6 +2941,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2980,7 +3031,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/ship/medical)
 "yO" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/light/dim/directional/north,
 /obj/structure/cable{
 	icon_state = "8-10"
@@ -2988,13 +3038,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/chair/handrail,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "yP" = (
@@ -3039,6 +3090,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "yY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "yZ" = (
@@ -3101,10 +3155,12 @@
 /area/ship/hallway/port)
 "zr" = (
 /obj/effect/spawner/random/vending/cola,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "zy" = (
 /obj/effect/turf_decal/box,
@@ -3440,10 +3496,14 @@
 /obj/structure/closet/secure_closet/freezer/fridge{
 	populate = 0
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/sugar,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "CK" = (
 /obj/structure/cable{
@@ -3484,15 +3544,12 @@
 /area/ship/security)
 "Dd" = (
 /obj/effect/turf_decal/industrial/warning,
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/obj/item/pickaxe,
 /obj/effect/turf_decal/box,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dm" = (
@@ -3534,6 +3591,7 @@
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "DD" = (
@@ -3663,6 +3721,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner_techfloor_grid,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "EJ" = (
@@ -3677,16 +3739,16 @@
 /area/ship/maintenance/port)
 "EM" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "EN" = (
 /obj/structure/cable{
@@ -3789,9 +3851,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gt" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
@@ -3799,7 +3858,10 @@
 	pixel_y = 24
 	},
 /obj/structure/chair/handrail,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "Gw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
@@ -3933,7 +3995,6 @@
 /area/ship/engineering/engine)
 "Hi" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/item/trash/can/food/beans,
 /obj/item/trash/chips,
 /obj/machinery/firealarm/directional/north,
@@ -3944,7 +4005,12 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "Hl" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -4065,16 +4131,14 @@
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "IE" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 4
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -21
 	},
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black,
+/turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "IJ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
@@ -4250,6 +4314,7 @@
 	icon_state = "5-9"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "Ki" = (
@@ -4329,9 +4394,6 @@
 /area/ship/engineering)
 "KS" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 4
-	},
 /obj/item/trash/candy,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch{
@@ -4339,7 +4401,12 @@
 	pixel_y = -20
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 7
+	},
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "KZ" = (
 /obj/structure/noticeboard{
@@ -4553,6 +4620,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "Mf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Mk" = (
@@ -4598,9 +4666,13 @@
 /area/ship/engineering/electrical)
 "ME" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "MF" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -4654,6 +4726,7 @@
 /obj/structure/cable{
 	icon_state = "5-6"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Na" = (
@@ -5262,9 +5335,11 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "RO" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /obj/item/kirbyplants/fullysynthetic,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "RP" = (
@@ -5607,32 +5682,32 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/corner/opaque/neutral/half,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel,
 /area/ship/crew/canteen)
 "Vg" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 4
-	},
 /obj/structure/filingcabinet/double/grey,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Vp" = (
 /turf/closed/wall,
 /area/ship/engineering/electrical)
 "Vr" = (
-/obj/effect/turf_decal/corner/opaque/neutral/half{
-	dir = 1
-	},
 /obj/item/kirbyplants/fullysynthetic,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black/half,
+/turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "Vt" = (
-/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
-	dir = 1
-	},
 /obj/machinery/computer/cargo/retro,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "VD" = (
@@ -5876,6 +5951,7 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Xt" = (
@@ -7129,7 +7205,7 @@ lo
 yW
 gq
 yO
-ZV
+lM
 DC
 Xr
 wr

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -1637,11 +1637,11 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
@@ -1899,10 +1899,10 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "qa" = (
@@ -2507,11 +2507,10 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "uO" = (
@@ -3485,11 +3484,11 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -185,8 +185,8 @@
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 7
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -2875,7 +2875,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/corner/opaque/black{
-	dir = 7
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -88,7 +88,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aS" = (
 /turf/closed/wall/r_wall/rust,
@@ -1734,7 +1734,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "oV" = (
 /turf/closed/wall/r_wall/rust/yesdiag,
@@ -1973,7 +1973,7 @@
 /obj/effect/turf_decal/corner/opaque/black{
 	dir = 4
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "qB" = (
 /obj/structure/bed,
@@ -2055,7 +2055,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 8
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "rc" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -2735,7 +2735,7 @@
 /obj/effect/turf_decal/corner/opaque/black{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "wM" = (
 /obj/structure/railing,
@@ -2905,7 +2905,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "xO" = (
 /obj/machinery/microwave,
@@ -2915,7 +2915,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "xT" = (
 /obj/structure/closet/emcloset,
@@ -3503,7 +3503,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "CK" = (
 /obj/structure/cable{
@@ -3748,7 +3748,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 4
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "EN" = (
 /obj/structure/cable{
@@ -4010,7 +4010,7 @@
 /obj/effect/turf_decal/corner/opaque/black{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Hl" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -4672,7 +4672,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "MF" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -5687,7 +5687,7 @@
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/turf/open/floor/hangar/plasteel,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Vg" = (
 /obj/machinery/light/small/directional/south,

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -2,6 +2,9 @@
 "ae" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "ah" = (
@@ -145,6 +148,7 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "bv" = (
@@ -339,17 +343,14 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
 /obj/structure/chair/handrail{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -967,17 +968,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -1633,9 +1634,14 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_x = -25
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4,
 /obj/structure/chair/handrail{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
@@ -1890,11 +1896,12 @@
 /area/ship/maintenance/port)
 "pY" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
-	dir = 1
-	},
 /obj/structure/chair/handrail{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
@@ -2162,8 +2169,10 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "rL" = (
@@ -2495,11 +2504,13 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_x = -25
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
-	dir = 1
-	},
 /obj/structure/chair/handrail{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
@@ -3259,9 +3270,6 @@
 /obj/effect/turf_decal/number/zero{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Aj" = (
@@ -3474,9 +3482,14 @@
 /area/ship/hallway/fore)
 "CF" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer2,
 /obj/structure/chair/handrail{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
@@ -3776,6 +3789,7 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "EX" = (
@@ -4635,6 +4649,7 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "Mr" = (
@@ -5167,6 +5182,7 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "Qy" = (
@@ -5469,6 +5485,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "Tc" = (
@@ -6037,8 +6056,10 @@
 /area/ship/engineering/engine)
 "XY" = (
 /obj/effect/turf_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "Ye" = (


### PR DESCRIPTION
## About The Pull Request

Minorly re-decals the Miskilamo line of ships. Mostly clearing out that sharp white against the grey / black that doesn't look that good. Kept it as consistent as I could throughout the three ships. I also did a few extra, smaller decaling in certain areas like crew quarters or areas with those weird grimy tiles.

Combines cryo and crewquarters into one area and combines the bathroom, washing machine room, and central hallway into one area as well for the Mudskipper.

Replaced the circular saw (angle grinder) with a plasmacutter.

Replaced the decaying armour vests with normal ones on the Kilo and Shetland.

Axes the airless turfs on the Kilo, and streamlines the big 2x3 airlocks on the Mudskipper and Shetland.

![image](https://github.com/user-attachments/assets/5e8c8f41-0d93-4589-873d-6288c1463bd5)
![image](https://github.com/user-attachments/assets/95228218-0036-4266-ab3e-9e2f33138fd0)
![image](https://github.com/user-attachments/assets/ce70c9f6-2f29-489d-a089-35b95586e19a)
![image](https://github.com/user-attachments/assets/08c18a13-1844-4a0f-9875-3182204e45e6)
![image](https://github.com/user-attachments/assets/61f0caad-6cf2-42cd-a912-1dbe2a1dde5d)




## Why It's Good For The Game

This pr does very little other than getting rid of those white decals which I felt weird to me. Most everything else was unchanged.

Mudskipper area stuff was cut down a bit because the thing chugged as much power as a Riggs at half the size, on one pacman to boot. I don't think a room needs a APC for a washing machine and one lightbulb. It's a salvage ship so its probably fair to have a plasmacutter and angle grinder.

The presence of the Shitty armour vests felt like an odd choice. They just sit there eternally, worn by no one. May as well just have normal ones. Not like they're that big of an advantage in the grand scheme of things.

## Changelog

:cl:
del: Removed the white decaling from Miskilamo ships (Mudskipper, Kilo, Shetland)
balance: Mudskipper is now more compact on areas and has a plasmacutter
balance: Kilo and Shetland now have normal armour vests
fix: Kilo no longer has airless tiles under the prechargers, and airlocks should Work Better
/:cl: