### PR TITLE
Cleans up security consoles and SecurEye refreshing

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -157,12 +157,6 @@
 			))
 	return data
 
-//This is the only way to refresh the UI, from what I've found
-/obj/machinery/computer/security/proc/ui_refresh(mob/user, datum/tgui/ui)
-	ui.close()
-	ui_interact(user, ui)
-	show_camera_static()
-
 /obj/machinery/computer/security/ui_act(action, params, ui)
 	. = ..()
 	if(.)
@@ -170,13 +164,13 @@
 
 	if(action == "set_network")
 		network = temp_network
-		ui_refresh(usr, ui)
+		update_static_data_for_all_viewers()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])
 
 	if(action == "refresh")
-		ui_refresh(usr, ui)
+		update_static_data_for_all_viewers()
 
 	if(action == "switch_camera")
 		var/c_tag = params["name"]

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -110,12 +110,6 @@
 			))
 	return data
 
-//This is the only way to refresh the UI, from what I've found
-/datum/computer_file/program/secureye/proc/ui_refresh(mob/user, datum/tgui/ui)
-	ui.close()
-	ui_interact(user, ui)
-	show_camera_static()
-
 /datum/computer_file/program/secureye/ui_act(action, params, ui)
 	. = ..()
 	if(.)
@@ -123,13 +117,13 @@
 
 	if(action == "set_network")
 		network = temp_network
-		ui_refresh(usr, ui)
+		update_static_data_for_all_viewers()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])
 
 	if(action == "refresh")
-		ui_refresh(usr, ui)
+		update_static_data_for_all_viewers()
 
 	if(action == "switch_camera")
 		var/c_tag = params["name"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes a bit of code in `secureye.dm` and `camera.dm` added in #3952 to instead use the `update_static_data_for_all_viewers()` instead of closing and reopening the ui.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleaner and quicker in-game to update the ui this way rather than closing and re-opening

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: camera consoles now refresh instead of reopen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
