### PR TITLE
Kali Andhi is better supplied

### DIFF
--- a/_maps/configs/syndicate_ngr_kaliandhi.json
+++ b/_maps/configs/syndicate_ngr_kaliandhi.json
@@ -18,6 +18,7 @@
 	"map_path": "_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm",
 	"map_id": "syndicate_gorlex_kaliandhi",
 	"limit": 1,
+	"starting_funds": 4000,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/syndicate/captain/ngr",

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -1275,8 +1275,8 @@
 "jL" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 8;
-	name = "Armory";
 	fast_close = 1;
+	name = "Armory";
 	req_access = list(3)
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -2153,8 +2153,8 @@
 /area/ship/crew)
 "oc" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Bridge";
 	fast_close = 1;
+	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -2684,6 +2684,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/item/folder/syndicate,
+/obj/item/folder/syndicate,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "rz" = (
@@ -3132,8 +3134,8 @@
 "vl" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 8;
-	name = "Armory";
 	fast_close = 1;
+	name = "Armory";
 	req_access = list(3)
 	},
 /obj/structure/cable{
@@ -3845,6 +3847,7 @@
 /obj/effect/turf_decal/industrial/outline{
 	color = "#791500"
 	},
+/obj/item/stack/sheet/mineral/uranium/twenty,
 /obj/item/stack/sheet/mineral/uranium/ten,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
@@ -4179,6 +4182,7 @@
 	open = 0;
 	req_access_txt = "3"
 	},
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/no_mag,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "Ba" = (
@@ -4439,6 +4443,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/corner/opaque/red/mono,
+/obj/item/folder/syndicate,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security/armory)
 "CK" = (
@@ -5508,8 +5513,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
-	name = "Control Room";
 	fast_close = 1;
+	name = "Control Room";
 	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5834,8 +5839,8 @@
 /area/ship/hallway/fore)
 "MS" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Command Deck";
 	fast_close = 1;
+	name = "Command Deck";
 	req_access_txt = "19"
 	},
 /obj/structure/cable{
@@ -5874,8 +5879,8 @@
 "MU" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Engineering";
 	fast_close = 1;
+	name = "Engineering";
 	req_access_txt = "10"
 	},
 /obj/structure/cable{
@@ -6986,47 +6991,27 @@
 /obj/item/storage/box/ammo/c10mm{
 	pixel_x = -7
 	},
-/obj/item/ammo_box/magazine/m57_39_asp{
-	pixel_x = 14;
-	pixel_y = -7
-	},
-/obj/item/ammo_box/magazine/m57_39_asp{
-	pixel_x = 14;
-	pixel_y = -7
-	},
-/obj/item/ammo_box/magazine/m556_42_hydra/small{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/m556_42_hydra/small{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/m57_39_sidewinder{
-	pixel_x = 4;
-	pixel_y = -9
-	},
-/obj/item/ammo_box/magazine/m57_39_sidewinder{
-	pixel_x = 4;
-	pixel_y = -9
-	},
+/obj/item/ammo_box/magazine/m57_39_asp/empty,
+/obj/item/ammo_box/magazine/m57_39_asp/empty,
+/obj/item/ammo_box/magazine/m556_42_hydra/small/empty,
+/obj/item/ammo_box/magazine/m556_42_hydra/small/empty,
+/obj/item/ammo_box/magazine/m57_39_sidewinder/empty,
+/obj/item/ammo_box/magazine/m57_39_sidewinder/empty,
 /obj/effect/turf_decal/corner/opaque/red/half{
 	dir = 8
 	},
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 4
 	},
-/obj/item/ammo_box/magazine/m57_39_asp{
-	pixel_x = 14;
-	pixel_y = -7
-	},
-/obj/item/ammo_box/magazine/m57_39_asp{
-	pixel_x = 14;
-	pixel_y = -7
-	},
+/obj/item/ammo_box/magazine/m57_39_asp/empty,
+/obj/item/ammo_box/magazine/m57_39_asp/empty,
 /obj/structure/sign/poster/contraband/c20r{
 	pixel_x = 32
 	},
+/obj/item/ammo_box/magazine/m12g_bulldog/empty,
+/obj/item/ammo_box/magazine/m12g_bulldog/empty,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/item/storage/box/ammo/a12g_buckshot,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "UM" = (
@@ -7589,8 +7574,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/hatch{
-	name = "Life Support";
 	fast_close = 1;
+	name = "Life Support";
 	req_access_txt = "10"
 	},
 /obj/machinery/door/firedoor/border_only,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improves Kali Andhi's starting supplies a bit to make its start-of-round a little less painful.
- added a Bulldog with small magazines to the armory, so all three troopers can use a longarm
- added more starting uranium fuel for the generators
- increased starting funds to 4k

## Why It's Good For The Game

![kuznetsov](https://github.com/user-attachments/assets/5fbed82d-d63d-4b98-a029-d5b925039d7d)

## Changelog

:cl:
balance: buffed Kali Andhi's starting funds, fuel, and weapons loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
