### PR TITLE
Replaces Cargo Incendiary Grenades with Frag Grenades

### DIFF
--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -91,9 +91,10 @@
 
 /datum/supply_pack/sec_supply/frag_grenade
 	name = "Frag Grenade Crate"
-	desc = "Contains one fragmentation grenade. Better not let it go off in your hands."
+	desc = "Contains two fragmentation grenades. Better not let it go off in your hands."
 	cost = 500
-	contains = list(/obj/item/grenade/frag)
+	contains = list(/obj/item/grenade/frag,
+					/obj/item/grenade/frag)
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon
 

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -89,15 +89,13 @@
 	faction = /datum/faction/syndicate/ngr
 	faction_discount = 20
 
-/datum/supply_pack/sec_supply/incendiary_grenade
-	name = "Incendiary Grenade Crate"
-	desc = "Contains one incendiary grenade. Better not let it go off in your hands."
-	cost = 750
-	contains = list(/obj/item/grenade/chem_grenade/incendiary)
-	crate_name = "incendiary grenade crate"
-	crate_type = /obj/structure/closet/crate/secure/plasma
-	faction = /datum/faction/syndicate/ngr
-	faction_discount = 20
+/datum/supply_pack/sec_supply/frag_grenade
+	name = "Frag Grenade Crate"
+	desc = "Contains one fragmentation grenade. Better not let it go off in your hands."
+	cost = 500
+	contains = list(/obj/item/grenade/frag)
+	crate_name = "frag grenade crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon
 
 /datum/supply_pack/sec_supply/halberd
 	name = "Energy Halberd Crate"


### PR DESCRIPTION
## About The Pull Request

Replaces cargo incendiary grenades with frag grenades, and lowers the price by a third. Incendiary grenades could:
- fullhusk people
- dust equipment and items
- cause irreparable atmos damage (due to Auxmos lag)
- ignite plasmafires and effectively blow up entire sections of a ship with various explosive items we have

Frag grenades are significantly less destructive in this manner, and frankly incendiary grenades seem like a- bad idea to just have for everyone to buy? Especially with all that?

## Why It's Good For The Game

Adds a grenade option that people already have relatively easy access to for purchase, and replaces the Incendiary Grenade (borderline WMD) purchase with it. 

## Changelog

:cl:
balance: Cargo Incendiary Grenades have been removed and replaced with Frag Grenades.
/:cl: