### PR TITLE
Fixes hollowpoint 8x50 boxes

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_rifle_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_rifle_stacks.dm
@@ -22,7 +22,7 @@
 	desc = "A box of hollow point 8x50mm ammo, designed to cause massive damage at the cost of armor penetration."
 	icon_state = "8x50mmbox-hp"
 
-/obj/item/storage/box/ammo/a8_50r_hp/PopulateContents()
+/obj/item/storage/box/ammo/a8_50r/hp/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a8_50r/hp = 4)
 	generate_items_inside(items_inside,src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a typo in the code. 8x50 HP ammo was spawning with normal ammo instead of hollowpoints.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes good.

## Changelog

:cl:
fix: 8x50 HP ammo boxes spawn with the correct ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
