### PR TITLE
Crate shelvers no longer persist after attempting to spawn

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -503,7 +503,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		log_mapping("[src] failed to find a crate at [AREACOORD(src)]")
 	else
 		shelve(crate)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mapping_helpers/crate_shelve/proc/shelve(crate)
 	var/obj/structure/crate_shelf/shelf = locate(/obj/structure/crate_shelf) in range(range, crate)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -503,6 +503,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		log_mapping("[src] failed to find a crate at [AREACOORD(src)]")
 	else
 		shelve(crate)
+		qdel(src)
 
 /obj/effect/mapping_helpers/crate_shelve/proc/shelve(crate)
 	var/obj/structure/crate_shelf/shelf = locate(/obj/structure/crate_shelf) in range(range, crate)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`mapping_helpers/crate_shelve` now qdels after attempting to shelve a crate, meaning observers won't see leftover helpers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Don't see mapping helpers as a ghost
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: the outpost's crate shelvers have been trained to leave no evidence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
