### PR TITLE
fix broken hanger number indie space

### DIFF
--- a/_maps/outpost/hangar/indie_space_56x40.dmm
+++ b/_maps/outpost/hangar/indie_space_56x40.dmm
@@ -144,6 +144,10 @@
 	planetary_atmos = 1
 	},
 /area/hangar)
+"RV" = (
+/obj/effect/landmark/outpost/hangar_numbers,
+/turf/open/floor/hangar/plasteel,
+/area/hangar)
 "Yz" = (
 /obj/machinery/light/floor/hangar,
 /turf/open/floor/plasteel/tech{
@@ -1864,7 +1868,7 @@ ck
 ck
 ck
 MN
-aA
+RV
 aP
 aE
 aM


### PR DESCRIPTION
:cl:
fix: indie space is no longer missing numbers on the 56x40 hangar
/:cl:

