### PR TITLE
Blocks items meant for other slots for being beak-holdable for Kepori

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -31,6 +31,8 @@
 
 //SLOT GROUP HELPERS
 #define ITEM_SLOT_POCKETS (ITEM_SLOT_LPOCKET|ITEM_SLOT_RPOCKET)
+//All the item slots that are allowed to be held in Kepori beaks (their mask slot)
+#define ITEM_SLOT_KEPORI_BEAK (ITEM_SLOT_MASK|ITEM_SLOT_ID|ITEM_SLOT_POCKETS|ITEM_SLOT_DEX_STORAGE|ITEM_SLOT_SUITSTORE)
 
 //Bit flags for the flags_inv variable, which determine when a piece of clothing hides another. IE a helmet hiding glasses.
 //Make sure to update check_obscured_slots() if you add more.

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -128,14 +128,19 @@
 /datum/species/kepori/can_equip(obj/item/I, slot, disable_warning, mob/living/carbon/human/H, bypass_equip_delay_self, swap)
 	if(..()) //If it already fits, then it's fine.
 		return TRUE
-	if(slot == ITEM_SLOT_MASK)
-		if(H.wear_mask && !swap)
-			return FALSE
-		if(I.w_class > WEIGHT_CLASS_SMALL)
-			return FALSE
-		if(!H.get_bodypart(BODY_ZONE_HEAD))
-			return FALSE
-		return equip_delay_self_check(I, H, bypass_equip_delay_self)
+	if(slot != ITEM_SLOT_MASK)
+		return FALSE
+	//Blocks all items that are equippable to other slots. (block anything with a flag that ISN'T item_slot_mask)
+	if(I.slot_flags & ~ITEM_SLOT_MASK)
+		return FALSE
+	if(H.wear_mask && !swap)
+		return FALSE
+	if(I.w_class > WEIGHT_CLASS_SMALL)
+		return FALSE
+	//ya ain't got no biters to put it in sir
+	if(!H.get_bodypart(BODY_ZONE_HEAD))
+		return FALSE
+	return equip_delay_self_check(I, H, bypass_equip_delay_self)
 
 /datum/species/kepori/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -131,7 +131,7 @@
 	if(slot != ITEM_SLOT_MASK)
 		return FALSE
 	//Blocks all items that are equippable to other slots. (block anything with a flag that ISN'T item_slot_mask)
-	if(I.slot_flags & ~ITEM_SLOT_MASK)
+	if(I.slot_flags & ~ITEM_SLOT_KEPORI_BEAK)
 		return FALSE
 	if(H.wear_mask && !swap)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm sorry to do this and make it even more niche, but it IS kind of jank. This also solves the issue of things being equipped to the wrong slot when you hit the quick-equip or quick-swap key. 

Fixes: #3657

## Why It's Good For The Game

Prevents any other oversights like welding goggles from being doable by Kepori. Hopefully this doesn't block TOO many items, I even added a few other slots that should be pretty harmless to equip items flagged as such, but if there's any exceptions that should be made, I'm open for feedback.

## Changelog

:cl:
tweak: Kepori can't hold items in their beak that are (allegedly) meant to be equipped to other slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
