### PR TITLE
Rebalances and rewrites Goliaths

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -18,7 +18,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother
 	name = "goliath broodmother"
-	desc = "An example of sexual dimorphism, this female goliath looks much different than the males of her species.  She is, however, just as dangerous, if not more."
+	desc = "Goliaths are sequential hermaphrodites, and will rarely enter an egg-bearing or \"female\" phase. As this specimen clearly demonstrates, Goliaths in this phase become significantly larger and more aggressive. These \"Broodmothers\" are even more dangerous than the common variety, and are best avoided entirely."
 	gender = FEMALE
 	icon = 'icons/mob/lavaland/lavaland_elites_64.dmi'
 	icon_state = "broodmother"
@@ -37,7 +37,7 @@
 	attack_verb_continuous = "beats down on"
 	attack_verb_simple = "beat down on"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	throw_message = "does nothing to the rocky hide of the"
+	throw_message = "does nothing to the thick hide of the"
 	speed = 2
 	move_to_delay = 5
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
@@ -166,7 +166,7 @@
 //The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child
 	name = "baby goliath"
-	desc = "A young goliath recently born from it's mother.  While they hatch from eggs, said eggs are incubated in the mother until they are ready to be born."
+	desc = "Goliaths are ovoviviparous; While egg-bearing, they incubate their eggs inside the mother. Newly-hatched Goliaths like this one are precocious and can defend themselves and their mother from the moment they hatch."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "goliath_baby"
 	icon_living = "goliath_baby"
@@ -180,7 +180,7 @@
 	attack_verb_continuous = "bashes against"
 	attack_verb_simple = "bash against"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	throw_message = "does nothing to the rocky hide of the"
+	throw_message = "does nothing to the hide of the"
 	speed = 2
 	move_to_delay = 5
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
@@ -247,7 +247,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/rockplanet
 	name = "baby gruboid"
-	desc = "A young gruboid recently born. As a defense mechanism, they violently explode if killed."
+	desc = "A newly-born gruboid. As a defense mechanism, they violently explode if killed."
 	icon_state = "gruboid_baby"
 	icon_living = "gruboid_baby"
 	icon_aggro = "gruboid_baby"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -20,8 +20,8 @@
 	speak_emote = list("bellows")
 	speed = 3
 	throw_deflection = 10
-	maxHealth = 150
-	health = 150
+	maxHealth = 140
+	health = 140
 	armor = list("melee" = 0, "bullet" = 0, "laser" = -50, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10) //Large and fleshy. Thick fat resists explosives, reacts poorly to lasers.
 	harm_intent_damage = 0
 	obj_damage = 100

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -1,7 +1,7 @@
 //A slow but strong beast that tries to stun using its tentacles
 /mob/living/simple_animal/hostile/asteroid/goliath
 	name = "goliath"
-	desc = "A massive beast that uses long tentacles to ensnare its prey, threatening them is not advised under any conditions."
+	desc = "A territorial species of megaherbivore mysteriously found throughout the Frontier that uses its burrowing tendrils to unearth roots, fungus, and occasional minerals. When agitated, it uses these tendrils to ensnare, and subsequently pulverize, perceived threats. CLIP-BARD recommends maintaining a very healthy distance."
 	icon = 'icons/mob/lavaland/lavaland_monsters_wide.dmi'
 	icon_state = "ancient_goliath"
 	icon_living = "ancient_goliath"
@@ -20,9 +20,9 @@
 	speak_emote = list("bellows")
 	speed = 3
 	throw_deflection = 10
-	maxHealth = 80
-	health = 80
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 25, "energy" = 10, "bomb" = 50, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10) //Thick carapace, weak to AP ammo.
+	maxHealth = 150
+	health = 150
+	armor = list("melee" = 0, "bullet" = 0, "laser" = -50, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10) //Large and fleshy. Thick fat resists explosives, reacts poorly to lasers.
 	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage_lower = 12
@@ -30,7 +30,7 @@
 	attack_verb_continuous = "pulverizes"
 	attack_verb_simple = "pulverize"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	throw_message = "does nothing to the rocky hide of the"
+	throw_message = "does nothing to the thick hide of the"
 	vision_range = 5
 	aggro_vision_range = 9
 	move_resist = MOVE_FORCE_VERY_STRONG
@@ -117,17 +117,17 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/pup
 	name = "goliath pup"
-	desc = "A small goliath pup. It's tendrils have not yet fully grown."
+	desc = "An immature goliath. Goliaths at this stage of life lack fully-developed tendrils, and are reliant on their parents to unearth and supply food."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "goliath_baby"
 	icon_living = "goliath_baby"
 	icon_aggro = "goliath_baby"
 	icon_dead = "goliath_baby_dead"
-	throw_message = "does nothing to the tough hide of the"
+	throw_message = "does nothing to the hide of the"
 	pre_attack_icon = "goliath_baby"
 	maxHealth = 60
 	health = 60
-	armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = -5, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage_lower = 2
@@ -139,13 +139,13 @@
 //Lavaland Goliath
 /mob/living/simple_animal/hostile/asteroid/goliath/beast
 	name = "goliath"
-	desc = "A hulking, armor-plated beast with long tendrils arching from its back."
+	desc = "A territorial species of megaherbivore mysteriously found throughout the Frontier that uses its burrowing tendrils to unearth roots, fungus, and occasional minerals. When agitated, it uses these tendrils to ensnare, and subsequently pulverize, perceived threats. CLIP-BARD recommends maintaining a very healthy distance."
 	icon = 'icons/mob/lavaland/lavaland_monsters_wide.dmi'
 	icon_state = "goliath"
 	icon_living = "goliath"
 	icon_aggro = "goliath"
 	icon_dead = "goliath_dead"
-	throw_message = "does nothing to the tough hide of the"
+	throw_message = "does nothing to the thick hide of the"
 	pre_attack_icon = "goliath_preattack"
 	//mob_trophy = /obj/item/mob_trophy/goliath_tentacle
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/bone = 2, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/ore/silver = 10)
@@ -369,7 +369,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/crystal
 	name = "crystal goliath"
-	desc = "Once a goliath, it is now an abomination composed of undead flesh and crystals that sprout throughout it's decomposing body."
+	desc = "Once a goliath, now an abominable mass of twisted flesh and crystals that sprout throughout its decomposing body."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "crystal_goliath"
 	icon_living = "crystal_goliath"
@@ -377,7 +377,7 @@
 	icon_dead = "crystal_goliath_dead"
 	pixel_x = 0
 	base_pixel_x = 0
-	throw_message = "does nothing to the tough hide of the"
+	throw_message = "does nothing to the calcified hide of the"
 	pre_attack_icon = "crystal_goliath2"
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/bone = 2, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/ore/silver = 10, /obj/item/strange_crystal = 2)
 	tentacle_type = /obj/effect/temp_visual/goliath_tentacle/crystal
@@ -437,7 +437,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/rockplanet
 	name = "gruboid"
-	desc = "A massive beast that uses long tentacles to ensnare its prey, threatening them is not advised under any conditions."
+	desc = "What appears to be a tremendous burrowing worm. Its burrowing tendrils ensnare prey, leaving them helpless."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "gruboid2"
 	icon_living = "gruboid2"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks Goliath health & armor and gives them new descriptions. Goliaths now have 140 health, no bullet armor, and slight laser vulnerability. In general, this makes shotguns and pistol-caliber weapons such as SMGs a little more effective (9mm and .45 both take one less shot to kill), while making high-penetration weapons such as rifles less effective. Use hollow point ammo to offset this weakness! Additionally, the extra health makes Goliaths quite a bit harder to kill in melee. We suggest not trying to fight what is effectively a space rhinocerous with a pocket knife.

## Why It's Good For The Game

SMGs and pistol caliber weapons, put bluntly, are terrible. This gives them one situation where they can shine at the expense of higher-penetration weapons, and makes them all-round useful choices for basic exploration by removing one form of armored wildlife. This makes SMGs in particular a more useful choice for drill missions, especially with hollow point ammo (as soon as prices can be adjusted, anyway)

## Changelog

:cl:
balance: Removed armor from Goliaths, gave them more health.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
