### PR TITLE
Scrapping Charges in Cargo

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -638,6 +638,9 @@
 	if(prob(5))
 		new /obj/item/reagent_containers/food/snacks/pizza/pineapple(src)
 
+/obj/item/storage/backpack/duffelbag/syndie/c4
+	name = "demolitions duffel bag"
+
 /obj/item/storage/backpack/duffelbag/syndie/c4/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/grenade/c4(src)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -7,7 +7,7 @@ FLOOR SAFES
 /// Chance for a sound clue
 #define SOUND_CHANCE 10
 /// Explosion number threshold for opening safe
-#define BROKEN_THRESHOLD 3
+#define BROKEN_THRESHOLD 1
 
 //SAFES
 /obj/structure/safe
@@ -92,10 +92,6 @@ FLOOR SAFES
 		explosion_count++
 		switch(explosion_count)
 			if(1)
-				desc = initial(desc) + "\nIt looks a little banged up."
-			if(2)
-				desc = initial(desc) + "\nIt's pretty heavily damaged."
-			if(3)
 				desc = initial(desc) + "\nThe lock seems to be broken."
 
 /obj/structure/safe/ui_assets(mob/user)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -6,8 +6,6 @@ FLOOR SAFES
 
 /// Chance for a sound clue
 #define SOUND_CHANCE 10
-/// Explosion number threshold for opening safe
-#define BROKEN_THRESHOLD 1
 
 //SAFES
 /obj/structure/safe
@@ -35,8 +33,8 @@ FLOOR SAFES
 	var/current_tumbler_index = 1
 	/// The combined w_class of everything in the safe
 	var/space = 0
-	/// Tough, but breakable if explosion counts reaches set value
-	var/explosion_count = 0
+	/// The lock is broken if this is true
+	var/safe_broken = FALSE
 
 /obj/structure/safe/Initialize(mapload)
 	. = ..()
@@ -88,11 +86,10 @@ FLOOR SAFES
 			return
 
 /obj/structure/safe/ex_act(severity, target)
-	if(((severity == 2 && target == src) || severity == 1) && explosion_count < BROKEN_THRESHOLD)
-		explosion_count++
-		switch(explosion_count)
-			if(1)
-				desc = initial(desc) + "\nThe lock seems to be broken."
+	if(((severity == 2 && target == src) || severity == 1) && !safe_broken)
+		safe_broken = TRUE
+		if(safe_broken)
+			desc = initial(desc) + "\nThe lock seems to be broken."
 
 /obj/structure/safe/ui_assets(mob/user)
 	return list(
@@ -207,7 +204,7 @@ FLOOR SAFES
 * Checks if safe is considered in a broken state for force-opening the safe
 */
 /obj/structure/safe/proc/check_broken()
-	return broken || explosion_count >= BROKEN_THRESHOLD
+	return broken || safe_broken
 
 /**
 * Called every dial turn to determine whether the safe should unlock or not.
@@ -245,4 +242,3 @@ FLOOR SAFES
 	AddElement(/datum/element/undertile)
 
 #undef SOUND_CHANCE
-#undef BROKEN_THRESHOLD

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -94,7 +94,6 @@
 	contains = list(/obj/item/flamethrower/full)
 	crate_name = "flamethrower crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon
-
 	faction = /datum/faction/syndicate/ngr
 	faction_discount = 20
 
@@ -106,6 +105,17 @@
 					/obj/item/grenade/frag)
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon
+
+/datum/supply_pack/sec_supply/frag_grenade
+	name = "C-4 Demolitions Charge Crate"
+	desc = "Contains a duffel of C-4 demolitions charges, for use in scrapping and demolitions of large-scale structures."
+	cost = 1000
+	contains = list(/obj/item/storage/backpack/duffelbag/syndie/c4)
+	crate_name = "demolitions charge crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon
+	faction = /datum/faction/syndicate/ngr
+	faction_discount = 10
+
 
 /datum/supply_pack/sec_supply/halberd
 	name = "Energy Halberd Crate"

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -116,7 +116,6 @@
 	faction = /datum/faction/syndicate/ngr
 	faction_discount = 10
 
-
 /datum/supply_pack/sec_supply/halberd
 	name = "Energy Halberd Crate"
 	desc = "Contains one Solarian Energy Halberd, for issue to your local Sonnensoldner battalion."


### PR DESCRIPTION
## About The Pull Request

Adds a C-4 duffel to cargo (10 charges at 100 a charge), at the cost of 1000 credits.
C-4 itself is surprisingly not as destructive as one might think, and in the things one performs in shiptest it could be particularly useful. Breaching a wall in a ruin is a big one, or blowing open safes (did you know you could do that with C4?)

C-4 is already available in a few places and even on certain military ships roundstart, so it wouldn't be too out of place.

This PR also makes it so you only need one C-4 charge to blow the lock on a safe, to make them another method to bypass the lock. Three charges on what was effectively rare to find explosives just to pop open a safe was a bit much. (Refactoring was done by @FalloutFalcon, thanks Fallcon!)

## Why It's Good For The Game

This adds additional gameplay options for clearing ruins, excavating, breaking open safes, and a number of other things. With a do_after to place them, a 10 second timer and a very visible overlay on items, it's hard to use them stealthily either. 

## Changelog

:cl: Cloudbreak, FalloutFalcon
add: Demolitions charges to Cargo
balance: Safes only take one C-4 charge to explode
/:cl:
