### PR TITLE
Halves Space Basilisk and Dwarf Legion Health

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -18,8 +18,8 @@
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
 	speed = 3
-	maxHealth = 175
-	health = 175
+	maxHealth = 90
+	health = 90
 	harm_intent_damage = 5
 	obj_damage = 60
 	melee_damage_lower = 7

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -152,8 +152,8 @@
 	icon_aggro = "dwarf_legion"
 	icon_dead = "dwarf_legion"
 	//mob_trophy = /obj/item/mob_trophy/dwarf_skull
-	maxHealth = 150
-	health = 150
+	maxHealth = 75
+	health = 75
 	move_to_delay = 2
 	speed = 1 //much faster!
 	dwarf_mob = TRUE


### PR DESCRIPTION
## About The Pull Request

Lowers Space Basilisk Health from 175 to 90.

Lowers Dwarf Legion Health from 150 to 75.

## Why It's Good For The Game

These spawn as "mook" mobs from drills done in space, rapid fire freezing bolts and move at decently high speeds while soaking *repeated* automatic gunfire. This should make them easier to handle when four of them pop out of the drill at once.

Dwarf legions would run across your screen and spam skulls at you while taking more bullets than a goliath on average. 

## Changelog

:cl:
balance: Space Basilisks and Dwarf Legions are decently weaker.
/:cl:

