### PR TITLE
515 EX mechs dont spawn with bluespace cells.

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -45,7 +45,7 @@
 	ME.attach(src)
 	max_ammo()
 
-/obj/mecha/combat/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
+/obj/mecha/combat/gygax/dark/loaded/add_cell(obj/item/stock_parts/cell/C=null)
 	if(C)
 		C.forceMove(src)
 		cell = C


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

They get standard cells instead. Loaded 515 Exs get the bluespace cell.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Probably shouldn't have bluespace cells sitting around too easily accessed.

## Changelog

:cl:
balance: Baseline 515EXs dont spawn with bluespace cells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
