### PR TITLE
Reduces the Raleigh's Hammer to Standard HE

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -396,9 +396,9 @@
 
 
 /datum/blackmarket_item/weapon/oneshot
-	name = "Hammer Launcher"
+	name = "Hammer-DP Launcher"
 	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HEDP rocket. "
-	item = /obj/item/gun/ballistic/rocketlauncher/oneshot
+	item = /obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
 
 	price_min = 3000
 	price_max = 4500

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -397,7 +397,7 @@
 /datum/blackmarket_item/weapon/oneshot
 	name = "Hammer Launcher"
 	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HE rocket. "
-	item = /obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
+	item = /obj/item/gun/ballistic/rocketlauncher/oneshot
 
 	price_min = 3000
 	price_max = 4500

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -394,10 +394,9 @@
 	stock_max = 2
 	availability_prob = 20
 
-
 /datum/blackmarket_item/weapon/oneshot
-	name = "Hammer-DP Launcher"
-	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HEDP rocket. "
+	name = "Hammer Launcher"
+	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HE rocket. "
 	item = /obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
 
 	price_min = 3000
@@ -405,3 +404,14 @@
 	stock_min = 1
 	stock_max = 5
 	availability_prob = 25
+
+/datum/blackmarket_item/weapon/oneshot/hedp
+	name = "Hammer-DP Launcher"
+	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HEDP rocket. "
+	item = /obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
+
+	price_min = 4000
+	price_max = 6000
+	stock_min = 1
+	stock_max = 5
+	availability_prob = 10

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -64,8 +64,8 @@ GLOBAL_LIST_INIT(rpg_scrawlings, list(
 	"A crudely-drawn picture of a Gorlex Marauder exploding",
 	"A scratched-out link to some kind of website",
 	".:|:;",
-	"\"SPEAR TO THE SHOAL, FOR A FREE FRONTIER!\""
-	"\"Arm this!\""
+	"\"SPEAR TO THE SHOAL, FOR A FREE FRONTIER!\"",
+	"\"Arm this!\"",
 ))
 
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -58,6 +58,13 @@ GLOBAL_LIST_INIT(rpg_scrawlings, list(
 	"A drawing of the Rilena character 'T4L1' smoking a boof",
 	"\"Eat it corpo!\"",
 	"A Sarathi woman in a suggestive pose",
+	"A masculine Sarathi shouldering a launcher",
+	"A Vox woman with a sledgehammer over their shoulder",
+	"A man in a floral patterned shirt and nothing else, drawn leaning against the rocket's tube",
+	"A crudely-drawn picture of a Gorlex Marauder exploding",
+	"A scratched-out link to some kind of website",
+	".:|:;",
+	"\"SPEAR TO THE SHOAL, FOR A FREE FRONTIER!\""
 	"\"Arm this!\""
 ))
 

--- a/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
@@ -247,7 +247,7 @@
 
 /obj/item/gun/ballistic/rocketlauncher/oneshot
 	name = "\improper Hammer"
-	desc = "A disposable rocket-propelled grenade launcher loaded with a HEDP shell."
+	desc = "A disposable rocket-propelled grenade launcher loaded with a standard HE shell."
 
 	icon = 'icons/obj/guns/manufacturer/frontier_import/48x32.dmi'
 	lefthand_file = 'icons/obj/guns/manufacturer/frontier_import/lefthand.dmi'
@@ -276,6 +276,15 @@
 
 	safety_multiplier = 0
 
+/obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
+	name = "\improper Hammer-DP"
+	desc = "A disposable rocket-propelled grenade launcher loaded with an HEDP shell for Direct Penetration of your target."
+
+	default_ammo_type = /obj/item/ammo_box/magazine/internal/rocketlauncher/oneshot/hedp
+	allowed_ammo_types = list(
+		/obj/item/ammo_box/magazine/internal/rocketlauncher/oneshot/hedp,
+	)
+
 /obj/item/gun/ballistic/rocketlauncher/oneshot/Initialize()
 	. = ..()
 	if(prob(1))
@@ -287,6 +296,12 @@
 		. += span_warning("It has been spent, and is now useless.")
 
 /obj/item/ammo_box/magazine/internal/rocketlauncher/oneshot
+	name = "oneshot rocket launcher magazine"
+	ammo_type = /obj/item/ammo_casing/caseless/rocket
+	caliber = "84mm"
+	max_ammo = 1
+
+/obj/item/ammo_box/magazine/internal/rocketlauncher/oneshot/hedp
 	name = "oneshot rocket launcher magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/rocket/hedp
 	caliber = "84mm"


### PR DESCRIPTION
## About The Pull Request

Replaces the Hammer Rocket Launcher on the Raleigh with Standard HE. 
Standard HE rockets still suffices against mechs.

## Why It's Good For The Game

Balancing adjustments.

## Changelog

:cl:
add: Hammer HEDP subtype.
add: New RPG scrawlings, by request of the original coder.
balance: Raleigh now only starts with an HE Hammer.
/:cl:
