### PR TITLE
ship orbit menu improvments

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -240,6 +240,7 @@
 	if(istype(atom_poi, /obj/machinery/computer/helm))
 		var/obj/machinery/computer/helm/helm_poi = atom_poi
 		if(helm_poi.current_ship)
+			misc["full_name"] = helm_poi.current_ship.name
 			misc["extra"] = "Ship: [helm_poi.current_ship.name]"
 
 		return list(misc, critical)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -240,8 +240,9 @@
 	if(istype(atom_poi, /obj/machinery/computer/helm))
 		var/obj/machinery/computer/helm/helm_poi = atom_poi
 		if(helm_poi.current_ship)
-			misc["full_name"] = helm_poi.current_ship.name
-			misc["extra"] = "Ship: [helm_poi.current_ship.name]"
+			var/datum/overmap/ship/controlled/helm_ship = helm_poi.current_ship
+			misc["full_name"] = helm_ship.name
+			misc["extra"] = "Crew Size: [length(helm_ship.manifest)]"
 
 		return list(misc, critical)
 

--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -49,8 +49,6 @@
 
 /obj/machinery/computer/helm/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-	if(!viewer)
-		SSpoints_of_interest.make_point_of_interest(src)
 	jump_allowed = world.time + CONFIG_GET(number/bluespace_jump_wait)
 	ntnet_relay = new(src)
 
@@ -111,6 +109,8 @@
 	qdel(current_ship)
 
 /obj/machinery/computer/helm/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	if(!viewer)
+		SSpoints_of_interest.make_point_of_interest(src)
 	if(current_ship && current_ship != port.current_ship)
 		current_ship.helms -= src
 	current_ship = port.current_ship


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ship helms in orbit menu now display there ship name first, and crew size in the tool tip.
move adding a helm as "intresting" to connect to shuttle which means it wont include ruin mapped shit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this sucks ass 
![image](https://github.com/user-attachments/assets/35798299-da6a-41ec-9b72-0ed4939392eb)
better
![image](https://github.com/user-attachments/assets/f4a2f7a0-1128-4b09-a68d-8407dad3e972)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Helms in the orbit menu now use the ship's name as its full name
fix: Random helms not connected to a ship don't appear in the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
