### PR TITLE
Adds one singular item to the Banshee that I forgot

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_hardliners_banshee.dmm
+++ b/_maps/shuttles/syndicate/syndicate_hardliners_banshee.dmm
@@ -1916,6 +1916,7 @@
 /obj/item/storage/box/ammo/a357,
 /obj/item/megaphone,
 /obj/item/clothing/under/syndicate/hardliners/jumpsuit,
+/obj/item/clothing/suit/armor/hardliners/sergeant,
 /obj/item/storage/guncase/pistol/a357,
 /obj/machinery/turretid/ship{
 	pixel_y = 24;


### PR DESCRIPTION
## About The Pull Request

Adds a Sergeants armoured vest as an alternative to the Captains vest on the Banshee

## Why It's Good For The Game

This singular addition gives the captain something else to wear, if they don't fancy the Captains coat they're given

## Changelog

:cl:
add: Adds a singular Sergeants vest to the Banshee Captains equipment
/:cl: