### PR TITLE
Stale-checks flaky test issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,13 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: "This PR has been inactive for a month. This means it is at risk of being auto closed in a week, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
           days-before-stale: 30
           days-before-close: 7
-          days-before-issue-stale: -1
-          stale-pr-label: "Stale"
           exempt-pr-labels: "RED LABEL, Test Merged, Test Merge Candidate, Stale Exempt"
           exempt-draft-pr: true
+
+          stale-issue-message: "This flaky fail has not been detected in 7 days. If it doesn't show up again in another 7 days, it will be auto-closed."
+          only-issue-labels: "🤖 Flaky Test Report"
+          days-before-issue-stale: 7
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically just makes flaky test fail issues stale after a week, then closes them another week afterwards. My reasoning is that we're going to end up with a bunch of flaky fails that were one-time (from issues introduced in a PR and then fixed, for instance) or were fixed without closing the issue. I feel like this is long enough, and if it does happen again, it SHOULD re-open the same issue.