### PR TITLE
Fixes the mech saw and improves it + Adds it to the outpost catalouge

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -501,7 +501,8 @@
 	var/dam_force = 30
 	harmful = TRUE
 	tool_behaviour = TOOL_DECONSTRUCT
-	toolspeed = 0.5
+	toolspeed = 0.3
+	wall_decon_damage = 400
 	var/datum/effect_system/spark_spread/spark_system
 
 /obj/item/mecha_parts/mecha_equipment/salvage_saw/can_attach(obj/mecha/M as obj)
@@ -512,7 +513,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/salvage_saw/attach()
 	..()
-	toolspeed = 0.5
+	toolspeed = 0.3
 	return
 
 /obj/item/mecha_parts/mecha_equipment/salvage_saw/detach()
@@ -532,10 +533,13 @@
 		target.add_overlay(GLOB.cutting_effect)
 		if(target.deconstruct_act(chassis.occupant, src))
 			do_sparks(2, TRUE, src)
-			chassis.stopped--
 		target.cut_overlay(GLOB.cutting_effect)
 		if(!chassis.stopped)
 			occupant_message("[src] finishes cutting, allowing movement again.")
+	if(chassis.stopped > 0)
+		chassis.stopped--
+	else
+		chassis.stopped = 0
 
 /obj/item/mecha_parts/mecha_equipment/salvage_saw/tool_start_check(user, amount)
 	if(!chassis.stopped)

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -117,6 +117,14 @@ Mech Equipment
 		/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
 	)
 
+/datum/supply_pack/mech/equipment/salvage_saw
+	name = "Exosuit Salvage Saw"
+	desc = "Contains an upsized angle grinder for an Exosuit, for all your larger salvage problems."
+	cost = 2000
+	contains = list(
+		/obj/item/mecha_parts/mecha_equipment/salvage_saw
+	)
+
 /datum/supply_pack/mech/equipment/scanner
 	name = "Exosuit scanner kit"
 	desc = "An electronic mining scanner, graded to interface with an exosuit."


### PR DESCRIPTION
## About The Pull Request

As is title. This PR adds the mech saw to the outpost market and fixes it at the same time while buffing it. Gristlebee was a big help in fixing this, as mech code has me quite stumped and would probably give me an aneurysm if I looked at it too long.

## Why It's Good For The Game

Mech saw was freezing if you sawed indestructible walls + the original PR never added damage to it which caused it to get stuck on regular walls too. Also adds the exosuit based salvage saw to the outpost market as it was originally unobtainable without it being spawned or somehow starting with it.

## Changelog

:cl:
add: Adds the exosuit based saw to the Outpost catalogue for 2000 credits
balance: Buffed the speed and deconstruction damage of the exosuit saw
fix: Exosuit saw no longer gets stuck on indestructible walls
/:cl: