### PR TITLE
308 price 250 down from 500

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -379,7 +379,7 @@
 	name = "308 Ammo Box Crate"
 	desc = "Contains a thirty-round .308 box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308)
-	cost = 500
+	cost = 250
 
 /datum/supply_pack/ammo/a308_ap
 	name = "308 Armour Piercing Ammo Box Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Was the same as specialist ammo for some reason
boosts ammo economy for it from 1.8 to 3.6

## Why It's Good For The Game

least efficient bullet in the game for no reason now not least efficient

## Changelog

:cl:
balance: .308 baseline price cut in half! Specialist ammo is still 500 cr though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
