### PR TITLE
fixes max weight on surgery cases

### DIFF
--- a/code/game/objects/items/storage/cases.dm
+++ b/code/game/objects/items/storage/cases.dm
@@ -13,6 +13,7 @@
 	throw_speed = 3
 	throw_range = 7
 	var/empty = FALSE
+	var/max_items = 10
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/case/ComponentInitialize()
@@ -30,7 +31,8 @@
 /obj/item/storage/case/surgery/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_w_class = INFINITY //workaround for the differently sized items, case is still limited to 7 items max and to the list.
+	STR.max_combined_w_class = INFINITY //part of the workaround, not setting a max combined weight defaults to some weird number.
 	STR.max_items = 7
 	STR.set_holdable(list(
 		/obj/item/healthanalyzer,

--- a/code/game/objects/items/storage/cases.dm
+++ b/code/game/objects/items/storage/cases.dm
@@ -13,7 +13,6 @@
 	throw_speed = 3
 	throw_range = 7
 	var/empty = FALSE
-	var/max_items = 10
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/case/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so the Circ-Saw and the 7th item can fit in by defining a max combined weight to the item
(I am aware it's infinity but there is a cap to the amount of items that can be held. If someone wants to use cases to smuggle 7 circ saws at a time then be my guest.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So surgery cases work as intended.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: surgery cases now hold all the items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
