### PR TITLE
Painkillers now reduce severity of damage overlays

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -710,7 +710,9 @@
 
 	//Fire and Brute damage overlay (BSSR)
 	var/hurtdamage = getBruteLoss() + getFireLoss() + damageoverlaytemp
-	if(hurtdamage)
+	if(HAS_TRAIT(src, TRAIT_PAIN_RESIST))
+		hurtdamage = round(hurtdamage/2)
+	if(hurtdamage && !HAS_TRAIT(src, TRAIT_ANALGESIA))
 		var/severity = 0
 		switch(hurtdamage)
 			if(5 to 15)


### PR DESCRIPTION
## About The Pull Request
Having medication in your system that makes you resist pain will now make the red hurt overlay not happen as hard.

## Why It's Good For The Game
immersion

## Changelog

:cl:
add: painkillers now reduce the intensity of the damage overlay
/:cl:
