### PR TITLE
Fixes a runtime with SecurEye and updates bodycamera descriptions

### DIFF
--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -39,7 +39,7 @@
 	if(in_range(src, user))
 		. += "<span class='notice'>The body camera is set to a nametag of '<b>[c_tag]</b>'.</span>"
 		. += "<span class='notice'>The body camera is set to transmit on the '<b>[network[1]]</b>' network.</span>"
-		. += "<span class='notice'>It looks like you can modify the camera settings by using a <b>multitool<b> on it.</span>"
+		. += "<span class='notice'>It looks like you can modify the camera settings by using a <b>multitool</b> on it.</span>"
 
 /obj/item/bodycamera/AltClick(mob/user)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -173,7 +173,11 @@
 
 	var/list/visible_turfs = list()
 
-	if(!active_camera.loc)
+	if(!active_camera)
+		show_camera_static()
+		return
+	else if (active_camera.loc == null)
+		show_camera_static()
 		return
 
 	var/cam_location = active_camera.loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR should fix a runtime that had been popping up with bodycameras during their testmerges. It should also fix part of the description for them that I'd erroneously made bold.

## Why It's Good For The Game

Runtimes are not good, and the description was a little confusing in what words were made bold. A single missing character causes untold havoc yet again.

## Changelog

:cl:
fix: fixed securEye runtime
fix: fixed bodycamera description typo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
