### PR TITLE
Babyproofs Cargo Conveyor Chutes

### DIFF
--- a/_maps/outpost/hangar/indie_space_20x20.dmm
+++ b/_maps/outpost/hangar/indie_space_20x20.dmm
@@ -317,7 +317,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel{

--- a/_maps/outpost/hangar/indie_space_40x20.dmm
+++ b/_maps/outpost/hangar/indie_space_40x20.dmm
@@ -262,7 +262,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel{

--- a/_maps/outpost/hangar/indie_space_40x40.dmm
+++ b/_maps/outpost/hangar/indie_space_40x40.dmm
@@ -140,7 +140,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel{

--- a/_maps/outpost/hangar/indie_space_56x20.dmm
+++ b/_maps/outpost/hangar/indie_space_56x20.dmm
@@ -305,7 +305,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel{

--- a/_maps/outpost/hangar/indie_space_56x40.dmm
+++ b/_maps/outpost/hangar/indie_space_56x40.dmm
@@ -196,7 +196,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel{

--- a/_maps/outpost/hangar/ngr_rock_20x20.dmm
+++ b/_maps/outpost/hangar/ngr_rock_20x20.dmm
@@ -422,7 +422,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/ngr_rock_40x20.dmm
+++ b/_maps/outpost/hangar/ngr_rock_40x20.dmm
@@ -176,7 +176,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/ngr_rock_40x40.dmm
+++ b/_maps/outpost/hangar/ngr_rock_40x40.dmm
@@ -440,7 +440,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/ngr_rock_56x20.dmm
+++ b/_maps/outpost/hangar/ngr_rock_56x20.dmm
@@ -17,7 +17,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/ngr_rock_56x40.dmm
+++ b/_maps/outpost/hangar/ngr_rock_56x40.dmm
@@ -403,7 +403,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/nt_ice_20x20.dmm
+++ b/_maps/outpost/hangar/nt_ice_20x20.dmm
@@ -1255,7 +1255,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/nt_ice_40x20.dmm
+++ b/_maps/outpost/hangar/nt_ice_40x20.dmm
@@ -382,7 +382,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/nt_ice_40x40.dmm
+++ b/_maps/outpost/hangar/nt_ice_40x40.dmm
@@ -1576,7 +1576,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/nt_ice_56x20.dmm
+++ b/_maps/outpost/hangar/nt_ice_56x20.dmm
@@ -1173,7 +1173,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/outpost/hangar/nt_ice_56x40.dmm
+++ b/_maps/outpost/hangar/nt_ice_56x40.dmm
@@ -1204,7 +1204,7 @@
 /obj/machinery/conveyor/auto/outpost{
 	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the delivery side chutes on the outpost cargo conveyors to be one-way outlets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should prevent a rare issue that I saw pop up where a crate somehow went back through the delivery chute and clogged the delivery system. Also prevents players from trying to softlock themselves into the cargo delivery chute should they manage to get back there somehow.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Adjusted the cargo delivery chutes so that crates can no longer travel backwards and clog the system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
