### PR TITLE
Minor mapcut fix

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -6,12 +6,13 @@
 	allow_duplicates = FALSE
 	ruin_type = RUINTYPE_SPACE
 
-/datum/map_template/ruin/space/corporate_mining
-	id = "corporate_mining"
-	suffix = "corporate_mining.dmm"
-	name = "Corporate Mining Module"
-	description = "An old and rusty mining facility, with big ore potential."
-	ruin_tags = list(RUIN_TAG_NO_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
+/datum/map_template/ruin/space/bigderelict1
+	id = "bigderelict1"
+	suffix = "bigderelict1.dmm"
+	name = "Derelict Tradepost"
+	description = "A once-bustling tradestation that handled imports and exports from nearby stations now lays eerily dormant. \
+	The last received message was a distress call from one of the on-board officers, but we had no success in making contact again."
+	ruin_tags = list(RUIN_TAG_MINOR_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
 
 /datum/map_template/ruin/space/onehalf
 	id = "onehalf"


### PR DESCRIPTION
## About The Pull Request

As is in the title, fixes a small error in the maptainer mapcut PR

## Why It's Good For The Game

Instead of corporate mining being removed in the ruin datum, bigderelict1 was instead removed in said datum, causing corporate mining to be spawned instead with nothing. Fixes that so derelict1 exists again

## Changelog

:cl:
fix: Bigderelict1 now properly spawns instead of Corporate Mining
/:cl: