### PR TITLE
Security Belt Additions

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -295,6 +295,7 @@
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash/handheld,
 		/obj/item/clothing/glasses,
+		/obj/item/binoculars,
 		/obj/item/ammo_casing/shotgun,
 		/obj/item/ammo_box/magazine,
 		/obj/item/ammo_box/c38, //speed loaders don't have a common path like magazines. pain.
@@ -309,6 +310,8 @@
 		/obj/item/flashlight/seclite,
 		/obj/item/melee/classic_baton/telescopic,
 		/obj/item/radio,
+		/obj/item/attachment,
+		/obj/item/extinguisher/mini,
 		/obj/item/clothing/gloves,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/holosign_creator/security,


### PR DESCRIPTION

## About The Pull Request

Adds the ability for secbelts to carry binoculars, attachments, and pocket fire extinguishers.

## Why It's Good For The Game

These are all small items with utility that make sense that they could be stored in a webbing, attachments especially. This should provide some utility while still not being particularly overpowered, given that there are no other changes to vest sizes.

## Changelog

:cl:
balance: Vests now have pockets for binoculars, attachments and pocket fire extinguishers
/:cl:
