### PR TITLE
Replaces CMGSV with CLSV in factions.dm

### DIFF
--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -37,7 +37,7 @@
 #define PREFIX_SOLGOV list("SCSV")
 #define PREFIX_SRM list("SRSV")
 #define PREFIX_INTEQ list("IRMV")
-#define PREFIX_CLIP list("CMSV", "CMGSV")
+#define PREFIX_CLIP list("CMSV", "CLSV")
 #define PREFIX_NT list("NTSV")
 	#define PREFIX_NS_LOGI list("NSSV")
 	#define PREFIX_VIGILITAS list("VISV")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Both Arke and Vela use that one, and it's not in the file. CMGSV is not really used anymore (it was used by the old Vela).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: Replaced the CMGSV prefix with CLSV.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
