### PR TITLE
Increases the projectile speed of sharplite laser bolts

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -2,6 +2,10 @@
 	projectile_type = /obj/projectile/beam/laser
 	select_name = "kill"
 
+/obj/item/ammo_casing/energy/laser/sharplite
+	projectile_type = /obj/projectile/beam/laser/sharplite
+	select_name = "kill"
+
 /obj/item/ammo_casing/energy/laser/underbarrel
 	projectile_type = /obj/projectile/beam/laser
 	e_cost =  1250
@@ -25,6 +29,12 @@
 	delay = 2
 	e_cost = 666 //30 per upgraded cell
 
+/obj/item/ammo_casing/energy/laser/assault/sharplite
+	projectile_type = /obj/projectile/beam/laser/assault/sharplite
+	fire_sound = 'sound/weapons/gun/laser/e40_las.ogg'
+	delay = 2
+	e_cost = 666 //30 per upgraded cell
+
 /obj/item/ammo_casing/energy/laser/eoehoma/e50
 	projectile_type = /obj/projectile/beam/emitter/hitscan
 	fire_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'
@@ -33,6 +43,11 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
+	e_cost = 830
+	select_name = "kill"
+
+/obj/item/ammo_casing/energy/lasergun/sharplite
+	projectile_type = /obj/projectile/beam/laser/sharplite
 	e_cost = 830
 	select_name = "kill"
 
@@ -46,16 +61,27 @@
 	select_name = "kill"
 	delay = 0.13 SECONDS
 
+/obj/item/ammo_casing/energy/laser/sharplite/smg
+	projectile_type = /obj/projectile/beam/weak/sharplite
+	e_cost = 799 //12 shots with a normal power cell, 25 with an upgraded
+	select_name = "kill"
+	delay = 0.13 SECONDS
+
 /obj/item/ammo_casing/energy/lasergun/old
 	projectile_type = /obj/projectile/beam/laser
 	e_cost = 2000
 	select_name = "kill"
 
-/obj/item/ammo_casing/energy/laser/hos
+/obj/item/ammo_casing/energy/laser/sharplite/hos
 	e_cost = 1200
 
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/projectile/beam/practice
+	select_name = "practice"
+	harmful = FALSE
+
+/obj/item/ammo_casing/energy/laser/practice/sharplite
+	projectile_type = /obj/projectile/beam/practice/sharplite
 	select_name = "practice"
 	harmful = FALSE
 

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -25,10 +25,17 @@
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/disabler/sharplite
+	projectile_type = /obj/projectile/beam/disabler/sharplite
+	select_name  = "disable"
+	e_cost = 500
+	fire_sound = 'sound/weapons/taser2.ogg'
+	harmful = FALSE
+
 /obj/item/ammo_casing/energy/disabler/underbarrel
 	e_cost = 625
 
-/obj/item/ammo_casing/energy/disabler/hos
+/obj/item/ammo_casing/energy/disabler/sharplite/hos
 	e_cost = 600
 
 /obj/item/ammo_casing/energy/disabler/scatter	//WS edit, scatter repathing
@@ -48,5 +55,10 @@
 
 /obj/item/ammo_casing/energy/disabler/smg
 	projectile_type = /obj/projectile/beam/disabler/weak/negative_ap
+	e_cost = 330
+	delay = 0.13 SECONDS
+
+/obj/item/ammo_casing/energy/disabler/sharplite/smg
+	projectile_type = /obj/projectile/beam/disabler/weak/negative_ap/sharplite
 	e_cost = 330
 	delay = 0.13 SECONDS

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -7,7 +7,7 @@
 	mob_overlay_icon = 'icons/obj/guns/manufacturer/nanotrasen_sharplite/onmob.dmi'
 	icon_state = "energy"
 	item_state = null	//so the human update icon uses the icon_state instead.
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/sharplite, /obj/item/ammo_casing/energy/laser/sharplite)
 	modifystate = TRUE
 	ammo_x_offset = 2
 	dual_wield_spread = 60
@@ -46,7 +46,7 @@
 	icon_state = "energytac"
 	ammo_x_offset = 2
 	charge_sections = 5
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/assault, /obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/assault/sharplite, /obj/item/ammo_casing/energy/disabler/sharplite)
 	default_ammo_type = /obj/item/stock_parts/cell/gun/upgraded
 
 	weapon_weight = WEAPON_MEDIUM
@@ -67,7 +67,7 @@
 	desc = "NT-P:01 Prototype Energy Gun. Early stage development of a unique laser rifle that has a multifaceted energy lens, allowing the gun to alter the form of projectile it fires on command. The project was a dud, and Nanotrasen later acquired Sharplite to suit its laser weapon needs."
 	icon_state = "protolaser"
 	ammo_x_offset = 2
-	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/electrode/old)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/sharplite, /obj/item/ammo_casing/energy/electrode/old)
 	manufacturer = MANUFACTURER_NANOTRASEN_OLD
 
 /obj/item/gun/energy/e_gun/hos
@@ -76,7 +76,7 @@
 	default_ammo_type = /obj/item/stock_parts/cell/gun/upgraded
 	icon_state = "hoslaser"
 	force = 10
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos, /obj/item/ammo_casing/energy/electrode/hos)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/sharplite/hos, /obj/item/ammo_casing/energy/laser/sharplite/hos, /obj/item/ammo_casing/energy/ion/hos, /obj/item/ammo_casing/energy/electrode/hos)
 	shaded_charge = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	manufacturer = MANUFACTURER_SHARPLITE_NEW
@@ -218,7 +218,7 @@
 	icon_state = "bsgun"
 	item_state = "gun"
 	force = 7
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/trap)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/sharplite/hos, /obj/item/ammo_casing/energy/laser/sharplite/hos, /obj/item/ammo_casing/energy/trap)
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 
@@ -226,7 +226,7 @@
 	name = "\improper E-TAR SMG"
 	desc = "A dual-mode energy gun capable of discharging weaker shots at a much faster rate than the standard energy gun."
 	icon_state = "esmg"
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/smg, /obj/item/ammo_casing/energy/laser/smg)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/sharplite/smg, /obj/item/ammo_casing/energy/laser/sharplite/smg)
 	ammo_x_offset = 2
 	charge_sections = 3
 	weapon_weight = WEAPON_LIGHT

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -6,7 +6,7 @@
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=2000)
-	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/sharplite)
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 	supports_variations = VOX_VARIATION
@@ -21,7 +21,7 @@
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the L-204 laser gun, this one fires less concentrated energy bolts designed for target practice."
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice/sharplite)
 	item_flags = NONE
 
 /obj/item/gun/energy/laser/retro

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -38,7 +38,7 @@
 	impact_type = /obj/effect/projectile/impact/laser
 
 /obj/projectile/beam/laser/sharplite
-	speed = 0.4
+	speed = 0.25
 
 /obj/projectile/beam/laser/light
 	damage = 15
@@ -54,6 +54,12 @@
 	icon_state = "heavylaser"
 	damage = 25
 	armour_penetration = 20
+
+/obj/projectile/beam/laser/assault/sharplite
+	icon_state = "heavylaser"
+	damage = 25
+	armour_penetration = 20
+	speed = 0.25
 
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
@@ -80,6 +86,10 @@
 /obj/projectile/beam/weak
 	damage = 15
 
+/obj/projectile/beam/weak/sharplite
+	damage = 15
+	speed = 0.25
+
 /obj/projectile/beam/weaker
 	damage = 10
 
@@ -102,6 +112,12 @@
 	name = "practice laser"
 	damage = 0
 	nodamage = TRUE
+
+/obj/projectile/beam/practice/sharplite
+	name = "practice laser"
+	damage = 0
+	nodamage = TRUE
+	speed = 0.25
 
 /obj/projectile/beam/laser/slug
 	name = "laser slug"
@@ -146,7 +162,7 @@
 	impact_type = /obj/effect/projectile/impact/disabler
 
 /obj/projectile/beam/disabler/sharplite
-	speed = 0.4
+	speed = 0.25
 
 /obj/projectile/beam/disabler/weak
 	damage = 15
@@ -157,6 +173,11 @@
 /obj/projectile/beam/disabler/weak/negative_ap
 	armour_penetration = -30
 	range = 9
+
+/obj/projectile/beam/disabler/weak/negative_ap/sharplite
+	armour_penetration = -30
+	range = 9
+	speed = 0.25
 
 /obj/projectile/beam/disabler/weak/negative_ap/low_range
 	range = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR modifies the projectile speeds of Sharplite-made laser weaponry so that the bolts travel much faster.
Only weapons that fire a single bolt were affected, so laser shotguns and accelerator projectile speeds have remained unchanged. Sharplite laser turrets have also been brought in line with this projectile speed, aside from the heavy laser variant.

Below is a video of an eoehoma weapon, which has not had its projectile speeds changed:
https://github.com/user-attachments/assets/561989ca-5a6c-49d8-8b9a-5cd7d1dc3efc

Below this is an example of a Sharplite weapon after the projectile speed change:
https://github.com/user-attachments/assets/d20ea439-37db-4282-9bd5-2530c74c561a

## Why It's Good For The Game

Laser weapon changes are in the works right now, and these changes are intended to help enhance laser weapon manufacturer identity, from what I understand. This PR works towards that goal and brings Sharplite weapons closer in line by making their projectiles much faster.

## Changelog

:cl:
balance: increased the projectile speed of sharplite weaponry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
