### PR TITLE
Maximum safe speeds on overmap hazards are now player-facing

### DIFF
--- a/code/modules/overmap/objects/event_datum.dm
+++ b/code/modules/overmap/objects/event_datum.dm
@@ -67,6 +67,8 @@
 	token.color = "#a08444"
 	token.light_color = "#a08444"
 	token.update_appearance()
+	if(safe_speed)
+		token.desc += " You can safely navigate through this if your ship is travelling under [safe_speed] Gm/s."
 
 /datum/overmap/event/meteor/apply_effect()
 	for(var/datum/overmap/ship/controlled/Ship in get_nearby_overmap_objects())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now you don't have to code-dive to find out how to survive meteors

## Why It's Good For The Game

i think players should know this 

## Changelog

:cl:
add: Examining overmap hazards now shows their maximum safe speed, if there is one, which there may not be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
