### PR TITLE
Applies some bugfixes to examine_more interaction with modular computers and adds examine_more interaction to tablets

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -124,6 +124,7 @@
 	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational)
 		return
 
-/obj/machinery/computer/examine_more(mob/user)
+/obj/machinery/computer/examine(mob/user)
+	. = ..()
 	ui_interact(user)
-	return ..()
+	return

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -124,7 +124,7 @@
 	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational)
 		return
 
-/obj/machinery/computer/examine(mob/user)
+/obj/machinery/computer/examine_more(mob/user)
 	. = ..()
 	ui_interact(user)
 	return

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -44,10 +44,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		ui = new(user, src, "CrewConsole")
 		ui.open()
 
-/obj/machinery/computer/crew/examine(mob/user)
+/obj/machinery/computer/crew/examine_more(mob/user)
 	. = ..()
 	interact(user)
-	return
 
 /datum/crewmonitor/ui_close(mob/user)
 	ui_sources -= user

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -44,9 +44,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		ui = new(user, src, "CrewConsole")
 		ui.open()
 
-/obj/machinery/computer/crew/examine_more(mob/user)
-	interact(user) //crew monitors use the interact method instead of ui_interact, for some reason. Not very consistent.
-	return ..()
+/obj/machinery/computer/crew/examine(mob/user)
+	. = ..()
+	interact(user)
+	return
 
 /datum/crewmonitor/ui_close(mob/user)
 	ui_sources -= user

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -32,6 +32,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 31)
 		. += "<span class='notice'>It's <b>screwed</b> and secured to the wall.</span>"
 	else
 		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.</span>"
+	interact(user)
 
 /obj/item/radio/intercom/attackby(obj/item/I, mob/living/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
@@ -176,10 +177,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 31)
 	. = ..()
 	set_frequency(FREQ_WIDEBAND)
 	freqlock = TRUE
-
-/obj/item/radio/intercom/wideband/examine_more(mob/user)
-	interact(user)
-	return ..()
 
 /obj/item/radio/intercom/wideband/unscrewed
 	unscrewed = TRUE

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -32,6 +32,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 31)
 		. += "<span class='notice'>It's <b>screwed</b> and secured to the wall.</span>"
 	else
 		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.</span>"
+
+/obj/item/radio/intercom/wideband/examine_more(mob/user)
+	. = ..()
 	interact(user)
 
 /obj/item/radio/intercom/attackby(obj/item/I, mob/living/user, params)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -263,7 +263,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 			. += "<span class='notice'>It is missing wiring.</span>"
 		if(2)
 			. += "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"] the interface.</span>"
-			ui_interact(user)
+
+/obj/machinery/airalarm/examine_more(mob/user)
+	. = ..()
+	if(buildstage == 2)
+		ui_interact(user)
+
 
 /obj/machinery/airalarm/ui_status(mob/user)
 	if(user.has_unlimited_silicon_privilege && aidisabled)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -263,6 +263,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 			. += "<span class='notice'>It is missing wiring.</span>"
 		if(2)
 			. += "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"] the interface.</span>"
+			ui_interact(user)
 
 /obj/machinery/airalarm/ui_status(mob/user)
 	if(user.has_unlimited_silicon_privilege && aidisabled)
@@ -277,10 +278,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	if(!ui)
 		ui = new(user, src, "AirAlarm", name)
 		ui.open()
-
-/obj/machinery/airalarm/examine_more(mob/user)
-	ui_interact(user)
-	return ..()
 
 /obj/machinery/airalarm/ui_data(mob/user)
 	var/data = list(

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -27,6 +27,8 @@
 	. = ..()
 	if(screen_on)
 		. += "<span class='notice'>Alt-click to close it.</span>"
+	if(screen_on && enabled)
+		interact(user)
 
 /obj/item/modular_computer/laptop/Initialize()
 	. = ..()
@@ -111,11 +113,6 @@
 	screen_on = !screen_on
 	display_overlays = screen_on
 	update_appearance()
-
-/obj/item/modular_computer/laptop/examine_more(mob/user)
-	if(screen_on)
-		interact(user)
-	return ..()
 
 // Laptop frame, starts empty and closed.
 /obj/item/modular_computer/laptop/buildable

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -27,6 +27,9 @@
 	. = ..()
 	if(screen_on)
 		. += "<span class='notice'>Alt-click to close it.</span>"
+
+/obj/item/modular_computer/laptop/examine_more(mob/user)
+	. = ..()
 	if(screen_on && enabled)
 		interact(user)
 

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -27,7 +27,6 @@
 	if(screen_on && enabled)
 		interact(user)
 
-
 /obj/item/modular_computer/tablet/syndicate_contract_uplink
 	name = "contractor tablet"
 	icon = 'icons/obj/contractor_tablet.dmi'

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -23,6 +23,11 @@
 		icon_state = icon_state_powered = icon_state_unpowered = "[base_icon_state]-[finish_color]"
 	return ..()
 
+/obj/item/modular_computer/tablet/examine(mob/user)
+	if(screen_on && enabled)
+		interact(user)
+
+
 /obj/item/modular_computer/tablet/syndicate_contract_uplink
 	name = "contractor tablet"
 	icon = 'icons/obj/contractor_tablet.dmi'

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -23,7 +23,8 @@
 		icon_state = icon_state_powered = icon_state_unpowered = "[base_icon_state]-[finish_color]"
 	return ..()
 
-/obj/item/modular_computer/tablet/examine(mob/user)
+/obj/item/modular_computer/tablet/examine_more(mob/user)
+	. = ..()
 	if(screen_on && enabled)
 		interact(user)
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -39,6 +39,8 @@
 /obj/machinery/modular_computer/examine(mob/user)
 	. = ..()
 	. += get_modular_computer_parts_examine(user)
+	if(cpu.enabled)
+		interact(user)
 
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
 	. = ..()
@@ -84,10 +86,6 @@
 		return cpu.interact(user) // CPU is an item, that's why we route attack_hand to attack_self
 	else
 		return ..()
-
-/obj/machinery/modular_computer/examine_more(mob/user)
-	interact(user)
-	return ..()
 
 // Process currently calls handle_power(), may be expanded in future if more things are added.
 /obj/machinery/modular_computer/process()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -39,6 +39,9 @@
 /obj/machinery/modular_computer/examine(mob/user)
 	. = ..()
 	. += get_modular_computer_parts_examine(user)
+
+/obj/machinery/modular_computer/examine_more(mob/user)
+	. = ..()
 	if(cpu.enabled)
 		interact(user)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -326,6 +326,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, 25)
 			. += "The cover is broken. It may be hard to force it open."
 		else
 			. += "The cover is closed."
+			ui_interact(user)
 
 	. += "<span class='notice'>Alt-Click the APC to [ locked ? "unlock" : "lock"] the interface.</span>"
 
@@ -899,10 +900,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, 25)
 	if(!ui)
 		ui = new(user, src, "Apc", name)
 		ui.open()
-
-/obj/machinery/power/apc/examine_more(mob/user)
-	ui_interact(user)
-	return ..()
 
 /obj/machinery/power/apc/ui_data(mob/user)
 	var/list/data = list(

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -326,12 +326,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, 25)
 			. += "The cover is broken. It may be hard to force it open."
 		else
 			. += "The cover is closed."
-			ui_interact(user)
 
 	. += "<span class='notice'>Alt-Click the APC to [ locked ? "unlock" : "lock"] the interface.</span>"
 
 	if(issilicon(user))
 		. += "<span class='notice'>Ctrl-Click the APC to switch the breaker [ operating ? "off" : "on"].</span>"
+
+/obj/machinery/power/apc/examine_more(mob/user)
+	. = ..()
+	ui_interact(user)
 
 // update the APC icon to show the three base states
 // also add overlays for indicator lights


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a few bugs in PR https://github.com/shiptest-ss13/Shiptest/pull/3553 and it also gives tablets the ability to be interacted with using the examine_more feature.

Please let me know how this may perform ingame. I'm still unsure as to if shuttling this functionality to examine_more is better than applying it to the examine function.

## Why It's Good For The Game

This PR fixes modular computers from being activated from long range via hidden bluetooth implants, and it gives tablets the ability to be interacted with without it having to be in a user's hand, which can be nice for those that may lay the item down on a table in order to let a group of people see the screen at once.

## Changelog

:cl:
code: applied some bugfixes to the interaction of examine_more with modular computers and laptops
add: adds the ability to interact with a tablet using the examine_more function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
