### PR TITLE
Cargo Security Tab Adjustments

### DIFF
--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -132,7 +132,8 @@
 
 /datum/supply_pack/sec_supply/baton
 	name = "Stun Baton Crate"
-	desc = "Arm your vessel security with a stun baton. Batteries included."	cost = 1500
+	desc = "Arm your vessel security with a stun baton. Batteries included."
+	cost = 1500
 	contains = list(/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
 

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -12,28 +12,14 @@
 	contains = list(/obj/item/clothing/accessory/holster)
 	crate_name = "holster crate"
 
-/datum/supply_pack/sec_supply/chemimp
-	name = "Chemical Implants Crate"
-	desc = "Contains five remote chemical implants."
-	cost = 1000
-	contains = list(/obj/item/storage/box/chemimp)
-	crate_name = "chemical implant crate"
-
-/datum/supply_pack/sec_supply/trackingimp
-	name = "Tracking Implants Crate"
-	desc = "Contains four tracking implants."
-	cost = 2000
-	contains = list(/obj/item/storage/box/trackimp)
-	crate_name = "tracking implant crate"
-
 /datum/supply_pack/sec_supply/securitybarriers
 	name = "Security Barrier Grenades"
-	desc = "Stem the tide with four Security Barrier grenades."
+	desc = "Halt the opposition with four Security Barrier grenades."
 	contains = list(/obj/item/grenade/barrier,
 					/obj/item/grenade/barrier,
 					/obj/item/grenade/barrier,
 					/obj/item/grenade/barrier)
-	cost = 2000
+	cost = 500
 	crate_name = "security barriers crate"
 
 /datum/supply_pack/sec_supply/empty_sandbags
@@ -43,25 +29,26 @@
 	cost = 150
 	crate_name = "sandbag crate"
 
-/datum/supply_pack/sec_supply/wall_flash
-	name = "Wall-Mounted Flash Crate"
-	desc = "Contains four wall-mounted flashes."
-	cost = 3000
-	contains = list(/obj/item/storage/box/wall_flash,
-					/obj/item/storage/box/wall_flash,
-					/obj/item/storage/box/wall_flash,
-					/obj/item/storage/box/wall_flash)
-	crate_name = "wall-mounted flash crate"
+/datum/supply_pack/sec_supply/flashbangs
+	name = "Flashbangs Crate"
+	desc = "Contains seven flashbangs for use in door breaching and riot control."
+	cost = 750
+	contains = list(/obj/item/storage/box/flashbangs)
+	crate_name = "flashbangs crate"
 
-/datum/supply_pack/sec_supply/supplies
-	name = "Security Supplies Crate"
-	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs."
-	cost = 5000
-	contains = list(/obj/item/storage/box/flashbangs,
-					/obj/item/storage/box/teargas,
-					/obj/item/storage/box/flashes,
-					/obj/item/storage/box/handcuffs)
-	crate_name = "security supply crate"
+/datum/supply_pack/sec_supply/teargas
+	name = "Teargas Grenades Crate"
+	desc = "Contains seven teargas grenades for use in crowd dispersion and riot control."
+	cost = 750
+	contains = list(/obj/item/storage/box/teargas)
+	crate_name = "teargas grenades crate"
+
+/datum/supply_pack/sec_supply/camera_console
+	name = "Camera Console Crate"
+	desc = "Contains a camera console circuit board, for a comprehensive surveillance system and peace of mind."
+	cost = 500
+	contains = list(/obj/item/circuitboard/computer/security)
+	crate_name = "camera console crate"
 
 /*
 		Misc. weapons / protection
@@ -122,6 +109,16 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
+/datum/supply_pack/sec_supply/pepper_spray
+	name = "Pepper Spray Crate"
+	desc = "Contains four pepper spray cans, for self defense on a budget."
+	cost = 250
+	contains = list(/obj/item/reagent_containers/spray/pepper,
+					/obj/item/reagent_containers/spray/pepper,
+					/obj/item/reagent_containers/spray/pepper,
+					/obj/item/reagent_containers/spray/pepper)
+	crate_name = "pepper spray crate"
+
 /*
 		Stamina / PVP weapons (intentionally overpriced due to odd balance position of stamina weapons)
 */
@@ -129,30 +126,15 @@
 /datum/supply_pack/sec_supply/stingpack
 	name = "Stingbang Grenade Pack"
 	desc = "Contains five \"stingbang\" grenades, perfect for stopping riots and playing morally unthinkable pranks."
-	cost = 7500
+	cost = 1500
 	contains = list(/obj/item/storage/box/stingbangs)
 	crate_name = "stingbang grenade pack crate"
 
-/datum/supply_pack/sec_supply/syringegun
-	name = "Syringe Gun Crate"
-	desc = "Contains a single syringe gun."
-	cost = 8000
-	contains = list(/obj/item/gun/syringe)
-	crate_name = "syringe gun crate"
-
 /datum/supply_pack/sec_supply/baton
-	name = "Stun Batons Crate"
-	desc = "Arm your vessel security with a stun baton. Batteries included."
-	cost = 3000
+	name = "Stun Baton Crate"
+	desc = "Arm your vessel security with a stun baton. Batteries included."	cost = 1500
 	contains = list(/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
-
-/datum/supply_pack/sec_supply/dragnet
-	name = "DRAGnet Crate"
-	desc = "Contains one \"Dynamic Rapid-Apprehension of the Guilty\" netting device, a recent breakthrough in law enforcement prisoner management technology."
-	cost = 2000
-	contains = list(/obj/item/gun/energy/e_gun/dragnet)
-	crate_name = "\improper DRAGnet crate"
 
 /datum/supply_pack/sec_supply/claymore
 	name = "C-10 Claymore Crate"

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -133,7 +133,7 @@
 /datum/supply_pack/sec_supply/baton
 	name = "Stun Baton Crate"
 	desc = "Arm your vessel security with a stun baton. Batteries included."
-	cost = 1500
+	cost = 2500
 	contains = list(/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
 


### PR DESCRIPTION
## About The Pull Request

Removes some crufty items from the Security tab in cargo, as well as putting some new things in. Also adjusts some prices.

![image](https://github.com/user-attachments/assets/ac7a7452-1ff7-4720-b48f-6dc3efb69a01)

## Why It's Good For The Game

Makes some of these crates more worth purchasing. This is really just a spite PR because I only want flashbangs from cargo and nothing else.

## Changelog

:cl:
del: Security Supplies crate
del: Chemical Implants crate
del: Tracking Implants crate
del: Wall Mounted Flash crate
del: Syringe Gun crate
del: DRAGnet crate
add: Flashbangs crate
add: Teargas Grenades crate
add: Camera Console crate
add: Pepper Spray crate
balance: Lowered Security Barrier Grenades crate cost to 500 (from 2000)
balance: Lowered Stingbang Grenades crate cost to 1500 (from 7500)
balance: Lowered Stun Baton crate cost to 2500 (from 3000)
/:cl: