### PR TITLE
Reduces Shotgun spread by one point

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -36,8 +36,8 @@
 
 	zoom_amt = SHOTGUN_ZOOM
 
-	spread = 4
-	spread_unwielded = 10
+	spread = 3
+	spread_unwielded = 9
 	recoil = 1
 	recoil_unwielded = 4
 
@@ -58,8 +58,8 @@
 
 // Automatic Shotguns//
 /obj/item/gun/ballistic/shotgun/automatic
-	spread = 4
-	spread_unwielded = 16
+	spread = 3
+	spread_unwielded = 15
 	recoil = 1
 	recoil_unwielded = 4
 	wield_delay = 0.65 SECONDS

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -559,6 +559,7 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 	empty_indicator = FALSE
 	unique_mag_sprites_for_variants = FALSE
 
+	show_magazine_on_sprite = TRUE
 	semi_auto = TRUE
 	internal_magazine = FALSE
 	casing_ejector = TRUE
@@ -574,8 +575,8 @@ NO_MAG_GUN_HELPER(automatic/smg/cm5)
 
 	rack_sound = 'sound/weapons/gun/rifle/ar_cock.ogg'
 
-	spread = 4
-	spread_unwielded = 16
+	spread = 3
+	spread_unwielded = 15
 	recoil = 1
 	recoil_unwielded = 4
 	wield_slowdown = HEAVY_SHOTGUN_SLOWDOWN

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -888,8 +888,8 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 
 	rack_sound = 'sound/weapons/gun/rifle/ar_cock.ogg'
 
-	spread = 4
-	spread_unwielded = 16
+	spread = 3
+	spread_unwielded = 15
 	recoil = 1
 	recoil_unwielded = 4
 	wield_slowdown = HEAVY_SHOTGUN_SLOWDOWN

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -396,8 +396,8 @@ EMPTY_GUN_HELPER(automatic/m15)
 
 	fire_sound = 'sound/weapons/gun/shotgun/bulldog.ogg'
 
-	spread = 4
-	spread_unwielded = 16
+	spread = 3
+	spread_unwielded = 15
 	recoil = 1
 	recoil_unwielded = 4
 	wield_slowdown = SHOTGUN_SLOWDOWN


### PR DESCRIPTION
## About The Pull Request

Reduces shotgun spread by one point on most shotguns. The Shredder and sawn off shotguns are untouched.

Also fixes a visual bug with the CM-15 not showing it's magazines.

In response to having used shotguns in-game and having to stand next to an enemy in order to use them effectively, this extends their range by a single (one) tile. Should make them a little bit less overly dangerous to use effectively without making them overpowered.

No other stats like recoil were changed.

## Why It's Good For The Game

Ideally, this makes shotguns a bit more worth using as at the moment they falter especially on high level drills, where you have to run directly up to an enemy to do much of worth to them and thus open yourself up to being turbomurdered. This now lets you keep a single (one) tile of distance between you.

## Changelog

:cl:
balance: Shotguns are slightly more accurate
fix: CM-15 magazine sprites
/:cl:

