### PR TITLE
Parity for the Colossus, Talos, Valor and Vaquero

### DIFF
--- a/_maps/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/shuttles/inteq/inteq_colossus.dmm
@@ -479,6 +479,10 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
+/obj/item/storage/toolbox/ammo/shotgun{
+	pixel_x = -4;
+	pixel_y = -10
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "fN" = (
@@ -2759,6 +2763,8 @@
 /obj/item/storage/belt/security/webbing/inteq,
 /obj/item/storage/belt/military/assault,
 /obj/item/clothing/head/inteq_peaked,
+/obj/item/storage/box/ammo/a44roum,
+/obj/item/storage/guncase/pistol/pinscher,
 /turf/open/floor/carpet/orange,
 /area/ship/bridge)
 "Dq" = (
@@ -2854,23 +2860,26 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ammo_box/magazine/co9mm{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/co9mm{
 	pixel_x = -5
 	},
 /obj/item/ammo_box/magazine/co9mm{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/co9mm{
 	pixel_x = -5
-	},
-/obj/item/gun/ballistic/automatic/pistol/commander/inteq{
-	pixel_y = 5
 	},
 /obj/item/gun/ballistic/automatic/pistol/commander/inteq,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/item/ammo_box/magazine/m12g_bulldog{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/ammo_box/magazine/m12g_bulldog{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq{
+	pixel_x = -1;
+	pixel_y = -12
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Eq" = (
@@ -4118,9 +4127,6 @@
 /obj/item/storage/lockbox/medal/sec{
 	pixel_y = 5
 	},
-/obj/item/spacecash/bundle/c1000,
-/obj/item/spacecash/bundle/c1000,
-/obj/item/spacecash/bundle/c1000,
 /obj/item/spacecash/bundle/c1000,
 /obj/item/spacecash/bundle/c1000,
 /obj/effect/turf_decal/corner/opaque/brown{

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -5466,21 +5466,9 @@
 /obj/structure/sign/poster/retro/lasergun_new{
 	pixel_x = -32
 	},
-/obj/item/storage/guncase/inherit{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq/no_mag,
-/obj/item/ammo_box/magazine/m12g_bulldog,
-/obj/item/ammo_box/magazine/m12g_bulldog,
-/obj/item/storage/guncase/inherit{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq/no_mag,
-/obj/item/ammo_box/magazine/m12g_bulldog,
-/obj/item/ammo_box/magazine/m12g_bulldog{
-	pixel_y = -1
+/obj/item/storage/guncase/mastiff,
+/obj/item/storage/guncase/mastiff{
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -7662,10 +7650,10 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/guncase/pistol/inherit,
-/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
-/obj/item/ammo_box/magazine/co9mm,
-/obj/item/ammo_box/magazine/co9mm,
+/obj/item/storage/guncase/commissioner,
+/obj/item/storage/guncase/kingsnake{
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Ws" = (
@@ -8043,6 +8031,8 @@
 /obj/item/storage/belt/security/webbing/inteq/alt,
 /obj/item/storage/belt/security/webbing/inteq,
 /obj/item/clothing/head/inteq_peaked,
+/obj/item/storage/guncase/pistol/pinscher,
+/obj/item/storage/box/ammo/a44roum,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "YC" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -7651,7 +7651,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/guncase/commissioner,
-},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Ws" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -7651,9 +7651,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/guncase/commissioner,
-/obj/item/storage/guncase/kingsnake{
-	pixel_y = 7
-	},
+},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Ws" = (

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -4540,6 +4540,8 @@
 /obj/item/clothing/glasses/hud/security/sunglasses/inteq,
 /obj/item/clothing/head/inteq_peaked,
 /obj/item/stamp/inteq/vanguard,
+/obj/item/storage/box/ammo/a44roum,
+/obj/item/storage/guncase/pistol/pinscher,
 /turf/open/floor/carpet/orange,
 /area/ship/bridge)
 "Od" = (

--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -272,6 +272,7 @@
 	pixel_y = -5
 	},
 /obj/item/gun/ballistic/automatic/pistol/commander/inteq,
+/obj/item/gun/ballistic/automatic/pistol/rattlesnake/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "fc" = (
@@ -935,6 +936,8 @@
 	dir = 1
 	},
 /obj/item/clothing/head/inteq_peaked,
+/obj/item/storage/guncase/pistol/pinscher,
+/obj/item/storage/box/ammo/a44roum,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "mE" = (
@@ -1985,6 +1988,8 @@
 /obj/item/storage/toolbox/ammo/c9mm{
 	pixel_y = 12
 	},
+/obj/item/ammo_box/magazine/m9mm_rattlesnake,
+/obj/item/ammo_box/magazine/m9mm_rattlesnake,
 /turf/open/floor/plasteel/tech,
 /area/ship/security)
 "Dh" = (

--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -271,7 +271,6 @@
 /obj/item/gun/ballistic/automatic/pistol/commander/inteq{
 	pixel_y = -5
 	},
-/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
 /obj/item/gun/ballistic/automatic/pistol/rattlesnake/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
@@ -1964,9 +1963,6 @@
 	},
 /obj/item/ammo_box/magazine/co9mm{
 	pixel_x = -5
-	},
-/obj/item/ammo_box/magazine/co9mm{
-	pixel_x = 5
 	},
 /obj/item/ammo_box/magazine/co9mm{
 	pixel_x = -5


### PR DESCRIPTION
## About The Pull Request

Slightly buffs the armories of the Colossus and Vaquero to bring them up to par with most modern combat-based ships.

Adds a singular Mastiff, a bit of ammo and 2 magazines for it onto the Colossus's armory. Removes 3,000 from roundstart funding in exchange and replaces a Commissioner.

Also adds a Rattlesnake + 2 magazines to the Vaquero. This replaces a Commissioner.

Third additions are Pinschers (the designated officer pistol for Inteq, as intended in the original M20 Auto Elite PR) to the Vanguard quarters of all Vanguards.

## Why It's Good For The Game

This brings these ships up to par with others within their class, and means that the designated go outside roles have enough long arms. 

## Changelog

:cl:
balance: Rattlesnake added to the Vaquero and Talos, Mastiff added to the Colossus.
add: Pinschers to all Vanguards.
/:cl:
