### PR TITLE
Signallers no longer hit the other signaller when you're copying frequencies

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -82,12 +82,13 @@
 	update_appearance()
 
 /obj/item/assembly/signaler/attackby(obj/item/W, mob/user, params)
-	if(issignaler(W))
+	if(issignaler(W) && secured)
 		var/obj/item/assembly/signaler/signaler2 = W
-		if(secured && signaler2.secured)
+		if(signaler2.secured)
 			code = signaler2.code
 			set_frequency(signaler2.frequency)
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
+			return TRUE
 	..()
 
 /obj/item/assembly/signaler/proc/signal()


### PR DESCRIPTION


:cl:
fix: Signallers no longer hit the other signaller when you're copying frequencies
/:cl:

