### PR TITLE
fixes qdel bug (mobs in wrapped closets can qdel contents) #4053

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -67,6 +67,9 @@
 	return
 
 /obj/structure/closet/Destroy()
+	if(istype(loc, /obj/structure/bigDelivery))
+		var/obj/structure/bigDelivery/wrap = loc
+		qdel(wrap)
 	dump_contents()
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #4053 with a check for if a closet's loc is a delivery package, and qdels the package thus dropping the stuff within.
There's probably a better way to do this but that requires redoing much more package code than I want to right now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
weird ass qdel bug from weird ass package wrap code. THERES CAMEL CASE IN THIS STUFF WHAT THE HELL.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: broken closet in package wrap qdel contents bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
