### PR TITLE
Mechs now fail do_afters immediately on moving or turning

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -97,28 +97,29 @@
 	return 0
 
 /obj/item/mecha_parts/mecha_equipment/proc/start_cooldown()
-	set_ready_state(0)
+	set_ready_state(FALSE)
 	chassis.use_power(energy_drain)
-	addtimer(CALLBACK(src, PROC_REF(set_ready_state), 1), equip_cooldown)
+	addtimer(CALLBACK(src, PROC_REF(set_ready_state), TRUE), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target)
 	if(!chassis)
 		return
 	var/C = chassis.loc
-	set_ready_state(0)
+	set_ready_state(FALSE)
 	chassis.use_power(energy_drain)
-	. = do_after(chassis.occupant, equip_cooldown, target=target)
-	set_ready_state(1)
-	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))
-		return 0
+	. = do_after(chassis.occupant, equip_cooldown, target=target, extra_checks = CALLBACK(src, PROC_REF(check_do_after), target, C))
+	set_ready_state(TRUE)
 
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, delay)
 	if(!chassis)
 		return
 	var/C = chassis.loc
-	. = do_after(chassis.occupant, delay, target=target)
-	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))
-		return 0
+	. = do_after(chassis.occupant, delay, target=target, extra_checks = CALLBACK(src, PROC_REF(check_do_after), target, C))
+
+/obj/item/mecha_parts/mecha_equipment/proc/check_do_after(atom/target, turf/chassis_turf)
+	. = TRUE
+	if(!chassis || 	chassis.loc != chassis_turf || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))
+		return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/mecha/M)
 	if(M.equipment.len<M.max_equip)
@@ -141,7 +142,7 @@
 		update_chassis_page()
 		log_message("[src] removed from equipment.", LOG_MECHA)
 		chassis = null
-		set_ready_state(1)
+		set_ready_state(TRUE)
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Changelog

:cl:
fix: mechs will now immediately fail a channel if they move, turn, or swap equipment. Previously the channel would run to completion before checking if it was valid.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
