### PR TITLE
Fixes Broken Hardline Decal on ngr_rock Outpost

### DIFF
--- a/_maps/outpost/ngr_rock.dmm
+++ b/_maps/outpost/ngr_rock.dmm
@@ -1269,7 +1269,7 @@
 /turf/open/floor/plasteel,
 /area/outpost/hallway/central)
 "gg" = (
-/obj/effect/turf_decal/number/eight,
+/obj/effect/turf_decal/number/left_eight,
 /turf/open/floor/plating/rust,
 /area/outpost/maintenance/central)
 "gh" = (

--- a/_maps/outpost/ngr_rock.dmm
+++ b/_maps/outpost/ngr_rock.dmm
@@ -656,10 +656,7 @@
 /turf/open/floor/plasteel,
 /area/outpost/vacant_rooms/shop)
 "dq" = (
-/obj/effect/turf_decal/hardline_big/two{
-	pixel_x = 16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/hardline_small/left,
 /turf/open/floor/plating,
 /area/outpost/maintenance/central)
 "dr" = (
@@ -1149,9 +1146,7 @@
 /turf/open/water/beach/deep,
 /area/outpost/maintenance/central)
 "fp" = (
-/obj/effect/turf_decal/hardline_big/six{
-	pixel_x = 16
-	},
+/obj/effect/turf_decal/number/right_two,
 /turf/open/floor/plating,
 /area/outpost/maintenance/central)
 "fq" = (
@@ -1274,9 +1269,7 @@
 /turf/open/floor/plasteel,
 /area/outpost/hallway/central)
 "gg" = (
-/obj/effect/turf_decal/hardline_big/five{
-	pixel_x = 16
-	},
+/obj/effect/turf_decal/number/eight,
 /turf/open/floor/plating/rust,
 /area/outpost/maintenance/central)
 "gh" = (
@@ -1845,9 +1838,6 @@
 /turf/open/floor/plating,
 /area/outpost/cargo)
 "jd" = (
-/obj/effect/turf_decal/hardline_big/one{
-	pixel_x = 16
-	},
 /obj/machinery/light/floor{
 	pixel_y = -7;
 	pixel_x = -7
@@ -4050,10 +4040,7 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
 "tt" = (
-/obj/effect/turf_decal/hardline_big/seven{
-	pixel_x = 16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/number/three,
 /turf/open/floor/plating,
 /area/outpost/maintenance/central)
 "tB" = (
@@ -5435,10 +5422,7 @@
 /turf/open/floor/plating/asteroid/rockplanet/cracked/safe,
 /area/outpost/vacant_rooms/office)
 "Ae" = (
-/obj/effect/turf_decal/hardline_big/four{
-	pixel_x = 16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/hardline_small/right,
 /turf/open/floor/plating,
 /area/outpost/maintenance/central)
 "Aj" = (
@@ -9782,10 +9766,7 @@
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dorm)
 "Xw" = (
-/obj/effect/turf_decal/hardline_big/three{
-	pixel_x = 16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/hardline_small,
 /turf/open/floor/plating,
 /area/outpost/maintenance/central)
 "Xz" = (
@@ -12996,7 +12977,7 @@ cF
 hX
 LU
 jd
-gg
+Iw
 bN
 bN
 dF
@@ -13278,7 +13259,7 @@ Ey
 xv
 MV
 Ae
-OJ
+gg
 bN
 dF
 fo


### PR DESCRIPTION
## About The Pull Request

does what the title says
![image](https://github.com/user-attachments/assets/c015962e-5580-4c72-b2d8-0313801021ab)

## Why It's Good For The Game

just is

## Changelog

:cl:
fix: fixed decal on ngr_rock
/:cl:
