### PR TITLE
Saber Magazines no longer faction locked

### DIFF
--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -18,11 +18,8 @@
 	name = "9mm SMG Magazine Crate"
 	desc = "Contains a 9mm magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
 	contains = list(/obj/item/ammo_box/magazine/smgm9mm/empty)
-	cost = 300
+	cost = 250
 	faction = /datum/faction/nt
-	faction_discount = 0
-	faction_locked = TRUE
-
 
 /* Hunter's Pride */
 


### PR DESCRIPTION
## About The Pull Request

9mm SMGs (often used as ruin loot) no longer have their magazines faction-locked. 

## Why It's Good For The Game

The basic magazines of a weapon probably shouldn't be locked behind a faction, especially when that weapon isn't super powerful.

## Changelog

:cl:
balance: SMG magazines for the Saber are now available.
/:cl:

