### PR TITLE
HP Sling fix

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -698,6 +698,7 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow/conflagration)
 		/obj/item/attachment/laser_sight,
 		/obj/item/attachment/rail_light,
 		/obj/item/attachment/bayonet,
+		/obj/item/attachment/sling,
 		/obj/item/attachment/scope,
 		/obj/item/attachment/long_scope,
 	)
@@ -854,6 +855,7 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow)
 		/obj/item/attachment/laser_sight,
 		/obj/item/attachment/rail_light,
 		/obj/item/attachment/bayonet,
+		/obj/item/attachment/sling,
 		/obj/item/attachment/scope,
 		/obj/item/attachment/long_scope,
 	)
@@ -951,6 +953,7 @@ EMPTY_GUN_HELPER(shotgun/doublebarrel/beacon)
 		/obj/item/attachment/laser_sight,
 		/obj/item/attachment/rail_light,
 		/obj/item/attachment/bayonet,
+		/obj/item/attachment/sling,
 		/obj/item/attachment/scope,
 		/obj/item/attachment/long_scope,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The:
- Flaming Arrow
- Conflagation
- Absolution
- Beacon
- Vickland

can have slings attached to them again.

![obraz](https://github.com/user-attachments/assets/8b7ac495-5788-46cc-9917-cccdafa30b19)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm guessing it's an oversight from #3736
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Flaming Arrow, Conflagation, Absolution, Beacon and Vickland can have shoulder slings attached to them again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
