### PR TITLE
Makes dogtag retrieval missions take both Ramzi and Frontiersman tags, removes RnD retrieval

### DIFF
--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -196,48 +196,15 @@ Acquire: Anomaly
 	num_wanted = 2
 
 /datum/mission/acquire/bounty
-	name = "Hunt down Frontiersmen Dogtags"
-	desc = "CLIP has assigned us to offer out bounties to hunt down Frontiersman cells and turn in their dogtags. We'll reward you well."
+	name = "Hunt down Dogtags"
+	desc = "CLIP has posted several bounties for wanted members of both the Frontiersman and the Clique. Bring back their tags, we'll reward you well."
 	weight = 4
-	value = 3000
-	duration = 100 MINUTES
-	dur_mod_range = 0.2
-	container_type = /obj/item/storage/toolbox/bounty/hunt
-	objective_type = /obj/item/clothing/neck/dogtag/frontier
-	num_wanted = 3
-
-/datum/mission/acquire/bounty/ramzi
-	name = "Hunt down Ramzi Clique Dogtags"
-	desc = "Gezena has assigned us to offer out bounties to hunt down Ramzi Clique outfits and turn in their dogtags. We'll reward you well."
-	weight = 3
 	value = 4000
 	duration = 120 MINUTES
 	dur_mod_range = 0.1
 	container_type = /obj/item/storage/toolbox/bounty/hunt
-	objective_type = /obj/item/clothing/neck/dogtag/ramzi
+	objective_type = /obj/item/clothing/neck/dogtag
 	num_wanted = 3
-
-/datum/mission/acquire/salvage
-	name = "Deliver Protolathe"
-	desc = "The Nanotrasen Corporation is contracting out to have scientific equipment returned. Looking for a rare circuitboard (R&D Console, Protolathe, Circuit Imprinter) of any type."
-	weight = 2
-	value = 4000
-	duration = 120 MINUTES
-	dur_mod_range = 0.3
-	container_type = /obj/item/storage/toolbox/bounty/salvage
-	objective_type = /obj/item/circuitboard/machine/protolathe
-	num_wanted = 1
-
-/datum/mission/acquire/salvage/console
-	name = "Deliver R&D Console"
-	desc = "The Nanotrasen Corporation is contracting out to have scientific equipment returned. Looking for a rare circuitboard (R&D Console, Protolathe, Circuit Imprinter) of any type."
-	weight = 3
-	value = 2500
-	duration = 120 MINUTES
-	dur_mod_range = 0.3
-	container_type = /obj/item/storage/toolbox/bounty/salvage
-	objective_type = /obj/item/circuitboard/computer/rdconsole
-	num_wanted = 1
 
 /*
 		Acquire: Fishing


### PR DESCRIPTION
## About The Pull Request

Title. 

Dogtags retrieval missions now take any dogtag, both frontiersman and ramzi. This was done as dogtag missions were already rare enough and sometimes even for doing these things you could get screwed over by not being able to turn in any of your tags. Anomaly core missions don't ask for specific cores, why should dogtag missions? Both are terrorists.

Also removes the RnD retrieval missions. We already culled RnD from nearly everywhere and it exists in scraps on certain ships. Barely any even have a full setup. This clogs the list for other missions that are actually completable. 

## Why It's Good For The Game

I discussed this with Thrax after seeing the dogtag issue in-game and came up with how the RnD missions are effectively never done since mapcuts removed almost all of the RnD ruins (thank god) and it's otherwise mostly unobtainable.

Hopefully this should make the missions easier to complete with more accessible missions and likewise not clog up the list.

## Changelog

:cl:
del: RnD retrieval missions
balance: Dogtag missions take any kind of dogtag, both Frontiersman and Ramzi
/:cl:


