### PR TITLE
Nerfs the health of basic giant spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -36,8 +36,8 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	maxHealth = 200
-	health = 200
+	maxHealth = 60
+	health = 60
 	obj_damage = 60
 	melee_damage_lower = 15
 	melee_damage_upper = 20


### PR DESCRIPTION
## About The Pull Request

Nerfs the health of basic giant spiders from 200 to 60.

All other health thresholds are untouched.

## Why It's Good For The Game

They had more health than the supposedly "tanky" Tarantulas, and oftentimes took more rounds to down than a goliath. All other spiders had around 40 health so I believe this was likely an oversight, but as the basic spiders were incredibly fast with this health it made them very hard to fight and very punishing being that they poison people.

## Changelog

:cl:
balance: Basic spiders no longer take more bullets than your average frontiersman.
/:cl:
