### PR TITLE
make the star and outpost tokens objects of interest

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -53,6 +53,7 @@
 	// init our template vars with the correct singletons
 	main_template = SSmapping.outpost_templates[main_template]
 	elevator_template = SSmapping.outpost_templates[elevator_template]
+	SSpoints_of_interest.make_point_of_interest(token)
 
 	for(var/i in 1 to hangar_templates.len)
 		hangar_templates[i] = SSmapping.outpost_templates[hangar_templates[i]]
@@ -74,6 +75,7 @@
 	addtimer(CALLBACK(src, PROC_REF(fill_missions)), 10 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
 
 /datum/overmap/outpost/Destroy(...)
+	SSpoints_of_interest.make_point_of_interest(token)
 	// cleanup our data structures. behavior here is currently relatively restrained; may be made more expansive in the future
 	for(var/list/datum/hangar_shaft/h_shaft as anything in shaft_datums)
 		qdel(h_shaft)

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -13,8 +13,8 @@
 	alter_token_appearance()
 
 /datum/overmap/star/Destroy(force)
-	. = ..()
 	SSpoints_of_interest.make_point_of_interest(token)
+	. = ..()
 
 /datum/overmap/star/proc/gen_star_name()
 	return "[pick(GLOB.star_names)] [pick(GLOB.greek_letters)]"

--- a/code/modules/overmap/objects/star.dm
+++ b/code/modules/overmap/objects/star.dm
@@ -6,11 +6,15 @@
 
 /datum/overmap/star/Initialize(position, ...)
 	var/name = gen_star_name()
+	SSpoints_of_interest.make_point_of_interest(token)
 	Rename(name)
 	set_station_name(name)
 	token.desc = token_desc
 	alter_token_appearance()
 
+/datum/overmap/star/Destroy(force)
+	. = ..()
+	SSpoints_of_interest.make_point_of_interest(token)
 
 /datum/overmap/star/proc/gen_star_name()
 	return "[pick(GLOB.star_names)] [pick(GLOB.greek_letters)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Star and outpost overmap tokens are now added as objects of intrest that show up in the orbit menu.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
having to use the teleport verb kinda sucks, it works, but its not great.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Stars and outposts now show up in the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
