### PR TITLE
platform / railing direction

### DIFF
--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -21,8 +21,8 @@
 
 /obj/structure/platform/update_appearance(updates)
 	. = ..()
-	if(dir == 1)
-		layer = 2.89
+	if(dir == (1 || 5 || 9))
+		layer = 2.76
 	else
 		layer = 3.08
 

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -13,7 +13,6 @@
 	var/buildstack = /obj/item/stack/rods
 	var/buildstackamount = 3
 
-
 /obj/structure/railing/Initialize()
 	. = ..()
 	if(density && flags_1 & ON_BORDER_1)
@@ -21,6 +20,13 @@
 			COMSIG_ATOM_EXIT = PROC_REF(on_exit),
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/structure/railing/update_appearance(updates)
+	. = ..()
+	if(dir = (1 || 5 || 9))
+		layer = 2.76
+	else
+		layer = 3.08
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/railing/update_appearance(updates)
 	. = ..()
-	if(dir = (1 || 5 || 9))
+	if(dir == (1 || 5 || 9))
 		layer = 2.76
 	else
 		layer = 3.08


### PR DESCRIPTION

## About The Pull Request

railing / platforms now are on lower layers when their direction is a northfacing dir.

## Changelog

:cl:
code: railing / platforms now are on lower layers when their direction is a northfacing dir.
/:cl:
