### PR TITLE
Allows the ion thruster to be detached from exosuits + Adds it to the outpost market

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -582,7 +582,6 @@
 /obj/item/mecha_parts/mecha_equipment/thrusters/ion //for mechs with built-in thrusters, should never really exist un-attached to a mech
 	name = "Ion thruster package"
 	desc = "A set of thrusters that allow for exosuit movement in zero-gravity enviroments."
-	detachable = FALSE
 	salvageable = FALSE
 	effect_type = /obj/effect/particle_effect/ion_trails
 

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -196,6 +196,14 @@ Mech Equipment
 		/obj/item/mecha_parts/mecha_equipment/thrusters/gas
 	)
 
+/datum/supply_pack/mech/equipment/ionthrust
+	name = "Exosuit Ion thruster kit"
+	desc = "An electrical powered thruster pack, perfect for exosuits without a functional way to refill more tradional RCS thrusters."
+	cost = 2000
+	contains = list(
+		/obj/item/mecha_parts/mecha_equipment/thrusters/ion
+	)
+
 /datum/supply_pack/mech/equipment/ripley_upgrade
 	name = "APLU upgrade kit"
 	desc = "Contains an APLU MK II upgrade kit. The upgrade will replace the cockpit with a spaceworthy canopy, but the added weight makes it slower."


### PR DESCRIPTION
## About The Pull Request

As is the title. Not only allows exosuit ion thrusters to be detachable from exosuits if attached (Since there was one ruin that had such not attached to a suit), but also adds it to the Outpost market for almost 150% increase in price to the old RCS thruster.

## Why It's Good For The Game

The RCS thruster honestly sucked ass to be real with you. It not only siphoned air exceptionally fast, you got only a few tiles in space before being left in a vacuum. This'll add the objectively superior version to the outpost, albeit for a relatively steep price to account with how much better it is compared to the gas powered one in terms of use.

## Changelog

:cl:
add: Adds the Ion thruster pack for Exosuits to the outpost market, for 2000 credits
balance: Ion thrusters can be detached from exosuits now
/:cl: