### PR TITLE
do_after_coeff cannot be lower than zero

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1245,7 +1245,7 @@
 
 /mob/living/carbon/human/do_after_coefficent()
 	. = ..()
-	. *= physiology.do_after_speed
+	return max(. *= physiology.do_after_speed, 0.1)
 
 /mob/living/carbon/human/updatehealth()
 	. = ..()


### PR DESCRIPTION
## Why It's Good For The Game

no 'true' instant do_afters

## Changelog

:cl:
balance: you can no longer achieve a sub-zero do_after_coefficient
/:cl:
