### PR TITLE
Fix shuttle transit resetting turfs modified by floor painter

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -82,6 +82,7 @@ All ShuttleMove procs go here
 /turf/proc/afterShuttleMove(turf/oldT, rotation, list/all_towed_shuttles)
 	//Dealing with the turf we left behind
 	oldT.TransferComponents(src)
+	src.base_icon_state = oldT.base_icon_state
 	SEND_SIGNAL(oldT, COMSIG_TURF_AFTER_SHUTTLE_MOVE, src) //Mostly for decals
 
 	if(rotation)


### PR DESCRIPTION
## About The Pull Request

The Floor Painter modifies a turf's `base_icon_state`, whereas turfs placed by mappers do not depend upon this variable. The post-transit code copies over each turf's _components_ and _decals_, but does not handle its icon state. Ideally, the Floor Painter should be refactored to use the same mechanisms that are already in place to modify a turf's appearance, but doing so is a much taller order and beyond the scope of this PR.

This is a one-liner PR that simply instructs BYOND to also copy over each turf's icon state in addition to its components and decals. I verified that the bug was fixed both visually and via VVs, and additionally applied a decal to the tile to trigger an icon update (prior to this PR, doing so would cause affected turfs to display their true icon state if they did not have a decal on them already).

## Why It's Good For The Game

Prior to this PR, Floor Painters were ineffective in Shiptest as a result of the shuttle-focused gameplay. All of the customization they offer was not actually available to players who ever intended to move their shuttle. Now, it is.

## Changelog

:cl: Yule&
fix: Tiles modified by the Floor Painter no longer reset after shuttle transit
/:cl: