### PR TITLE
Equalizes DMR Zoom

### DIFF
--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -81,7 +81,7 @@
 #define SHOTGUN_ZOOM 2
 #define SMG_ZOOM 2
 #define RIFLE_ZOOM 2
-#define DMR_ZOOM 4
+#define DMR_ZOOM 6
 
 //ads slowdown
 #define PISTOL_AIM_SLOWDOWN 0.1

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -587,8 +587,8 @@ NO_MAG_GUN_HELPER(automatic/marksman/boomslang)
 	icon_state = "boomslang90"
 	item_state = "boomslang90"
 
-	zoom_amt = 3 //Long range, enough to see in front of you, but no tiles behind you.
-	zoom_out_amt = 0
+	zoom_amt = 6
+	zoom_out_amt = 2
 
 NO_MAG_GUN_HELPER(automatic/marksman/boomslang/indie)
 
@@ -800,6 +800,8 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra)
 	wield_slowdown = DMR_SLOWDOWN //dmrrrr
 	wield_delay = 0.85 SECONDS //above
 	zoomable = TRUE
+	zoom_amt = 6
+	zoom_out_amt = 2
 	default_ammo_type = /obj/item/ammo_box/magazine/m556_42_hydra/small
 
 NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)


### PR DESCRIPTION
## About The Pull Request

Makes most DMRs the same when it comes to zoom.

## Why It's Good For The Game

Most of these were set prior to the scope pr, just updates them accordingly.

## Changelog

:cl:
balance: DMR's are now equalized according to new scopes
/:cl: