### PR TITLE
beacons use a real cooldown tied to world

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -40,6 +40,7 @@
 	COOLDOWN_DECLARE(beacon_cooldown)
 	/// Is the console in beacon mode? exists to let beacon know when a pod may come in
 	var/use_beacon = FALSE
+
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
 	var/obj/item/circuitboard/computer/cargo/board = circuit

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -24,8 +24,6 @@
 
 	var/blockade_warning = "Bluespace instability detected. Delivery impossible."
 	var/message
-	/// Number of beacons printed. Used to determine beacon names.
-	var/printed_beacons = 0
 	var/list/supply_pack_data
 	/// The currently linked supplypod beacon
 	var/obj/item/supplypod_beacon/beacon
@@ -33,13 +31,15 @@
 	var/area/landingzone
 	/// The pod type used to deliver orders
 	var/podType = /obj/structure/closet/supplypod/centcompod
-	/// Cooldown to prevent printing supplypod beacon spam
-	var/cooldown = 0
-	/// Is the console in beacon mode? exists to let beacon know when a pod may come in
-	var/use_beacon = FALSE
 	/// The account to charge purchases to, defaults to the cargo budget
 	var/datum/bank_account/charge_account
 
+	/// Number of beacons printed. Used to determine beacon names.
+	var/printed_beacons = 0
+	/// Cooldown to prevent printing supplypod beacon spam
+	COOLDOWN_DECLARE(beacon_cooldown)
+	/// Is the console in beacon mode? exists to let beacon know when a pod may come in
+	var/use_beacon = FALSE
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
 	var/obj/item/circuitboard/computer/cargo/board = circuit
@@ -111,11 +111,11 @@
 	data["beaconZone"] = beacon ? get_area(beacon) : ""//where is the beacon located? outputs in the tgui
 	data["usingBeacon"] = use_beacon //is the mode set to deliver to the beacon or the cargobay?
 	data["canBeacon"] = !use_beacon || canBeacon //is the mode set to beacon delivery, and is the beacon in a valid location?
-	data["canBuyBeacon"] = charge_account ? (cooldown <= 0) : FALSE
+	data["canBuyBeacon"] = charge_account ? COOLDOWN_FINISHED(src, beacon_cooldown) : FALSE
 	data["beaconError"] = use_beacon && !canBeacon ? "(BEACON ERROR)" : ""//changes button text to include an error alert if necessary
 	data["hasBeacon"] = beacon != null//is there a linked beacon?
 	data["beaconName"] = beacon ? beacon.name : "No Beacon Found"
-	data["printMsg"] = cooldown > 0 ? "Print Beacon ([cooldown])" : "Print Beacon"//buttontext for printing beacons
+	data["printMsg"] = COOLDOWN_FINISHED(src, beacon_cooldown) ? "Print Beacon" : "Print Beacon ([DisplayTimeText(COOLDOWN_TIMELEFT(src, beacon_cooldown), 1)])" //buttontext for printing beacons
 	data["supplies"] = list()
 	message = "Sales are near-instantaneous - please choose carefully."
 	if(SSshuttle.supplyBlocked)
@@ -127,8 +127,6 @@
 	data["message"] = message
 
 	data["supplies"] = supply_pack_data
-	if (cooldown > 0)//cooldown used for printing beacons
-		cooldown--
 
 	data["shipMissions"] = list()
 	data["outpostMissions"] = list()
@@ -171,11 +169,13 @@
 			if (beacon)
 				beacon.update_status(SP_READY) //turns on the beacon's ready light
 		if("printBeacon")
-			cooldown = 300
+			if(!COOLDOWN_FINISHED(src, beacon_cooldown))
+				return
 			var/obj/item/supplypod_beacon/C = new /obj/item/supplypod_beacon(drop_location())
 			C.link_console(src, usr)//rather than in beacon's Initialize(), we can assign the computer to the beacon by reusing this proc)
 			printed_beacons++//printed_beacons starts at 0, so the first one out will be called beacon # 1
 			beacon.name = "Supply Pod Beacon #[printed_beacons]"
+			COOLDOWN_START(src, beacon_cooldown, 300 SECONDS)
 		if("add")
 			var/datum/overmap/outpost/current_outpost = current_ship.docked_to
 			if(istype(current_ship.docked_to))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Beacons cooldown was tied to ui_data and since typing calls it to refresh data, rolling your hands across your keyboard speeds up the cooldown alot. The second display is also now formated pretty and the code is better
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more uhh.. competetive beacon printing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: You can no longer print beacons faster by typing really fast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
