### PR TITLE
Factional Cargo Part 3: Magazines now come unloaded + Commissioner and Other Weapons in cargo

### DIFF
--- a/code/game/objects/items/storage/filled_guncases.dm
+++ b/code/game/objects/items/storage/filled_guncases.dm
@@ -121,6 +121,10 @@
 	gun_type = /obj/item/gun/ballistic/automatic/assault/hydra/dmr
 	mag_type = /obj/item/ammo_box/magazine/m556_42_hydra/small
 
+/obj/item/storage/guncase/saw80
+	gun_type = /obj/item/gun/ballistic/automatic/assault/hydra/lmg
+	mag_type = /obj/item/ammo_box/magazine/m556_42_hydra/extended
+
 /obj/item/storage/guncase/taipan
 	gun_type = /obj/item/gun/ballistic/automatic/marksman/taipan
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -507,6 +507,16 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
+/datum/supply_pack/gun/gar
+	name = "Solarian 'GAR' Automatic Rifle"
+	desc = "A modern solarian military rifle, chambered in ferromagnetic lances. Not for export."
+	cost = 5000
+	contains = list(/obj/item/storage/guncase/gar)
+	crate_name = "auto rifle crate"
+	faction = /datum/faction/solgov
+	faction_discount = 0
+	faction_locked = TRUE
+
 /datum/supply_pack/gun/hades
 	name = "SL AL-655 'Hades' energy rifle"
 	desc = "Contains a high-energy, automatic laser rifle. For NT employee use only."
@@ -547,6 +557,27 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
+/* Heavy */
+
+/datum/supply_pack/gun/cm40
+	name = "CM-40 Squad Automatic Weapon"
+	desc = "Contains a CM-40 Squad Automatic Weapon, a CLIP-produced LMG for Minuteman usage in situations that require heavy firepower. For Minuteman use only."
+	cost = 6000
+	contains = list(/obj/item/storage/guncase/cm40)
+	crate_name = "LMG crate"
+	faction = /datum/faction/clip
+	faction_discount = 0
+	faction_locked = TRUE
+
+/datum/supply_pack/gun/saw80
+	name = "SAW-80 Squad Automatic Weapon"
+	desc = "Contains one of the rarely-produced SAW-80 Squad Automatic Weapon platforms, exclusively for licensed buyers. Remember, short controlled bursts!"
+	cost = 6000
+	contains = list(/obj/item/storage/guncase/saw80)
+	crate_name = "LMG crate"
+	faction = /datum/faction/syndicate/scarborough_arms
+	faction_discount = 0
+	faction_locked = TRUE
 
 /* Marksman Rifles */
 

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -61,6 +61,15 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
+/datum/supply_pack/gun/commissioner
+	name = "Commissioner Pistol Crate"
+	desc = "Contains a modified Commander pistol, adjusted to fit the IRMG's standards and painted in the brown and gold of all IRMG firearms."
+	cost = 750
+	contains = list(/obj/item/storage/guncase/commissioner)
+	faction = /datum/faction/inteq
+	faction_discount = 0
+	faction_locked = TRUE
+
 /datum/supply_pack/gun/candors
 	name = "Candor Pistol Crate"
 	desc = "Contains a Candor pistol, the trusty sidearm of any spacer, produced by Hunter's Pride and chambered in .45 ACP."

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -35,6 +35,7 @@
 	cost = 750
 	contains = list(/obj/item/storage/guncase/pistol/commander)
 	faction = /datum/faction/nt
+	faction_discount = 20
 
 /datum/supply_pack/gun/ringneck
 	name = "Ringneck Pistol Crate"
@@ -463,6 +464,7 @@
 	contains = list(/obj/item/storage/guncase/winchester)
 	crate_name = "rifle crate"
 	faction = /datum/faction/srm
+	faction_discount = 20
 
 /datum/supply_pack/gun/absolution
 	name = "Absolution Lever Action Rifle Crate"

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -361,11 +361,11 @@
 	faction_locked = TRUE
 
 /datum/supply_pack/gun/wt550
-	name = "WT-550 Auto Rifle Crate"
+	name = "WT-550 PDW Crate"
 	desc = "Contains a high-powered, automatic personal defense weapon chambered in 4.6x30mm."
-	cost = 4000
+	cost = 3000
 	contains = list(/obj/item/storage/guncase/wt550)
-	crate_name = "auto rifle crate"
+	crate_name = "PDW crate"
 	faction_discount = 10
 	faction = /datum/faction/nt
 

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -175,6 +175,7 @@
 	contains = list(/obj/item/ammo_box/magazine/m9mm_cm70)
 	cost = 750
 	faction = /datum/faction/clip
+	faction_discount = 20
 
 /datum/supply_pack/magazine/cm357_mag
 	name = "CM-357 Magazine Crate"
@@ -189,6 +190,7 @@
 	contains = list(/obj/item/ammo_box/magazine/cm5_9mm)
 	cost = 750
 	faction = /datum/faction/clip
+	faction_discount = 20
 
 /datum/supply_pack/magazine/cm82_mag
 	name = "CM-82 Magazine Crate"
@@ -249,6 +251,7 @@
 	contains = list(/obj/item/ammo_box/magazine/pistol556mm)
 	cost = 750
 	faction = /datum/faction/solgov
+	faction_discount = 20
 
 /datum/supply_pack/magazine/fms_mag
 	name = "Ferromagnetic Slug Magazine Crate"
@@ -256,6 +259,7 @@
 	contains = list(/obj/item/ammo_box/magazine/modelh)
 	cost = 750
 	faction = /datum/faction/solgov
+	faction_discount = 20
 
 /datum/supply_pack/magazine/gar_ammo
 	name = "GAR Ferromagnetic Lance Magazine Crate"
@@ -279,6 +283,7 @@
 	contains = list(/obj/item/ammo_box/magazine/smgm10mm)
 	cost = 750
 	faction = /datum/faction/inteq
+	faction_discount = 20
 
 /* Shotguns */
 

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -2,22 +2,23 @@
 	group = "Magazines"
 	crate_type = /obj/structure/closet/crate/secure/gear
 	crate_name = "magazine crate"
+	faction_discount = 0
 
 
 /* VI */
 
 /datum/supply_pack/magazine/co9mm_mag
 	name = "9mm Commander Magazine Crate"
-	desc = "Contains a 9mm magazine for the standard-issue Commander pistol, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/co9mm)
-	cost = 500
+	desc = "Contains a 9mm magazine for the standard-issue Commander pistol, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
+	cost = 150
 	faction = /datum/faction/nt
 
 /datum/supply_pack/magazine/smgm9mm_mag
 	name = "9mm SMG Magazine Crate"
-	desc = "Contains a 9mm magazine for the Vector and Saber SMGs, containing thirty rounds."
-	contains = list(/obj/item/ammo_box/magazine/smgm9mm)
-	cost = 500
+	desc = "Contains a 9mm magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
+	contains = list(/obj/item/ammo_box/magazine/smgm9mm/empty)
+	cost = 300
 	faction = /datum/faction/nt
 	faction_discount = 0
 	faction_locked = TRUE
@@ -28,202 +29,206 @@
 /datum/supply_pack/magazine/c38_mag
 	name = ".38 Speedloader Crate"
 	desc = "Contains a .38 speedloader for revolvers, containing six rounds."
-	contains = list(/obj/item/ammo_box/c38)
-	cost = 250
+	contains = list(/obj/item/ammo_box/c38/empty)
+	cost = 100
 	faction_discount = 20
-	faction = /datum/faction/srm
-
-/datum/supply_pack/magazine/c38match
-	name = ".38 Match Grade Speedloader"
-	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots."
-	cost = 200
-	small_item = TRUE
-	contains = list(/obj/item/ammo_box/c38/match)
-	crate_name = ".38 match crate"
-	faction = /datum/faction/srm
-
-/datum/supply_pack/magazine/c38dumdum
-	name = ".38 DumDum Speedloader"
-	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."
-	cost = 200
-	small_item = TRUE
-	contains = list(/obj/item/ammo_box/c38/dumdum)
-	crate_name = ".38 match crate"
 	faction = /datum/faction/srm
 
 /datum/supply_pack/magazine/m45_mag
 	name = ".45 ACP Candor Magazine Crate"
-	desc = "Contains a .45 ACP magazine for the Candor pistol, containing eight rounds."
-	contains = list(/obj/item/ammo_box/magazine/m45)
-	cost = 500
+	desc = "Contains a .45 ACP magazine for the Candor pistol, with a capacity of eight rounds."
+	contains = list(/obj/item/ammo_box/magazine/m45/empty)
+	cost = 100
 	faction = /datum/faction/srm
 
 /datum/supply_pack/magazine/a44roum_speedloader
 	name = ".44 Roumain Speedloader Crate"
-	desc = "Contains a .44 Roumain speedloader for the HP Montagne, containing six rounds."
-	contains = list(/obj/item/ammo_box/a44roum_speedloader)
-	cost = 400
+	desc = "Contains a .44 Roumain speedloader for the HP Montagne, with a capacity of six rounds."
+	contains = list(/obj/item/ammo_box/a44roum_speedloader/empty)
+	cost = 250
 	faction = /datum/faction/srm
+
+/datum/supply_pack/magazine/firestorm_mag
+	name = "Firestorm Magazine Crate"
+	desc = "Contains a 28-round magazine for the Hunter's Pride Firestorm SMG."
+	contains = list(/obj/item/ammo_box/magazine/c45_firestorm_mag/empty)
+	cost = 300
+	faction = /datum/faction/srm
+
 
 /* Serene Sporting */
 
 /datum/supply_pack/magazine/m17_mag
 	name = "Micro Target Magazine Crate"
-	desc = "Contains a .22lr magazine for the Micro Target pistol, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/m17)
+	desc = "Contains a .22lr magazine for the Micro Target pistol, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/m17/empty)
 	cost = 100
 
 /datum/supply_pack/magazine/m12_mag
 	name = "Sporter Magazine Crate"
-	desc = "Contains a .22lr magazine for the Sporter Rifle, containing 25 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m12_sporter)
+	desc = "Contains a .22lr magazine for the Sporter Rifle, with a capacity of 25 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m12_sporter/empty)
 	cost = 200
 
 /datum/supply_pack/magazine/m15_mag
 	name = "Super Sporter Magazine Crate"
-	desc = "Contains a 5.56 CLIP magazine for the Super Sporter Rifle, containing 20 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m15)
+	desc = "Contains a 5.56 CLIP magazine for the Super Sporter Rifle, with a capacity of 20 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m15/empty)
 	cost = 300
 
 /* Scarbie */
 
 /datum/supply_pack/magazine/himehabu_mag
 	name = "Himehabu Magazine Crate"
-	desc = "Contains a .22lr magazine for the Himehabu pistol, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/m22lr_himehabu)
-	cost = 200
+	desc = "Contains a .22lr magazine for the Himehabu pistol, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/m22lr_himehabu/empty)
+	cost = 100
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/asp_mag
 	name = "Asp Magazine Crate"
-	desc = "Contains a 5.7x39mm magazine for the Asp pistol, containing 12 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m57_39_asp)
-	cost = 400
+	desc = "Contains a 5.7x39mm magazine for the Asp pistol, with a capacity of 12 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m57_39_asp/empty)
+	cost = 250
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/m10mm_mag
 	name = "Ringneck Magazine Crate"
-	desc = "Contains a 10mm magazine for the Ringneck pistol, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/m10mm_ringneck)
-	cost = 500
+	desc = "Contains a 10mm magazine for the Ringneck pistol, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/m10mm_ringneck/empty)
+	cost = 150
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/m9mm_rattlesnake
 	name = "Rattlesnake Magazine Crate"
-	desc = "Contains a 9mm magazine for the Rattlesnake machine pistol, contains 18 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m9mm_rattlesnake)
-	cost = 500
+	desc = "Contains a 9mm magazine for the Rattlesnake machine pistol, with a capacity of 18 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m9mm_rattlesnake/empty)
+	cost = 300
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/a357_mag
 	name = ".357 Speedloader Crate"
-	desc = "Contains a .357 speedloader for revolvers, containing seven rounds."
-	contains = list(/obj/item/ammo_box/a357)
-	cost = 750
+	desc = "Contains a .357 speedloader for revolvers, with a capacity of six rounds."
+	contains = list(/obj/item/ammo_box/a357/empty)
+	cost = 250
 	faction_discount = 20
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/sidewinder_mag
 	name = "Sidewinder Magazine Crate"
 	desc = "Contains a 30 round magazine for the Sidewinder SMG."
-	contains = list(/obj/item/ammo_box/magazine/m57_39_sidewinder)
-	cost = 750
-	faction_discount = 20
+	contains = list(/obj/item/ammo_box/magazine/m57_39_sidewinder/empty)
+	cost = 300
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/c45_cobra_mag
 	name = "Cobra Magazine Crate"
-	desc = "Contains a .45 magazine for the Cobra-20, containing 24 rounds."
-	cost = 750
-	contains = list(/obj/item/ammo_box/magazine/m45_cobra)
-	faction_discount = 20
+	desc = "Contains a .45 magazine for the Cobra-20, with a capacity of 24 rounds."
+	cost = 300
+	contains = list(/obj/item/ammo_box/magazine/m45_cobra/empty)
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/short_hydra_mag
 	name = "SBR-80 DMR Short Magazine Crate"
-	desc = "Contains a 5.56x42mm CLIP made specially for the SBR-80 Designated Marksman Rifle, containing 20 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra/small)
-	cost = 1000
+	desc = "Contains a 5.56x42mm CLIP made specially for the SBR-80 Designated Marksman Rifle, with a capacity of 20 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra/small/empty)
+	cost = 400
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /datum/supply_pack/magazine/hydra_mag
 	name = "SMR-80 Rifle Magazine Crate"
-	desc = "Contains a 5.56x42mm CLIP for the SMR-80 assault rifle, containing 30 rounds."
-	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra)
-	cost = 1500
+	desc = "Contains a 5.56x42mm CLIP for the SMR-80 assault rifle, with a capacity of 30 rounds."
+	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra/empty)
+	cost = 500
 	faction = /datum/faction/syndicate/scarborough_arms
+
+/datum/supply_pack/magazine/saw_mag
+	name = "SAW-80 Magazine Crate"
+	desc = "Contains a 5.56x42mm CLIP magazine for the SAW-80 Squad Automatic Weapon, with a capacity of sixty rounds. Count your shots, they run out fast."
+	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra/extended/empty)
+	cost = 750
+	faction = /datum/faction/syndicate/scarborough_arms
+	faction_discount = 0
+	faction_locked = TRUE
 
 /datum/supply_pack/magazine/boomslang_mag
 	name = "Boomslang-90 Magazine Crate"
-	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, containing five rounds."
-	contains = list(/obj/item/ammo_box/magazine/boomslang/short)
-	cost = 1000
+	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, with a capacity of five rounds."
+	contains = list(/obj/item/ammo_box/magazine/boomslang/short/empty)
+	cost = 750
 	faction = /datum/faction/syndicate/scarborough_arms
 
 /* CM Lancaster */
 
 /datum/supply_pack/magazine/cm23_mag
 	name = "CM-23 Magazine Crate"
-	desc = "Contains a 10mm magazine for the CM-23 handgun."
-	contains = list(/obj/item/ammo_box/magazine/cm23)
-	cost = 500
+	desc = "Contains a 10mm magazine for the CM-23 handgun with a capacity of 10 rounds."
+	contains = list(/obj/item/ammo_box/magazine/cm23/empty)
+	cost = 150
 	faction = /datum/faction/clip
 
 /datum/supply_pack/magazine/cm70_mag
 	name = "CM-70 Magazine Crate"
 	desc = "Contains a 9mm magazine for the CM-70 machinepistol."
-	contains = list(/obj/item/ammo_box/magazine/m9mm_cm70)
-	cost = 750
+	contains = list(/obj/item/ammo_box/magazine/m9mm_cm70/empty)
+	cost = 350
 	faction = /datum/faction/clip
 	faction_discount = 20
 
 /datum/supply_pack/magazine/cm357_mag
 	name = "CM-357 Magazine Crate"
-	desc = "Contains a .357 magazine for the CM-357 automag pistol."
-	contains = list(/obj/item/ammo_box/magazine/cm357)
-	cost = 1000
+	desc = "Contains a .357 magazine for the CM-357 automag pistol with a capacity of 7 rounds."
+	contains = list(/obj/item/ammo_box/magazine/cm357/empty)
+	cost = 250
 	faction = /datum/faction/clip
 
 /datum/supply_pack/magazine/cm5_mag
 	name = "CM-5 Magazine Crate"
-	desc = "Contains a 9mm magazine for the CM-5 SMG."
-	contains = list(/obj/item/ammo_box/magazine/cm5_9mm)
-	cost = 750
+	desc = "Contains a 9mm magazine for the CM-5 SMG with a capacity of 30 rounds."
+	contains = list(/obj/item/ammo_box/magazine/cm5_9mm/empty)
+	cost = 300
 	faction = /datum/faction/clip
 	faction_discount = 20
 
 /datum/supply_pack/magazine/cm82_mag
 	name = "CM-82 Magazine Crate"
-	desc = "Contains a 5.56mm magazine for the CM-82 rifle, containing thirty rounds. Notably, these are also compatable with the P-16 rifle."
-	contains = list(/obj/item/ammo_box/magazine/p16)
-	cost = 1000
+	desc = "Contains a 5.56mm magazine for the CM-82 rifle, with a capacity of thirty rounds."
+	contains = list(/obj/item/ammo_box/magazine/p16/empty)
+	cost = 500
 	faction = /datum/faction/clip
 
 /datum/supply_pack/magazine/skm_ammo
 	name = "SKM Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, containing twenty rounds."
-	contains = list(/obj/item/ammo_box/magazine/skm_762_40)
-	cost = 1000
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of twenty rounds."
+	contains = list(/obj/item/ammo_box/magazine/skm_762_40/empty)
+	cost = 500
 
 /datum/supply_pack/magazine/f4_mag
 	name = "F4 Magazine Crate"
-	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/f4_308)
-	cost = 1000
+	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/f4_308/empty)
+	cost = 500
 	faction = /datum/faction/clip
 
 /datum/supply_pack/magazine/f90
 	name = "CM-F90 Magazine Crate"
 	desc = "Contains a 5-round 6.5mm magazine for use with the CM-F90 sniper rifle."
-	contains = list(/obj/item/ammo_box/magazine/f90)
-	cost = 1000
+	contains = list(/obj/item/ammo_box/magazine/f90/empty)
+	cost = 750
 	faction = /datum/faction/clip
 
 /datum/supply_pack/magazine/cm15
 	name = "CM-15 Magazine Crate"
 	desc = "Contains an 8-round 12ga magazine for the CM-15 Automatic Shotgun."
-	contains = list(/obj/item/ammo_box/magazine/cm15_12g)
-	cost = 1500
+	contains = list(/obj/item/ammo_box/magazine/cm15_12g/empty)
+	cost = 750
+	faction = /datum/faction/clip
+
+/datum/supply_pack/magazine/cm40
+	name = "CM-40 Magazine Crate"
+	desc = "Contains an 80-round 7.62x40mm CLIP box for the CM-40 Squad Automatic Weapon. Consider designating an ammo bearer."
+	contains = list(/obj/item/ammo_box/magazine/cm40_762_40_box/empty)
+	cost = 1000
 	faction = /datum/faction/clip
 
 /* NT */
@@ -231,67 +236,56 @@
 /datum/supply_pack/magazine/wt550_mag
 	name = "WT-550 Auto Rifle Magazine Crate"
 	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
-	cost = 750
-	contains = list(/obj/item/ammo_box/magazine/wt550m9)
-	faction_discount = 20
-	faction = /datum/faction/nt
-
-/datum/supply_pack/magazine/ap_wt550_mag
-	name = "WT-550 Auto Rifle AP Magazine Crate"
-	desc = "Contains one magazine of armor-piercing ammunition for the WT-550 Auto Rifle."
-	cost = 1000
-	contains = list(/obj/item/ammo_box/magazine/wt550m9/ap)
+	cost = 300
+	contains = list(/obj/item/ammo_box/magazine/wt550m9/empty)
 	faction = /datum/faction/nt
 
 /* Solgov */
 
 /datum/supply_pack/magazine/mag_556mm
 	name = "5.56 Pistole C Magazine Crate"
-	desc = "Contains a 5.56mm magazine for the Pistole C, containing twelve rounds."
-	contains = list(/obj/item/ammo_box/magazine/pistol556mm)
-	cost = 750
+	desc = "Contains a 5.56mm magazine for the Pistole C, with a capacity of twelve rounds."
+	contains = list(/obj/item/ammo_box/magazine/pistol556mm/empty)
+	cost = 150
 	faction = /datum/faction/solgov
-	faction_discount = 20
 
 /datum/supply_pack/magazine/fms_mag
 	name = "Ferromagnetic Slug Magazine Crate"
-	desc = "Contains a ferromagnetic slug magazine for the Model H pistol, containing ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/modelh)
-	cost = 750
+	desc = "Contains a ferromagnetic slug magazine for the Model H pistol, with a capacity of ten rounds."
+	contains = list(/obj/item/ammo_box/magazine/modelh/empty)
+	cost = 350
 	faction = /datum/faction/solgov
-	faction_discount = 20
 
 /datum/supply_pack/magazine/gar_ammo
 	name = "GAR Ferromagnetic Lance Magazine Crate"
-	desc = "Contains a ferromagnetic lance magazine for the GAR rifle, containing thirty two rounds."
-	contains = list(/obj/item/ammo_box/magazine/gar)
-	cost = 1000
+	desc = "Contains a ferromagnetic lance magazine for the GAR rifle, with a capacity of thirty two rounds."
+	contains = list(/obj/item/ammo_box/magazine/gar/empty)
+	cost = 500
 	faction = /datum/faction/solgov
 
 /datum/supply_pack/magazine/claris_ammo
 	name = "Claris Ferromagnetic Pellet Speedloader Crate"
-	desc = "Contains a ferromagnetic pellet speedloader for the Claris rifle, containing twenty two rounds."
-	contains = list(/obj/item/ammo_box/amagpellet_claris)
-	cost = 1000
+	desc = "Contains a ferromagnetic pellet speedloader for the Claris rifle, with a capacity of twenty two rounds."
+	contains = list(/obj/item/ammo_box/amagpellet_claris/empty)
+	cost = 400
 	faction = /datum/faction/solgov
 
 /* Inteq */
 
 /datum/supply_pack/magazine/mongrel_mag
 	name = "Mongrel Magazine Crate"
-	desc = "Contains a 10mm magazine for the SKM-44v 'Mongrel' SMG, containing twenty-four rounds."
-	contains = list(/obj/item/ammo_box/magazine/smgm10mm)
-	cost = 750
+	desc = "Contains a 10mm magazine for the SKM-44v 'Mongrel' SMG, with a capacity of twenty-four rounds."
+	contains = list(/obj/item/ammo_box/magazine/smgm10mm/empty)
+	cost = 300
 	faction = /datum/faction/inteq
-	faction_discount = 20
 
 /* Shotguns */
 
 /datum/supply_pack/magazine/bulldog
 	name = "Bulldog Magazine Crate"
 	desc = "Contains an 8-round 12ga box magazine for the Bulldog weapons platform."
-	contains = list(/obj/item/ammo_box/magazine/m12g_bulldog)
-	cost = 1000
+	contains = list(/obj/item/ammo_box/magazine/m12g_bulldog/empty)
+	cost = 750
 	faction = /datum/faction/syndicate/scarborough_arms
 
 
@@ -317,7 +311,7 @@
 	name = "Upgraded Weapon Cell Crate"
 	desc = "Contains an upgraded weapon cell, compatible with laser guns. For NT use only."
 	contains = list(/obj/item/stock_parts/cell/gun/upgraded)
-	cost = 1500
+	cost = 1000
 	faction = /datum/faction/nt
 	faction_discount = 0
 	faction_locked = TRUE
@@ -335,7 +329,7 @@
 	name = "Etherbor Cell Crate"
 	desc = "Contains a military-grade Etherbor weapon cell produced for the PGFMC, compatible with Etherbor armaments with a significantly higher capacity."
 	contains = list(/obj/item/stock_parts/cell/gun/pgf)
-	cost = 1500
+	cost = 1000
 	faction = /datum/faction/pgf
 	faction_discount = 0
 	faction_locked = TRUE

--- a/code/modules/projectiles/boxes_magazines/ammo_loaders.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_loaders.dm
@@ -41,6 +41,9 @@
 	w_class = WEIGHT_CLASS_TINY
 	instant_load = TRUE
 
+/obj/item/ammo_box/c38/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/c38/trac
 	name = "speed loader (.38 TRAC)"
 	desc = "A 6-round speed loader for quickly reloading .38 special revolvers. These TRAC rounds do pitiful damage, but embed a tracking device in targets hit."
@@ -148,6 +151,9 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	item_flags = NO_MAT_REDEMPTION
 	instant_load = TRUE
+
+/obj/item/ammo_box/amagpellet_claris/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/a40mm
 	name = "ammo box (40mm grenades)"

--- a/code/modules/projectiles/boxes_magazines/external/gauss.dm
+++ b/code/modules/projectiles/boxes_magazines/external/gauss.dm
@@ -7,6 +7,9 @@
 	max_ammo = 24
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
+/obj/item/ammo_box/magazine/gauss/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/modelh
 	name = "Model H magazine (ferromagnetic slugs)"
 	desc = "A 10-round magazine for the Model H pistol. Ferromagnetic slugs are slow and incredibly powerful bullets, but are easily stopped by even a sliver of armor."
@@ -31,3 +34,6 @@
 /obj/item/ammo_box/magazine/gar/update_icon()
 	. = ..()
 	icon_state = "gar-mag-[!!ammo_count()]"
+
+/obj/item/ammo_box/magazine/gar/empty
+	start_empty = TRUE

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -52,6 +52,8 @@
 	else
 		icon_state = "[base_icon_state]-0"
 
+/obj/item/ammo_box/magazine/pistol556mm/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/co9mm/hp
 	name = "pistol magazine (9mm HP)"

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,13 +1,3 @@
-/obj/item/ammo_box/magazine/m556_42_hydra
-	name = "toploader magazine (5.56x42mm)"
-	desc = "An advanced, 30-round toploading magazine for the M-90gl Carbine. These rounds do moderate damage with good armor penetration."
-	icon_state = "5.56m-1"
-	base_icon_state = "5.56m"
-	ammo_type = /obj/item/ammo_casing/a556_42
-	caliber = "5.56x42mm"
-	max_ammo = 30
-	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
 /obj/item/ammo_box/magazine/rifle47x33mm
 	name = "\improper Solarian LMG magazine (4.73x33mm caseless)"
 	desc = "A large, 50-round magazine for the Solar machine gun. These rounds do moderate damage with good armor penetration."
@@ -72,6 +62,9 @@
 	caliber = ".308"
 	max_ammo = 10
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/f4_308/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/p16 //repath to /obj/item/ammo_box/magazine/generic_556 sometime
 	name = "assault rifle magazine (5.56x42mm CLIP)"

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -8,6 +8,9 @@
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
+/obj/item/ammo_box/magazine/cm15_12g/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/cm15_12g/incendiary
 	name = "CM-15 magazine (12g incendiary)"
 	desc = "An almost straight, 8-round magazine designed for the CM-15 shotgun. This one was loaded with incendiary slugs. Be careful!"

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -34,6 +34,9 @@
 	. = ..()
 	icon_state = "[base_icon_state]-[ammo_count() ? 42 : 0]"
 
+/obj/item/ammo_box/magazine/smgm9mm/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/smgm9mm/ap
 	name = "SMG magazine (9mm AP)"
 	desc = "A 30-round magazine for 9mm submachine guns. These armor-piercing rounds are okay at piercing protective equipment, but lose some stopping power."
@@ -56,6 +59,9 @@
 /obj/item/ammo_box/magazine/smgm10mm/update_icon_state()
 	. = ..()
 	icon_state = "[base_icon_state]-[ammo_count() == 1 ? 1 : round(ammo_count(),3)]"
+
+/obj/item/ammo_box/magazine/smgm10mm/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/smgm10mm/rubber
 	name = "SMG magazine (10mm rubber)"
@@ -90,6 +96,9 @@
 /obj/item/ammo_box/magazine/c45_firestorm_mag/update_icon_state()
 	. = ..()
 	icon_state = "firestorm_mag-[!!ammo_count()]"
+
+/obj/item/ammo_box/magazine/c45_firestorm_mag/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/c45_firestorm_mag/pan
 	name = "pan magazine (.45)"

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -107,6 +107,9 @@
 	. = ..()
 	icon_state = "[base_icon_state]_[ammo_count() == 1 ? 1 : round(ammo_count(),3)]"
 
+/obj/item/ammo_box/magazine/m9mm_cm70/empty
+	start_empty = TRUE
+
 /obj/item/gun/ballistic/automatic/pistol/cm357
 	name = "\improper CM-357"
 	desc = "A semi-automatic magnum handgun designed specifically for BARD's megafauna removal unit, as standard handguns had proven useless as backup weapons. Its heft and power have also made it a status symbol among the few CLIP officers able to requisition one. Chambered in .357."
@@ -204,6 +207,9 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 	caliber = "9mm"
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/cm5_9mm/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/cm5_9mm/rubber
 	desc = "A 30-round magazine for the CM-5 submachine gun. These rubber rounds trade lethality for a heavy impact which can incapacitate targets. Performs even worse against armor."
@@ -398,6 +404,9 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 	. = ..()
 	icon_state = "[base_icon_state]-[!!ammo_count()]"
 
+/obj/item/ammo_box/magazine/f90/empty
+	start_empty = TRUE
+
 //########### RIFLES ###########//
 /obj/item/gun/ballistic/automatic/assault/cm82
 	name = "\improper CM-82"
@@ -514,6 +523,9 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 /obj/item/ammo_box/magazine/cm40_762_40_box/update_icon_state()
 	. = ..()
 	icon_state = "[base_icon_state]-[!!ammo_count()]"
+
+/obj/item/ammo_box/magazine/cm40_762_40_box/empty
+	start_empty = TRUE
 
 //########### MISC ###########//
 

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -353,6 +353,9 @@ NO_MAG_GUN_HELPER(automatic/pistol/himehabu)
 	w_class = WEIGHT_CLASS_SMALL
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
+/obj/item/ammo_box/magazine/m22lr_himehabu/empty
+	start_empty = TRUE
+
 //########### SMGS ###########//
 
 
@@ -507,6 +510,9 @@ NO_MAG_GUN_HELPER(automatic/smg/sidewinder)
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
+/obj/item/ammo_box/magazine/m57_39_sidewinder/empty
+	start_empty = TRUE
+
 //########### MARKSMAN ###########//
 /obj/item/gun/ballistic/automatic/marksman/boomslang
 	name = "MSR-90 \"Boomslang\""
@@ -595,6 +601,9 @@ NO_MAG_GUN_HELPER(automatic/marksman/boomslang/indie)
 	caliber = "6.5CLIP"
 	max_ammo = 5
 	multiple_sprites = AMMO_BOX_PER_BULLET
+
+/obj/item/ammo_box/magazine/boomslang/short/empty
+	start_empty = TRUE
 
 /obj/item/gun/ballistic/automatic/marksman/taipan
 	name = "AMR-83 \"Taipan\""
@@ -868,12 +877,18 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 		return
 	icon_state = "[base_icon_state]-[ammo_count() == 1 ? 1 : round(ammo_count(),5)]"
 
+/obj/item/ammo_box/magazine/m556_42_hydra/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/m556_42_hydra/small
 	name = "Short Hydra assault rifle magazine (5.56x42mm CLIP)"
 	desc = "A short, 20-round magazine for the Hydra platform of 5.56x42mm CLIP assault rifles; intended for the DMR variant. These rounds do moderate damage with good armor penetration."
 	icon_state = "hydra_small_mag-20"
 	base_icon_state = "hydra_small_mag"
 	max_ammo = 20
+
+/obj/item/ammo_box/magazine/m556_42_hydra/small/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/m556_42_hydra/extended
 	name = "extended Hydra assault rifle magazine (5.56x42mm CLIP)"
@@ -882,6 +897,9 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 	base_icon_state = "hydra_extended_mag"
 	max_ammo = 60
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/m556_42_hydra/extended/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/m556_42_hydra/casket
 	name = "casket Hydra assault rifle magazine (5.56x42mm CLIP)"


### PR DESCRIPTION
## About The Pull Request

Some cargo packs due to discounts were priced at decimal values. This is not good, so I fixed it. In the process, I realized magazines should probably come empty and added empty variants. As such I have also decreased the cost of magazines to not be absolutely absurd. I mean seriously, who pays 500 credits (half the cost of a Commander) for a magazine for the gun? It can't be that expensive to manufacture. 

Also adds other weapons I forgot into factional cargo, namely the last member of the SMR-80 AR family, the SAW-80. Also the CM-40, and magazines for it (the gun is also available in ruins so this now allows it to be fielded easier.)

Additional changes involve the lowering of the price of the WT-550 PDW from 4000 to 3000 (you might as well buy an assault rifle at that price) and the Solarian 'GAR' Carbine for 5000. 

The GAR is equivalent in firepower to an SKM following a nerf in another PR apparently, so it has been priced as such.

## Why It's Good For The Game

Doesn't potentially destroy our economic systems by creating a decimal value of currency anymore. Magazines generally aren't sold in gun stores with live ammunition, and also - they probably shouldn't be nearing the costs of the rifles. 

## Changelog

:cl:
add: Commissioner, SAW-80, GAR Carbine, and CM-40 to factional cargo
fix: Decimal cargo prices
balance: Magazines now come completely empty. As a result of this, they have now been made cheaper.
/:cl:
