### PR TITLE
Removes Ship observer_start Landmarks and Gives Indie Outpost One

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -6918,6 +6918,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/wood,
 /area/outpost/crew/bar)
 "ID" = (

--- a/_maps/shuttles/independent/independent_bubble.dmm
+++ b/_maps/shuttles/independent/independent_bubble.dmm
@@ -44,7 +44,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "cF" = (

--- a/_maps/shuttles/independent/independent_junker.dmm
+++ b/_maps/shuttles/independent/independent_junker.dmm
@@ -2590,7 +2590,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/landmark/observer_start,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)
 "XM" = (

--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -276,7 +276,6 @@
 /area/ship/crew/canteen)
 "ee" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/landmark/observer_start,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -14,7 +14,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "ai" = (

--- a/_maps/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/shuttles/inteq/inteq_colossus.dmm
@@ -3340,7 +3340,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/hallway/central)
 "JO" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -1316,7 +1316,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/observer_start,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},

--- a/_maps/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/shuttles/inteq/inteq_valor.dmm
@@ -780,7 +780,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/observer_start,
 /obj/machinery/holopad/emergency/security,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)

--- a/_maps/shuttles/nanotrasen/nanotrasen_meta.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_meta.dmm
@@ -3402,7 +3402,6 @@
 "Rf" = (
 /obj/effect/turf_decal/corner/transparent/neutral/full,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Rv" = (

--- a/_maps/shuttles/syndicate/syndicate_hardliners_banshee.dmm
+++ b/_maps/shuttles/syndicate/syndicate_hardliners_banshee.dmm
@@ -2728,7 +2728,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/floor,
-/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Yv" = (


### PR DESCRIPTION
## About The Pull Request

says whats in the title.

## Why It's Good For The Game

makes it consistent towards only outposts having observer_start landmarks instead of random ships

## Changelog

:cl:
add: indie outpost observer_start landmar
del: ship observer_start landmarks
/:cl:

