### PR TITLE
Removes Lavaland Tumors from Planetary Generation

### DIFF
--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -98,13 +98,11 @@
 	feature_spawn_chance = 0.3
 	feature_spawn_list = list(
 		/obj/structure/flora/rock/hell = 20,
-		/obj/structure/elite_tumor = 4,
 		/obj/structure/geyser/random = 4,
 		/obj/effect/spawner/random/anomaly/lava = 2,
 		/obj/structure/flora/rock/hell = 14,
 		/obj/structure/vein = 5,
 		/obj/structure/vein/classtwo = 2,
-		/obj/structure/elite_tumor = 2,
 		/obj/structure/geyser/random = 2,
 		/obj/structure/vein/classthree = 1,
 		/obj/effect/spawner/minefield = 1,

--- a/code/datums/mapgen/planetary/RockGenerator.dm
+++ b/code/datums/mapgen/planetary/RockGenerator.dm
@@ -87,7 +87,6 @@
 	feature_spawn_list = list(
 		/obj/structure/geyser/random = 80,
 		/obj/structure/vein = 60,
-		/obj/structure/elite_tumor = 40,
 		/obj/structure/vein/classtwo = 40,
 		/obj/effect/spawner/random/anomaly/rock = 10,
 		/obj/structure/vein/classthree = 10,
@@ -158,7 +157,6 @@
 		/obj/structure/vein = 3,
 		/obj/structure/geyser/random = 2,
 		/obj/structure/vein/classtwo = 2,
-		/obj/structure/elite_tumor = 1,
 		/obj/structure/vein/classthree = 1,
 		/obj/structure/spawner/burrow/rock_plant = 4,
 		/obj/effect/spawner/minefield = 1,

--- a/code/datums/mapgen/planetary/SandGenerator.dm
+++ b/code/datums/mapgen/planetary/SandGenerator.dm
@@ -94,7 +94,6 @@
 		/obj/structure/geyser/random = 8,
 		/obj/structure/vein = 8,
 		/obj/structure/vein/classtwo = 4,
-		/obj/structure/elite_tumor = 4,
 		/obj/structure/vein/classthree = 2,
 		/obj/effect/spawner/random/anomaly/sand = 1,
 	)
@@ -198,7 +197,6 @@
 		/obj/structure/vein = 8,
 		/obj/structure/geyser/random = 4,
 		/obj/structure/vein/classtwo = 4,
-		/obj/structure/elite_tumor = 4,
 		/obj/effect/spawner/random/anomaly/sand/cave = 1
 	)
 	mob_spawn_chance = 4


### PR DESCRIPTION
## About The Pull Request

Removes lavaland tumors from planetary generation. These are just- like, seriously cruft. Nobody interacts with them to begin with and the loot they drop is nearly 100% all cruft as well, being lavaland loot chests. I have not removed them completely from code as I have heard from a few people interest in doing something with them, but as it stands these are just- extremely out of place on planets and serve no purpose. 

## Changelog

:cl:
del: Surgically removed tumors (from planetary generation)
/:cl:
