### PR TITLE
Accessibility change: Suffocation and organ lists made readable for dark mode

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -234,7 +234,7 @@ GENE SCANNER
 							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
 							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
 							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
-							<td><font color='blue'>[CEILING(oxy_loss,1)]</font></td></tr>"
+							<td><font color='#1d63e6'>[CEILING(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
@@ -289,9 +289,9 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#0000CC'><b>Organ</b></font></td>\
-				[advanced ? "<td style='width:3em;'><font color='#0000CC'><b>Dmg</b></font></td>" : ""]\
-				<td style='width:12em;'><font color='#0000CC'><b>Status</b></font></td>"
+				<td style='width:6em;'><font color='#1d63e6'><b>Organ</b></font></td>\
+				[advanced ? "<td style='width:3em;'><font color='#1d63e6'><b>Dmg</b></font></td>" : ""]\
+				<td style='width:12em;'><font color='#1d63e6'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ in H.internal_organs)
 				var/status = ""
@@ -300,8 +300,8 @@ GENE SCANNER
 				else if (organ.damage > organ.low_threshold) status = "<font color='#F28F1F'>Mildly Damaged</font>"
 				if (status != "")
 					render = TRUE
-					toReport += "<tr><td><font color='#0000CC'>[organ.name]</font></td>\
-						[advanced ? "<td><font color='#0000CC'>[CEILING(organ.damage,1)]</font></td>" : ""]\
+					toReport += "<tr><td><font color='#1d63e6'>[organ.name]</font></td>\
+						[advanced ? "<td><font color='#1d63e6'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 
 			if (render)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change modifies the color of the font for suffocation damage and organ listings in health scans.

|            | Before | After |
|------------|--------|-------|
| Dark Mode  |![image](https://github.com/user-attachments/assets/d830c55e-2aea-4198-996b-04ca807fa6f4)|![image](https://github.com/user-attachments/assets/e35fe488-a044-46ad-a8f2-72744bd1a461)|
| Light Mode |![image](https://github.com/user-attachments/assets/b697526f-fa2e-41c0-99ba-6c634d48d9f3)|![image](https://github.com/user-attachments/assets/95d85b32-0ea8-488f-9302-77b5f9f3fc70)|

## Why It's Good For The Game

This should make it so that someone using the dark UI theme will not need to highlight the text for suffocation or organs in order to see what's being listed. It should still be readable for those that instead prefer light mode.

## Changelog

:cl:
code: modified font colors in health scans to make them more readable in dark mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
