### PR TITLE
Removes an erroneous airlock from the Derecho

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
@@ -2587,12 +2587,6 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Locker Room";
-	req_access_txt = null;
-	req_one_access_txt = "48,56"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "vF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A second locker room airlock was accidentally mapped into the Derecho, and this PR removes it.

## Why It's Good For The Game

This fixes a mistake in an earlier PR

## Changelog

:cl:
fix: fixed an accidental second locker room airlock in the derecho
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
