### PR TITLE
Loadout jumpsuits tweak.

### DIFF
--- a/code/modules/client/loadout/loadout_uniform.dm
+++ b/code/modules/client/loadout/loadout_uniform.dm
@@ -19,39 +19,12 @@
 //Colored jumpsuits
 
 /datum/gear/uniform/color
-	subtype_path = /datum/gear/uniform/color
+	display_name = "jumpsuit, recolorable"
+	path = /obj/item/clothing/under/color
 
-/datum/gear/uniform/color/red
-	display_name = "jumpsuit, red"
-	path = /obj/item/clothing/under/color/red
-
-/datum/gear/uniform/color/green
-	display_name = "jumpsuit, green"
-	path = /obj/item/clothing/under/color/green
-
-/datum/gear/uniform/color/blue
-	display_name = "jumpsuit, blue"
-	path = /obj/item/clothing/under/color/blue
-
-/datum/gear/uniform/color/yellow
-	display_name = "jumpsuit, yellow"
-	path = /obj/item/clothing/under/color/yellow
-
-/datum/gear/uniform/color/pink
-	display_name = "jumpsuit, pink"
-	path = /obj/item/clothing/under/color/pink
-
-/datum/gear/uniform/color/black
-	display_name = "jumpsuit, black"
-	path = /obj/item/clothing/under/color/black
-
-/datum/gear/uniform/color/white
-	display_name = "jumpsuit, white"
-	path = /obj/item/clothing/under/color/white
-
-/datum/gear/uniform/color/random
-	display_name = "jumpsuit, random"
-	path = /obj/item/clothing/under/color/random //literally useless if grey assistants is off
+/datum/gear/uniform/color_skirt
+	display_name = "jumpskirt, recolorable"
+	path = /obj/item/clothing/under/color/jumpskirt
 
 //Shorts
 

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -1,13 +1,52 @@
 /obj/item/clothing/under/color
+	name = "jumpsuit"
 	desc = "A standard issue colored jumpsuit. Variety is the spice of life!"
 	dying_key = DYE_REGISTRY_UNDER
 	icon = 'icons/obj/clothing/under/color.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/under/color.dmi'
 	supports_variations = DIGITIGRADE_VARIATION | VOX_VARIATION
+	icon_state = "black"
+	item_state = "bl_suit"
+	unique_reskin = list("black jumpsuit" = "black",
+						"grey jumpsuit" = "grey",
+						"blue jumpsuit" = "blue",
+						"green jumpsuit" = "green",
+						"orange jumpsuit" = "orange",
+						"pink jumpsuit" = "pink",
+						"red jumpsuit" = "red",
+						"white jumpsuit" = "white",
+						"yellow jumpsuit" = "yellow",
+						"dark blue jumpsuit" = "darkblue",
+						"teal jumpsuit" = "teal",
+						"light purple jumpsuit" = "lightpurple",
+						"dark green jumpsuit" = "darkgreen",
+						"light brown jumpsuit" = "lightbrown",
+						"brown jumpsuit" = "brown",
+						"maroon jumpsuit" = "maroon"
+						)
 
 /obj/item/clothing/under/color/jumpskirt
+	name = "jumpskirt"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = TRUE
+	icon_state = "black_skirt"
+	unique_reskin = list("black jumpskirt" = "black_skirt",
+						"grey jumpskirt" = "grey_skirt",
+						"blue jumpskirt" = "blue_skirt",
+						"green jumpskirt" = "green_skirt",
+						"orange jumpskirt" = "orange_skirt",
+						"pink jumpskirt" = "pink_skirt",
+						"red jumpskirt" = "red_skirt",
+						"white jumpskirt" = "white_skirt",
+						"yellow jumpskirt" = "yellow_skirt",
+						"dark blue jumpskirt" = "darkblue_skirt",
+						"teal jumpskirt" = "teal_skirt",
+						"light purple jumpskirt" = "lightpurple_skirt",
+						"dark green jumpskirt" = "darkgreen_skirt",
+						"light brown jumpskirt" = "lightbrown_skirt",
+						"brown jumpskirt" = "brown_skirt",
+						"maroon jumpskirt" = "maroon_skirt"
+						)
 
 /obj/item/clothing/under/color/random
 	icon_state = "random_jumpsuit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaced the selection of 16 jumpsuits with a single re-skinnable one.
Added a re-skinnable jumpskirt too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less "bloated" loadout. Easier to scroll through, as the jumpsuit category was kind of really long.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
tweak: Replaced the selection of 16 jumpsuits in the loadout with a single re-skinnable one.
add: Added a re-skinnable jumpskirt to the loadout too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
