### PR TITLE
Adds CLIP gas masks to CLIP SSUs.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -184,7 +184,7 @@
 
 /obj/machinery/suit_storage_unit/minutemen
 	suit_type = /obj/item/clothing/suit/space/hardsuit/clip_patroller
-	mask_type = /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/gas/clip
 
 /obj/machinery/suit_storage_unit/minutemen/spotter
 	suit_type = /obj/item/clothing/suit/space/hardsuit/clip_spotter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Having access on both Atlas and Typhon (coming soon:tm:) is good I think. I know that #4207 adds it to the armory, but I think this is a better solution than putting gas masks in a uniform crate. Vela did the same but with an inherit SSU too, so points for bonus consistency. Also it's like, consistent with other factions (for example, IRMG).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Minuteman SSUs start with the CLIP gas mask now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
