### PR TITLE
removes grey assistant config option

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -280,7 +280,6 @@
 	min_val = -1
 
 /datum/config_entry/flag/starlight
-/datum/config_entry/flag/grey_assistants
 
 /datum/config_entry/flag/allow_random_events	// Enables random events mid-round when set
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -25,23 +25,12 @@ Assistant
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (CONFIG_GET(flag/grey_assistants))
-		switch(H.jumpsuit_style)
-			if(PREF_SUIT)
-				uniform = initial(uniform)
-			if(PREF_ALTSUIT)
-				uniform = /obj/item/clothing/under/misc/assistantformal
-			if(PREF_SKIRT)
-				uniform = /obj/item/clothing/under/color/jumpskirt/grey
-			else
-				uniform = /obj/item/clothing/under/color/grey
-	else
-		switch(H.jumpsuit_style)
-			if(PREF_SUIT)
-				uniform = initial(uniform)
-			if(PREF_ALTSUIT)
-				uniform = /obj/item/clothing/under/misc/assistantformal
-			if(PREF_SKIRT)
-				uniform = /obj/item/clothing/under/utility/skirt
-			else
-				uniform = /obj/item/clothing/under/utility
+	switch(H.jumpsuit_style)
+		if(PREF_SUIT)
+			uniform = initial(uniform)
+		if(PREF_ALTSUIT)
+			uniform = /obj/item/clothing/under/misc/assistantformal
+		if(PREF_SKIRT)
+			uniform = /obj/item/clothing/under/utility/skirt
+		else
+			uniform = /obj/item/clothing/under/utility

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -424,9 +424,6 @@ OVERFLOW_CAP -1
 ## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting
 #STARLIGHT
 
-## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
-#GREY_ASSISTANTS
-
 ## Midround Antag (aka Mulligan antag) config options ###
 
 ## A time, in minutes, after which the midround antag system stops attempting to run and continuous rounds end immediately upon completion.


### PR DESCRIPTION
vestigal code removal means cleaner config file

:cl:
config: The grey assistant config option has been removed. It hasn't done what it was supposed to do in a while so i ated it.
/:cl:
