### PR TITLE
Fixes ammo cans

### DIFF
--- a/code/game/objects/items/storage/ammo_can.dm
+++ b/code/game/objects/items/storage/ammo_can.dm
@@ -169,7 +169,7 @@
 	for (var/i in 1 to 4)
 		new /obj/item/storage/box/ammo/a12g_buckshot(src)
 
-/obj/item/storage/toolbox/ammo/shotgun/PopulateContents()
+/obj/item/storage/toolbox/ammo/a858/PopulateContents()
 	name = "ammo can (8x58mm)"
 	icon_state = "ammobox_858"
 	for (var/i in 1 to 4)

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -152,7 +152,7 @@
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
-/datum/supply_pack/sec_supply/frag_grenade
+/datum/supply_pack/sec_supply/c4duffel
 	name = "C-4 Demolitions Charge Crate"
 	desc = "Contains a duffel of C-4 demolitions charges, for use in scrapping and demolitions of large-scale structures."
 	cost = 1000


### PR DESCRIPTION
## About The Pull Request

I fucked up. Forgot to change a typepath in a PR and I thought I did but apparently I didn't (twice).

Ammo cans are proper again.
Cargo listing works again.

## Why It's Good For The Game

Correct ammo type where it belongs.

## Changelog

:cl:
fix: Shotgun ammo cans correctly have shotgun ammo now
fix: Grenades on the market.
/:cl:

