### PR TITLE
Washing machine density fix + nimbus bathroom lock

### DIFF
--- a/_maps/shuttles/cybersun/cybersun_nimbus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_nimbus.dmm
@@ -2197,6 +2197,15 @@
 	pixel_y = 6
 	},
 /obj/item/soap/deluxe,
+/obj/machinery/button/door{
+	pixel_y = -20;
+	pixel_x = 22;
+	dir = 1;
+	name = "door lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	id = "nimbbath"
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/cargo)
 "NU" = (
@@ -2460,7 +2469,8 @@
 /area/ship/crew/ccommons)
 "SN" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Restroom"
+	name = "Restroom";
+	id_tag = "nimbbath"
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/white,
 /turf/open/floor/plasteel/tech,

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -349,5 +349,6 @@ GLOBAL_LIST_INIT(dye_registry, list(
 
 /obj/machinery/washing_machine/open_machine(drop = 1)
 	..()
-	density = TRUE //because machinery/open_machine() sets it to 0
+	if(initial(density))
+		density = TRUE //because machinery/open_machine() sets it to 0
 	color_source = null


### PR DESCRIPTION
## About The Pull Request

makes washing machines that are set to not be dense when loaded not become dense later

adds a bathroom lock to the nimbus.

## Changelog

:cl:
add: nimbus bathroom lock
fix: some washing machines no longer magically become dense
/:cl: