### PR TITLE
Reduce Claymore Explosive Power

### DIFF
--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -631,8 +631,8 @@
 
 	//customize explosive power
 	var/range_devastation = -1
-	var/range_heavy = 1
-	var/range_light = 2
+	var/range_heavy = 0
+	var/range_light = 1
 	var/range_flame = 0
 
 	//using this to indicate pb

--- a/code/game/objects/items/shrapnel.dm
+++ b/code/game/objects/items/shrapnel.dm
@@ -153,7 +153,7 @@
 /obj/item/ammo_casing/caseless/shrapnel
 	name = "directional shrapnel burst :D"
 	desc = "I May Have Overreacted"
-	pellets = 4
+	pellets = 5
 	variance = 70
 	projectile_type = /obj/projectile/bullet/shrapnel/claymore
 	randomspread = TRUE
@@ -161,7 +161,7 @@
 /obj/item/ammo_casing/caseless/shrapnel/shred
 	name = "point blank directional shrapnel burst"
 	desc = "Claymores are lethal to armored infantry at point blank range."
-	pellets = 3
+	pellets = 4
 	variance = 50
 	projectile_type = /obj/projectile/bullet/shrapnel/claymore/pointbl
 	randomspread = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About My PR
Claymores work off shrapnel. not delimbing someone with a shaped blast.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: claymores are now less explody - they have increased shrapnel prowess to mildly compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
