### PR TITLE
Adds var for turrets to respect ID

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
@@ -1,9 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ab" = (
-/obj/machinery/porta_turret/ship/frontiersmen/light{
-	dir = 8;
-	reqpower = 0;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/light/tesla_lab{
+	dir = 8
 	},
 /turf/open/floor/concrete/slab_1,
 /area/ruin/icemoon/tesla_lab/turrets)
@@ -2378,10 +2376,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/tesla_lab/central_hall)
 "jM" = (
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen")
-	},
+/obj/machinery/porta_turret/ship/frontiersmen/tesla_lab,
 /turf/open/floor/concrete/slab_1,
 /area/ruin/icemoon/tesla_lab/turrets)
 "jV" = (
@@ -4527,11 +4522,8 @@
 /turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "sw" = (
-/obj/machinery/porta_turret/ship/frontiersmen/light{
-	dir = 10;
-	id = "haymaker";
-	lethal = 1;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/light/tesla_lab{
+	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/icemoon/tesla_lab/haymaker)
@@ -4554,11 +4546,8 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ruin/icemoon/tesla_lab/office_two)
 "sF" = (
-/obj/machinery/porta_turret/ship/frontiersmen/light{
-	dir = 9;
-	id = "haymaker";
-	lethal = 1;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/light/tesla_lab{
+	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/icemoon/tesla_lab/haymaker)
@@ -10938,11 +10927,8 @@
 /turf/open/floor/plating,
 /area/ruin/icemoon/tesla_lab/containment)
 "RS" = (
-/obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 6;
-	id = "haymaker";
-	lethal = 1;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/tesla_lab{
+	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/icemoon/tesla_lab/haymaker)
@@ -11001,11 +10987,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/tesla_lab/lab_halls)
 "RZ" = (
-/obj/machinery/porta_turret/ship/frontiersmen{
-	dir = 5;
-	id = "haymaker";
-	lethal = 1;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/tesla_lab{
+	dir = 5
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/icemoon/tesla_lab/haymaker)
@@ -12590,10 +12573,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/tesla_lab/central_hall)
 "YV" = (
-/obj/machinery/porta_turret/ship/frontiersmen/light{
-	dir = 2;
-	reqpower = 0;
-	faction = list("Frontiersmen")
+/obj/machinery/porta_turret/ship/frontiersmen/light/tesla_lab{
+	dir = 2
 	},
 /turf/open/floor/concrete/slab_1,
 /area/ruin/icemoon/tesla_lab/turrets)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -70,6 +70,9 @@
 
 	var/list/target_faction = list("hostile")
 
+	/// does our turret give a flying fuck about what accesses someone has?
+	var/turret_respects_id = TRUE
+
 	/// The spark system, used for generating... sparks?
 	var/datum/effect_system/spark_spread/spark_system
 
@@ -522,8 +525,9 @@
 	//We know the target must be a human now
 	var/mob/living/carbon/human/target_carbon = target_mob
 
-	if(req_ship_access && (check_access(target_carbon.get_active_held_item()) || check_access(target_carbon.wear_id)))
-		return FALSE
+	if(turret_respects_id)
+		if(req_ship_access && (check_access(target_carbon.get_active_held_item()) || check_access(target_carbon.wear_id)))
+			return FALSE
 
 	if(!(check_flags & TURRET_FLAG_SHOOT_DANGEROUS_ONLY))
 		return target(target_carbon)

--- a/code/modules/ruins/icemoonruin_code/tesla_lab.dm
+++ b/code/modules/ruins/icemoonruin_code/tesla_lab.dm
@@ -112,3 +112,16 @@
 	name = "CLIP Minuteman Spawner"
 	outfit = /datum/outfit/job/clip/minutemen/grunt/dressed
 	mob_gender = FEMALE
+
+
+/obj/machinery/porta_turret/ship/frontiersmen/tesla_lab
+	faction = list(FACTION_ANTAG_FRONTIERSMEN, "turret")
+	turret_flags = TURRET_FLAG_HOSTILE
+	req_ship_access = FALSE
+	turret_respects_id = FALSE
+
+/obj/machinery/porta_turret/ship/frontiersmen/light/tesla_lab
+	faction = list(FACTION_ANTAG_FRONTIERSMEN, "turret")
+	turret_flags = TURRET_FLAG_HOSTILE
+	req_ship_access = FALSE
+	turret_respects_id = FALSE

--- a/code/modules/ruins/jungleplanet_ruin_code/airbase.dm
+++ b/code/modules/ruins/jungleplanet_ruin_code/airbase.dm
@@ -34,3 +34,5 @@
 /obj/machinery/porta_turret/ship/syndicate/heavy/starport
 	faction = list(FACTION_SYNDICATE, "turret")
 	turret_flags = TURRET_FLAG_HOSTILE
+	req_ship_access = FALSE
+	turret_respects_id = FALSE

--- a/code/modules/ruins/rockplanet_ruin_code/mining_base.dm
+++ b/code/modules/ruins/rockplanet_ruin_code/mining_base.dm
@@ -1,5 +1,6 @@
 /obj/machinery/porta_turret/ship/nt/light/mining_base
 	req_ship_access = FALSE
+	turret_respects_id = FALSE
 	lethal = TRUE
 	turret_flags = TURRET_FLAG_SHOOT_FAUNA
 

--- a/code/modules/ruins/sandplanet_ruin_code/cave_base.dm
+++ b/code/modules/ruins/sandplanet_ruin_code/cave_base.dm
@@ -46,7 +46,8 @@
 	stun_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	lethal_projectile = /obj/projectile/beam/laser/heavylaser
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
-	turret_flags = TURRET_FLAG_SHOOT_ALLMOBS
+	turret_flags = TURRET_FLAG_HOSTILE
+	turret_respects_id = FALSE
 
 //gut wrenching content
 


### PR DESCRIPTION
disables it on default-hostile ruin turrets. why do you have access to them anyways.

## Why It's Good For The Game

turret threat works more often

## Changelog

:cl:
fix: tesla lab and bombed airbase now avoid checking to see if you're some sort of security-head before firing.
/:cl:
