### PR TITLE
Ship renaming now properly abides by the renaming timer

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -276,6 +276,7 @@
 				return
 			if(!current_ship.Rename(new_name))
 				say("Error: [COOLDOWN_TIMELEFT(current_ship, rename_cooldown)/10] seconds until ship designation can be changed.")
+				return
 			update_static_data(usr, ui)
 			return
 		if("reload_ship")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you rename a ship, but there's a cooldown, the ship properly identifies this in the code for the overmap datum and for the helm console, but the latter doesn't actually do anything about it, which leads to a mismatch in names.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Ships now properly follow the rename cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
