### PR TITLE
Make gun locker buildable and tweak it a bit.

### DIFF
--- a/code/game/objects/items/stacks/sheets/recipes/recipes_metal.dm
+++ b/code/game/objects/items/stacks/sheets/recipes/recipes_metal.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		new/datum/stack_recipe("radiation closet", /obj/structure/closet/radiation/empty, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE)
 		)),
 	null, \
-		new/datum/stack_recipe_list("crates", list(
+	new/datum/stack_recipe_list("crates", list(
 		new/datum/stack_recipe("crate", /obj/structure/closet/crate, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
 		new/datum/stack_recipe("internals crate", /obj/structure/closet/crate/internals, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
 		new/datum/stack_recipe("engineering crate", /obj/structure/closet/crate/engineering, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
@@ -191,6 +191,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		new/datum/stack_recipe("science crate", /obj/structure/closet/crate/science, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE),
 		new/datum/stack_recipe("hydroponics crate", /obj/structure/closet/crate/hydroponics, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE)
 		)),
+	new/datum/stack_recipe("gun locker", /obj/structure/guncloset, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -14,8 +14,7 @@
 
 /obj/structure/guncloset/examine(mob/user)
 	. = ..()
-	if (open)
-		. += span_notice("Alt-click to close it")
+	. += span_notice("Alt-click to [open ? "close" : "open"] it.")
 
 /obj/structure/guncloset/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -12,6 +12,11 @@
 	var/open = TRUE
 	var/capacity = 4
 
+/obj/structure/guncloset/examine(mob/user)
+	. = ..()
+	if (open)
+		. += span_notice("Alt-click to close it")
+
 /obj/structure/guncloset/Initialize(mapload)
 	. = ..()
 	if(mapload)
@@ -43,12 +48,42 @@
 		else
 			to_chat(user, "<span class='warning'>[src] is full.</span>")
 		return
-
-	else if(user.a_intent != INTENT_HARM)
-		open = !open
-		update_appearance()
 	else
 		return ..()
+
+/obj/structure/guncloset/tool_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if (I.tool_behaviour == TOOL_WRENCH)
+		if(isinspace() && !anchored)
+			return
+		set_anchored(!anchored)
+		I.play_tool_sound(src, 75)
+		user.visible_message(span_notice("[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
+				span_notice("You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
+				span_hear("You hear a ratchet.")
+		)
+		return
+	else if (I.tool_behaviour == TOOL_WELDER || I.tool_behaviour == TOOL_DECONSTRUCT)
+		if(contents.len)
+			to_chat(user, span_danger("\The [src] is not empty!"))
+			return
+		to_chat(user, span_notice("You begin cutting \the [src] apart..."))
+		if(I.use_tool(src, user, 40, volume=50))
+			user.visible_message(span_notice("[user] slices apart \the [src]."),
+					span_notice("You cut \the [src] apart with \the [I]."),
+					span_hear("You hear cutting."))
+			deconstruct(TRUE)
+	else
+		return FALSE
+
+/obj/structure/guncloset/deconstruct(disassembled = TRUE)
+	if (disassembled)
+		new /obj/item/stack/sheet/metal(loc, 10)
+	for(var/obj/stuff in contents)
+		stuff.forceMove(loc)
+
+	SEND_SIGNAL(src, COMSIG_OBJ_DECONSTRUCT, disassembled)
+	qdel(src)
 
 /obj/structure/guncloset/attack_hand(mob/user)
 	. = ..()
@@ -61,6 +96,14 @@
 	else
 		open = !open
 		update_appearance()
+
+
+/obj/structure/guncloset/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
+		return FALSE
+	open = !open
+	update_appearance()
+	return TRUE
 
 /**
  * show_menu: Shows a radial menu to a user consisting of an available weaponry for taking

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -6,6 +6,7 @@
 	icon_state = "shotguncase"
 	anchored = FALSE
 	density = TRUE
+	drag_slowdown = 1.5
 	opacity = FALSE
 	var/case_type = ""
 	var/gun_category = /obj/item/gun


### PR DESCRIPTION
## About The Pull Request

- Gun lockers can now be built with 10 metal sheets.
- They can be deconstructed with a welder/angle grinder.
- When broken/destroyed the closet will drop it's content instead of deleting it.
- They can be anchored/unanchored with a wrench.
- You previously had to click it with a random item in hand in order to close the closet when it's full, this behavior was removed.
- You can now open/close gun lockers with Alt+click.

## Why It's Good For The Game

Gun lockers are nice.

## Changelog

:cl:
add: Gun lockers can be constructed with 10 metal, anchored/unanchored with a wrench and deconstructed with a welder.
fix: Gun lockers no longer delete their content when broken.
:cl: