### PR TITLE
fix fax naming

### DIFF
--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -85,6 +85,9 @@
 		shipkey.name = "ship key ([new_name])"
 	for(var/area/shuttle_area as anything in shuttle_port?.shuttle_areas)
 		shuttle_area.rename_area("[new_name] [initial(shuttle_area.name)]")
+	for(var/datum/weakref/stupid_fax in shuttle_port.fax_list)
+		var/obj/machinery/fax/our_fax = stupid_fax.resolve()
+		our_fax.fax_name = "[get_area_name(our_fax)] Fax Machine"
 	if(!force)
 		COOLDOWN_START(src, rename_cooldown, 5 MINUTES)
 		if(shuttle_port?.virtual_z() == null)

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -85,7 +85,7 @@
 		shipkey.name = "ship key ([new_name])"
 	for(var/area/shuttle_area as anything in shuttle_port?.shuttle_areas)
 		shuttle_area.rename_area("[new_name] [initial(shuttle_area.name)]")
-	for(var/datum/weakref/stupid_fax in shuttle_port.fax_list)
+	for(var/datum/weakref/stupid_fax in shuttle_port?.fax_list)
 		var/obj/machinery/fax/our_fax = stupid_fax.resolve()
 		our_fax.fax_name = "[get_area_name(our_fax)] Fax Machine"
 	if(!force)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -89,6 +89,9 @@
 	// Override in subtypes // no
 	radio.on = TRUE
 
+/obj/machinery/fax/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	port.fax_list |= WEAKREF(src)
+
 /obj/machinery/fax/ruin
 	visible_to_network = FALSE
 	special_networks = list()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -324,6 +324,9 @@
 	///A list of all turrets currently linked to the shuttle.
 	var/list/turret_list = list()
 
+	///A list of all Fax Machines Linked To The Shuttle. God we have a list of all linked
+	var/list/fax_list = list()
+
 	///if this shuttle can move docking ports other than the one it is docked at
 	var/can_move_docking_ports = TRUE
 


### PR DESCRIPTION
:cl:
fix: fax machines once again tell you what ship they're on
/:cl:
