### PR TITLE
(Autowiki) Ship size is calculated by area rather than longest dimension

### DIFF
--- a/code/modules/autowiki/pages/ships.dm
+++ b/code/modules/autowiki/pages/ships.dm
@@ -16,9 +16,9 @@
 		switch(longest_dimension)
 			if(0 to 749)
 				size = "Small"
-			if(750 to 1499)
+			if(750 to 1249)
 				size = "Medium"
-			if(1500 to INFINITY)
+			if(1250 to INFINITY)
 				size = "Large"
 
 		var/ship_name = escape_value(ship.name)

--- a/code/modules/autowiki/pages/ships.dm
+++ b/code/modules/autowiki/pages/ships.dm
@@ -12,8 +12,8 @@
 			continue
 
 		var/size = "Unknown"
-		var/longest_dimension = (ship.width * ship.height)
-		switch(longest_dimension)
+		var/ship_area = (ship.width * ship.height)
+		switch(ship_area)
 			if(0 to 749)
 				size = "Small"
 			if(750 to 1249)

--- a/code/modules/autowiki/pages/ships.dm
+++ b/code/modules/autowiki/pages/ships.dm
@@ -12,16 +12,14 @@
 			continue
 
 		var/size = "Unknown"
-		var/longest_dimension = max(ship.width, ship.height)
+		var/longest_dimension = (ship.width * ship.height)
 		switch(longest_dimension)
-			if(0 to 19)
+			if(0 to 999)
 				size = "Small"
-			if(20 to 39)
+			if(1000 to 1499)
 				size = "Medium"
-			if(40 to 56)
+			if(1500 to INFINITY)
 				size = "Large"
-			if(57 to INFINITY)
-				size = "Undockable" //let's hope this is never the case
 
 		var/ship_name = escape_value(ship.name)
 		output[ship_name] = include_template("Autowiki/Ship", list(

--- a/code/modules/autowiki/pages/ships.dm
+++ b/code/modules/autowiki/pages/ships.dm
@@ -14,9 +14,9 @@
 		var/size = "Unknown"
 		var/longest_dimension = (ship.width * ship.height)
 		switch(longest_dimension)
-			if(0 to 999)
+			if(0 to 749)
 				size = "Small"
-			if(1000 to 1499)
+			if(750 to 1499)
 				size = "Medium"
 			if(1500 to INFINITY)
 				size = "Large"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Calculates the ship size used on the autowiki templates by `width*height` instead of `max(width, height)`, distributing the calculated sizes found away from mostly being medium.

<details><summary>New calculated sizes</summary>
<p>

- Nimbus-Class, Small
- Atoll-class, Medium
- Bubble-class, Small
- Mk.II Dwayne-class, Small
- Falmouth-class, Small
- Junker-class, Small
- Kilo-class, Small
- Mudskipper-class, Small
- Raleigh-class, Large
- Riggs-class, Medium
- Scarab-class, Medium
- Shetland-class, Medium
- Sunskipper-class, Small
- Colossus-class, Medium
- Talos-class, Large
- Valor-class, Medium
- Vaquero-class, Small
- Arke-class, Small
- Atlas-class, Medium
- Delta-class, Small
- Harrier-class, Large
- Meta-class, Small
- Ranger-class, Large
- Tegu-class, Medium
- Crying Sun-class, Large
- Elated Bolide-Class, Large
- Cthonian-class, Small
- Tortuga-class, Large
- Inkwell-class, Medium
- Paracelsus-class, Medium
- Elder-class, Large
- Li Tieguai-class, Small
- Komodo-class, Medium
- Banshee-Class, Medium
- Derecho-class, Medium
- Haboob-class, Small
- Kali Andhi-class, Large
- Panacea-class, Large
- Twinkleshine-class, Large

</p>
</details> 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better representation of the size of a ship in its wiki description, rather than most ships being Medium.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: adjusted autowiki ship size calculations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
