### PR TITLE
Removes Wirecarp from Player Access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -6,7 +6,7 @@
 	size = 12
 	requires_ntnet = TRUE
 	required_access = ACCESS_NETWORK	//NETWORK CONTROL IS A MORE SECURE PROGRAM.
-	available_on_ntnet = TRUE
+	available_on_ntnet = FALSE
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"
 


### PR DESCRIPTION
## About The Pull Request

Removes Wirecarp app from player access.

## Why It's Good For The Game

Isn't it FUN for people to be able to turn off everyone in the entire round's devices using an obscure app with only an obscure way to fix it?

ISN'T IT FUN???

## Changelog

:cl:
remove: Wirecarp from Player Access
/:cl:

