### PR TITLE
Flamethrower qol

### DIFF
--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -99,7 +99,7 @@
 			to_chat(user, span_notice("The [src] already has an igniter!"))
 			return
 		if(I.secured)
-			to_chat(user, span_notice("You need to unsecure \the [igniter] with a screwdriver first!"))
+			to_chat(user, span_notice("You need to unsecure \the [I] with a screwdriver first!"))
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
@@ -147,7 +147,7 @@
 		if(!igniter)
 			to_chat(user, span_notice("The [src] needs an igniter to function!"))
 		else if (!igniter.secured)
-			to_chat(user, span_notice("Secure the igniter first!"))
+			to_chat(user, span_notice("Secure the igniter with a screwdriver first!"))
 		return
 	to_chat(user, "<span class='notice'>You [lit ? "extinguish" : "ignite"] [src]!</span>")
 	lit = !lit

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -87,32 +87,19 @@
 			flame_turf(target)
 
 /obj/item/flamethrower/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WRENCH && !status)//Taking this apart
-		var/turf/T = get_turf(src)
-		if(weldtool)
-			weldtool.forceMove(T)
-			weldtool = null
-		if(igniter)
-			igniter.forceMove(T)
-			igniter = null
-		if(beaker)
-			beaker.forceMove(T)
-			beaker = null
-		new /obj/item/stack/rods(T)
-		qdel(src)
-		return
-
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER && igniter && !lit)
+	if(W.tool_behaviour == TOOL_SCREWDRIVER && igniter && !lit)
 		status = !status
-		to_chat(user, "<span class='notice'>[igniter] is now [status ? "secured" : "unsecured"]!</span>")
+		to_chat(user, span_notice("[igniter] is now [status ? "secured" : "unsecured"]!"))
 		update_appearance()
 		return
 
 	else if(isigniter(W))
 		var/obj/item/assembly/igniter/I = W
-		if(I.secured)
-			return
 		if(igniter)
+			to_chat(user, span_notice("The [src] already has an igniter!"))
+			return
+		if(I.secured)
+			to_chat(user, span_notice("You need to unsecure \the [igniter] with a screwdriver first!"))
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
@@ -157,7 +144,10 @@
 		to_chat(user, "<span class='notice'>Attach a fuel container first!</span>")
 		return
 	if(!status)
-		to_chat(user, "<span class='notice'>Secure the igniter first!</span>")
+		if(!igniter)
+			to_chat(user, span_notice("The [src] needs an igniter to function!"))
+		else if (!igniter.secured)
+			to_chat(user, span_notice("Secure the igniter first!"))
 		return
 	to_chat(user, "<span class='notice'>You [lit ? "extinguish" : "ignite"] [src]!</span>")
 	lit = !lit


### PR DESCRIPTION
## About The Pull Request

- You can no longer deconstruct flamethrowers (since it's not worth it and they are not craftable).
- Adds a bit of in game indication as to how to get the flamethrower working.

## Why It's Good For The Game

Less need to wiki/code dive.

## Changelog

:cl:
add: In game feedback about getting a flamethrower to work.
del: Can't deconstruct flamethrowers with a wrench.
/:cl: