### PR TITLE
Hand Labeler is now Small + Paper Rolls and Evidence Bags in the Autolathe

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
+	w_class = WEIGHT_CLASS_SMALL
 	var/label = null
 	var/labels_left = 30
 	var/mode = 0

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -223,6 +223,14 @@
 	build_path = /obj/item/wallframe/light_switch
 	category = list("initial", "Misc")
 
+/datum/design/lightswitch_frame
+	name = "Hand Labeler Paper Roll"
+	id = "handlabeler_refill"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 50)
+	build_path = /obj/item/hand_labeler_refill
+	category = list("initial", "Misc")
+
 /datum/design/camera
 	name = "Camera"
 	id = "camera"
@@ -802,6 +810,14 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/restraints/handcuffs
+	category = list("initial", "Security")
+
+/datum/design/evidencebag
+	name = "Evidence Bag"
+	id = "evidencebag"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 500)
+	build_path = /obj/item/evidencebag
 	category = list("initial", "Security")
 
 /datum/design/receiver

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -223,7 +223,7 @@
 	build_path = /obj/item/wallframe/light_switch
 	category = list("initial", "Misc")
 
-/datum/design/lightswitch_frame
+/datum/design/paper_roll
 	name = "Hand Labeler Paper Roll"
 	id = "handlabeler_refill"
 	build_type = AUTOLATHE


### PR DESCRIPTION
## About The Pull Request

Hand Labeler is now small, so it can fit in bags and other storage spaces (like cabinets). Paper rolls are now in the autolathe. So are evidence bags.

## Why It's Good For The Game

Hand Labelers (bureaucracy tool for labeling things) really shouldn't be... the size of boxes and weapons and the like. They're not super powerful and honestly could fit in a bag or a cabinet quite easily.
Paper refill rolls means you don't have to dump 50,000 of these things as waste products.

Evidence bags are on a side note something that should be available for storing small items securely and sorting them. I've heard it floated for organs and similar.

## Changelog

:cl:
balance: Hand Labelers are now small.
add: Paper Rolls and Evidence Bags are now in the autolathe.
/:cl:
