### PR TITLE
Chat Client is now secure for military operations.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -48,6 +48,7 @@
 				if(channel.password == message)
 					channel.add_client(src)
 					return TRUE
+				return
 
 			channel.add_message(message, username)
 			var/mob/living/user = usr
@@ -89,7 +90,7 @@
 					channel.remove_client(src) // We shouldn't be in channel's user list, but just in case...
 				return TRUE
 			var/mob/living/user = usr
-			if(can_run(user, TRUE, ACCESS_NETWORK))
+			if(can_run(user, TRUE, ACCESS_CENT_GENERAL))
 				for(var/C in SSnetworks.station_network.chat_channels)
 					var/datum/ntnet_conversation/chan = C
 					chan.remove_client(src)
@@ -178,7 +179,7 @@
 
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
-	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK)
+	data["can_admin"] = can_run(user, FALSE, ACCESS_CENT_GENERAL)
 	return data
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)


### PR DESCRIPTION


## About The Pull Request

Removes administrator mode from players by stripping captains of ACCESE_NETWORK, but leaves the functionalities in for admins 
Also removes wrong password attempts putting a message into the chat, so JoeBlowFrontierman5252 can't spam your private channel with Gruel.

## Why It's Good For The Game

Chat Client's are used a lot. 
They are also abused a lot.
Operation Security Good

## Changelog

:cl:
fix: Chat Clients now can be used for secure communication which cannot be breached by players using one button.
fix: Chat Clients no longer get messages from people with the wrong password.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
