### PR TITLE
Loadout Additions: Desk Flags, Action Figures, Posters and Two Neck Items

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -65,6 +65,12 @@
 	poster_type = /obj/structure/sign/poster/rilena/random
 	icon_state = "rolled_rilena"
 
+/obj/item/poster/gec
+	name = "GEC poster"
+	poster_type = /obj/structure/sign/poster/contraband/gec
+	icon_state = "rolled_poster"
+
+
 // The poster sign/structure
 
 /obj/structure/sign/poster

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -70,7 +70,6 @@
 	poster_type = /obj/structure/sign/poster/contraband/gec
 	icon_state = "rolled_poster"
 
-
 // The poster sign/structure
 
 /obj/structure/sign/poster

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -24,6 +24,10 @@
 	display_name = "shemagh"
 	path = /obj/item/clothing/neck/shemagh
 
+/datum/gear/accessory/shemagh
+	display_name = "shemagh, new gorlex"
+	path = /obj/item/clothing/neck/shemagh/ngr
+
 //(The actually good scarves)
 
 /datum/gear/accessory/scarf/striped
@@ -40,6 +44,10 @@
 /datum/gear/accessory/scarf/striped/blue
 	display_name = "striped scarf, blue"
 	path = /obj/item/clothing/neck/stripedbluescarf
+
+/datum/gear/accessory/scarf/striped/solarian
+	display_name = "striped scarf, solarian"
+	path = /obj/item/clothing/neck/stripedsolgovscarf
 
 //Ties
 
@@ -135,7 +143,6 @@
 /datum/gear/accessory/stethoscope
 	display_name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
-	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 
 /datum/gear/accessory/headphones
 	display_name = "headphones"

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -91,6 +91,38 @@
 	display_name = "paper bin"
 	path = /obj/item/paper_bin
 
+/datum/gear/desklamp
+	display_name = "desk lamp"
+	path = /obj/item/flashlight/lamp
+
+/datum/gear/desklamp_green
+	display_name = "desk lamp, old"
+	path = /obj/item/flashlight/lamp/green
+
+/datum/gear/deskflag
+	display_name = "desk flag, white"
+	path = /obj/item/desk_flag
+
+/datum/gear/deskflag_gezena
+	display_name = "desk flag, gezena"
+	path = /obj/item/desk_flag/gezena
+
+/datum/gear/deskflag_solgov
+	display_name = "desk flag, solcon"
+	path = /obj/item/desk_flag/solgov
+
+/datum/gear/deskflag_NGR
+	display_name = "desk flag, new gorlex"
+	path = /obj/item/desk_flag/ngr
+
+/datum/gear/deskflag_SUNS
+	display_name = "desk flag, suns"
+	path = /obj/item/desk_flag/suns
+
+/datum/gear/deskflag_trans
+	display_name = "desk flag, trans"
+	path = /obj/item/desk_flag/trans
+
 /datum/gear/cane
 	display_name = "cane"
 	path = /obj/item/cane
@@ -128,6 +160,30 @@
 	display_name = "toy, rilena tali plushie"
 	path = /obj/item/toy/plush/tali
 
+/datum/gear/tali_figure
+	display_name = "toy, rilena tali action figure"
+	path = /obj/item/toy/figure/tali
+
+/datum/gear/xeno_figure
+	display_name = "toy, xenomorph action figure"
+	path = /obj/item/toy/toy_xeno
+
+/datum/gear/inteq_figure
+	display_name = "toy, inteq enforcer action figure"
+	path = /obj/item/toy/figure/inteq
+
+/datum/gear/nuke_figure
+	display_name = "toy, nuclear weapon action figure"
+	path = /obj/item/toy/nuke
+
+/datum/gear/griffin_figure
+	display_name = "toy, rilena tali action figure"
+	path = /obj/item/toy/talking/griffin
+
+/datum/gear/owl_figure
+	display_name = "toy, rilena tali action figure"
+	path = /obj/item/toy/talking/owl
+
 /datum/gear/amongus
 	display_name = "toy, suspicious pill plushie"
 	path = /obj/item/toy/plush/among
@@ -162,6 +218,26 @@
 	display_name = "poster, rilena"
 	path = /obj/item/poster/random_rilena
 	description = "A random poster of the RILENA series."
+
+/datum/gear/gec_poster
+	display_name = "poster, gec"
+	path = /obj/item/poster/gec
+	description = "A poster representing the Galactic Engineering Concordat union."
+
+/obj/item/poster/random_minutemen
+	display_name = "poster, clip"
+	path = /obj/item/poster/gec
+	description = "A random poster from the Confederated League of Independent Planets."
+
+/obj/item/poster/random_retro
+	display_name = "poster, retro"
+	path = /obj/item/poster/gec
+	description = "A random retro poster from the early days of NT."
+
+/obj/item/poster/random_solgov
+	display_name = "poster, solcon"
+	path = /obj/item/poster/gec
+	description = "A random poster from the Solar Confederation."
 
 /datum/gear/camera
 	display_name = "polaroid camera"

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -177,11 +177,11 @@
 	path = /obj/item/toy/nuke
 
 /datum/gear/griffin_figure
-	display_name = "toy, rilena tali action figure"
+	display_name = "toy, griffin action figure"
 	path = /obj/item/toy/talking/griffin
 
 /datum/gear/owl_figure
-	display_name = "toy, rilena tali action figure"
+	display_name = "toy, owl action figure"
 	path = /obj/item/toy/talking/owl
 
 /datum/gear/amongus

--- a/code/modules/client/loadout/loadout_hat.dm
+++ b/code/modules/client/loadout/loadout_hat.dm
@@ -9,17 +9,14 @@
 /datum/gear/hat/hhat_yellow
 	display_name = "hardhat, yellow"
 	path = /obj/item/clothing/head/hardhat
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
 
 /datum/gear/hat/hhat_orange
 	display_name = "hardhat, orange"
 	path = /obj/item/clothing/head/hardhat/orange
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
 
 /datum/gear/hat/hhat_blue
 	display_name = "hardhat, blue"
 	path = /obj/item/clothing/head/hardhat/dblue
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
 
 //Berets, AKA how I lost my will to live again
 
@@ -76,7 +73,6 @@
 /datum/gear/hat/beret/engineering/hazard
 	display_name = "beret, hazard"
 	path = /obj/item/clothing/head/beret/eng/hazard
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer")
 
 //Soft caps
 


### PR DESCRIPTION
## About The Pull Request

Adds all available desk flags, a few generic action figures, the NGR Shemagh and Solarian Scarf, and random retro, CLIP and Solarian posters to the loadout. This also adds desk lamps.

Also removes "job restrictions" from certain loadout items. These literally never worked anyway and only served to gaslight people into not using said items. They used station role names anyways.

## Why It's Good For The Game

About everything here looks like I could buy it for 5$ on Etsy and goddamn I will spend those 5$ on Etsy to have a plastic flag on my desk to represent my nation.
This should allow people to personalize their in-game desks and workplaces much better and even represent their characters' heritages.

## Changelog

:cl:
add: A bunch of new loadout items! Check out the Accessories and General tab for more!
/:cl:
