### PR TITLE
Gives SRM loadouts a emergency box again.

### DIFF
--- a/code/modules/clothing/outfits/factions/roumain.dm
+++ b/code/modules/clothing/outfits/factions/roumain.dm
@@ -2,10 +2,8 @@
 	name = "Saint-Roumain Militia - Base Outfit"
 
 	uniform = /obj/item/clothing/under/suit/roumain
-	id = /obj/item/card/id
 	faction_icon = "bg_srm"
 
-	box = null
 
 /datum/outfit/job/roumain/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
@@ -21,8 +19,6 @@
 	jobtype = /datum/job/assistant
 	job_icon = "srm_shadow"
 
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/armor/roumain/shadow
 
@@ -37,7 +33,6 @@
 	jobtype = /datum/job/captain
 
 	ears = /obj/item/radio/headset/headset_com/alt
-	uniform = /obj/item/clothing/under/suit/roumain
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/armor/roumain/montagne
 	head = /obj/item/clothing/head/cowboy/sec/roumain/montagne
@@ -63,7 +58,6 @@
 	jobtype = /datum/job/head_of_personnel
 
 	ears = /obj/item/radio/headset/headset_com
-	uniform = /obj/item/clothing/under/suit/roumain
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/armor/roumain/colligne
 	head = /obj/item/clothing/head/cowboy/sec/roumain/colligne
@@ -86,8 +80,6 @@
 	jobtype = /datum/job/officer
 	job_icon = "srm_hunter"
 
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/armor/roumain
 	head = /obj/item/clothing/head/cowboy/sec/roumain
@@ -108,8 +100,6 @@
 	job_icon = "srm_machinist"
 	jobtype = /datum/job/engineer
 
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	belt = /obj/item/storage/belt/utility/full/engi
 	suit = /obj/item/clothing/suit/hazardvest/roumain
@@ -130,8 +120,6 @@
 	job_icon = "srm_doctor"
 	jobtype = /datum/job/doctor
 
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/toggle/labcoat/roumain_med
 	head = /obj/item/clothing/head/cowboy/sec/roumain/med
@@ -151,8 +139,6 @@
 	job_icon = "srm_flamebearer"
 	jobtype = /datum/job/chaplain
 
-	uniform = /obj/item/clothing/under/suit/roumain
-	alt_uniform = null
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	suit = /obj/item/clothing/suit/armor/roumain/flamebearer
 	head = /obj/item/clothing/head/cowboy/sec/roumain/flamebearer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Also some redundant line removal
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't see a reason they SHOULDN'T have a box. Its quite frustrating to at least not have a cardboard box to store some spare junk and having to fumble around your ship for a mask.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: SRM have a box again. no watching your crew rot to death cause you don't come with a pen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
