### PR TITLE
Legion Core Toxins

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1957,7 +1957,7 @@
 	color = "#302f20"
 	metabolization_rate = REAGENTS_METABOLISM * 0.8
 	overdose_threshold = 50
-	var/clone_dam = 0.1
+	var/tox_dam = 0.25
 
 /datum/reagent/medicine/soulus/expose_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -1976,7 +1976,7 @@
 /datum/reagent/medicine/soulus/on_mob_life(mob/living/carbon/M)
 	M.adjustFireLoss(-0.1*REM, 0)
 	M.adjustBruteLoss(-0.1*REM, 0)
-	M.adjustCloneLoss(clone_dam*REM, 0)
+	M.adjustToxLoss(tox_dam*REM, 0)
 	..()
 
 /datum/reagent/medicine/soulus/overdose_process(mob/living/M)
@@ -1997,7 +1997,7 @@
 	color = "#302f20"
 	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 100
-	clone_dam = 0
+	tox_dam = 0
 
 /datum/reagent/medicine/puce_essence		// P U C E
 	name = "Pucetylline Essence"


### PR DESCRIPTION

## About The Pull Request

I was wrong about the cloneloss. It blows. Legion cores now do toxin damage instead.


## Changelog

:cl:
balance: Legion cores now do toxin damage instead of cloneloss.
/:cl: