### PR TITLE
Gun misfires now target only the leg again

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1002,10 +1002,9 @@
 			if(at_risk == human_holder.s_store)
 				chance_to_fire = round(GUN_NO_SAFETY_MALFUNCTION_CHANCE_LOW * at_risk.safety_multiplier)
 		if(at_risk.safety == FALSE && prob(chance_to_fire))
-			var/bodyzone = pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG,BODY_ZONE_R_LEG)
-			if(at_risk.process_fire(src,src,FALSE, null, bodyzone) == TRUE)
+			if(at_risk.process_fire(src,src,FALSE, null,  pick(BODY_ZONE_L_LEG,BODY_ZONE_R_LEG)) == TRUE)
 				log_combat(src,src,"misfired",at_risk,"caused by [cause]")
-				visible_message(span_danger("\The [at_risk.name]'s trigger gets caught as [src] falls, suddenly going off into [src]'s [bodyzone]!"), span_danger("\The [at_risk.name]'s trigger gets caught on something as you fall, suddenly going off into your [bodyzone]!"))
+				visible_message(span_danger("\The [at_risk.name]'s trigger gets caught as [src] falls, suddenly going off into [src]'s leg without its safties on!"), span_danger("\The [at_risk.name]'s trigger gets caught on something as you fall, suddenly going off into your leg without its safeties on!"))
 				human_holder.force_scream()
 
 //I need to refactor this into an attachment


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gun misfires now only target the left leg as they were originally coded. 

## Why It's Good For The Game

Originally, the purpose of misfires was to encourage through gameplay mechanics that people perform gun safety and targeting the leg was so that it was able to be destructive but not cause things that are incredibly difficult to treat or in some cases instantaneously kill you.

This brings it back to that original purpose of being a mechanic-encouraged gun safety feature and not a "gotcha" for stepping on an ice tile with an unsafed firearm.

## Changelog

:cl:
balance: Misfires only go off in the your leg again.
/:cl:

