### PR TITLE
Talos Job Slot Changes

### DIFF
--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -40,7 +40,7 @@
 		},
 		"Enforcer": {
 			"outfit": "/datum/outfit/job/inteq/security",
-			"slots": 1
+			"slots": 2
 		},
 		"Corpsman": {
 			"outfit": "/datum/outfit/job/inteq/paramedic",
@@ -48,7 +48,7 @@
 		},
 		"Recruit": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
-			"slots": 4
+			"slots": 2
 		}
 	},
 	"enabled": true

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -3759,10 +3759,15 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
 	},
-/obj/machinery/autolathe,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
+/obj/machinery/suit_storage_unit/inherit{
+	req_access_txt = "1"
+	},
+/obj/item/clothing/mask/gas/inteq,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/security/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "wv" = (
@@ -5318,6 +5323,11 @@
 /obj/item/clothing/suit/armor/vest/alt,
 /obj/item/clothing/head/helmet/inteq,
 /obj/item/clothing/gloves/combat,
+/obj/item/clothing/head/helmet/inteq,
+/obj/item/clothing/head/helmet/swat/inteq,
+/obj/item/clothing/head/helmet/swat/inteq,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/suit/armor/vest/alt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Gv" = (
@@ -7927,6 +7937,10 @@
 /obj/item/clothing/glasses/hud/security/sunglasses/inteq,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/belt/security/webbing/inteq/alt,
+/obj/item/storage/belt/security/webbing/inteq,
+/obj/item/storage/belt/security/webbing/inteq/alt,
+/obj/item/clothing/glasses/hud/security/sunglasses/inteq,
+/obj/item/clothing/mask/balaclava/inteq,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Ya" = (


### PR DESCRIPTION
## About The Pull Request

The Talos now has two enforcers, and in exchange now has only two recruits.
Updates the armory to have an additional suit for the new Enforcer, as well as webbings/vests/helmets for the Enforcer.

![image](https://github.com/user-attachments/assets/ac41d646-aac5-4d8b-bf16-f162da0e74df)


## Why It's Good For The Game

Parity with the Valor, another specialist ship which also has two Enforcers. This ship also has a much bigger salvage/combat engineering focus meaning it can benefit from having one more Enforcer for EVA operations.

## Changelog

:cl:
balance: The Talos-class now has Two Enforcers.
/:cl: