### PR TITLE
Revert "Trickwine refactor to use status effects"

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -751,8 +751,6 @@
 ///sent when the access on an id is changed/updated, ensures wallets get updated once ids generate there access
 #define COSMIG_ACCESS_UPDATED "acces_updated"
 
-///sent by carbons to check if they can reflect a projectile
-#define COMSIG_CHECK_REFLECT "check_reflect"
 // Point of interest signals
 /// Sent from base of /datum/controller/subsystem/points_of_interest/proc/on_poi_element_added : (atom/new_poi)
 #define COMSIG_ADDED_POINT_OF_INTEREST "added_point_of_interest"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -356,13 +356,6 @@
 #define ELZUOSE_CHARGE_FACTOR (0.05 * ELZUOSE_CHARGE_SCALING_MULTIPLIER) //factor at which ethereal's charge decreases
 #define REAGENTS_METABOLISM 0.4 //How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
-///Greater numbers mean that less alcohol has greater intoxication potential
-#define ALCOHOL_THRESHOLD_MODIFIER 1
-///The rate at which alcohol affects you
-#define ALCOHOL_RATE 0.005
-///The exponent applied to boozepwr to make higher volume alcohol at least a little bit damaging to the liver
-#define ALCOHOL_EXPONENT 1.6
-#define ETHANOL_METABOLISM 0.5 * REAGENTS_METABOLISM
 
 // Eye protection
 #define FLASH_PROTECTION_SENSITIVE -1

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -286,8 +286,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //non-mob traits
 /// Used for limb-based paralysis, where replacing the limb will fix it.
 #define TRAIT_PARALYSIS "paralysis"
-/// Granted by prismwine, reflects lasers
-#define TRAIT_REFLECTIVE "reflective"
+
 #define TRAIT_HEARING_SENSITIVE "hearing_sensitive"
 
 /*
@@ -453,6 +452,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FISH_SAFE_STORAGE "fish_case"
 /// Stuff that can go inside fish cases
 #define TRAIT_FISH_CASE_COMPATIBILE "fish_case_compatibile"
+/// Granted by prismwine
+#define TRAIT_REFLECTIVE "reflective"
 /// Self-explainatory.
 #define BEAUTY_ELEMENT_TRAIT "beauty_element"
 #define MOOD_COMPONENT_TRAIT "mood_component"

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -353,22 +353,6 @@
 		for(var/obj/item/Item in O)
 			Item.extinguish()
 
-/obj/structure/foamedmetal/forcewine
-	name = "resin"
-	desc = "It's rapidly decaying!"
-	opacity = FALSE
-	icon_state = "atmos_resin"
-	alpha = 120
-	max_integrity = 10
-	var/timeleft = 50
-
-/obj/structure/foamedmetal/forcewine/Initialize(mapload, new_timeleft)
-	. = ..()
-	if(new_timeleft)
-		timeleft = new_timeleft
-	if(timeleft)
-		QDEL_IN(src, timeleft)
-
 #undef ALUMINIUM_FOAM
 #undef IRON_FOAM
 #undef RESIN_FOAM

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -37,4 +37,4 @@
 	name = "resin"
 	icon_state = "atmos_resin"
 	CanAtmosPass = ATMOS_PASS_NO
-	timeleft = 50
+	timeleft = 1

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -303,6 +303,7 @@
 
 			</body>
 			</html>"}
+
 // Wiki books that are linked to the configured wiki link.
 
 // A book that links to the wiki

--- a/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/consumables.dm
@@ -69,21 +69,17 @@
 	desc = "The SRM keeps the recipes for their trickwines a closely guarded secret. The Hunters carrying those bottles? Less so."
 	item = /datum/reagent/consumable/ethanol/trickwine/ash_wine
 
-	price_min = 300
+	price_min = 200
 	price_max = 600
 	stock_min = 3
 	stock_max = 7
-	availability_prob = 30
+	availability_prob = 40
 
 /datum/blackmarket_item/consumable/trickwine/spawn_item(loc)
-	var/trickwine = pick(list(
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
-		/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine
-	))
+	var/trickwine = pick(list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
+						/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,))
 	return new trickwine(loc)
 
 /datum/blackmarket_item/consumable/stimpack

--- a/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
@@ -72,13 +72,3 @@
 	name = "Vintage Hearthflame"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/hearth_wine = 45, /datum/reagent/consumable/ethanol/hcider = 5)
 	desc = "Hearthflame is one of the most important tonics devised by the SRM – both for its potent abilities in staunching wounds or setting enemies aflame, and for its closeness to the divine fire associated with the Ashen Huntsman."
-
-/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine
-	name = "Vintage Saint-Roumain Forcewine"
-	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/force_wine = 45, /datum/reagent/consumable/ethanol/tequila = 5)
-	desc = "Forcewine was originally created as a means to create temporary shelters during long tracking expeditions. While the structures proved to be not as versatile in shape as its brewers had hoped, its utility in creating barricades or heming in hostiles was still greatly appreciated."
-
-/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine
-	name = "Vintage Saint-Roumain Prismwine"
-	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/prism_wine = 45, /datum/reagent/consumable/ethanol/gin = 5)
-	desc = "Prismwine is one of the most recent additions to the Saint-Roumain Militia's reserve of trickwines. It was purpose-created for fighting hostiles that utilized more advanced energy projection attacks, such as the cryonic beams of watchers or the laser guns of interstellar pirates."

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -637,18 +637,6 @@
 	required_container = /obj/structure/fermenting_barrel/distiller
 	mix_sound ='sound/items/welder.ogg'
 
-/datum/chemical_reaction/force_wine
-	results = list(/datum/reagent/consumable/ethanol/trickwine/force_wine = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 3, /datum/reagent/calcium = 1, /datum/reagent/consumable/comet_trail = 1)
-	required_container = /obj/structure/fermenting_barrel/distiller
-	mix_sound ='sound/magic/forcewall.ogg'
-
-/datum/chemical_reaction/prism_wine
-	results = list(/datum/reagent/consumable/ethanol/trickwine/prism_wine = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 3, /datum/reagent/toxin/plasma = 1, /datum/reagent/consumable/tinlux = 1)
-	required_container = /obj/structure/fermenting_barrel/distiller
-	mix_sound ='sound/weapons/laser.ogg'
-
 /datum/chemical_reaction/molten_bubbles
 	results = list(/datum/reagent/consumable/molten = 30)
 	required_reagents = list(/datum/reagent/clf3 = 10, /datum/reagent/consumable/space_cola = 20, /datum/reagent/medicine/leporazine = 1, /datum/reagent/medicine/lavaland_extract = 1)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -97,9 +97,8 @@
 	for(var/obj/item/I in held_items)
 		if(I.IsReflect(def_zone))
 			return TRUE
-	if(SEND_SIGNAL(src, COMSIG_CHECK_REFLECT, def_zone))
-		return TRUE
-	if(HAS_TRAIT(src, TRAIT_REFLECTIVE))
+	///Granted by prismwine
+	if(HAS_TRAIT(src, TRAIT_REFLECTIVE) && prob(50))
 		return TRUE
 	return FALSE
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents/ethanol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents/ethanol.dm
@@ -2,13 +2,22 @@
 // ALCOHOLS //
 //////////////
 
+
+///Greater numbers mean that less alcohol has greater intoxication potential
+#define ALCOHOL_THRESHOLD_MODIFIER 1
+///The rate at which alcohol affects you
+#define ALCOHOL_RATE 0.005
+///The exponent applied to boozepwr to make higher volume alcohol at least a little bit damaging to the liver
+#define ALCOHOL_EXPONENT 1.6
+
+
 /datum/reagent/consumable/ethanol
 	name = "Ethanol"
 	description = "A well-known alcohol with a variety of applications."
 	color = "#404030" // rgb: 64, 64, 48
 	nutriment_factor = 0
 	taste_description = "alcohol"
-	metabolization_rate = ETHANOL_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	var/boozepwr = 65 //Higher numbers equal higher hardness, higher hardness equals more intense alcohol poisoning
 	accelerant_quality = 5
 

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -1,117 +1,6 @@
-///////////////////
-// STATUS EFFECT //
-///////////////////
-/atom/movable/screen/alert/status_effect/trickwine
-	name = "Trickwine"
-	desc = "Your empowered or weakened by a trickwine!"
-	icon_state = "breakaway_flask"
-
-/atom/movable/screen/alert/status_effect/trickwine/proc/setup(datum/reagent/consumable/ethanol/trickwine/trickwine_reagent)
-	name = trickwine_reagent.name
-	icon_state = "template"
-	cut_overlays()
-	var/icon/flask_icon = icon('icons/obj/drinks/drinks.dmi', trickwine_reagent.breakaway_flask_icon_state)
-	add_overlay(flask_icon)
-
-/datum/status_effect/trickwine
-	id = "trick_wine"
-	examine_text = span_notice("They seem to be affected by a trickwine.")
-	alert_type = /atom/movable/screen/alert/status_effect/trickwine
-	// Try to match normal reagent tick rate based on on_mob_life
-	tick_interval = 20
-	// Used to make icon for status_effect
-	var/flask_icon_state
-	var/flask_icon = 'icons/obj/drinks/drinks.dmi'
-	// Used for mod outline
-	var/reagent_color = "#FFFFFF"
-	var/message_apply_others = "is affected by a wine!"
-	var/message_apply_self = "You are affected by trickwine!"
-	var/message_remove_others = "is no longer affected by a wine!"
-	var/message_remove_self = "You are no longer affected by trickwine!"
-	var/trickwine_examine_text
-	var/alert_desc
-	// Applied and removes with reagent
-	var/trait
-
-/datum/status_effect/trickwine/on_creation(mob/living/new_owner, datum/reagent/consumable/ethanol/trickwine/trickwine_reagent)
-	flask_icon_state = trickwine_reagent.breakaway_flask_icon_state
-	if(!trickwine_reagent)
-		CRASH("A trickwine status effect was created without a attached reagent")
-	reagent_color = trickwine_reagent.color
-	. = ..()
-	if(istype(linked_alert, /atom/movable/screen/alert/status_effect/trickwine))
-		var/atom/movable/screen/alert/status_effect/trickwine/trickwine_alert = linked_alert
-		trickwine_alert.setup(trickwine_reagent)
-		trickwine_alert.desc = alert_desc
-
-/datum/status_effect/trickwine/on_apply()
-	owner.visible_message(span_notice("[owner] " + message_apply_others), span_notice(message_apply_self))
-	owner.add_filter(id, 2, drop_shadow_filter(x = 0, y = -1, size = 2, color = reagent_color))
-	if(trait)
-		ADD_TRAIT(owner, trait, id)
-	return ..()
-
-/datum/status_effect/trickwine/on_remove()
-	owner.visible_message(span_notice("[owner] " + message_remove_others), span_notice(message_remove_self))
-	owner.remove_filter(id)
-	if(trait)
-		REMOVE_TRAIT(owner, trait, id)
-
-//////////
-// BUFF //
-//////////
-/datum/status_effect/trickwine/buff
-	id = "trick_wine_buff"
-	alert_desc = "Your empowered a trickwine!"
-
-/datum/status_effect/trickwine/buff/on_creation(mob/living/new_owner, datum/reagent/consumable/ethanol/trickwine/trickwine_reagent)
-	. = ..()
-	if(trickwine_examine_text)
-		examine_text = span_notice(trickwine_examine_text)
-	else
-		examine_text = span_notice("SUBJECTPRONOUN seems to be affected by [trickwine_reagent.name].")
-
-////////////
-// DEBUFF //
-////////////
-/datum/status_effect/trickwine/debuff
-	id = "trick_wine_debuff"
-	alert_desc = "Your weakened a trickwine!"
-
-/datum/status_effect/trickwine/debuff/on_creation(mob/living/new_owner, datum/reagent/consumable/ethanol/trickwine/trickwine_reagent, set_duration = null)
-	if(isnum(set_duration))
-		duration = set_duration
-	. = ..()
-	if(trickwine_examine_text)
-		examine_text = span_notice(trickwine_examine_text)
-	else
-		examine_text = span_notice("SUBJECTPRONOUN seems to be covered in [trickwine_reagent.name].")
-
-//////////////
-// REAGENTS //
-//////////////
-
 /datum/reagent/consumable/ethanol/trickwine
 	name = "Trickwine"
-	var/datum/status_effect/trickwine/debuff_effect = null
-	var/datum/status_effect/trickwine/buff_effect = null
-
-/datum/reagent/consumable/ethanol/trickwine/on_mob_metabolize(mob/living/consumer)
-	if(buff_effect)
-		consumer.apply_status_effect(buff_effect, src)
-	..()
-
-/datum/reagent/consumable/ethanol/trickwine/on_mob_end_metabolize(mob/living/consumer)
-	if(buff_effect && consumer.has_status_effect(buff_effect))
-		consumer.remove_status_effect((buff_effect))
-	..()
-
-/datum/reagent/consumable/ethanol/trickwine/expose_mob(mob/living/exposed_mob, method = TOUCH, reac_volume)
-	if(method == TOUCH)
-		if(debuff_effect)
-			exposed_mob.apply_status_effect(debuff_effect, src, (reac_volume / ETHANOL_METABOLISM) * 10)
-	return ..()
-
+	description = "How is this even possible"
 
 /datum/reagent/consumable/ethanol/trickwine/ash_wine
 	name = "Wine Of Ash"
@@ -123,47 +12,26 @@
 	glass_name = "Wine Of Ash"
 	glass_desc = "A traditional sacrament for members of the Saint-Roumain Militia. Believed to grant visions, seeing use both in ritual and entertainment within the Militia."
 	breakaway_flask_icon_state = "baflaskashwine"
-	buff_effect = /datum/status_effect/trickwine/buff/ash
-	debuff_effect = /datum/status_effect/trickwine/debuff/ash
 
 /datum/reagent/consumable/ethanol/trickwine/ash_wine/on_mob_life(mob/living/M)
-	var/high_message = pick("You feel far more devoted to the cause", "You feel like you should go on a hunt")
-	var/cleanse_message = pick("Divine light purifies you.", "You are purged of foul spirts.")
-	if(prob(10))
+	if(prob(15))
+		M.adjustToxLoss(-1)
 		M.adjust_drugginess(5)
-		to_chat(M, "<span class='notice'>[high_message]</span>")
-	if(M.faction && ("roumain" in M.faction))
-		M.adjustToxLoss(-2)
-		if(prob(10))
-			to_chat(M, "<span class='notice'>[cleanse_message]</span>")
+		var/high_message = pick("Devotion runs wild within your soul", "A lust for hunting leaps from within your psyche", "The inner beauty of nature courses within your minds' eye.", "Calm warmth spreads within your body.")
+		to_chat(M, span_notice("[high_message]"))
 	return ..()
 
-/datum/status_effect/trickwine/buff/ash
-	id = "ash_wine_buff"
-	trickwine_examine_text = "SUBJECTPRONOUN seems to be filled with energy and devotion. There eyes are dialated and they seem to be twitching."
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/ash
-	id = "ash_wine_debuff"
-	trickwine_examine_text = "SUBJECTPRONOUN seems to be covered in a thin layer of ash. They seem to be twitching and jittery."
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/ash/tick()
-	switch(pick("jitter", "dizzy", "drug"))
-		if("jitter")
-			owner.adjust_jitter(3)
-		if("dizzy")
-			owner.Dizzy(2)
-		if("drug")
-			owner.adjust_drugginess(3)
+/datum/reagent/consumable/ethanol/trickwine/ash_wine/expose_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(method == TOUCH)
+		if(!iscarbon(M))
+			var/mob/living/simple_animal/hostile/hostile_target = M
+			var/hostile_ai_status = hostile_target.AIStatus
+			hostile_target.toggle_ai(AI_OFF)
+			addtimer(VARSET_CALLBACK(hostile_target, AIStatus, hostile_ai_status),reac_volume)
+		M.adjust_jitter(3 * reac_volume)
+		M.Dizzy(2 * reac_volume)
+		M.set_drugginess(3 * reac_volume)
+	return ..()
 
 /datum/reagent/consumable/ethanol/trickwine/ice_wine
 	name = "Wine Of Ice"
@@ -174,8 +42,6 @@
 	glass_name = "Wine Of Ice"
 	glass_desc = "A specialized brew utilized by members of the Saint-Roumain Militia, designed to assist in temperature regulation while working in hot environments. Known to give one the cold shoulder when thrown."
 	breakaway_flask_icon_state = "baflaskicewine"
-	buff_effect = /datum/status_effect/trickwine/buff/ice
-	debuff_effect = /datum/status_effect/trickwine/debuff/ice
 
 /datum/reagent/consumable/ethanol/trickwine/ice_wine/on_mob_life(mob/living/M)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal(), FALSE)
@@ -184,44 +50,23 @@
 		to_chat(M, span_notice("Sweat runs down your body."))
 	return ..()
 
-/datum/status_effect/trickwine/buff/ice
-	id = "ice_wine_buff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-	trait = TRAIT_NOFIRE
 
-/datum/status_effect/trickwine/debuff/ice
-	id = "ice_wine_debuff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-	var/icon/cube
-
-/datum/status_effect/trickwine/debuff/ice/on_apply()
-	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(owner_moved))
-	owner.Paralyze(duration)
-	to_chat(owner, span_userdanger("You become frozen in a cube!"))
-	cube = icon('icons/effects/freeze.dmi', "ice_cube")
-	var/icon/size_check = icon(owner.icon, owner.icon_state)
-	cube.Scale(size_check.Width(), size_check.Height())
-	owner.add_overlay(cube)
+/datum/reagent/consumable/ethanol/trickwine/ice_wine/expose_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(method == TOUCH)
+		var/paralyze_dur
+		if(!iscarbon(M))
+			reac_volume = reac_volume * 2
+			paralyze_dur = reac_volume
+		else
+			if(reac_volume <= 50)
+				paralyze_dur = reac_volume
+			else
+				paralyze_dur = 50 + ((reac_volume - 50) / 4)
+		M.adjust_bodytemperature((-1*reac_volume) * TEMPERATURE_DAMAGE_COEFFICIENT, 50)
+		M.Paralyze(paralyze_dur)
+		walk(M, 0) //stops them mid pathing even if they're stunimmunee
+		M.apply_status_effect(/datum/status_effect/ice_block_talisman, paralyze_dur)
 	return ..()
-
-/// Blocks movement from the status effect owner
-/datum/status_effect/trickwine/debuff/ice/proc/owner_moved()
-	return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
-
-/datum/status_effect/trickwine/debuff/ice/on_remove()
-	to_chat(owner, span_notice("The cube melts!"))
-	owner.cut_overlay(cube)
-	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 
 /datum/reagent/consumable/ethanol/trickwine/shock_wine
 	name = "Lightning's Blessing"
@@ -232,46 +77,26 @@
 	glass_name = "Lightning's Blessing"
 	glass_desc = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey. Known to have a shocking effect when thrown"
 	breakaway_flask_icon_state = "baflaskshockwine"
-	buff_effect = /datum/status_effect/trickwine/buff/shock
-	debuff_effect = /datum/status_effect/trickwine/debuff/shock
+
+/datum/reagent/consumable/ethanol/trickwine/shock_wine/on_mob_metabolize(mob/living/M)
+	..()
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
+	to_chat(M, span_notice("You feel like a bolt of lightning!"))
+
+/datum/reagent/consumable/ethanol/trickwine/shock_wine/on_mob_end_metabolize(mob/living/M)
+	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
+	to_chat(M, span_notice("Inertia leaves your body!"))
+	..()
 
 /datum/reagent/consumable/ethanol/trickwine/shock_wine/expose_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method == TOUCH)
+		//simple mobs are so tanky and i want this to be useful on them
+		if(iscarbon(M))
+			reac_volume = reac_volume / 4
 		M.electrocute_act(reac_volume, src, siemens_coeff = 1, flags = SHOCK_NOSTUN|SHOCK_TESLA)
 		do_sparks(5, FALSE, M)
 		playsound(M, 'sound/machines/defib_zap.ogg', 100, TRUE)
 	return ..()
-
-/datum/status_effect/trickwine/buff/shock
-	id = "shock_wine_buff"
-	trickwine_examine_text = "SUBJECTPRONOUN seems to be crackling with energy."
-	message_apply_others =  "seems to be crackling with energy!"
-	message_apply_self = "You feel like a bolt of lightning!"
-	message_remove_others = "has lost their statis energy."
-	message_remove_self = "Inertia leaves your body!"
-	alert_desc = "You feel faster then lightning and cracking with energy! Your immune to shock damage and move faster!"
-	trait = TRAIT_SHOCKIMMUNE
-
-/datum/status_effect/trickwine/buff/shock/on_apply()
-	owner.add_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
-	return ..()
-
-/datum/status_effect/trickwine/buff/shock/on_remove()
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
-	..()
-
-/datum/status_effect/trickwine/debuff/shock
-	id = "shock_wine_debuff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/shock/tick()
-	if(rand(25))
-		do_sparks(5, FALSE, owner)
 
 /datum/reagent/consumable/ethanol/trickwine/hearth_wine
 	name = "Hearthflame"
@@ -280,12 +105,9 @@
 	boozepwr = 70
 	taste_description = "apple cut apart by tangy pricks"
 	glass_name = "Hearthflame"
-	glass_desc = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and cauterize wounds. Goes out in a blaze of glory when thrown."
+	glass_desc = "Fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and cauterize wounds. Goes out in a blaze of glory when thrown."
 	breakaway_flask_icon_state = "baflaskhearthwine"
-	buff_effect = /datum/status_effect/trickwine/buff/hearth
-	debuff_effect = /datum/status_effect/trickwine/debuff/hearth
 
-//This needs a buff
 /datum/reagent/consumable/ethanol/trickwine/hearth_wine/on_mob_life(mob/living/M)
 	M.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal(), FALSE)
 	if(ishuman(M))
@@ -293,150 +115,17 @@
 		H.heal_bleeding(0.25)
 	return ..()
 
-/datum/status_effect/trickwine/buff/hearth
-	id = "hearth_wine_buff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-	trait = TRAIT_RESISTCOLD
-
-/datum/status_effect/trickwine/debuff/hearth
-	id = "hearth_wine_debuff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/hearth/tick()
-	//owner.fire_act()
-	var/turf/owner_turf = get_turf(owner)
-	owner_turf.IgniteTurf(duration)
-	//new /obj/effect/hotspot(owner_turf, 1)
-
-/datum/reagent/consumable/ethanol/trickwine/force_wine
-	name = "Forcewine"
-	description = "Creates a barrier on the skin that catches sharpnel and when reversed locks threats down with a barrier"
-	color = "#709AAF"
-	boozepwr = 70
-	taste_description = "the strength of your convictions"
-	glass_name = "Forcewine"
-	glass_desc = "Creates a barrier on the skin that catches sharpnel and when reversed locks threats down with a barrier"
-	breakaway_flask_icon_state = "baflaskforcewine"
-	buff_effect = /datum/status_effect/trickwine/buff/force
-	debuff_effect = /datum/status_effect/trickwine/debuff/force
-
-/datum/status_effect/trickwine/buff/force
-	id = "force_wine_buff"
-	trickwine_examine_text = ""
-	message_apply_others =  "glows a dim grey aura."
-	message_apply_self = "You feel faster than lightning!"
-	message_remove_others = "'s aura fades away."
-	message_remove_self = "You feel sluggish."
-	alert_desc = ""
-	// No shrapnel seems useful
-	trait = TRAIT_PIERCEIMMUNE
-
-/datum/status_effect/trickwine/debuff/force
-	id = "force_wine_debuff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/force/on_apply()
-	var/turf/turf = get_turf(owner)
-	var/turf/other_turf
-	new /obj/structure/foamedmetal/forcewine(turf, duration)
-	for(var/direction in GLOB.cardinals)
-		other_turf = get_step(turf, direction)
-		new /obj/structure/foamedmetal/forcewine(other_turf, duration)
+/datum/reagent/consumable/ethanol/trickwine/hearth_wine/expose_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(method == TOUCH)
+		if(!iscarbon(M))
+			reac_volume = reac_volume * 2
+		M.fire_act()
+		var/turf/T = get_turf(M)
+		T.IgniteTurf(reac_volume)
+		new /obj/effect/hotspot(T, reac_volume * 1, FIRE_MINIMUM_TEMPERATURE_TO_EXIST + reac_volume * 10)
+		var/turf/otherT
+		for(var/direction in GLOB.alldirs)
+			otherT = get_step(T, direction)
+			otherT.IgniteTurf(reac_volume)
+			new /obj/effect/hotspot(otherT, reac_volume * 1, FIRE_MINIMUM_TEMPERATURE_TO_EXIST + reac_volume * 10)
 	return ..()
-
-/datum/reagent/consumable/ethanol/trickwine/prism_wine
-	name = "Prismwine"
-	description = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to provide defense against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
-	color = "#F0F0F0"
-	boozepwr = 70
-	taste_description = "the reflective quality of meditation"
-	glass_name = "Prismwine"
-	glass_desc = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to provide defense against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
-	breakaway_flask_icon_state = "baflaskprismwine"
-	buff_effect = /datum/status_effect/trickwine/buff/prism
-	debuff_effect = /datum/status_effect/trickwine/debuff/prism
-
-#define MAX_REFLECTS 3
-/datum/status_effect/trickwine/buff/prism
-	id = "prism_wine_buff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-	var/reflect_count = 0
-	var/recent_movement = FALSE
-
-/datum/status_effect/trickwine/buff/prism/on_apply()
-	RegisterSignal(owner, COMSIG_CHECK_REFLECT, PROC_REF(on_check_reflect))
-	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
-	return ..()
-
-/datum/status_effect/trickwine/buff/prism/on_remove()
-	UnregisterSignal(owner, list(COMSIG_CHECK_REFLECT, COMSIG_MOVABLE_MOVED))
-	..()
-
-/datum/status_effect/trickwine/buff/prism/tick()
-	. = ..()
-	if(prob(25) && reflect_count < MAX_REFLECTS)
-		if(recent_movement)
-			adjust_charge(1)
-			to_chat(owner, span_notice("Your resin sweat builds up another layer!"))
-		else
-			to_chat(owner, span_warning("You need to keep moving to build up resin sweat!"))
-	recent_movement = FALSE
-
-/datum/status_effect/trickwine/buff/prism/proc/adjust_charge(change)
-	reflect_count = clamp(reflect_count + change, 0, MAX_REFLECTS)
-	owner.add_filter(id, 2, drop_shadow_filter(x = 0, y = -1, size = 1 + reflect_count, color = reagent_color))
-
-/datum/status_effect/trickwine/buff/prism/proc/on_check_reflect(mob/living/carbon/human/owner, def_zone)
-	SIGNAL_HANDLER
-	if(reflect_count > 0)
-		to_chat(owner, span_notice("Your resin sweat protects you!"))
-		adjust_charge(-1)
-		return TRUE
-
-// The idea is that its a resin made of sweat, therfore stay moving
-/datum/status_effect/trickwine/buff/prism/proc/on_move()
-	recent_movement = TRUE
-#undef MAX_REFLECTS
-
-/datum/status_effect/trickwine/debuff/prism
-	id = "prism_wine_debuff"
-	trickwine_examine_text = ""
-	message_apply_others =  ""
-	message_apply_self = ""
-	message_remove_others = ""
-	message_remove_self = ""
-	alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/prism/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/the_human = owner
-		the_human.physiology.burn_mod *= 2
-	return ..()
-
-/datum/status_effect/trickwine/debuff/prism/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/the_human = owner
-		the_human.physiology.burn_mod *= 0.5
-	..()
-
-


### PR DESCRIPTION
Reverts shiptest-ss13/Shiptest#3390

This pr added large swathes of blank flavortext in trickwine usage leading to things like
[The vigorous Elzu person]

What is present would not pass muster on a middle school english paper.

I'm decidedly unhappy and until the original author fixes it I want it reverted.