### PR TITLE
Fixes Balaclava Layering

### DIFF
--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -7,6 +7,7 @@
 	visor_flags = ALLOWINTERNALS
 	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEARS|HIDEHAIR
 	visor_flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	alternate_worn_layer = BODY_LAYER
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.1
 	permeability_coefficient = 0.5


### PR DESCRIPTION
## About The Pull Request

Adjusts Balaclava layering to prevent it from layering over goggles and looking really weird.

## Why It's Good For The Game

Balaclavas shouldn't be layering over goggles. It just looks weird.

## Changelog

:cl:
fix: Balaclavas now layer correctly.
/:cl:
