### PR TITLE
Linter for Ship-class capitalization

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -86,7 +86,7 @@ if $grep -i'centcomm' $map_files; then
     echo -e "${RED}ERROR: Misspelling(s) of CentCom detected in maps, please remove the extra M(s).${NC}"
     st=1
 fi;
-if $grep '-Class' $map_files; then
+if $grep -- '-Class' $map_files; then
 	echo
 	echo -e "${RED}ERROR: Misspellings(s) of -class detected in maps, please uncapitalize the C(s).${NC}"
 	st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -86,6 +86,11 @@ if $grep -i'centcomm' $map_files; then
     echo -e "${RED}ERROR: Misspelling(s) of CentCom detected in maps, please remove the extra M(s).${NC}"
     st=1
 fi;
+if $grep '-Class' $map_files; then
+	echo
+	echo -e "${RED}ERROR: Misspellings(s) of -class detected in maps, please uncapitalize the C(s).${NC}"
+	st=1
+fi;
 
 section "whitespace issues"
 part "space indentation"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check for ships to be styled as "Name-class" rather than some cases of "Name-Class". Only checks lines within the _maps/ directory, to avoid other legitimate cases of "-Class" within code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistent capitlization for ship classes, hopefully removes the need to be repeated in PRs like #2304, #3815, and #4231.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: added a linter for ship class capitilzation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
