### PR TITLE
Wasteplanet wall girders are less tough

### DIFF
--- a/code/game/objects/effects/spawners/random/waste_planet.dm
+++ b/code/game/objects/effects/spawners/random/waste_planet.dm
@@ -78,6 +78,9 @@
 
 /obj/effect/spawner/random/waste/girder
 	loot = list(
+		/obj/structure/girder/wasteworld,
+		/obj/structure/girder/wasteworld,
+		/obj/structure/girder/wasteworld,
 		/obj/structure/girder,
 		/obj/structure/girder/displaced,
 		/obj/structure/girder/reinforced

--- a/code/game/turfs/open/floor/plating/wasteplanet.dm
+++ b/code/game/turfs/open/floor/plating/wasteplanet.dm
@@ -269,6 +269,7 @@
 	max_integrity = 800
 	integrity = 800
 	baseturfs = /turf/open/floor/plating/wasteplanet
+	girder_type = /obj/structure/girder/wasteworld
 
 /turf/closed/wall/r_wall/wasteplanet/Initialize(mapload, inherited_virtual_z)
 	. = ..()
@@ -280,6 +281,7 @@
 	max_integrity = 600
 	integrity = 600
 	baseturfs = /turf/open/floor/plating/wasteplanet/rust
+	girder_type = /obj/structure/girder/wasteworld
 
 /turf/closed/wall/r_wall/rust/wasteplanet/Initialize(mapload, inherited_virtual_z)
 	. = ..()

--- a/code/game/turfs/open/floor/plating/wasteplanet.dm
+++ b/code/game/turfs/open/floor/plating/wasteplanet.dm
@@ -290,6 +290,7 @@
 	max_integrity = 200
 	integrity = 200
 	baseturfs = /turf/open/floor/plating/wasteplanet
+	girder_type = /obj/structure/girder/wasteworld
 
 /turf/closed/wall/wasteplanet/Initialize(mapload, inherited_virtual_z)
 	. = ..()
@@ -300,6 +301,7 @@
 	max_integrity = 100
 	integrity = 100
 	baseturfs = /turf/open/floor/plating/wasteplanet/rust
+	girder_type = /obj/structure/girder/wasteworld
 
 /turf/closed/wall/rust/wasteplanet/Initialize(mapload, inherited_virtual_z)
 	. = ..()
@@ -325,3 +327,8 @@
 	. = ..()
 	if(prob(25))
 		alter_integrity(-rand(0,500))
+
+//girlder
+
+/obj/structure/girder/wasteworld
+	max_integrity = 40


### PR DESCRIPTION
:cl:
balance: Girders on wasteplanet walls are no longer more durable than the walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
