### PR TITLE
Claris and Gar Can Now Be Stored On Your Back

### DIFF
--- a/code/modules/projectiles/guns/ballistic/gauss.dm
+++ b/code/modules/projectiles/guns/ballistic/gauss.dm
@@ -103,6 +103,7 @@
 	allowed_cell_types = list(
 		/obj/item/stock_parts/cell/gun/solgov,
 	)
+	slot_flags = ITEM_SLOT_BACK
 	fire_delay = 0.4 SECONDS
 	bolt_type = BOLT_TYPE_NO_BOLT
 	internal_magazine = TRUE
@@ -143,8 +144,8 @@
 	allowed_cell_types = list(
 		/obj/item/stock_parts/cell/gun/solgov,
 	)
+	slot_flags = ITEM_SLOT_BACK
 	burst_size = 1
-
 	fire_delay = 0.2 SECONDS
 
 	actions_types = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Claris and Gar can now be stored on your back, and suit storage (if you have armour)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It was massively inconsistent that every other large rifle can be stored on the back slot.
Also Solarians are the kind of mf'ers to sacrifice their bag to look more 'proper'.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Claris and Gar can now be stored on your back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
