### PR TITLE
outpost doesnt generate a new faction for every cargo pack

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -153,7 +153,7 @@
 	for(var/datum/supply_pack/current_pack as anything in subtypesof(/datum/supply_pack))
 		current_pack = new current_pack()
 		if(current_pack.faction)
-			current_pack.faction = new current_pack.faction()
+			current_pack.faction = SSfactions.faction_path_to_datum(current_pack.faction)
 		if(!current_pack.contains)
 			continue
 		supply_packs += current_pack


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Get references of the real facitons instead of generating new ones. nothing player facing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bad behavoir
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
refactor: outpost uses faction_path_to_datum instead of making new factions for cargo packs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
