### PR TITLE
Makes some minor changes to Lavaland Buried Shrine

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
@@ -625,10 +625,8 @@
 /turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "pK" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/turf/open/floor/plating/moss,
+/obj/item/reagent_containers/food/snacks/grown/random,
+/turf/open/floor/plating/grass/lava,
 /area/ruin/unpowered/buried_shrine)
 "qh" = (
 /obj/structure/stone_tile{
@@ -675,6 +673,7 @@
 	dir = 5
 	},
 /obj/structure/chair/wood,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "qT" = (
@@ -931,11 +930,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wt" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/flashlight/flare/torch{
-	pixel_x = -18
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "wy" = (
 /obj/structure/stone_tile{
@@ -947,8 +945,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wM" = (
-/obj/item/reagent_containers/food/snacks/grown/random,
-/turf/open/floor/plating/grass/lava,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
+/obj/item/reagent_containers/food/snacks/grown/meatwheat{
+	pixel_x = -15;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wS" = (
 /obj/structure/stone_tile/surrounding/cracked{
@@ -1178,6 +1181,7 @@
 /obj/item/chair/wood/wings{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "CD" = (
@@ -1279,6 +1283,7 @@
 	dir = 1
 	},
 /obj/structure/chair/wood/wings,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "FC" = (
@@ -1689,11 +1694,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "RK" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
-/obj/item/reagent_containers/food/snacks/grown/meatwheat{
-	pixel_x = -15;
-	pixel_y = 4
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/flashlight/flare/torch{
+	pixel_x = -18
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
@@ -2707,7 +2710,7 @@ WZ
 TO
 Qb
 Mt
-wM
+pK
 Hv
 FC
 Qb
@@ -3977,7 +3980,7 @@ uP
 di
 zN
 Ad
-wt
+RK
 Ad
 BF
 yz
@@ -4061,7 +4064,7 @@ WZ
 WZ
 Yh
 Fw
-RK
+wM
 lJ
 WZ
 ta
@@ -4937,7 +4940,7 @@ Xr
 Fq
 Fq
 TO
-pK
+wt
 kp
 WZ
 Eh

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
@@ -625,8 +625,13 @@
 /turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "pK" = (
-/obj/item/reagent_containers/food/snacks/grown/random,
-/turf/open/floor/plating/grass/lava,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
+/obj/item/reagent_containers/food/snacks/grown/meatwheat{
+	pixel_x = -15;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "qh" = (
 /obj/structure/stone_tile{
@@ -945,14 +950,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
-/obj/item/reagent_containers/food/snacks/grown/meatwheat{
-	pixel_x = -15;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/buried_shrine)
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface/lit,
+/area/overmap_encounter/planetoid/lava/explored)
 "wS" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 4
@@ -1946,6 +1946,10 @@
 /obj/structure/flora/ausbushes/sparsegrass/hell,
 /turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
+"Zd" = (
+/obj/item/reagent_containers/food/snacks/grown/random,
+/turf/open/floor/plating/grass/lava,
+/area/ruin/unpowered/buried_shrine)
 "Zk" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -2710,7 +2714,7 @@ WZ
 TO
 Qb
 Mt
-pK
+Zd
 Hv
 FC
 Qb
@@ -3703,7 +3707,7 @@ Eh
 nh
 aD
 nh
-nh
+wM
 nh
 nh
 nh
@@ -4064,7 +4068,7 @@ WZ
 WZ
 Yh
 Fw
-wM
+pK
 lJ
 WZ
 ta
@@ -4330,7 +4334,7 @@ Eh
 Eh
 nh
 nh
-nh
+wM
 aD
 nh
 nh

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
@@ -424,7 +424,7 @@
 "kp" = (
 /obj/structure/table_frame/wood,
 /obj/structure/stone_tile/slab,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "kt" = (
 /obj/structure/stone_tile/block{
@@ -625,11 +625,10 @@
 /turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "pK" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/flashlight/flare/torch{
-	pixel_x = -18
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "qh" = (
 /obj/structure/stone_tile{
@@ -899,7 +898,7 @@
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/bow/ashen,
 /obj/structure/stone_tile/slab,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "vJ" = (
 /obj/structure/flora/ash/stem_shroom,
@@ -932,8 +931,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wt" = (
-/obj/item/reagent_containers/food/snacks/grown/random,
-/turf/open/floor/plating/grass/lava,
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/flashlight/flare/torch{
+	pixel_x = -18
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wy" = (
 /obj/structure/stone_tile{
@@ -943,6 +945,10 @@
 	dir = 6
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/buried_shrine)
+"wM" = (
+/obj/item/reagent_containers/food/snacks/grown/random,
+/turf/open/floor/plating/grass/lava,
 /area/ruin/unpowered/buried_shrine)
 "wS" = (
 /obj/structure/stone_tile/surrounding/cracked{
@@ -1536,7 +1542,7 @@
 	pixel_y = 12
 	},
 /obj/structure/stone_tile/slab,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "LW" = (
 /obj/structure/destructible/tribal_torch{
@@ -2701,7 +2707,7 @@ WZ
 TO
 Qb
 Mt
-wt
+wM
 Hv
 FC
 Qb
@@ -3046,7 +3052,7 @@ Td
 TO
 TO
 TO
-TO
+eI
 TO
 TO
 WZ
@@ -3102,8 +3108,8 @@ WZ
 WZ
 WZ
 TO
-TO
-TO
+eI
+eI
 WZ
 WZ
 WZ
@@ -3971,7 +3977,7 @@ uP
 di
 zN
 Ad
-pK
+wt
 Ad
 BF
 yz
@@ -4928,10 +4934,10 @@ TO
 Xr
 hn
 Xr
+Fq
+Fq
 TO
-TO
-TO
-Wd
+pK
 kp
 WZ
 Eh
@@ -4986,9 +4992,9 @@ TO
 TO
 TO
 TO
-TO
-TO
-TO
+BF
+Ws
+Ws
 LP
 WZ
 Eh
@@ -5159,7 +5165,7 @@ YK
 WZ
 WZ
 TO
-Fq
+Ws
 WZ
 DB
 yJ

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_buried_shrine.dmm
@@ -63,7 +63,17 @@
 /area/ruin/unpowered/buried_shrine)
 "cv" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle/potion,
+/obj/item/reagent_containers/glass/bottle/potion{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/cherrybulbs{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb{
+	pixel_x = -14;
+	pixel_y = 11
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "cA" = (
@@ -615,8 +625,10 @@
 /turf/open/floor/plating/moss,
 /area/ruin/unpowered/buried_shrine)
 "pK" = (
-/obj/structure/stone_tile/slab,
-/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/flashlight/flare/torch{
+	pixel_x = -18
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "qh" = (
@@ -664,7 +676,6 @@
 	dir = 5
 	},
 /obj/structure/chair/wood,
-/obj/structure/spawner/burrow/lava_planet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "qT" = (
@@ -821,6 +832,9 @@
 	pixel_x = -11;
 	pixel_y = 10
 	},
+/obj/item/stack/sheet/bone{
+	pixel_x = 10
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "tL" = (
@@ -866,14 +880,18 @@
 /area/ruin/unpowered/buried_shrine)
 "vi" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle/potion,
+/obj/item/reagent_containers/glass/bottle/potion{
+	list_reagents = list(/datum/reagent/medicine/bonefixingjuice = 30)
+	},
 /obj/item/reagent_containers/glass/bottle/potion{
 	pixel_x = -10;
-	pixel_y = 9
+	pixel_y = 9;
+	list_reagents = list(/datum/reagent/medicine/soulus/pure = 30)
 	},
 /obj/item/reagent_containers/glass/bottle/potion{
 	pixel_x = 10;
-	pixel_y = 9
+	pixel_y = 9;
+	list_reagents = list(/datum/reagent/toxin/coniine = 30)
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
@@ -914,11 +932,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wt" = (
-/obj/structure/stone_tile/surrounding/cracked{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/asteroid/brimdemon,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/item/reagent_containers/food/snacks/grown/random,
+/turf/open/floor/plating/grass/lava,
 /area/ruin/unpowered/buried_shrine)
 "wy" = (
 /obj/structure/stone_tile{
@@ -927,14 +942,6 @@
 /obj/structure/stone_tile/block/cracked{
 	dir = 6
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/buried_shrine)
-"wM" = (
-/obj/structure/stone_tile/surrounding/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/center,
-/obj/structure/spawner/burrow/lava_planet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "wS" = (
@@ -1586,6 +1593,9 @@
 /area/template_noop)
 "Ni" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/apple/gold{
+	pixel_y = 9
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "Nk" = (
@@ -1650,7 +1660,6 @@
 /obj/structure/stone_tile/cracked{
 	dir = 1
 	},
-/obj/structure/spawner/burrow/lava_planet,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
@@ -1674,8 +1683,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "RK" = (
-/obj/structure/stone_tile/center/cracked,
-/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
+/obj/item/reagent_containers/food/snacks/grown/meatwheat{
+	pixel_x = -15;
+	pixel_y = 4
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_shrine)
 "RN" = (
@@ -2688,7 +2701,7 @@ WZ
 TO
 Qb
 Mt
-eI
+wt
 Hv
 FC
 Qb
@@ -3431,7 +3444,7 @@ TO
 Xr
 Ht
 Td
-pK
+Ad
 on
 Ii
 Tp
@@ -3932,7 +3945,7 @@ LJ
 ta
 NN
 ta
-wM
+Xv
 Ad
 mM
 Ad
@@ -3953,12 +3966,12 @@ LZ
 WZ
 Ka
 dB
-RK
+qt
 uP
 di
 zN
 Ad
-Td
+pK
 Ad
 BF
 yz
@@ -4042,7 +4055,7 @@ WZ
 WZ
 Yh
 Fw
-SA
+RK
 lJ
 WZ
 ta
@@ -4333,7 +4346,7 @@ WZ
 WZ
 Td
 lJ
-wt
+yM
 ta
 TO
 TO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed the three creature den spawners in the ruin that were never supposed to be there. Also removed the brimdemons due to their beams layering under the tiles for some godforsaken reason. Added a few more legions and some goliaths outside to balance this.
Added some useful reagents to the potion bottles in the lava-flooded center of the ruin so players would actually pick them up. (Coniine, C4LZ1UM, and Purified Soulus Dust)
Added some more rare botanical loot to the dining table at the north end of the ruin to incentivize players to pick them up and grow them. (One each of a golden apple, ambrosia gaia branch, cherry bulbs, and cherry bombs)

![image](https://github.com/user-attachments/assets/9fa13e91-cfc1-44a6-b548-27d7cd745966)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tired of hearing complaints that my ruin has shit loot and way too many mobs because I cant put any tendril loot in and spawners got added by a mistake that wasn't mine. Maybe someday that draconic amber will actually be worth credits.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Buried Shrine has had some changes to its mobs and loot within to make it more rewarding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
