### PR TITLE
Minor Kali Andhi and Derecho Equipment Tweaks

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
@@ -1262,6 +1262,7 @@
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/mask/breath/ngr,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "lh" = (
@@ -4849,6 +4850,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/melee/knife/survival,
+/obj/item/clothing/mask/breath/ngr,
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "QD" = (
@@ -5386,6 +5388,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/knife/survival,
+/obj/item/clothing/mask/breath/ngr,
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "UA" = (

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -3008,6 +3008,8 @@
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/airalarm/directional/north,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "tO" = (
@@ -4465,6 +4467,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -10;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "CQ" = (
@@ -6814,10 +6820,7 @@
 	pixel_x = 6;
 	pixel_y = 12
 	},
-/obj/item/storage/firstaid/medical{
-	pixel_x = -5;
-	pixel_y = 4
-	},
+/obj/item/storage/case/surgery,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a surgical case and anesthetics to the Kali Andhi, and it adds half masks to the lockers for the Wreckers and the Mechanic aboard the Derecho.

## Why It's Good For The Game

Surgical equipment is nice to have on the Kali Andhi, and it allows the onboard doctor to be able to do more roundstart. Halfmasks are a nice and stylish secondary option for NGR characters to use for their internals.

## Changelog

:cl:
add: Added surgical equipment to the Kali Andhi
add: Added additional half masks for the wreckers and the mechanic aboard the Derecho
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
