### PR TITLE
Fixes some typos in the Stamped Steel Machete Crate

### DIFF
--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -71,8 +71,8 @@
 	crate_name = "survival knife crate"
 
 /datum/supply_pack/sec_supply/machete
-	name = "Stampted Steel Machete Crate"
-	desc = "Contains five mass produced machetes. A perfect choice for crews on a budget."
+	name = "Stamped Steel Machete Crate"
+	desc = "Contains two mass produced machetes. A perfect choice for crews on a budget."
 	cost = 500
 	contains = list(/obj/item/melee/sword/mass,
 					/obj/item/melee/sword/mass)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a very minor typo with machete crates, and it makes the description for the quantity of machetes in the crate more accurate. 

## Why It's Good For The Game

Ultimately, these very minor errors aren't anything significant, but I figured it was worth fixing, regardless. 

## Changelog

:cl:
fix: fixed a few typos with the machete crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
