### PR TITLE
More Hivebot Changes

### DIFF
--- a/code/game/objects/effects/spawners/random.dm/waste_planet.dm
+++ b/code/game/objects/effects/spawners/random.dm/waste_planet.dm
@@ -82,6 +82,7 @@
 		/obj/structure/girder/displaced,
 		/obj/structure/girder/reinforced
 	)
+
 /obj/effect/spawner/random/waste/hivebot
 	loot = list(
 		/obj/effect/spawner/random/salvage/metal,
@@ -96,6 +97,45 @@
 		/obj/item/stack/ore/salvage/scrapuranium
 	)
 	spawn_loot_count = 2
+
+/obj/effect/spawner/random/waste/hivebot/more
+	spawn_loot_count = 4
+
+/obj/effect/spawner/random/waste/hivebot/part
+	loot = list(
+		/obj/item/stock_parts/capacitor,
+		/obj/item/stock_parts/scanning_module,
+		/obj/item/stock_parts/manipulator,
+		/obj/item/stock_parts/micro_laser,
+		/obj/item/stock_parts/matter_bin,
+		/obj/item/stock_parts/capacitor/adv,
+		/obj/item/stock_parts/scanning_module/adv,
+		/obj/item/stock_parts/manipulator/nano,
+		/obj/item/stock_parts/micro_laser/high,
+		/obj/item/stock_parts/matter_bin/adv,
+	)
+	spawn_loot_count = 1
+	spawn_loot_chance = 100
+
+/obj/effect/spawner/random/waste/hivebot/part/heavy
+	loot = list(
+		/obj/item/stock_parts/capacitor/super,
+		/obj/item/stock_parts/scanning_module/phasic,
+		/obj/item/stock_parts/manipulator/pico,
+		/obj/item/stock_parts/micro_laser/ultra,
+		/obj/item/stock_parts/matter_bin/super,
+	)
+
+
+/obj/effect/spawner/random/waste/hivebot/part/superheavy
+	loot = list(
+		/obj/item/stock_parts/capacitor/quadratic,
+		/obj/item/stock_parts/scanning_module/triphasic,
+		/obj/item/stock_parts/manipulator/femto,
+		/obj/item/stock_parts/micro_laser/quadultra,
+		/obj/item/stock_parts/matter_bin/bluespace,
+	)
+
 
 /obj/effect/spawner/random/waste/hivebot/beacon
 	spawn_loot_count = 6

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -35,7 +35,11 @@
 	del_on_death = 1
 	minbodytemp = 0
 	maxbodytemp = 600
-	loot = list(/obj/effect/decal/cleanable/robot_debris)
+	loot = list(
+		/obj/effect/decal/cleanable/robot_debris,
+		/obj/effect/spawner/random/waste/hivebot,
+		/obj/effect/spawner/random/waste/hivebot/part,
+		)
 
 	//yeah so it turns out that /simple_animal/hostile gets upset when you call say because say contains a sleep. so we have to do this on subtypes.
 	var/list/aggro_blurb = list("INFILTRATOR WITHIN AO!!", "TERMINATE HOSTILE!!", "DEFEND TERMINUS!!", "CODE 7-34!!")
@@ -75,7 +79,6 @@
 
 /mob/living/simple_animal/hostile/hivebot/death(gibbed)
 	do_sparks(3, TRUE, src)
-	new /obj/effect/spawner/random/waste/hivebot(loc)
 	..(TRUE)
 
 /mob/living/simple_animal/hostile/hivebot/ranged
@@ -87,6 +90,12 @@
 	ranged = TRUE
 	retreat_distance = 5
 	minimum_distance = 5
+	loot = list(
+		/obj/effect/decal/cleanable/robot_debris,
+		/obj/effect/spawner/random/waste/hivebot,
+		/obj/effect/spawner/random/waste/hivebot/part,
+		/obj/effect/spawner/random/waste/hivebot/part,
+		)
 
 /mob/living/simple_animal/hostile/hivebot/ranged/rapid
 	ranged = TRUE
@@ -108,7 +117,14 @@
 	projectilesound = 'sound/weapons/gun/rifle/hydra.ogg'
 	melee_damage_lower = 12
 	melee_damage_upper = 20
-	move_to_delay = 7
+	move_to_delay = 10
+	loot = list(
+		/obj/effect/decal/cleanable/robot_debris,
+		/obj/effect/spawner/random/waste/hivebot/more,
+		/obj/effect/spawner/random/waste/hivebot/part/heavy,
+		/obj/effect/spawner/random/waste/hivebot/part,
+		/obj/effect/spawner/random/waste/hivebot/part,
+		)
 
 /mob/living/simple_animal/hostile/hivebot/defender //slave to the system
 	name = "core hivebot"
@@ -131,7 +147,22 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 28
 
-	move_to_delay = 15
+	move_to_delay = 20
+
+	loot = list(
+		/obj/effect/decal/cleanable/robot_debris,
+		/obj/effect/spawner/random/waste/hivebot/more,
+		/obj/effect/spawner/random/waste/hivebot/part/superheavy,
+		/obj/effect/spawner/random/waste/hivebot/part/heavy,
+		/obj/effect/spawner/random/waste/hivebot/part/heavy,
+		)
+
+/mob/living/simple_animal/hostile/hivebot/defender/death(gibbed)
+	//once we get better sprites i want this to be like the claw's death. aka fucking cool.
+	radiation_pulse(src, 500)
+	explosion(src, 0,1,3,3,)
+	..(TRUE)
+
 
 /mob/living/simple_animal/hostile/hivebot/defender/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Hivebots now drop stock parts. Stronger ones drop better parts.
Some hivebots drop more metal
core defender hivebots now explode on death.

## Why It's Good For The Game
I heard the hivebot stuff get called nothingburgers and honestly yeag. this should make them less so

## Changelog

:cl:
add: hivebots now drop stock parts. Stronger ones drop better parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
