### PR TITLE
Add Ramzi Turrets

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret_types.dm
+++ b/code/game/machinery/porta_turret/portable_turret_types.dm
@@ -182,6 +182,56 @@
 	shot_delay = 30
 
 
+/* Ramzi Turrets */
+/* Near NGR turrets in power. Easier to destroy */
+
+/obj/machinery/porta_turret/ship/ramzi
+	name = "Resistance Turret"
+	desc = "A midline turret manufactured by the Gorlex Marauders during the ICW. Most surviving examples have experienced less than stellar upkeep."
+	stun_projectile = /obj/projectile/bullet/a556_42/rubber
+	stun_projectile_sound = 'sound/weapons/gun/rifle/hydra.ogg'
+	lethal_projectile = /obj/projectile/bullet/a556_42
+	lethal_projectile_sound = 'sound/weapons/gun/rifle/hydra.ogg'
+	faction = list(FACTION_SYNDICATE, "turret")
+	max_integrity = 180
+	integrity_failure = 0.6
+
+/obj/machinery/porta_turret/ship/ramzi/light
+	name = "Strike Turret"
+	desc = "A light turret manufactured by the Gorlex Marauders during the ICW. Most surviving examples are poorly maintained."
+	stun_projectile = /obj/projectile/bullet/c45/rubber
+	stun_projectile_sound = 'sound/weapons/gun/smg/cobra.ogg'
+	lethal_projectile = /obj/projectile/bullet/c45
+	lethal_projectile_sound = 'sound/weapons/gun/smg/cobra.ogg'
+	scan_range = 8
+	shot_delay = 8
+	max_integrity = 140
+	integrity_failure = 0.6
+
+/obj/machinery/porta_turret/ship/ramzi/heavy
+	name = "Revolt Turret"
+	desc = "A durable turret manufactured by the Gorlex Marauders during the ICW. Some reported examples used anti-vehicle munitions. Most surviving examples are poorly maintained."
+	stun_projectile = /obj/projectile/bullet/a65clip/rubber
+	stun_projectile_sound = 'sound/weapons/gun/sniper/cmf90.ogg'
+	lethal_projectile = /obj/projectile/bullet/a65clip
+	lethal_projectile_sound = 'sound/weapons/gun/sniper/cmf90.ogg'
+	scan_range = 12
+	shot_delay = 20
+	max_integrity = 300
+	integrity_failure = 0.6
+
+/obj/machinery/porta_turret/ship/ramzi/super_heavy
+	name = "Rebellion Turret"
+	desc = "A durable anti-vehicle turret system manufactured by the Gorlex Marauders during the ICW. Most users are unable to get more parts for the turret, leading to a slow reduction in the amount of redundant, working parts."
+	stun_projectile = /obj/item/ammo_casing/p50/soporific
+	stun_projectile_sound = 'sound/weapons/gun/sniper/shot.ogg'
+	lethal_projectile = /obj/item/ammo_casing/p50
+	lethal_projectile_sound = 'sound/weapons/gun/sniper/shot.ogg'
+	scan_range = 14
+	shot_delay = 30
+	max_integrity = 350
+	integrity_failure = 0.7
+
 /* Inteq Turrets */
 //slower rof, higher damage + range
 


### PR DESCRIPTION
## About The Pull Request

adds ramzi-specific / general icw-era syndicate turrets

resistance - 5.56 similar to ngr medium
strike - ngr light equiv
revolt - ngr heavy equiv
rebellion - they taped a fucking taipan to a scanner what the fuck

## Changelog

:cl:
add: Ramzi turrets, for mappers
/:cl:
