### PR TITLE
Adds Green Nitrile Gloves to the Talos, Vaquero, and Colossus

### DIFF
--- a/_maps/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/shuttles/inteq/inteq_colossus.dmm
@@ -2283,6 +2283,7 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
+/obj/item/clothing/gloves/color/latex/nitrile/inteq,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "xO" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -4455,6 +4455,9 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Ai" = (
@@ -8199,6 +8202,25 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ship/storage/port)
+"ZS" = (
+/obj/structure/closet/crate/medical,
+/obj/item/storage/backpack/satchel/med,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/clothing/suit/armor/inteq/corpsman,
+/obj/item/clothing/head/soft/inteq/corpsman,
+/obj/item/clothing/under/syndicate/inteq/corpsman/skirt,
+/obj/item/clothing/under/syndicate/inteq/corpsman,
+/obj/item/clothing/gloves/color/latex/nitrile/inteq,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "ZU" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/telecomms/server/presets/inteq{
@@ -9009,7 +9031,7 @@ oi
 Oc
 iy
 qB
-Oc
+ZS
 HD
 hT
 VS

--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -1249,6 +1249,7 @@
 /obj/structure/platform/ship_three{
 	dir = 8
 	},
+/obj/item/clothing/gloves/color/latex/nitrile/inteq,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "uy" = (


### PR DESCRIPTION
## About The Pull Request

Adds the Inteq nitrile gloves to the Talos, Vaquero, and Colossus corpsman supplies. Talos now has a spare uniform crate like all other Inteq vessels for their Corpsman.

## Why It's Good For The Game

Basic cleanliness in all hospitals and even small town practices, dentistry, and pharmacies, involves the use of gloves during operations or other kinds of medical care. The Frontier is arguably a substantially less clean environment, making use of gloves make even more sense. Inteq fights against pirates and other organizations in said unsanitary environments, so ideally to keep a sanitary environment their Corpsman should be issued their gloves to avoid sepsis and other transmissible diseases due to not wearing gloves during medical care.

## Changelog

:cl:
balance: Basic cleanliness is now a thing on Inteq ships, Corpsmen have been equipped with gloves.
/:cl:

