### PR TITLE
Fix railing corners blocking movement && makes thin/thick railings craftable

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -8,6 +8,10 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("modern railing", /obj/structure/railing/modern, 3, time = 18, window_checks = TRUE), \
 	new/datum/stack_recipe("modern railing corner", /obj/structure/railing/modern/corner, 1, time = 10, window_checks = TRUE), \
 	new/datum/stack_recipe("modern railing end", /obj/structure/railing/modern/end, 3, time = 18, window_checks = TRUE), \
+	new/datum/stack_recipe("thin railing", /obj/structure/railing/thin, 3, time = 18, window_checks = TRUE), \
+	new/datum/stack_recipe("thin railing corner", /obj/structure/railing/thin/corner, 1, time = 10, window_checks = TRUE), \
+	new/datum/stack_recipe("thick railing", /obj/structure/railing/thick, 3, time = 18, window_checks = TRUE), \
+	new/datum/stack_recipe("thick railing corner", /obj/structure/railing/thick/corner, 1, time = 10, window_checks = TRUE), \
 	new/datum/stack_recipe("ladder", /obj/structure/ladder/crafted, 15, time = 150, one_per_turf = TRUE, on_floor = FALSE), \
 	new/datum/stack_recipe("handrail", /obj/structure/chair/handrail, 4, time = 15, one_per_turf = TRUE), \
 	))

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -216,3 +216,5 @@
 
 /obj/structure/railing/thin/corner
 	icon_state = "railing_thin_corner"
+	density = FALSE
+	climbable = FALSE

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -210,6 +210,9 @@
 
 /obj/structure/railing/thick/corner
 	icon_state = "railing_thick_corner"
+	density = FALSE
+	climbable = FALSE
+	buildstackamount = 1
 
 /obj/structure/railing/thin
 	icon_state = "railing_thin"
@@ -218,3 +221,4 @@
 	icon_state = "railing_thin_corner"
 	density = FALSE
 	climbable = FALSE
+	buildstackamount = 1


### PR DESCRIPTION
## Changelog

:cl:
add: you can now craft thick/thin railings
fix: railing corners should no longer block movement
/:cl:
