### PR TITLE
Nerfs buckshot AP, buffs .357 damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -74,7 +74,7 @@
 
 /obj/projectile/bullet/a357
 	name = ".357 bullet"
-	damage = 30
+	damage = 35
 
 	speed = BULLET_SPEED_REVOLVER
 	bullet_identifier = "medium bullet"
@@ -92,7 +92,7 @@
 
 /obj/projectile/bullet/a357/hp
 	name = ".357 hollow point bullet"
-	damage = 45
+	damage = 50
 	armour_penetration = -20
 	speed_mod = BULLET_SPEED_HP_MOD
 	ricochet_chance = 0

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -69,10 +69,10 @@
 	var/tile_dropoff_stamina = 1.5 //As above
 
 	var/ap_dropoff = 5
-	var/ap_dropoff_cutoff = -35
+	var/ap_dropoff_cutoff = -50
 
 	icon_state = "pellet"
-	armour_penetration = -20
+	armour_penetration = -30
 	speed = BULLET_SPEED_SHOTGUN
 	bullet_identifier = "pellet"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs buckshot to -30 AP, decaying to a max of -50 at long range. Buffs .357 to deal 35 damage per shot, allowing it to triple tap unarmored humanoids.

## Why It's Good For The Game

buckshot was a little too strong against armor again and was elbowing out shotgun slugs at close range, .357 felt a little too anemic for what it is

## Changelog

:cl:
balance: Nerfed buckshot, buffed .357
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
