### PR TITLE
You can do damage to walls again

### DIFF
--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -150,11 +150,7 @@
 		alter_integrity(-dam, shooter)
 
 /turf/closed/proc/get_item_damage(obj/item/used_item, t_min = min_dam)
-	var/damage = used_item.force
-	if(istype(used_item, /obj/item/clothing/gloves/gauntlets))
-		damage = 20
-	else
-		damage = damage * used_item.demolition_mod
+	var/damage = used_item.force * used_item.demolition_mod
 	// if dam is below t_min, then the hit has no effect
 	return (damage < t_min ? 0 : damage)
 
@@ -228,7 +224,7 @@
 /turf/closed/proc/try_destroy(obj/item/used_item, mob/user, turf/T)
 	var/total_damage = get_item_damage(used_item)
 	user.do_attack_animation(src)
-	if(total_damage >= 0)
+	if(total_damage <= 0)
 		to_chat(user, "<span class='warning'>[used_item] isn't strong enough to damage [src]!</span>")
 		playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixs small bug created in #4285 that meant any attack could not damage a wall.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bag
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: walls can now be meleed again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
