### PR TITLE
Replaces tail pulling with entwining.

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -280,10 +280,8 @@
 		if(T.is_holding_item_of_type(/obj/item/shield))
 			defense_mod += 2
 
-		if(islizard(T))
-			if(!T.getorganslot(ORGAN_SLOT_TAIL)) // lizards without tails are off-balance
-				defense_mod -= 1
-			else if(T.dna.species.is_wagging_tail()) // lizard tail wagging is robust and can swat away assailants!
+		if(!isnull(T.getorgan(/obj/item/organ/tail)))
+			(T.dna.species.is_wagging_tail()) // stealth buff to people with tails? in my shiptest 13? it's more likely than you thought. joking
 				defense_mod += 1
 
 	// OF-FENSE

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -281,7 +281,7 @@
 			defense_mod += 2
 
 		if(!isnull(T.getorgan(/obj/item/organ/tail)))
-			(T.dna.species.is_wagging_tail()) // stealth buff to people with tails? in my shiptest 13? it's more likely than you thought. joking
+			if(T.dna.species.is_wagging_tail()) // stealth buff to people with tails? in my shiptest 13? it's more likely than you thought
 				defense_mod += 1
 
 	// OF-FENSE

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -305,11 +305,6 @@
 	mood_change = -3
 	timeout = 2 MINUTES
 
-/datum/mood_event/rippedtail
-	description = span_boldwarning("I ripped their tail right off, what have I done!")
-	mood_change = -5
-	timeout = 30 SECONDS
-
 /datum/mood_event/bad_boop
 	description = span_warning("Someone booped my nose... ACK!")
 	mood_change = -3

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -463,24 +463,12 @@
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(M, "<span class='warning'>[src] looks visibly upset as you pat [p_them()] on the head.</span>")
 
-// Tail pulls!
-	else if((M.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.getorgan(/obj/item/organ/tail)))
-		M.visible_message(span_notice("[M] pulls on [src]'s tail!"), \
+// Tail entwining. daring are we!
+	else if((M.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.getorgan(/obj/item/organ/tail)) && !isnull(M.getorgan(/obj/item/organ/tail)))
+		M.visible_message(span_notice("[M] entwines their tail with [src]'s tail!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(M, src))
-		to_chat(M, span_notice("You pull on [src]'s tail!"))
-		to_chat(src, span_notice("[M] pulls on your tail!"))
-
-// Rips off fake tails
-	else if((M.zone_selected == BODY_ZONE_PRECISE_GROIN) && (istype(head, /obj/item/clothing/head/kitty) || istype(head, /obj/item/clothing/head/collectable/kitty)))
-		var/obj/item/clothing/head/faketail = head
-		M.visible_message(span_danger("[M] pulls on [src]'s tail... and it rips off!"), \
-					null, span_hear("You hear a ripping sound."), DEFAULT_MESSAGE_RANGE, list(M, src))
-		to_chat(M, span_danger("You pull on [src]'s tail... and it rips off!"))
-		to_chat(src, span_userdanger("[M] pulls on your tail... and it rips off!"))
-		playsound(loc, 'sound/effects/rip1.ogg', 75, TRUE)
-		dropItemToGround(faketail)
-		M.put_in_hands(faketail)
-		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "rippedtail", /datum/mood_event/rippedtail)
+		to_chat(M, span_notice("You entwine your tail on [src]'s tail!"))
+		to_chat(src, span_notice("[M] entwines their tail with your tail!"))
 
 	else if(M.zone_selected == BODY_ZONE_CHEST || M.zone_selected == BODY_ZONE_PRECISE_GROIN)			//WS Edit - Adds more help emotes
 		SEND_SIGNAL(src, COMSIG_CARBON_HUGGED, M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is sort of taking the idea from TG but it's entirely new code so it's not really a port more like an idea steal????
Anyway, removes fake tail ripping off because it takes up the slot too and I don't really know how to make it work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The masses *require* it.

## Changelog

:cl:
add: Replaces tail pulling with tail entwining. Aim groin and click on help intent with someone who also has a tail to do it.
del: You can no longer pull people's tails mechanically. Nor can you rip fake ones off either. You win some you lose some.
/:cl:


