### PR TITLE
Ammo Cans can hold Weapon Cells

### DIFF
--- a/code/game/objects/items/storage/ammo_can.dm
+++ b/code/game/objects/items/storage/ammo_can.dm
@@ -23,7 +23,8 @@
 		/obj/item/ammo_box/magazine/ammo_stack,
 		/obj/item/ammo_casing,
 		/obj/item/mine,
-		/obj/item/grenade
+		/obj/item/grenade,
+		/obj/item/stock_parts/cell/gun
 		))
 
 /obj/item/storage/toolbox/ammo/a850r/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Ammo cans can hold weapon cells. 

## Why It's Good For The Game

Wnergy cells are ammo too. Consistency.

## Changelog

:cl:
balance: Ammo cans can hold weapon cells now too.
/:cl:
