### PR TITLE
Adds the assault belt to cargo

### DIFF
--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -39,6 +39,13 @@
 					/obj/item/clothing/glasses/meson/engine)
 	crate_name = "engineering gear crate"
 
+/datum/supply_pack/tools/assbelt
+	name = "Assault Belt"
+	desc = "Contains an assault belt, with not one, not two, but six pockets."
+	cost = 500
+	contains = list(/obj/item/storage/belt/military/assault)
+	crate_name = "assault belt crate"
+
 /datum/supply_pack/tools/cellcharger
 	name = "Cell Charger Crate"
 	desc = "Contains a cell charger, able to charge all sorts of power cells."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Returns the assault belt to cargo for 500 credits which is a number I pulled out of my assault belt
The assault belt holds 6 small or tiny items with no themed restrictions

## Why It's Good For The Game

Reduces storage reliance on backpacks very slightly & makes storing guns on the back slot a little more viable

## Changelog

:cl:
add: The assault belt has been freed from its SWAT suit prison and is now purchasable in cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
