### PR TITLE
Adds a singular light tube to the Atlas + Sergeant can access their own belongings now

### DIFF
--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -1700,7 +1700,7 @@
 /obj/structure/closet/secure_closet{
 	icon_state = "hop";
 	name = "sergeant's locker";
-	req_access_txt = "19"
+	req_access_txt = "3"
 	},
 /obj/item/storage/guncase/doublebarrel{
 	pixel_x = 1;

--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -3269,7 +3269,7 @@
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Bridge";
-	req_one_access = list(19, 3)
+	req_one_access = list(19,3)
 	},
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 9
@@ -3360,7 +3360,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/coffee{
 	pixel_x = 5;
-	list_reagents = list(/datum/reagent/consumable/ice = 30)
+	list_reagents = list(/datum/reagent/consumable/ice=30)
 	},
 /turf/open/floor/plating,
 /area/ship/external/dark)
@@ -4931,6 +4931,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Ze" = (
@@ -4964,7 +4965,7 @@
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Bridge";
-	req_one_access = list(19, 3)
+	req_one_access = list(19,3)
 	},
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Says it in the title, adds a singular light to the Atlas, and fixes the access on the Sergeants locker so they can now access it

## Why It's Good For The Game

![WHAT!!](https://github.com/user-attachments/assets/3d92b242-c748-463d-bc52-cf04b8e3da3a)
![Fixies](https://github.com/user-attachments/assets/95b33a2b-56e4-4034-b07c-77908172091b)
(I have no idea why they're different sizes)

## Changelog

:cl:
add: Adds a singular light tube to the SSU room in the Atlas
fix: The Atlas Sergeant can now access their belongings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
