### PR TITLE
Plexagon ID management can assign job's from the ship's job list.

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -240,7 +240,7 @@ SUBSYSTEM_DEF(mapping)
 				job_slot = GLOB.name_occupations[job]
 				slots = value
 			else if(islist(value))
-				var/datum/outfit/job_outfit = text2path(value["outfit"])
+				var/datum/outfit/job/job_outfit = text2path(value["outfit"])
 				if(isnull(job_outfit))
 					stack_trace("Invalid job outfit! [value["outfit"]] on [S.name]'s config! Defaulting to assistant clothing.")
 					job_outfit = /datum/outfit/job/assistant

--- a/code/modules/clothing/outfits/ert/frontiersmen_ert.dm
+++ b/code/modules/clothing/outfits/ert/frontiersmen_ert.dm
@@ -1,5 +1,6 @@
 /datum/outfit/job/frontiersmen/ert //most basic of grunts
 	name = "ERT - Frontiersman Basic"
+	jobtype = /datum/job/officer
 
 	head = /obj/item/clothing/head/beret/sec/frontier
 	suit = /obj/item/clothing/suit/armor/vest/bulletproof

--- a/code/modules/clothing/outfits/ert/minutemen_ert.dm
+++ b/code/modules/clothing/outfits/ert/minutemen_ert.dm
@@ -110,6 +110,7 @@
 
 /datum/outfit/job/clip/minutemen/military_police
 	name = "ERT - C-MM Military Police"
+	jobtype = /datum/job/officer
 	id_assignment = "Military Police"
 	job_icon = "clip_cmm3"
 

--- a/code/modules/clothing/outfits/factions/independent.dm
+++ b/code/modules/clothing/outfits/factions/independent.dm
@@ -676,6 +676,9 @@
 
 /datum/outfit/job/independent/bartender
 	name = "Independent - Bartender"
+	job_icon = "bartender"
+	jobtype = /datum/job/bartender
+
 
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	ears = /obj/item/radio/headset/headset_srv

--- a/code/modules/clothing/outfits/factions/nanotrasen.dm
+++ b/code/modules/clothing/outfits/factions/nanotrasen.dm
@@ -478,6 +478,8 @@
 /datum/outfit/job/nanotrasen/pilot
 	name = "Nanotrasen - Pilot"
 	id_assignment = "Pilot"
+	jobtype = /datum/job/head_of_personnel
+
 
 	uniform = /obj/item/clothing/under/rank/security/officer/military
 	suit = /obj/item/clothing/suit/jacket/leather/duster

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -35,10 +35,9 @@
 	name = new_name
 	outfit = new_outfit
 
-	var/datum/job/outfit_job = new_outfit.jobtype
+	var/datum/job/outfit_job = new new_outfit.jobtype
 	if(outfit_job)
-		access = outfit_job.access
-		minimal_access = outfit_job.minimal_access
+		access = outfit_job.get_access()
 
 	register()
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -28,11 +28,19 @@
 	///Levels unlocked at roundstart in physiology
 	var/list/roundstart_experience
 
-/datum/job/New(new_name, datum/outfit/new_outfit)
-	if(new_name)
-		name = new_name
-		outfit = new_outfit
-		register()
+/datum/job/New(new_name, datum/outfit/job/new_outfit)
+	if(!new_name)
+		return
+
+	name = new_name
+	outfit = new_outfit
+
+	var/datum/job/outfit_job = new_outfit.jobtype
+	if(outfit_job)
+		access = outfit_job.access
+		minimal_access = outfit_job.minimal_access
+
+	register()
 
 /datum/job/proc/register()
 	GLOB.occupations += src
@@ -176,7 +184,7 @@
 /datum/outfit/job
 	name = "Standard Gear"
 
-	var/jobtype = null
+	var/datum/job/jobtype = null
 
 	uniform = /obj/item/clothing/under/color/grey
 	wallet = /obj/item/storage/wallet

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -24,10 +24,26 @@
 	///Which departments this computer has access to. Defined as access regions. null = all departments
 	var/target_dept
 
+	// Can only get defined on stationary console altough you can carry it away if you yoink the hard drive or copy the file
+	var/datum/overmap/ship/controlled/ship
+
 	//For some reason everything was exploding if this was static.
 	var/list/sub_managers
 
 	COOLDOWN_DECLARE(silicon_access_print_cooldown)
+
+/datum/computer_file/program/card_mod/run_program(mob/living/user)
+	. = ..()
+	if (!.)
+		return 0
+	if (computer.req_ship_access && !ship)
+		ship = SSshuttle.get_ship(computer) // get it once and never again
+	return 1
+
+/datum/computer_file/program/card_mod/clone()
+	var/datum/computer_file/program/card_mod/temp = ..()
+	temp.ship = ship
+	return temp
 
 /datum/computer_file/program/card_mod/New(obj/item/modular_computer/comp)
 	. = ..()
@@ -63,10 +79,8 @@
 	if(!id_card)
 		return
 
-	if (computer.req_ship_access)
-		var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(computer)
-		if (ship?.unique_ship_access && !(id_card?.has_ship_access(SSshuttle.get_ship(computer))))
-			return FALSE
+	if (ship?.unique_ship_access && !(id_card?.has_ship_access(ship)))
+		return FALSE
 
 	region_access = list()
 	if(!target_dept && (ACCESS_CHANGE_IDS in id_card.access))
@@ -75,14 +89,11 @@
 		update_static_data(user)
 		return TRUE
 
-	var/list/head_types = list()
 	for(var/access_text in sub_managers)
 		var/list/info = sub_managers[access_text]
 		var/access = text2num(access_text)
 		if((access in id_card.access) && ((info["region"] in target_dept) || !length(target_dept)))
 			region_access += info["region"]
-			//I don't even know what I'm doing anymore
-			head_types += info["head"]
 
 	if(length(region_access))
 		minor = TRUE
@@ -169,6 +180,7 @@
 			id_card.access -= get_all_centcom_access() + get_all_accesses()
 			id_card.assignment = "Unassigned"
 			id_card.update_label()
+			SEND_SIGNAL(id_card, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_edit")
@@ -180,6 +192,7 @@
 			id_card.registered_name = new_name
 			id_card.update_label()
 			id_card.update_appearance()
+			SEND_SIGNAL(id_card, COSMIG_ACCESS_UPDATED)
 			playsound(computer, "terminal_type", 50, FALSE)
 			return TRUE
 		if("PRG_assign")
@@ -200,6 +213,11 @@
 				var/list/new_access = list()
 				if(is_centcom)
 					new_access = get_centcom_access(target)
+				else if(ship)
+					for (var/datum/job/J in ship.job_slots)
+						if(J.name == target)
+							new_access = J.get_access()
+							break
 				else
 					var/datum/job/job
 					for(var/jobtype in subtypesof(/datum/job))
@@ -215,6 +233,7 @@
 				id_card.access |= new_access
 				id_card.assignment = target
 				id_card.update_label()
+				SEND_SIGNAL(id_card, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_access")
@@ -226,41 +245,39 @@
 					id_card.access -= access_type
 				else
 					id_card.access |= access_type
+				SEND_SIGNAL(id_card, COSMIG_ACCESS_UPDATED)
 				playsound(computer, "terminal_type", 50, FALSE)
 				return TRUE
 		if ( "PRG_grantship" )
-			if(!computer || !authenticated || !computer.req_ship_access) // Only stationary computers can grant ship access. Prevents funny tablet exploits
+			if(!computer || !authenticated || !ship)
 				return
-			id_card.add_ship_access(SSshuttle.get_ship(computer))
+			id_card.add_ship_access(ship)
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if ( "PRG_denyship" )
-			if(!computer || !authenticated || !computer.req_ship_access)
+			if(!computer || !authenticated || !ship)
 				return
-			id_card.remove_ship_access(SSshuttle.get_ship(computer))
+			id_card.remove_ship_access(ship)
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if ( "PRG_enableuniqueaccess" )
-			if(!computer || !authenticated || !computer.req_ship_access)
+			if(!computer || !authenticated || !ship)
 				return
-			var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(computer)
-			ship?.unique_ship_access = TRUE
+			ship.unique_ship_access = TRUE
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if ( "PRG_disableuniqueaccess" )
-			if(!computer || !authenticated || !computer.req_ship_access)
+			if(!computer || !authenticated || !ship)
 				return
-			var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(computer)
-			ship?.unique_ship_access = FALSE
+			ship.unique_ship_access = FALSE
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if ( "PRG_printsiliconaccess" )
-			if(!computer || !authenticated || !computer.req_ship_access)
+			if(!computer || !authenticated || !ship)
 				return
 			if(!COOLDOWN_FINISHED(src, silicon_access_print_cooldown))
 				computer.say("Printer unavailable. Please allow a short time before attempting to print.")
 				return
-			var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(computer)
 			if (ship)
 				var/obj/item/borg/upgrade/ship_access_chip/chip = new(get_turf(computer))
 				chip.ship = ship
@@ -271,12 +288,14 @@
 			if(!computer || !authenticated || minor)
 				return
 			id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
+			SEND_SIGNAL(src, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyall")
 			if(!computer || !authenticated || minor)
 				return
 			id_card.access.Cut()
+			SEND_SIGNAL(src, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_grantregion")
@@ -286,6 +305,7 @@
 			if(isnull(region))
 				return
 			id_card.access |= get_region_accesses(region)
+			SEND_SIGNAL(src, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyregion")
@@ -295,6 +315,7 @@
 			if(isnull(region))
 				return
 			id_card.access -= get_region_accesses(region)
+			SEND_SIGNAL(src, COSMIG_ACCESS_UPDATED)
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 
@@ -309,6 +330,11 @@
 	var/list/departments = target_dept
 	if(is_centcom)
 		departments = list("CentCom" = get_all_centcom_jobs())
+	else if(ship)
+		var/jobs = list()
+		for (var/datum/job/job in ship.job_slots)
+			jobs += job.name
+		departments = list("Jobs" = jobs)
 	else if(isnull(departments))
 		departments = list(
 			CARDCON_DEPARTMENT_COMMAND = list("Captain"),//lol
@@ -325,7 +351,7 @@
 		var/list/department_jobs = list()
 		for(var/job in job_list)
 			if(minor)
-				continue
+				break
 			department_jobs += list(list(
 				"display_name" = replacetext(job, "&nbsp", " "),
 				"job" = job
@@ -386,11 +412,10 @@
 			data["id_owner"] = id_card.registered_name ? id_card.registered_name : "-----"
 			data["access_on_card"] = id_card.access
 
-		data[ "req_ship_access" ] = computer.req_ship_access // Only stationary computers can grant ship access. Prevents funny tablet exploits
 		if (id_card)
-			data[ "id_has_ship_access" ] = id_card.has_ship_access(SSshuttle.get_ship(computer))
-		var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(computer)
+			data[ "id_has_ship_access" ] = id_card.has_ship_access(ship)
 		if (ship)
+			data[ "has_ship" ] = 1
 			data[ "ship_has_unique_access" ] = ship.unique_ship_access
 
 	return data

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -35,7 +35,7 @@ export const NtosCardContent = (props, context) => {
     have_printer,
     have_id_slot,
     id_name,
-    req_ship_access,
+    has_ship,
     id_has_ship_access,
     ship_has_unique_access,
   } = data;
@@ -111,7 +111,7 @@ export const NtosCardContent = (props, context) => {
           </Tabs>
           {tab === 1 && (
             <>
-              {req_ship_access === 1 && (
+              {has_ship === 1 && (
                 <Section
                   title={
                     'ID Ship Access: ' +
@@ -177,19 +177,21 @@ export const NtosCardContent = (props, context) => {
                 }
               />
               <Flex>
-                <Flex.Item>
-                  <Tabs vertical>
-                    {Object.keys(jobs).map((department) => (
-                      <Tabs.Tab
-                        key={department}
-                        selected={department === selectedDepartment}
-                        onClick={() => setSelectedDepartment(department)}
-                      >
-                        {department}
-                      </Tabs.Tab>
-                    ))}
-                  </Tabs>
-                </Flex.Item>
+                {Object.keys(jobs).length > 1 && (
+                  <Flex.Item>
+                    <Tabs vertical>
+                      {Object.keys(jobs).map((department) => (
+                        <Tabs.Tab
+                          key={department}
+                          selected={department === selectedDepartment}
+                          onClick={() => setSelectedDepartment(department)}
+                        >
+                          {department}
+                        </Tabs.Tab>
+                      ))}
+                    </Tabs>
+                  </Flex.Item>
+                )}
                 <Flex.Item grow={1}>
                   {departmentJobs.map((job) => (
                     <Button
@@ -207,7 +209,7 @@ export const NtosCardContent = (props, context) => {
               </Flex>
             </Section>
           )}
-          {tab === 3 && req_ship_access === 1 && (
+          {tab === 3 && has_ship === 1 && (
             <>
               <Section
                 title={


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- If a console get started on a ship it will now be able to assign an ID to any job that can be joined on the ship.
- This behavior can be extended to any computer if you copy Plexagon acces management to another computer or yoink the hard drive, but you'll still need a card with proper access (including ship access) to do so.

The old behavior is still present if Plexagon is not connected to any ship.

## Why It's Good For The Game

Id management felt off since we were only able to assign crew to station job. With this pr we will now be able to actualy demote/promote crew.

## Changelog

:cl:
add: Assigning a crew to a job that comes on the ship is now possible with command consoles.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
