### PR TITLE
Mech Paths and 515 EX kit

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -79,7 +79,7 @@
 	charge_power_consume = 100
 	charge_windup = 0
 
-/obj/mecha/combat/gygax/charger/nt/loaded/Initialize()
+/obj/mecha/combat/gygax/charger/mp/loaded/Initialize()
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser(src)
 	ME.attach(src)

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -672,3 +672,9 @@
 	source_mech = list(/obj/mecha/combat/gygax,/obj/mecha/combat/gygax/dark)
 	result_mech = /obj/mecha/combat/gygax/charger/mp
 
+/obj/item/mecha_parts/mecha_equipment/conversion_kit/dark_gygax
+	name = "515 EX Conversion Kit"
+	desc = "An offical Cybersun-made conversion kit for a 501p combat exosuit, to convert it to the upgraded 515 EX exosuit."
+	source_mech = list(/obj/mecha/combat/gygax)
+	result_mech = /obj/mecha/combat/gygax/dark
+

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -271,12 +271,23 @@ Mech Equipment
 
 /datum/supply_pack/mech/equipment/basenji_upgrade
 	name = "IRMG Basenji upgrade kit"
-	desc = "Contains an IRMG-custom conversion kit for a Gygax combat exosuit, to convert it to the specialized Basenji breaching exosuit. The upgrade will overclock the Gygax's leg actuators, allowing for short ranged charges capable of smashing through most obstacles."
+	desc = "Contains an IRMG-custom conversion kit for a 501p combat exosuit, to convert it to the specialized Basenji breaching exosuit. The upgrade will overclock the Gygax's leg actuators, allowing for short ranged charges capable of smashing through most obstacles."
 	cost = 500
 	contains = list(
 		/obj/item/mecha_parts/mecha_equipment/conversion_kit/inteq_gygax
 	)
 	faction = /datum/faction/inteq
+	faction_discount = 0
+	faction_locked = TRUE
+
+/datum/supply_pack/mech/equipment/dark_upgrade
+	name = "515 EX upgrade kit"
+	desc = "Contains a military grade conversion kit for a 501p combat exosuit, to convert it to the fearsome 515 EX models. Features a much stronger set of leg actuators."
+	cost = 500
+	contains = list(
+		/obj/item/mecha_parts/mecha_equipment/conversion_kit/dark_gygax
+	)
+	faction = /datum/faction/syndicate
 	faction_discount = 0
 	faction_locked = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the path on the loaded MP charger

Kills a few instances of Gygax in descs and replaces them with 501p

Adds a 515 EX kit for Syndicate factions in cargo.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I forgot to add the 515 EX kit in #3918. It's nice to be able to fly your faction colours I think.

Also bug fixes are good.



## Changelog

:cl:
add: 515 Conversion kit
fix: Loaded MP charger path
spellcheck: Removed a few instances of Gygax
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
