### PR TITLE
Ancient Goliath Tweaks & Fixes

### DIFF
--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/asteroid/goliath/beast/nest = 60,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest = 30,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
-		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 5,
+		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 1,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf/nest = 5,
 		)
 
@@ -158,7 +158,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/asteroid/goliath/beast/nest = 60,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest = 30,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
-		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 10,
+		/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient = 5,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf/nest = 10,
 		)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -245,6 +245,7 @@
 	icon_living = "ancient_goliath"
 	icon_aggro = "ancient_goliath_alert"
 	icon_dead = "ancient_goliath_dead"
+	pre_attack_icon = "ancient_goliath_preattack"
 	maxHealth = 180
 	health = 180
 	speed = 4


### PR DESCRIPTION
## About The Pull Request

Ancient goliaths no longer magically turn into regular goliaths constantly when spawned in. 
Also slightly reduces their chances of spawning on drills, because for some reason they spawn way too often and they're a bit crazy to fight en-mass. 

## Why It's Good For The Game

Makes Ancient Goliaths a bit easier to handle and ID as the threat they are. Drills no longer turbokill you.

## Changelog

:cl:
balance: Ancient goliaths are slightly rarer on C2 and C3 drills.
fix: Ancient goliaths no longer turn into regular goliaths.
/:cl: