### PR TITLE
Clarifies latch usage and fixes a bug with cell ejection on the E-40

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -375,7 +375,7 @@
 /obj/item/gun/energy/examine(mob/user)
 	. = ..()
 	if(!internal_magazine)
-		. += "The cell retainment latch is [latch_closed ? "<span class='green'>CLOSED</span>" : "<span class='red'>OPEN</span>"]. Alt-Click to toggle the latch."
+		. += "The cell retainment latch is [latch_closed ? "<span class='green'>CLOSED</span>" : "<span class='red'>OPEN</span>"]. Alt-Click on <b>help</b> intent to toggle the latch."
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	if(ammo_type.len > 1)
 		. += "You can switch firemodes by pressing the <b>unique action</b> key. By default, this is <b>space</b>"

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/ballistics.dm
@@ -55,7 +55,7 @@
 /obj/item/gun/ballistic/automatic/assault/e40/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	var/current_firemode = gun_firemodes[firemode_index]
 	if(current_firemode != FIREMODE_OTHER)
-		if(!secondary.latch_closed && prob(65))
+		if(!secondary.latch_closed && secondary.cell && prob(65))
 			to_chat(user, span_warning("[src]'s cell falls out!"))
 			secondary.eject_cell()
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR updates the examine text on weapons to include that latches are to only be toggled on help intent. It also fixes a bug where firing the E-40's ballistic component with the latch loose would repeatedly "drop a cell", even if one had already been ejected.

## Why It's Good For The Game

This should hopefully reduce some confusion as to when latches can be toggled, and it should remove a slightly immersion-breaking bug.

## Changelog

:cl:
fix: updated cell latch descriptions
fix: fixed a minor bug with cell latches on the E-40
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
