### PR TITLE
Removes Miners (Minimum character age is now 18)

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	///Whether or not the race has sexual characteristics (biological genders). At the moment this is only FALSE for skeletons and shadows
 	var/sexes = TRUE
 	///Minimum species_age
-	var/species_age_min = 17
+	var/species_age_min = 18
 	///Maximum species age
 	var/species_age_max = 85
 


### PR DESCRIPTION
## About The Pull Request

Minimum age for non-IPC species changed from 17 to 18.

## Why It's Good For The Game

Avoids a nearly limitless number of potentially weird situations, from child soldiers/workers to... age of consent issues. 

I don't really want to list a bunch of specific situations, but I have a feeling we don't want to have certain situations relating to minors existing.

## Changelog

:cl:
del: Removes children
/:cl:
