### PR TITLE
Brazil lab tile fix

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_brazillianlab.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_brazillianlab.dmm
@@ -37,7 +37,7 @@
 "bB" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "cr" = (
 /obj/structure/barricade/sandbags,
@@ -141,7 +141,7 @@
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "gk" = (
 /obj/structure/flora/rock,
@@ -191,7 +191,7 @@
 /area/ruin/unpowered)
 "hO" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "hR" = (
 /mob/living/simple_animal/hostile/human/hermit/survivor,
@@ -201,7 +201,7 @@
 "hT" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/item/cultivator/rake,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "ib" = (
 /obj/structure/table/wood,
@@ -394,7 +394,7 @@
 /area/ruin/unpowered)
 "nG" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "oo" = (
 /turf/open/floor/wood{
@@ -512,7 +512,7 @@
 "si" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "sj" = (
 /obj/structure/girder/reinforced,
@@ -573,7 +573,7 @@
 /area/ruin/unpowered)
 "uG" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "vg" = (
 /obj/item/stack/sheet/metal/ten{
@@ -595,7 +595,7 @@
 "vH" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "vR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -626,7 +626,7 @@
 /area/ruin/unpowered)
 "wh" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "wk" = (
 /obj/structure/table/wood/reinforced,
@@ -901,7 +901,7 @@
 /area/ruin/unpowered)
 "CS" = (
 /obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "CT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -942,7 +942,7 @@
 /area/ruin/unpowered)
 "DA" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "DH" = (
 /obj/structure/barricade/sandbags,
@@ -950,7 +950,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "DX" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "DY" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1030,7 +1030,7 @@
 /area/ruin/unpowered)
 "GK" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "GO" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -1169,7 +1169,7 @@
 "LC" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "LI" = (
 /turf/open/floor/wood{
@@ -1188,7 +1188,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "Mt" = (
 /obj/structure/flora/ash/fern,
@@ -1206,7 +1206,7 @@
 /area/ruin/unpowered)
 "MI" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "MM" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1220,7 +1220,7 @@
 "Nt" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "NG" = (
 /obj/structure/guncloset,
@@ -1257,7 +1257,7 @@
 /area/ruin/unpowered)
 "Pm" = (
 /obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "Ps" = (
 /obj/structure/table/wood,
@@ -1283,7 +1283,7 @@
 /area/ruin/unpowered)
 "Ql" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "Qm" = (
 /turf/open/floor/wood{
@@ -1377,7 +1377,7 @@
 /area/ruin/unpowered)
 "Tx" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "TA" = (
 /turf/open/floor/wood{
@@ -1411,7 +1411,7 @@
 /area/ruin/unpowered)
 "Ux" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "UE" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
@@ -1537,7 +1537,7 @@
 /area/ruin/unpowered)
 "Yh" = (
 /obj/item/shovel,
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "Yk" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1564,7 +1564,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "YX" = (
-/turf/open/floor/plating/grass/jungle,
+/turf/open/floor/grass/ship/jungle,
 /area/ruin/unpowered)
 "YZ" = (
 /obj/effect/turf_decal/siding/wood{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the **PLANETARY** jungle tiles to be "regular" ship jungle tiles. ~~I should shake you Zevo~~

## Why It's Good For The Game

Oh boy, I can't wait to go into this rui- _gets flunged into a lake of acid for even thinking of having fun_

## Changelog

:cl:
fix: Swaps the planetary tiles on Brazil lab to be non-planetary tile types.
/:cl: