### PR TITLE
Adds ammo boxes to the Vaquero

### DIFF
--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -391,7 +391,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "gh" = (
-/obj/machinery/photocopier,
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 4
 	},
@@ -399,6 +398,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/helm/viewscreen/directional/north,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "gl" = (
@@ -1854,7 +1854,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ci" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 4
@@ -1865,6 +1864,9 @@
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/gas/inteq,
+/obj/item/clothing/suit/space/hardsuit/security/independent/inteq,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Cl" = (
@@ -3281,10 +3283,15 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/security/independent/inteq,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/mask/gas/inteq,
+/obj/structure/rack,
+/obj/item/storage/toolbox/ammo/c9mm{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/ammo/shotgun{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "XO" = (

--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -261,37 +261,17 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet{
-	icon_state = "armory";
-	name = "weapons locker";
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null;
 	req_access_txt = "3"
 	},
-/obj/machinery/light/small/directional/north,
-/obj/item/ammo_box/magazine/m12g_bulldog{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/ammo_box/magazine/m12g_bulldog{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/co9mm{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/co9mm{
-	pixel_x = -5
-	},
-/obj/item/ammo_box/magazine/co9mm{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/co9mm{
-	pixel_x = -5
-	},
 /obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq/no_mag,
-/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
 /obj/item/gun/ballistic/automatic/pistol/commander/inteq{
 	pixel_y = -5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "fc" = (
@@ -1864,9 +1844,7 @@
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/mask/gas/inteq,
-/obj/item/clothing/suit/space/hardsuit/security/independent/inteq,
+/obj/machinery/photocopier,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Cl" = (
@@ -1976,6 +1954,36 @@
 /obj/machinery/firealarm/directional/south,
 /obj/structure/chair/handrail{
 	dir = 1
+	},
+/obj/structure/closet/crate/secure/gear{
+	req_access_txt = "1";
+	name = "ammo crate"
+	},
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = -5
+	},
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = 5
+	},
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = -5
+	},
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = 5
+	},
+/obj/item/ammo_box/magazine/m12g_bulldog{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m12g_bulldog{
+	pixel_x = 5
+	},
+/obj/item/storage/toolbox/ammo/shotgun{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/ammo/c9mm{
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security)
@@ -2217,11 +2225,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "Hw" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "sec";
-	name = "equipment locker";
-	req_access_txt = "1"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -2229,26 +2232,31 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
 	},
-/obj/item/clothing/suit/armor/vest/bulletproof,
-/obj/item/clothing/head/helmet/swat/inteq,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/glasses/hud/security/sunglasses/inteq,
-/obj/item/clothing/mask/balaclava/inteq,
-/obj/item/storage/belt/security/webbing/inteq,
-/obj/item/storage/belt/security/webbing/inteq/alt,
-/obj/item/melee/baton/loaded,
-/obj/item/storage/box/zipties,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/melee/knife/survival,
-/obj/item/melee/knife/survival,
-/obj/item/melee/knife/survival,
+/obj/structure/crate_shelf,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/structure/closet/crate/secure/gear{
+	req_access_txt = "1"
+	},
 /obj/item/attachment/rail_light,
 /obj/item/attachment/rail_light,
 /obj/item/attachment/rail_light,
+/obj/item/storage/box/zipties,
+/obj/item/melee/knife/survival,
+/obj/item/melee/knife/survival,
+/obj/item/melee/knife/survival,
+/obj/item/clothing/gloves/combat,
+/obj/item/melee/baton/loaded,
+/obj/item/storage/belt/security/webbing/inteq,
+/obj/item/clothing/mask/balaclava/inteq,
+/obj/item/clothing/glasses/hud/security/sunglasses/inteq,
+/obj/item/clothing/head/helmet/swat/inteq,
+/obj/item/storage/belt/security/webbing/inteq/alt,
+/obj/item/clothing/suit/armor/vest/bulletproof,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "HN" = (
@@ -3284,14 +3292,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack,
-/obj/item/storage/toolbox/ammo/c9mm{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/ammo/shotgun{
-	pixel_x = -6;
-	pixel_y = 4
-	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/security/independent/inteq,
+/obj/item/clothing/mask/gas/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "XO" = (


### PR DESCRIPTION
## About The Pull Request

Slightly adjusts the armory of the Vaquero and adds a 9mm and Buckshot ammo can to it.

## Why It's Good For The Game

The ship has guns. The guns lack ammo boxes. Nearly all other ships that start with guns come with ammo boxes.
9mm and Buckshot are infamous at chewing through ammo when doing anything.

The ship no longer needs to buy boxes roundstart to function in it's intended role.

## Changelog

:cl:
balance: Vaquero now has ammo.
/:cl:
