### PR TITLE
Unloading machines no longer pick up ice

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -1009,7 +1009,6 @@
 	},
 /obj/machinery/elevator_call_button{
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2982,7 +2981,6 @@
 	},
 /obj/structure/sign/directions/supply{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = 28
 	},
 /obj/structure/sign/directions/security{
@@ -3307,14 +3305,16 @@
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
 "qc" = (
-/obj/machinery/conveyor_switch{
-	id = "outpost2";
-	layer = 3.11;
-	pixel_y = 9;
-	pixel_x = -2
-	},
 /obj/structure/railing/thin{
 	dir = 9
+	},
+/obj/effect/turf_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	pixel_y = 8;
+	layer = 3.09;
+	id = "outpost2"
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo)
@@ -3700,7 +3700,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random{
-	pixel_y = 0;
 	pixel_x = -28
 	},
 /turf/open/floor/wood,
@@ -3803,7 +3802,6 @@
 /obj/structure/noticeboard{
 	name = "refinery notice board";
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/corner/opaque/white{
@@ -4439,7 +4437,6 @@
 /area/outpost/cargo)
 "wa" = (
 /obj/structure/sign/painting/library{
-	pixel_y = 0;
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/wrapping,
@@ -4519,7 +4516,6 @@
 "ws" = (
 /obj/structure/sink{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 14
 	},
 /obj/structure/mirror{
@@ -4934,7 +4930,6 @@
 /area/outpost/crew/bar)
 "yH" = (
 /obj/structure/railing/wood{
-	dir = 2;
 	color = "#792f27"
 	},
 /turf/open/floor/plasteel/stairs/wood{
@@ -5457,9 +5452,7 @@
 /turf/open/floor/carpet/green,
 /area/outpost/crew/bar)
 "Bg" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 0
-	},
+/obj/structure/closet/crate/bin,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/insectguts,
 /obj/item/reagent_containers/syringe{
@@ -6314,7 +6307,6 @@
 "FK" = (
 /obj/structure/toilet{
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = -6
 	},
 /obj/structure/mirror{
@@ -6359,7 +6351,6 @@
 "FY" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "electricdanger";
-	pixel_y = 0;
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/steeldecal/steel_decals10,
@@ -6475,12 +6466,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "f";
-	pixel_y = 0;
 	pixel_x = -19
 	},
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "f";
-	pixel_y = 0;
 	pixel_x = -19
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6751,7 +6740,6 @@
 	},
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "f";
-	pixel_y = 0;
 	pixel_x = -19
 	},
 /obj/effect/decal/cleanable/crayon{
@@ -7460,8 +7448,7 @@
 	},
 /obj/structure/sign/directions/medical{
 	pixel_y = -12;
-	pixel_x = -28;
-	dir = 2
+	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7529,7 +7516,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/crayon{
-	icon_state = "firedanger";
 	pixel_y = -28
 	},
 /turf/open/floor/plating,
@@ -7753,7 +7739,6 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kitchen/fork{
-	pixel_y = 0;
 	pixel_x = -7
 	},
 /obj/item/kitchen/fork{
@@ -9214,7 +9199,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/sign/directions/medical{
 	pixel_x = 28;
-	dir = 2;
 	pixel_y = -10
 	},
 /obj/structure/cable/yellow{
@@ -9245,17 +9229,6 @@
 	},
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
-"UR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/conveyor_switch{
-	id = "outpost1";
-	layer = 3.11;
-	pixel_y = 4;
-	pixel_x = 5
-	},
-/obj/structure/railing/thin,
-/turf/open/floor/plasteel/patterned,
-/area/outpost/cargo)
 "UT" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9663,6 +9636,14 @@
 /obj/structure/railing/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/effect/turf_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	pixel_y = 8;
+	layer = 3.09;
+	id = "outpost1"
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo)
@@ -10205,8 +10186,7 @@
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
-	pixel_y = 38;
-	dir = 2
+	pixel_y = 38
 	},
 /obj/structure/sign/directions/service{
 	pixel_y = 20;
@@ -19165,7 +19145,7 @@ Va
 QJ
 CV
 CV
-UR
+kp
 SK
 pc
 Uw

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -15,7 +15,9 @@
 	if(istype(target, /obj/structure/ore_box))
 		var/obj/structure/ore_box/box = target
 		for(var/obj/item/stack/ore/O in box)
-			unload_mineral(O)
+			if(!istype(O, /obj/item/stack/ore/ice)) // Doesn't automatically unload ice, other machines will still process (or melt) the ice normally.
+				unload_mineral(O)
 	else if(istype(target, /obj/item/stack/ore))
 		var/obj/item/stack/ore/O = target
-		unload_mineral(O)
+		if(!istype(O, /obj/item/stack/ore/ice))
+			unload_mineral(O)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #4154
Fixes #4155

See title, unloading machines don't automatically move ice onto the furnace belt. Should reduce mishaps, especially with ore boxes. However, if ice ends up on the belt regardless, it will still be melted by the furnace.

Also slight movement of the electrolyzer on the indie outpost, as well as making both levers one-way and decal'd.

![image](https://github.com/user-attachments/assets/299e2db1-d353-42da-9246-b6f7beff9a4b)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes less mistakes of accidentally melting the ice that your well-insured deckhands have died mining for.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: unloading machines no longer pick up ice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
