### PR TITLE
Fixes wall wardrobes having missing doors

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
@@ -1123,9 +1123,7 @@
 "sw" = (
 /obj/effect/turf_decal/siding/wood/end,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/wall/directional/east{
-	icon_door = "grey_wall"
-	},
+/obj/structure/closet/wall/directional/east,
 /obj/item/flashlight/lantern{
 	pixel_x = 8
 	},

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
@@ -851,7 +851,6 @@
 	dir = 1
 	},
 /obj/structure/closet/wall/directional/north{
-	icon_door = "orange_wall";
 	name = "Mining equipment"
 	},
 /obj/item/clothing/glasses/meson,

--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -654,7 +654,6 @@
 	dir = 4
 	},
 /obj/structure/closet/wall/directional/east{
-	icon_door = "white_wall";
 	name = "medical closet"
 	},
 /obj/item/storage/backpack/satchel/med,
@@ -1422,7 +1421,6 @@
 /area/ship/external)
 "sq" = (
 /obj/structure/closet/wall/directional/north{
-	icon_door = "red_wall";
 	name = "security closet"
 	},
 /obj/item/storage/backpack/security,
@@ -1596,7 +1594,6 @@
 	},
 /obj/structure/catwalk/over,
 /obj/structure/closet/wall/directional/north{
-	icon_door = "yellow_wall";
 	name = "engineering closet"
 	},
 /obj/item/storage/backpack/industrial,

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -2169,7 +2169,6 @@
 "rQ" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /obj/structure/closet/wall/directional/west{
-	icon_door = "white_wall";
 	name = "medical closet"
 	},
 /obj/item/storage/backpack/satchel/med,

--- a/_maps/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/shuttles/inteq/inteq_colossus.dmm
@@ -256,7 +256,6 @@
 /obj/item/clothing/head/soft/inteq,
 /obj/item/clothing/head/soft/inteq,
 /obj/structure/closet/wall/directional/north{
-	icon_door = "orange_wall";
 	name = "uniform closet"
 	},
 /obj/machinery/firealarm/directional/east,
@@ -2333,7 +2332,6 @@
 /obj/item/clothing/shoes/sneakers/black,
 /obj/item/clothing/shoes/sneakers/black,
 /obj/structure/closet/wall/directional/north{
-	icon_door = "orange_wall";
 	name = "uniform closet"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -2946,7 +2944,6 @@
 "GL" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/structure/closet/wall/directional/east{
-	icon_door = "yellow_wall";
 	name = "engineering closet"
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -2002,7 +2002,6 @@
 /obj/item/clothing/shoes/sneakers/black,
 /obj/item/clothing/shoes/sneakers/black,
 /obj/structure/closet{
-	icon_door = "orange";
 	name = "inteq wardrobe"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2674,9 +2673,7 @@
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/railing,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/closet/wall/directional/west{
-	icon_door = "grey_wall"
-	},
+/obj/structure/closet/wall/directional/west,
 /obj/item/radio/headset,
 /obj/item/radio/headset,
 /obj/item/radio/headset,
@@ -4668,7 +4665,6 @@
 /obj/item/clothing/head/soft/inteq,
 /obj/item/clothing/head/soft/inteq,
 /obj/structure/closet{
-	icon_door = "orange";
 	name = "inteq wardrobe"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,

--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -892,7 +892,6 @@
 /obj/item/clothing/shoes/combat,
 /obj/effect/turf_decal/hardline_small/right,
 /obj/structure/closet/wall/directional/east{
-	icon_door = "yellow_wall";
 	name = "engineering closet"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -1744,9 +1743,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Bu" = (
-/obj/structure/closet/wall/directional/north{
-	icon_door = "grey_wall"
-	},
+/obj/structure/closet/wall/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},

--- a/_maps/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/shuttles/pirate/pirate_libertatia.dmm
@@ -888,9 +888,7 @@
 /obj/item/clothing/under/costume/sailor,
 /obj/item/clothing/under/costume/sailor,
 /obj/item/clothing/under/costume/sailor,
-/obj/structure/closet/wall/directional/east{
-	icon_door = "grey_wall"
-	},
+/obj/structure/closet/wall/directional/east,
 /turf/open/floor/pod/light,
 /area/ship/crew)
 "By" = (

--- a/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
+++ b/_maps/shuttles/syndicate/syndicate_gorlex_komodo.dmm
@@ -1431,7 +1431,6 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /obj/structure/closet/wall/directional/south{
-	icon_door = "orange_wall";
 	name = "Mining equipment"
 	},
 /obj/item/gps/mining,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some wall closets having missing doors because of referencing a removed icon for wardrobes. Instead uses the generic locker door icon. 

![image](https://github.com/user-attachments/assets/bc3f97a2-f688-4c2c-aa69-3e6b68b5fa07)
Example on the Colossus 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks better and is less confusing when closed closets aren't missing doors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed some wall closets missing doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
