### PR TITLE
Pricehikes the SAW-80

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -572,7 +572,7 @@
 /datum/supply_pack/gun/saw80
 	name = "SAW-80 Squad Automatic Weapon"
 	desc = "Contains one of the rarely-produced SAW-80 Squad Automatic Weapon platforms, exclusively for licensed buyers. Remember, short controlled bursts!"
-	cost = 7000
+	cost = 8000
 	contains = list(/obj/item/storage/guncase/saw80)
 	crate_name = "LMG crate"
 	faction = /datum/faction/syndicate/scarborough_arms

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -572,7 +572,7 @@
 /datum/supply_pack/gun/saw80
 	name = "SAW-80 Squad Automatic Weapon"
 	desc = "Contains one of the rarely-produced SAW-80 Squad Automatic Weapon platforms, exclusively for licensed buyers. Remember, short controlled bursts!"
-	cost = 8000
+	cost = 7000
 	contains = list(/obj/item/storage/guncase/saw80)
 	crate_name = "LMG crate"
 	faction = /datum/faction/syndicate/scarborough_arms

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -572,7 +572,7 @@
 /datum/supply_pack/gun/saw80
 	name = "SAW-80 Squad Automatic Weapon"
 	desc = "Contains one of the rarely-produced SAW-80 Squad Automatic Weapon platforms, exclusively for licensed buyers. Remember, short controlled bursts!"
-	cost = 6000
+	cost = 8000
 	contains = list(/obj/item/storage/guncase/saw80)
 	crate_name = "LMG crate"
 	faction = /datum/faction/syndicate/scarborough_arms


### PR DESCRIPTION
## About The Pull Request

Oops! This is way too cheap for what it should be! At the current price it's being purchased over assault rifles on the regular.

Boosts the SAW-80 to 7000 credits instead of 6000.

## Why It's Good For The Game

This was not intended to be sold as the SMR-80 but better. 

## Changelog

:cl:
balance: SAW-80 is more expensive.
/:cl:
