### PR TITLE
fixes spacesuits being in the wrong category

### DIFF
--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -35,7 +35,7 @@
 /datum/supply_pack/costumes_toys/lasertag
 	name = "Laser Tag Crate"
 	desc = "Are you tired of Foam Force? Looking for a real thrill? The new NT-Lasertag System is sure to Rock Your Socks, no cleanup required, just plain fun. The NT Way: includes enough equipment for a 3v3 laser-tag shootout."
-	cost = 100
+	cost = 500
 	contains = list(/obj/item/gun/energy/laser/redtag,
 					/obj/item/gun/energy/laser/redtag,
 					/obj/item/gun/energy/laser/redtag,

--- a/code/modules/cargo/packs/spacesuits.dm
+++ b/code/modules/cargo/packs/spacesuits.dm
@@ -6,7 +6,7 @@
 		Spacesuits (two parts, helm and suit)
 */
 
-/datum/supply_pack/spacesuit_armor/spacesuit
+/datum/supply_pack/spacesuits/spacesuit
 	name = "Space Suit Crate"
 	desc = "Contains two basic space suits. Although the technology is centuries old, it should protect you from the vacuum of space."
 	cost = 500 //changed the suit type to be the one without pockets, making it more consistent with the rest of the EVA suits available


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spacesuits are in the correct category now.
Also the price of the laser tag crate is 500 like it was meant to be

## Why It's Good For The Game

Fixes my big mistake

## Changelog

:cl:
fix: spacesuit crates are now correctly categorised
fix: laser tag crates are 500 instead of 100
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
