### PR TITLE
Minor Dwayne change

### DIFF
--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -2699,7 +2699,8 @@
 /obj/machinery/light/directional/west,
 /obj/structure/filingcabinet/filingcabinet{
 	dir = 4;
-	pixel_x = -10
+	pixel_x = -10;
+	density = 0
 	},
 /obj/effect/turf_decal/corner/opaque/ntblue/border{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As is the title

## Why It's Good For The Game

Makes the filing cabinet in the dwayne bridge not "dense"
![image](https://github.com/user-attachments/assets/4e1bc236-f0e0-43e5-8091-948095682ccc)

## Changelog

:cl:
balance: The Dwayne filing cabinet located in the bridge is no longer dense
/:cl: