### PR TITLE
Cheaper Vipers

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -146,7 +146,7 @@
 /datum/supply_pack/gun/viperrevolver
 	name = "Viper-23 Revolver Crate"
 	desc = "Contains a civilian variant of the Viper revolver, chambered in .357 magnum."
-	cost = 2500
+	cost = 1500
 	contains = list(/obj/item/storage/guncase/pistol/viper)
 	faction = /datum/faction/syndicate/scarborough_arms
 	faction_discount = 5
@@ -154,7 +154,7 @@
 /datum/supply_pack/gun/a357
 	name = "R-23 'Viper' Revolver Crate"
 	desc = "Contains a double-action military variant of the Viper revolver, chambered in .357 magnum."
-	cost = 3000
+	cost = 1750
 	contains = list(/obj/item/storage/guncase/pistol/a357)
 	faction = /datum/faction/syndicate/scarborough_arms
 	faction_discount = 0


### PR DESCRIPTION
## About The Pull Request

Lowers the price of the civilian Viper revolver to 1500cr (from 2500cr) and the military Viper revolver to 1750cr (from 3000cr).

## Why It's Good For The Game

These guns were way overpriced for their actual worth. Similarly priced guns such as the Rattlesnake (2500cr) and Cobra (3000cr) *severely* outperforms the Viper in nearly any combat scenario.

## Changelog

:cl:
balance: Lowers the price of the civilian Viper revolver to 1500cr (from 2500cr) and the military Viper revolver to 1750cr (from 3000cr).
/:cl: