### PR TITLE
Black Market Minor Addition - Swiss Cheese

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
@@ -333,3 +333,12 @@
 	price_max = 500
 	stock_min = 4
 	stock_max = 8
+
+/datum/blackmarket_item/ammo/swisscheesemagazine
+	name = "Swiss Cheese Box Magazine"
+	desc = "A 30-round box for the Swiss Cheese's Matter Autofire mode. Not made with actual cheese, despite it's look."
+	item = /obj/item/ammo_box/magazine/swiss
+	price_min = 400
+	price_max = 500
+	stock_min = 4
+	stock_max = 6

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -447,3 +447,14 @@
 	stock_max = 2
 	availability_prob = 15
 	spawn_weighting = FALSE
+
+/datum/blackmarket_item/weapon/swiss_cheese
+	name = "Swiss Cheese"
+	desc = "Buddy of mine cracked open a cache full of old Terran Regency assault rifles! They took a few bumps in transit, but it's sure to give a good backshot with it's burstfire."
+	item = /obj/item/gun/ballistic/automatic/assault/swiss_cheese
+	pair_item = list(/datum/blackmarket_item/ammo/swisscheesemagazine)
+
+	price_min = 4750
+	price_max = 5500
+	stock_max = 2
+	availability_prob = 25

--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -457,4 +457,4 @@
 	price_min = 4750
 	price_max = 5500
 	stock_max = 2
-	availability_prob = 25
+	availability_prob = 15


### PR DESCRIPTION
## About The Pull Request

Adds the obscure Swiss Cheese rifle to the Black Market, a 30-round 5.56 CLIP assault rifle that was previously (supposedly) the Terran Regency's premier assault rifle. Priced at around the same as an assault rifle with some variation. 

## Why It's Good For The Game

Frankly this thing just looks cool, and it's only real defining characteristic is that it gets a burstfire and looks cool as hell. I've heard a few people say they'd love to play with it and I agree, I love this thing.

Plus, weird-ass obscure rifles are perfectly in character for the black market to be selling, and this rifle appears nowhere else in the game at all.

## Changelog

:cl:
add: Swiss Cheese to the black market.
/:cl: