### PR TITLE
.45-70 Ammo Can Be Stacked to 6 Rounds

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -28,7 +28,7 @@
 	caliber = ".45-70"
 	icon_state = "magnum-brass"
 	projectile_type = /obj/projectile/bullet/a4570
-	stack_size = 5
+	stack_size = 6
 
 /obj/item/ammo_casing/a4570/match
 	name = ".45-70 match bullet casing"


### PR DESCRIPTION
## About The Pull Request

.45-70 comes in stacks of 6 rounds in a box. It can only be manually stacked to 5. This fixes that.

## Why It's Good For The Game

Consistency

## Changelog

:cl:
fix: .45-70 stack size
/:cl: