### PR TITLE
Cargo Telescopic Riot Shields

### DIFF
--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -13,7 +13,7 @@
 /datum/crafting_recipe/strobeshield
 	name = "Strobe Shield"
 	result = /obj/item/shield/riot/flash
-	reqs = list(/obj/item/wallframe/flasher = 1,
+	reqs = list(/obj/item/stack/cable_coil = 1,
 				/obj/item/assembly/flash/handheld = 1,
 				/obj/item/shield/riot = 1)
 	time = 40

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -101,11 +101,18 @@
 */
 
 /datum/supply_pack/sec_supply/riotshields
-	name = "Riot Shields Crate"
+	name = "Riot Shield Crate"
 	desc = "Contains a riot shield, effective at holding back hostile fauna, xenofauna, or large crowds."
 	cost = 600
 	contains = list(/obj/item/shield/riot)
-	crate_name = "riot shields crate"
+	crate_name = "riot shield crate"
+
+/datum/supply_pack/sec_supply/teleriotshields
+	name = "Telescopic Riot Shield Crate"
+	desc = "Contains a telescopic riot shield, effective at holding back hostile fauna, xenofauna, or large crowds in tight spaces."
+	cost = 750
+	contains = list(/obj/item/shield/riot/tele)
+	crate_name = "riot shield crate"
 
 /datum/supply_pack/sec_supply/survknives
 	name = "Survival Knives Crate"


### PR DESCRIPTION
## About The Pull Request

Adds telescopic riot shields to cargo. 750 credits for one.

Also makes Strobe Shields not require wall flashers (unobtainable).

## Why It's Good For The Game

With the way shields are and how our combat is these are... surprisingly kinda okay at best, but it's got a slight leg up over standard riot shields. Hopefully this encourages people to use shields more often, 

Standard riot shields can also be upgraded to strobe shields now.

## Changelog

:cl:
add: Telescopic Riot Shields to Cargo
balance: Strobe Shields no longer require unobtainable wall flashers.
/:cl:

