### PR TITLE
Dimorlin recipe slight buff

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -241,8 +241,8 @@ WS End */
 	required_temp = 340
 
 /datum/chemical_reaction/dimorlin
-	results = list(/datum/reagent/medicine/dimorlin = 2, /datum/reagent/hydrogen = 4)
-	required_reagents = list(/datum/reagent/carbon = 6, /datum/reagent/diethylamine = 2, /datum/reagent/oxygen = 2, /datum/reagent/phenol = 2,)
+	results = list(/datum/reagent/medicine/dimorlin = 2, /datum/reagent/hydrogen = 2)
+	required_reagents = list(/datum/reagent/carbon = 3, /datum/reagent/diethylamine = 1, /datum/reagent/oxygen = 1, /datum/reagent/phenol = 1)
 	required_temp = 730
 	mix_message = "The mixture rapidly incorporates, leaving a layer of liquid hydrogen atop!"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

halves the reagent requirements & hydrogen output for dimorlin since they are all even
the amount of dimorlin output from the recipe is unchanged (at 2), resulting in doubled output. The original pr had an output buff (2-4) but it was committed after the pr entered the merge queue so it wasn't merged

## Why It's Good For The Game

Makes painkiller mechanics easier to use by making the recipe more efficient

## Changelog

:cl:
tweak: mixing dimorlin now requires half the required reagents, meaning the same amount makes twice as much
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
