### PR TITLE
reduces landmines in planetgen

### DIFF
--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -150,7 +150,7 @@
 		/obj/structure/flora/ausbushes/sparsegrass/hell = 35,
 		/obj/structure/flora/ausbushes/ywflowers/hell = 1,
 		/obj/structure/flora/ausbushes/grassybush/hell = 4,
-		/obj/structure/flora/firebush = 1
+		/obj/structure/flora/firebush = 1,
 		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	flora_spawn_chance = 15

--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -93,7 +93,6 @@
 		/obj/structure/flora/ash/fern = 5,
 		/obj/structure/flora/ash/fireblossom = 1,
 		/obj/structure/flora/ash/puce = 5,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	feature_spawn_chance = 0.3
 	feature_spawn_list = list(
@@ -152,6 +151,7 @@
 		/obj/structure/flora/ausbushes/ywflowers/hell = 1,
 		/obj/structure/flora/ausbushes/grassybush/hell = 4,
 		/obj/structure/flora/firebush = 1
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	flora_spawn_chance = 15
 
@@ -248,7 +248,6 @@
 		/obj/structure/flora/ash/tall_shroom = 2,
 		/obj/structure/flora/ash/fern = 2,
 		/obj/structure/flora/ash/puce = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/cave/lavaland/rocky
@@ -269,8 +268,7 @@
 		/obj/structure/flora/ash/cap_shroom = 2,
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/cacti = 1,
-		/obj/structure/flora/ash/tall_shroom = 2
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
+		/obj/structure/flora/ash/tall_shroom = 2,
 	)
 
 /datum/biome/cave/lavaland/lava

--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -93,6 +93,7 @@
 		/obj/structure/flora/ash/fern = 5,
 		/obj/structure/flora/ash/fireblossom = 1,
 		/obj/structure/flora/ash/puce = 5,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	feature_spawn_chance = 0.3
 	feature_spawn_list = list(
@@ -247,6 +248,7 @@
 		/obj/structure/flora/ash/tall_shroom = 2,
 		/obj/structure/flora/ash/fern = 2,
 		/obj/structure/flora/ash/puce = 2,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/cave/lavaland/rocky
@@ -268,6 +270,7 @@
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/cacti = 1,
 		/obj/structure/flora/ash/tall_shroom = 2
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/cave/lavaland/lava

--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -93,7 +93,6 @@
 		/obj/structure/flora/ash/fern = 5,
 		/obj/structure/flora/ash/fireblossom = 1,
 		/obj/structure/flora/ash/puce = 5,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	feature_spawn_chance = 0.3
 	feature_spawn_list = list(
@@ -105,7 +104,6 @@
 		/obj/structure/vein/classtwo = 2,
 		/obj/structure/geyser/random = 2,
 		/obj/structure/vein/classthree = 1,
-		/obj/effect/spawner/minefield = 1,
 		/obj/effect/spawner/random/anomaly/lava = 1,
 	)
 	mob_spawn_chance = 4
@@ -249,16 +247,13 @@
 		/obj/structure/flora/ash/tall_shroom = 2,
 		/obj/structure/flora/ash/fern = 2,
 		/obj/structure/flora/ash/puce = 2,
-		/obj/item/mine/proximity/explosive/live = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 
 /datum/biome/cave/lavaland/rocky
 	open_turf_types = list(/turf/open/floor/plating/asteroid/purple = 1)
 	flora_spawn_list = list(
-		/obj/structure/flora/rock/pile/lava = 3,
-		/obj/structure/flora/rock/lava = 3,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
+		/obj/structure/flora/rock/pile/lava = 6,
+		/obj/structure/flora/rock/lava = 6,
 	)
 	flora_spawn_chance = 5
 
@@ -272,7 +267,6 @@
 		/obj/structure/flora/ash/cap_shroom = 2,
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/cacti = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 		/obj/structure/flora/ash/tall_shroom = 2
 	)
 

--- a/code/datums/mapgen/planetary/RockGenerator.dm
+++ b/code/datums/mapgen/planetary/RockGenerator.dm
@@ -90,7 +90,6 @@
 		/obj/structure/vein/classtwo = 40,
 		/obj/effect/spawner/random/anomaly/rock = 10,
 		/obj/structure/vein/classthree = 10,
-		/obj/effect/spawner/minefield = 2,
 		/obj/effect/spawner/random/anomaly/big = 1 //get out of here stalker
 	)
 
@@ -102,7 +101,6 @@
 		/obj/structure/flora/tree/cactus = 8,
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/ash/garden/arid = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 
 	mob_spawn_list = list(
@@ -137,7 +135,6 @@
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/grass/rockplanet/dead = 8,
 		/obj/structure/flora/ash/garden/arid = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 
 /datum/biome/cave/rock
@@ -149,8 +146,6 @@
 		/obj/structure/flora/rock/pile/rockplanet = 8,
 		/obj/structure/flora/ash/fern = 4,
 		/obj/structure/flora/ash/puce = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
-		/obj/item/mine/proximity/explosive/live = 1,
 	)
 	feature_spawn_chance = 0.5
 	feature_spawn_list = list(
@@ -159,7 +154,6 @@
 		/obj/structure/vein/classtwo = 2,
 		/obj/structure/vein/classthree = 1,
 		/obj/structure/spawner/burrow/rock_plant = 4,
-		/obj/effect/spawner/minefield = 1,
 		/obj/effect/spawner/random/anomaly/rock/cave = 1,
 	)
 	mob_spawn_chance = 6
@@ -181,8 +175,6 @@
 		/obj/structure/flora/ash/fern = 6,
 		/obj/structure/flora/ash/puce = 4,
 		/obj/structure/flora/ash/garden/arid = 2,
-		/obj/item/mine/proximity/explosive/live = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 	mob_spawn_list = list(
 		/mob/living/simple_animal/hostile/netherworld/asteroid = 30,

--- a/code/datums/mapgen/planetary/RockGenerator.dm
+++ b/code/datums/mapgen/planetary/RockGenerator.dm
@@ -101,6 +101,7 @@
 		/obj/structure/flora/tree/cactus = 8,
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/ash/garden/arid = 2,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 	mob_spawn_list = list(
@@ -135,6 +136,7 @@
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/grass/rockplanet/dead = 8,
 		/obj/structure/flora/ash/garden/arid = 1,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/cave/rock
@@ -146,6 +148,7 @@
 		/obj/structure/flora/rock/pile/rockplanet = 8,
 		/obj/structure/flora/ash/fern = 4,
 		/obj/structure/flora/ash/puce = 2,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	feature_spawn_chance = 0.5
 	feature_spawn_list = list(

--- a/code/datums/mapgen/planetary/SandGenerator.dm
+++ b/code/datums/mapgen/planetary/SandGenerator.dm
@@ -91,11 +91,12 @@
 	)
 	feature_spawn_chance = 0.1
 	feature_spawn_list = list(
-		/obj/structure/geyser/random = 8,
+		/obj/structure/geyser/random = 4,
 		/obj/structure/vein = 8,
 		/obj/structure/vein/classtwo = 4,
 		/obj/structure/vein/classthree = 2,
-		/obj/effect/spawner/random/anomaly/sand = 1,
+		/obj/effect/spawner/random/anomaly/sand = 2,
+		/obj/effect/spawner/minefield = 1,
 	)
 	mob_spawn_chance = 4
 	mob_spawn_list = list(

--- a/code/datums/mapgen/planetary/SnowGenerator.dm
+++ b/code/datums/mapgen/planetary/SnowGenerator.dm
@@ -96,7 +96,6 @@
 		/obj/structure/flora/grass/both = 12,
 		/obj/structure/flora/ash/chilly = 4,
 		/obj/structure/flora/ash/garden/frigid = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 	flora_spawn_chance = 10
 	mob_spawn_chance = 1
@@ -116,7 +115,6 @@
 		/obj/effect/spawner/random/anomaly/big = 1,
 		/obj/structure/spawner/burrow/ice_planet = 80,
 		/obj/structure/vein/ice = 25,
-		/obj/effect/spawner/minefield = 2,
 		/obj/structure/vein/ice/classtwo = 50,
 		/obj/structure/vein/ice/classthree = 10,
 	)
@@ -150,7 +148,6 @@
 		/obj/structure/flora/tree/pine = 20,
 		/obj/structure/flora/tree/dead = 6,
 		/obj/structure/flora/grass/both = 8,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/snow/forest/dense
@@ -159,7 +156,6 @@
 		/obj/structure/flora/tree/pine = 20,
 		/obj/structure/flora/grass/both = 6,
 		/obj/structure/flora/tree/dead = 3,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/arctic
@@ -247,8 +243,6 @@
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/puce = 2,
 		/obj/structure/flora/ash/garden/frigid = 2,
-		/obj/item/mine/proximity/explosive/live = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1
 	)
 	closed_turf_types = list(
 		/turf/closed/mineral/random/snow = 1
@@ -272,7 +266,6 @@
 		/obj/structure/vein/ice = 30,
 		/obj/structure/vein/ice/classtwo = 50,
 		/obj/structure/vein/ice/classthree = 6,
-		/obj/effect/spawner/minefield = 2,
 	)
 
 /datum/biome/cave/snow/thawed
@@ -314,7 +307,6 @@
 		/obj/structure/flora/ash/leaf_shroom = 3,
 		/obj/structure/flora/ash/cap_shroom = 3,
 		/obj/structure/flora/ash/stem_shroom = 3,
-		/obj/item/mine/pressure/explosive/fire/live = 1,
 	)
 	feature_spawn_chance = 0.2
 

--- a/code/datums/mapgen/planetary/SnowGenerator.dm
+++ b/code/datums/mapgen/planetary/SnowGenerator.dm
@@ -134,12 +134,13 @@
 	)
 	flora_spawn_chance = 40
 	flora_spawn_list = list(
-		/obj/structure/flora/ausbushes/fullgrass = 1,
-		/obj/structure/flora/ausbushes/sparsegrass = 1,
-		/obj/structure/flora/ausbushes = 1,
-		/obj/structure/flora/ausbushes/ppflowers = 1,
-		/obj/structure/flora/ausbushes/lavendergrass = 1,
-		/obj/structure/flora/ash/garden/frigid = 1,
+		/obj/structure/flora/ausbushes/fullgrass = 2,
+		/obj/structure/flora/ausbushes/sparsegrass = 2,
+		/obj/structure/flora/ausbushes = 2,
+		/obj/structure/flora/ausbushes/ppflowers = 2,
+		/obj/structure/flora/ausbushes/lavendergrass = 2,
+		/obj/structure/flora/ash/garden/frigid = 2,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/snow/forest
@@ -243,6 +244,7 @@
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/puce = 2,
 		/obj/structure/flora/ash/garden/frigid = 2,
+		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	closed_turf_types = list(
 		/turf/closed/mineral/random/snow = 1

--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -202,7 +202,7 @@
 		/obj/effect/spawner/random/maintenance/four = 20,
 		/obj/structure/flora/ash/garden/waste = 300,
 		/obj/structure/flora/ash/glowshroom = 1800,
-		/obj/item/mine/pressure/explosive/shrapnel/live = 30,
+		/obj/item/mine/pressure/explosive/rusty/live = 30,
 		/obj/effect/spawner/random/mine = 8,
 		/obj/effect/spawner/minefield = 2
 	)
@@ -248,7 +248,7 @@
 		/obj/effect/spawner/random/waste/atmos_can = 180,
 		/obj/effect/spawner/random/waste/atmos_can/rare = 1,
 		/obj/effect/spawner/random/waste/salvageable = 300,
-		/obj/item/mine/pressure/explosive/rad/live = 30,
+		/obj/item/mine/pressure/explosive/rusty/live = 30,
 		/obj/effect/spawner/random/mine = 8,
 		/obj/effect/spawner/minefield = 2
 	)
@@ -308,7 +308,7 @@
 		/obj/effect/spawner/random/waste/salvageable = 400,
 		/obj/structure/flora/ash/garden/waste = 70,
 		/obj/structure/flora/ash/glowshroom = 400, //more common in caves
-		/obj/item/mine/pressure/explosive/rad/live = 10,
+		/obj/item/mine/pressure/explosive/rusty/live = 10,
 		/obj/effect/spawner/random/mine = 8,
 		/obj/effect/spawner/minefield = 2
 	)
@@ -364,7 +364,7 @@
 		/obj/effect/spawner/random/maintenance/three = 100,
 		/obj/effect/spawner/random/maintenance/four = 200,
 		/obj/structure/flora/ash/glowshroom = 1800,
-		/obj/item/mine/pressure/explosive/rad/live = 30,
+		/obj/item/mine/pressure/explosive/rusty/live = 30,
 		/obj/effect/spawner/random/mine = 8,
 		/obj/effect/spawner/minefield = 2
 	)

--- a/code/modules/overmap/missions/acquire_mission.dm
+++ b/code/modules/overmap/missions/acquire_mission.dm
@@ -184,17 +184,6 @@ Acquire: Anomaly
 		Acquire: Salvage
 */
 
-/datum/mission/acquire/landmine
-	name = "Defuse landmines"
-	desc = "CLIP and Gezena have assigned us to offer a bounty to turn in disarmed ordnance for future ventures. We'll pay you well, but we're not responsible for any accidents."
-	weight = 6
-	value = 1500
-	duration = 80 MINUTES
-	dur_mod_range = 0.4
-	container_type = /obj/item/storage/toolbox/bounty
-	objective_type = /obj/item/mine/pressure/explosive
-	num_wanted = 2
-
 /datum/mission/acquire/bounty
 	name = "Hunt down Dogtags"
 	desc = "CLIP has posted several bounties for wanted members of both the Frontiersman and the Clique. Bring back their tags, we'll reward you well."


### PR DESCRIPTION
## About The Pull Request
heavily trims planetgen lists for land mines
## Changelog

:cl:
del: All those mine removal bounties have paid off, since the amount of landmines on most worlds has plummeted
del: CLIP pulled the bounty for landmines as a result.
add: someone blew a landmine freighter up over a sand world.
/:cl:
