### PR TITLE
CMM Atlas Tweaks

### DIFF
--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -57,7 +57,7 @@
 /area/ship/medical)
 "aI" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "aS" = (
 /obj/machinery/firealarm/directional/west,
@@ -261,7 +261,8 @@
 "eB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
-	name = "Bathroom"
+	name = "Bathroom";
+	id_tag = "atlas_bathroom"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -825,6 +826,18 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/item/spacecash/bundle/c1000{
+	pixel_y = -10;
+	pixel_x = -5
+	},
+/obj/item/spacecash/bundle/c1000{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/spacecash/bundle/c1000{
+	pixel_y = -2;
+	pixel_x = -3
+	},
 /turf/open/floor/wood,
 /area/ship/crew/crewthree)
 "jR" = (
@@ -844,35 +857,10 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "jZ" = (
-/obj/item/chair{
-	dir = 8;
-	pixel_y = -10;
-	pixel_x = 5
-	},
-/obj/item/cigbutt{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/obj/item/cigbutt{
-	pixel_x = -10;
-	pixel_y = -7
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kd" = (
 /obj/structure/table,
-/obj/item/storage/box/evidence{
-	pixel_y = 19;
-	pixel_x = -7
-	},
-/obj/item/storage/box/flares{
-	pixel_y = 18;
-	pixel_x = 7
-	},
-/obj/item/storage/box/zipties{
-	pixel_x = 2;
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 4
 	},
@@ -881,7 +869,55 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/recharger{
-	pixel_y = 1
+	pixel_y = 1;
+	pixel_x = -7
+	},
+/obj/structure/closet/wall/red/directional/north{
+	name = "field supply cabinet"
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = -8;
+	pixel_y = 23
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_y = 3;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_y = 1;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_y = 1;
+	pixel_x = -3
+	},
+/obj/item/storage/box/flares{
+	pixel_y = 17;
+	pixel_x = 7
+	},
+/obj/item/assembly/flash{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/assembly/flash{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/obj/item/assembly/flash{
+	pixel_y = 3;
+	pixel_x = 5
+	},
+/obj/item/assembly/flash{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
@@ -1429,6 +1465,17 @@
 "ps" = (
 /turf/template_noop,
 /area/template_noop)
+"pw" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 1
+	},
+/obj/structure/curtain/cloth,
+/obj/structure/window/reinforced{
+	dir = 2;
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "pE" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1729,6 +1776,10 @@
 	pixel_x = -7;
 	pixel_y = -12
 	},
+/obj/item/clothing/head/helmet/bulletproof/x11/clip{
+	pixel_y = 1;
+	pixel_x = -1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "sA" = (
@@ -1795,11 +1846,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/machinery/door/airlock/grunge{
-	req_access = list(3);
-	dir = 4;
-	name = "Armory"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "sL" = (
@@ -2102,13 +2148,11 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "vT" = (
-/obj/structure/dresser{
+/obj/effect/turf_decal/siding/wood/corner{
+	pixel_y = 0;
 	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/beaglemug{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "vW" = (
 /obj/structure/sign/poster/clip/random{
@@ -2134,6 +2178,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-6"
+	},
+/obj/structure/platform/industrial{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -2179,10 +2226,6 @@
 /obj/item/defibrillator/loaded{
 	pixel_y = 26
 	},
-/obj/item/storage/belt/medical/surgery{
-	pixel_x = -7;
-	pixel_y = -8
-	},
 /obj/item/storage/backpack/satchel/med{
 	pixel_x = 11;
 	pixel_y = -14
@@ -2194,6 +2237,9 @@
 /obj/item/storage/backpack/medic{
 	pixel_x = 9;
 	pixel_y = -14
+	},
+/obj/item/storage/case/surgery{
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
@@ -2246,10 +2292,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "wJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "wU" = (
@@ -2298,7 +2344,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "yi" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -2310,6 +2355,10 @@
 	},
 /obj/effect/turf_decal/box/corners{
 	color = "#75A2BB"
+	},
+/obj/item/clothing/head/helmet/bulletproof/m10/clip_vc{
+	pixel_y = 5;
+	pixel_x = -9
 	},
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
@@ -2327,6 +2376,56 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/closet/crate{
+	name = "spare uniform crate"
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = 0;
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = 0;
+	pixel_x = -1
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = 0;
+	pixel_x = 5
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = -11;
+	pixel_y = -6
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -6
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "yx" = (
@@ -2405,37 +2504,13 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/closet/crate,
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = -8;
-	pixel_y = 11
+/obj/structure/closet/secure_closet/armorycage{
+	anchored = 1;
+	can_be_unanchored = 1;
+	name = "confiscation locker"
 	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = 12;
-	pixel_y = 9
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = -11;
-	pixel_y = -6
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = -6;
-	pixel_y = -7
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_y = -6
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = 7;
-	pixel_y = -8
+/obj/item/storage/box/evidence{
+	pixel_y = -4
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
@@ -2550,20 +2625,25 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "zE" = (
-/obj/structure/bed{
-	dir = 1
-	},
-/obj/item/bedsheet/blue{
-	dir = 1
-	},
-/obj/structure/curtain/cloth,
 /obj/machinery/button/door{
 	id = "atlas_dorms";
 	name = "private windows button";
 	pixel_x = -23;
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/dresser{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/beaglemug{
+	pixel_y = 8;
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "zQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2581,11 +2661,13 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
-/obj/structure/sign/poster/clip/maxin{
-	pixel_y = 32
+/obj/machinery/door/airlock/grunge{
+	req_access = list(3);
+	dir = 4;
+	name = "Armory"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ship/crew/canteen)
+/area/ship/security)
 "Aa" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/effect/turf_decal/trimline/transparent/blue/filled/arrow_ccw{
@@ -2603,14 +2685,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "An" = (
-/obj/structure/bed{
-	dir = 1
-	},
-/obj/item/bedsheet/blue{
-	dir = 1
+/obj/machinery/light/directional/west,
+/obj/effect/spawner/bunk_bed{
+	dir = 4;
+	pixel_y = 0
 	},
 /obj/structure/curtain/cloth,
-/obj/machinery/light/directional/west,
+/obj/structure/window/reinforced{
+	dir = 2;
+	pixel_y = -1
+	},
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "Av" = (
@@ -3401,8 +3485,8 @@
 	pixel_y = 1
 	},
 /obj/item/wirecutters{
-	pixel_x = -5;
-	pixel_y = -15
+	pixel_x = -12;
+	pixel_y = -8
 	},
 /obj/item/crowbar/large{
 	pixel_y = 14
@@ -3535,7 +3619,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/suit_storage_unit/minutemen,
+/obj/effect/turf_decal/box{
+	color = "#75A2BB"
+	},
+/turf/open/floor/pod/dark,
 /area/ship/crew/canteen)
 "MH" = (
 /obj/machinery/power/port_gen/pacman{
@@ -3693,13 +3781,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Pi" = (
-/obj/machinery/suit_storage_unit/minutemen,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/box{
 	color = "#75A2BB"
 	},
+/obj/machinery/suit_storage_unit/minutemen,
 /turf/open/floor/pod/dark,
 /area/ship/crew/canteen)
 "Pk" = (
@@ -3716,6 +3804,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
+"Pu" = (
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
 "Py" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	populate = 0
@@ -3770,6 +3861,11 @@
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
@@ -3785,15 +3881,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/suit_storage_unit/minutemen,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/box{
-	color = "#75A2BB"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/crew/canteen)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/security)
 "PU" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
@@ -3843,7 +3935,7 @@
 /area/ship/engineering)
 "Qb" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Qg" = (
 /obj/item/cigbutt{
@@ -3889,6 +3981,15 @@
 	},
 /obj/item/clothing/head/wig/random{
 	pixel_x = 11
+	},
+/obj/machinery/button/door{
+	pixel_x = -20;
+	pixel_y = -10;
+	dir = 4;
+	id = "atlas_bathroom";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	name = "Bathroom Lock"
 	},
 /turf/open/floor/plastic,
 /area/ship/crew)
@@ -4050,15 +4151,31 @@
 	pixel_x = -6
 	},
 /obj/item/clothing/head/helmet/bulletproof/x11/clip{
-	pixel_y = 5;
+	pixel_y = 4;
 	pixel_x = -10
 	},
 /obj/item/clothing/head/helmet/bulletproof/x11/clip{
-	pixel_y = 1;
+	pixel_y = -2;
 	pixel_x = -7
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/flashlight/seclite{
+	pixel_y = -5;
+	pixel_x = 1
+	},
+/obj/item/flashlight/seclite{
+	pixel_y = -7;
+	pixel_x = 1
+	},
+/obj/item/flashlight/seclite{
+	pixel_y = -9;
+	pixel_x = 1
+	},
+/obj/item/flashlight/seclite{
+	pixel_y = -11;
+	pixel_x = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
@@ -4185,17 +4302,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/transparent/blue/filled,
+/obj/item/storage/box/ammo/a556_42{
+	pixel_y = -4
+	},
 /obj/item/storage/box/ammo/c10mm{
-	pixel_x = 5;
-	pixel_y = 8
+	pixel_y = 4
+	},
+/obj/item/storage/box/ammo/c10mm{
+	pixel_y = 4
 	},
 /obj/item/storage/box/ammo/c9mm{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/storage/box/ammo/a556_42{
-	pixel_x = 1;
-	pixel_y = -6
+	pixel_y = 10;
+	pixel_x = -2
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
@@ -4395,7 +4513,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/suit_storage_unit/minutemen,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
@@ -4403,6 +4520,7 @@
 	color = "#75A2BB"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/suit_storage_unit/minutemen,
 /turf/open/floor/pod/dark,
 /area/ship/crew/canteen)
 "UC" = (
@@ -4435,7 +4553,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/carpet/blue,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "UP" = (
 /obj/effect/turf_decal/box/corners{
@@ -4525,65 +4646,59 @@
 /area/ship/medical)
 "Vq" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/spray/pepper{
-	pixel_y = 12;
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_y = 13;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_y = 10;
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_y = 8;
-	pixel_x = 9
-	},
 /obj/effect/turf_decal/trimline/transparent/blue/filled,
-/obj/item/ammo_box/magazine/cm5_9mm{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/cm5_9mm{
-	pixel_x = -1;
-	pixel_y = -5
-	},
-/obj/item/ammo_box/magazine/p16{
-	pixel_x = -9
-	},
-/obj/item/ammo_box/magazine/p16{
-	pixel_x = -9
-	},
 /obj/machinery/light/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/ammo_box/magazine/cm5_9mm{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ammo_box/magazine/cm23{
+	pixel_y = 9;
+	pixel_x = 8
+	},
 /obj/item/melee/knife/survival{
-	pixel_x = 12;
-	pixel_y = -3
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/ammo_box/magazine/cm23{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/cm23{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/cm23{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/cm5_9mm{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ammo_box/magazine/p16{
+	pixel_y = 0;
+	pixel_x = -6
+	},
+/obj/item/ammo_box/magazine/p16{
+	pixel_y = 0;
+	pixel_x = -6
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 7;
+	pixel_y = -1
 	},
 /obj/item/melee/knife/survival{
 	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/item/melee/knife/survival{
-	pixel_x = 11;
-	pixel_y = -4
-	},
-/obj/item/melee/knife/survival{
-	pixel_x = 11;
 	pixel_y = -6
 	},
 /obj/item/melee/knife/survival{
-	pixel_x = 11;
-	pixel_y = -8
+	pixel_x = 9;
+	pixel_y = -4
 	},
-/obj/item/ammo_box/magazine/cm23,
-/obj/item/ammo_box/magazine/cm23,
-/obj/item/ammo_box/magazine/cm23,
-/obj/item/ammo_box/magazine/cm23,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Vw" = (
@@ -4774,10 +4889,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "WR" = (
-/obj/structure/bed{
-	dir = 1
-	},
-/obj/item/bedsheet/blue{
+/obj/effect/spawner/bunk_bed{
 	dir = 1
 	},
 /obj/structure/curtain/cloth,
@@ -5010,11 +5122,13 @@
 /obj/structure/sign/poster/clip/enlist{
 	pixel_y = 32
 	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/effect/spawner/bunk_bed{
+	dir = 1
+	},
+/obj/structure/curtain/cloth,
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "ZM" = (
@@ -5023,6 +5137,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-5"
+	},
+/obj/structure/platform/industrial{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -5337,7 +5454,7 @@ PK
 HW
 ZG
 fR
-fR
+pw
 zE
 di
 ps
@@ -5423,7 +5540,7 @@ ps
 ps
 gT
 bQ
-gT
+Pu
 sI
 gT
 gT

--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -56,7 +56,85 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "aI" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/closet/wall/blue/directional/east{
+	name = "uniforms locker"
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -8;
+	pixel_x = 12
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -8;
+	pixel_x = 10
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -8;
+	pixel_x = 8
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -8;
+	pixel_x = 6
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/clothing/head/clip{
+	pixel_x = -7;
+	pixel_y = -11
+	},
+/obj/item/clothing/head/clip{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/clothing/head/clip{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/head/clip{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/clip{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/backpack/satchel/sec/clip{
+	pixel_y = 14;
+	pixel_x = -6
+	},
+/obj/item/storage/backpack/satchel/sec/clip{
+	pixel_y = 13;
+	pixel_x = -8
+	},
+/obj/item/storage/backpack/security/clip{
+	pixel_y = 13;
+	pixel_x = 12
+	},
+/obj/item/storage/backpack/security/clip{
+	pixel_y = 12;
+	pixel_x = 10
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 14;
+	pixel_y = 3
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "aS" = (
@@ -868,10 +946,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/recharger{
-	pixel_y = 1;
-	pixel_x = -7
-	},
 /obj/structure/closet/wall/red/directional/north{
 	name = "field supply cabinet"
 	},
@@ -1961,25 +2035,7 @@
 /obj/structure/table,
 /obj/item/clipboard{
 	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = -1;
 	pixel_y = 3
-	},
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = -5
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_x = 1
 	},
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 5
@@ -2366,9 +2422,6 @@
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "yo" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 8
 	},
@@ -2379,66 +2432,32 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/closet/crate{
-	name = "spare uniform crate"
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/clothing/under/clip/minutemen{
-	pixel_x = 12;
-	pixel_y = 9
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_y = 0;
-	pixel_x = -8
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_y = 0;
-	pixel_x = -5
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_y = 0;
-	pixel_x = -1
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_y = 0;
-	pixel_x = 5
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = -11;
-	pixel_y = -6
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = -6;
-	pixel_y = -7
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_y = -6
-	},
-/obj/item/clothing/shoes/combat{
-	pixel_x = 7;
-	pixel_y = -8
-	},
-/obj/item/clothing/mask/gas/clip{
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 6;
 	pixel_x = -7
 	},
-/obj/item/clothing/mask/gas/clip{
-	pixel_x = -1
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/obj/item/clothing/mask/gas/clip{
-	pixel_x = 5
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/obj/item/clothing/mask/gas/clip{
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/cigarette{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_y = -1;
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/tech/grid,
@@ -3960,6 +3979,7 @@
 /area/ship/engineering)
 "Qb" = (
 /obj/machinery/recharge_station,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Qg" = (
@@ -4489,21 +4509,24 @@
 "Uh" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/transparent/blue/filled,
-/obj/item/clothing/head/clip{
-	pixel_x = -6;
-	pixel_y = 8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/clothing/head/clip{
-	pixel_x = -9;
-	pixel_y = 3
+/obj/item/clothing/gloves/combat{
+	pixel_y = 8;
+	pixel_x = -9
 	},
-/obj/item/clothing/head/clip{
-	pixel_x = -9;
-	pixel_y = -3
+/obj/item/clothing/gloves/combat{
+	pixel_y = 3;
+	pixel_x = -11
 	},
-/obj/item/clothing/head/clip{
-	pixel_x = -7;
-	pixel_y = -8
+/obj/item/clothing/gloves/combat{
+	pixel_y = -1;
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = -5;
+	pixel_x = -10
 	},
 /obj/item/storage/belt/military/clip{
 	pixel_y = 14;
@@ -4520,9 +4543,6 @@
 /obj/item/storage/belt/military/clip{
 	pixel_y = -2;
 	pixel_x = 7
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)

--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -2429,6 +2429,18 @@
 	pixel_x = 7;
 	pixel_y = -8
 	},
+/obj/item/clothing/mask/gas/clip{
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/gas/clip{
+	pixel_x = -1
+	},
+/obj/item/clothing/mask/gas/clip{
+	pixel_x = 5
+	},
+/obj/item/clothing/mask/gas/clip{
+	pixel_x = 11
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "yx" = (

--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -1944,6 +1944,10 @@
 	pixel_y = 4;
 	name = "bridge shutters"
 	},
+/obj/item/megaphone/command{
+	pixel_y = -7;
+	pixel_x = 7
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "uG" = (
@@ -3789,6 +3793,19 @@
 /obj/machinery/suit_storage_unit/minutemen,
 /turf/open/floor/pod/dark,
 /area/ship/crew/canteen)
+"Pj" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/clothing/head/cone{
+	pixel_y = -8;
+	pixel_x = -13
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "Pk" = (
 /obj/effect/turf_decal/minutemen/corner{
 	dir = 4
@@ -4062,13 +4079,13 @@
 /area/ship/hallway/central)
 "QM" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/weather_monitor{
-	pixel_x = -6;
-	pixel_y = 20
-	},
 /obj/item/radio/intercom/table{
 	dir = 4;
 	pixel_y = 3
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = -6;
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -5238,7 +5255,7 @@ ps
 pp
 eW
 My
-bK
+Pj
 PU
 jY
 jY

--- a/_maps/shuttles/minutemen/minutemen_atlas.dmm
+++ b/_maps/shuttles/minutemen/minutemen_atlas.dmm
@@ -1465,17 +1465,6 @@
 "ps" = (
 /turf/template_noop,
 /area/template_noop)
-"pw" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 1
-	},
-/obj/structure/curtain/cloth,
-/obj/structure/window/reinforced{
-	dir = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
 "pE" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1776,11 +1765,10 @@
 	pixel_x = -7;
 	pixel_y = -12
 	},
-/obj/item/clothing/head/helmet/bulletproof/x11/clip{
-	pixel_y = 1;
-	pixel_x = -1
-	},
 /turf/open/floor/plasteel/dark,
+/area/ship/security)
+"sz" = (
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "sA" = (
 /obj/effect/turf_decal/trimline/transparent/blue/filled/corner,
@@ -1917,6 +1905,17 @@
 /area/ship/crew/canteen)
 "us" = (
 /obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
+"ut" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 1
+	},
+/obj/structure/curtain/cloth,
+/obj/structure/window/reinforced{
+	dir = 2;
+	pixel_y = -1
+	},
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "ux" = (
@@ -3804,9 +3803,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
-"Pu" = (
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/security)
 "Py" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	populate = 0
@@ -5454,7 +5450,7 @@ PK
 HW
 ZG
 fR
-pw
+ut
 zE
 di
 ps
@@ -5540,7 +5536,7 @@ ps
 ps
 gT
 bQ
-Pu
+sz
 sI
 gT
 gT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slightly re-maps the Atlas-class Light Armored Cruiser's armory and re-organizes it's contents to be more organized and friendly to the eyes. Additionally increases starting funds on the Atlas to 4000 as opposed to the previous 1000.

The armory change in question:
![Screenshot 2025-03-06 225224](https://github.com/user-attachments/assets/07e01429-cc26-4587-bf0d-18a9b0164192)

The dorm adjustments:
![Screenshot 2025-03-06 225234](https://github.com/user-attachments/assets/fa0d536c-1c47-4344-9498-2baecc4ee6f5)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Compared to similiar ships of it's class, the Atlas class is simultaneously underfunded, and under-equipped. This change brings their funding at least up to par with a similar ship, but still leaves them behind materially. This lends itself well to the scrappier militia look of the CLIP Minutemen while also allowing them to fulfill their function without having to grind missions round start just to be functional. Additionally, the armory was just terrible to work out of, this should alleviate the issue, making the space more comfortable and better organized.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Atlas Armory has been redesigned.
balance: Atlas starting funds increased to 4000
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
