### PR TITLE
Ammo cost rebalance

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -245,7 +245,7 @@
 	name = ".45-70 Match Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition, that travels faster, pierces armour better, and ricochets off targets."
 	contains = list(/obj/item/storage/box/ammo/a4570_match)
-	cost = 380
+	cost = 235
 
 /* 7.62 */
 

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -221,7 +221,7 @@
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains a box of 32 slug shells for use in lethal persuasion."
-	cost = 220 //5.81 ammo efficiency at 40 damage
+	cost = 221 //5.6 ammo efficiency at 40 damage
 	contains = list(/obj/item/storage/box/ammo/a12g_slug)
 
 /datum/supply_pack/ammo/blank_shells

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -186,28 +186,19 @@
 /datum/supply_pack/ammo/c57x39mm_boxcrate
 	name = "5.7x39mm Ammo Box Crate"
 	desc = "Contains two 48-round 5.7x39mm box for PDWs such as the Sidewinder."
-	contains = list(
-		/obj/item/storage/box/ammo/c57x39,
-		/obj/item/storage/box/ammo/c57x39,
-	)
+	contains = list(/obj/item/storage/box/ammo/c57x39)
 	cost = 355 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c57x39mm_ap
 	name = "5.7x39mm Armour Piercing Ammo Box Crate"
 	desc = "Contains two 48-round 5.7x39mm box for PDWs such as the Sidewinder."
-	contains = list(
-		/obj/item/storage/box/ammo/c57x39/ap,
-		/obj/item/storage/box/ammo/c57x39/ap,
-	)
+	contains = list(/obj/item/storage/box/ammo/c57x39/ap)
 	cost = 443
 
 /datum/supply_pack/ammo/c57x39mm_hp
 	name = "5.7x39mm Hollow Point Ammo Box Crate"
 	desc = "Contains two 48-round 5.7x39mm Hollow Point boxes for PDWs such as the Sidewinder."
-	contains = list(
-		/obj/item/storage/box/ammo/c57x39/hp,
-		/obj/item/storage/box/ammo/c57x39/hp,
-	)
+	contains = list(/obj/item/storage/box/ammo/c57x39/hp)
 	cost = 443
 
 /* 12 Gauge */

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -302,7 +302,7 @@
 	name = "5.56 Caseless Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless box for SolGov sidearms like the Pistole C."
 	contains = list(/obj/item/storage/box/ammo/c556mm)
-	cost = 168 //3.84 ammo efficiency at 20 damage
+	cost = 168 //5.7 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c556mmHITPap_ammo_box
 	name = "5.56 caseless AP Ammo Box Crate"
@@ -336,19 +336,19 @@
 	name = "8x50mm Ammo Box Crate"
 	desc = "Contains a 40-round 8x50mm ammo box for rifles such as the Illestren."
 	contains = list(/obj/item/storage/box/ammo/a8_50r)
-	cost = 291 //4.8 ammo efficiency at 35 damage
+	cost = 291 //4.8 ammo efficiency at 35 damage //TTD 37 damage 308 cr DMR buff
 
 /datum/supply_pack/ammo/c8x50mm_boxhp_boxcrate
 	name = "8x50mm Hollow Point Crate"
 	desc = "Contains a 40-round 8x50mm ammo box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/hp)
-	cost = 363
+	cost = 363 //TTD 385
 
 /datum/supply_pack/ammo/c8x50mm_tracbox
 	name = "8x50mm Tracker Crate"
 	desc = "Contains a 30-round 8x50mm ammo box loaded with tracker ammo, great for sustained hunts."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/trac)
-	cost = 363
+	cost = 363 //TTD 385
 
 
 /* .300 */
@@ -357,13 +357,13 @@
 	name = ".300 Ammo Box Crate"
 	desc = "Contains a twenty-round .300 Magnum ammo box for sniper rifles such as the HP Scout."
 	contains = list(/obj/item/storage/box/ammo/a300)
-	cost = 200 //4 ammo efficiency at 40 damage
+	cost = 200 //4 ammo efficiency at 40 damage //TTD 50 damage 250 cr DMR buff
 
 /datum/supply_pack/ammo/a300_trac
 	name = ".300 Trac Ammo Box Crate"
 	desc = "Contains a ten-round .300 TRAC ammo box for sniper rifles such as the HP Scout."
 	contains = list(/obj/item/storage/box/ammo/a300/trac)
-	cost = 250
+	cost = 250 //TTD 312
 
 
 /* .308 */
@@ -372,19 +372,19 @@
 	name = "308 Ammo Box Crate"
 	desc = "Contains a thirty-round .308 box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308)
-	cost = 187 //4.8 ammo efficiency at 30 damage
+	cost = 187 //4.8 ammo efficiency at 30 damage //TTD 35 damage 218 cr DMR buff
 
 /datum/supply_pack/ammo/a308_ap
 	name = "308 Armour Piercing Ammo Box Crate"
 	desc = "Contains a thirty-round .308 armour piercing box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/ap)
-	cost = 233
+	cost = 233 //TTD 272
 
 /datum/supply_pack/ammo/a308_hp
 	name = "308 Hollow Point Ammo Box Crate"
 	desc = "Contains a thirty-round .308 hollow point box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/hp)
-	cost = 233
+	cost = 233 //TTD 272
 
 /* 6.5 */
 
@@ -406,7 +406,7 @@
 	name = "8x58mm Ammo Box Crate"
 	desc = "Contains a twenty-round 8x58 ammo box for Solarian-manufactured sniper rifles, such as the SSG-69."
 	contains = list(/obj/item/storage/box/ammo/a858)
-	cost = 200 //4 ammo efficiency at 40 damage
+	cost = 200 //4 ammo efficiency at 40 damage //TTD 225
 
 /* .50 BMG */
 

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -185,21 +185,21 @@
 
 /datum/supply_pack/ammo/c57x39mm_boxcrate
 	name = "5.7x39mm Ammo Box Crate"
-	desc = "Contains two 48-round 5.7x39mm box for PDWs such as the Sidewinder."
+	desc = "Contains one 48-round 5.7x39mm box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39)
-	cost = 355 //5.4 ammo efficiency at 20 damage
+	cost = 177 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c57x39mm_ap
 	name = "5.7x39mm Armour Piercing Ammo Box Crate"
-	desc = "Contains two 48-round 5.7x39mm box for PDWs such as the Sidewinder."
+	desc = "Contains one 48-round 5.7x39mm box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39/ap)
-	cost = 443
+	cost = 221
 
 /datum/supply_pack/ammo/c57x39mm_hp
 	name = "5.7x39mm Hollow Point Ammo Box Crate"
-	desc = "Contains two 48-round 5.7x39mm Hollow Point boxes for PDWs such as the Sidewinder."
+	desc = "Contains one 48-round 5.7x39mm Hollow Point box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39/hp)
-	cost = 443
+	cost = 221
 
 /* 12 Gauge */
 
@@ -251,19 +251,19 @@
 
 /datum/supply_pack/ammo/a762_ammo_box
 	name = "7.62x40mm CLIP Ammo Box Crate"
-	desc = "Contains one 60-round 7.62x40mm CLIP boxes for the SKM rifles."
+	desc = "Contains one 60-round 7.62x40mm CLIP box for the SKM rifles."
 	contains = list(/obj/item/storage/box/ammo/a762_40)
 	cost = 360 //5 ammo efficiency at 30 damage
 
 /datum/supply_pack/ammo/a762_ap
 	name = "7.62x40mm CLIP Armour Piercing Ammo Box Crate"
-	desc = "Contains one 60-round 7.62x40mm CLIP Armour Piercing boxes for the SKM rifles."
+	desc = "Contains one 60-round 7.62x40mm CLIP Armour Piercing box for the SKM rifles."
 	contains = list(/obj/item/storage/box/ammo/a762_40/ap)
 	cost = 450
 
 /datum/supply_pack/ammo/a762_hp
 	name = "7.62x40mm CLIP Hollow Point Ammo Box Crate"
-	desc = "Contains one 60-round 7.62x40mm CLIP Hollow Point boxes for the SKM rifles."
+	desc = "Contains one 60-round 7.62x40mm CLIP Hollow Point box for the SKM rifles."
 	contains = list(/obj/item/storage/box/ammo/a762_40/hp)
 	cost = 450
 
@@ -271,19 +271,19 @@
 
 /datum/supply_pack/ammo/a556_ammo_box
 	name = "5.56x42mm CLIP Ammo Box Crate"
-	desc = "Contains one 60-round 5.56x42mm CLIP boxes for most newer rifles."
+	desc = "Contains one 60-round 5.56x42mm CLIP box for most newer rifles."
 	contains = list(/obj/item/storage/box/ammo/a556_42)
 	cost = 300 //5 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/a556_ap
 	name = "5.56x42mm CLIP Armour Piercing Ammo Box Crate"
-	desc = "Contains one 60-round 5.56x42mm CLIP Armour Piercing boxes for most newer rifles."
+	desc = "Contains one 60-round 5.56x42mm CLIP Armour Piercing box for most newer rifles."
 	contains = list(/obj/item/storage/box/ammo/a556_42/ap)
 	cost = 375
 
 /datum/supply_pack/ammo/a556_hp
 	name = "5.56x42mm CLIP Hollow Point Ammo Box Crate"
-	desc = "Contains one 60-round 5.56x42mm CLIP Hollow Point boxes for most newer rifles."
+	desc = "Contains one 60-round 5.56x42mm CLIP Hollow Point box for most newer rifles."
 	contains = list(/obj/item/storage/box/ammo/a556_42/hp)
 	cost = 375
 
@@ -317,7 +317,7 @@
 
 /datum/supply_pack/ammo/c299
 	name = ".299 Eoehoma Caseless Ammo Box Crate"
-	desc = "Contains one 60-round boxes of .299 Caseless ammo from the defunct Eoehoma. Used for the E-40 Hybrid Rifle."
+	desc = "Contains one 60-round box of .299 Caseless ammo from the defunct Eoehoma. Used for the E-40 Hybrid Rifle."
 	contains = list(/obj/item/storage/box/ammo/c299)
 	cost = 222 //5.4 ammo efficiency at 20 damage
 

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -17,19 +17,19 @@
 	name = ".22 LR Ammo Box Crate"
 	desc = "Contains a 100-round ammo box for refilling .22 LR weapons."
 	contains = list(/obj/item/storage/box/ammo/c22lr)
-	cost = 250
+	cost = 250 //8 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c22lr_hp
 	name = ".22 LR HP Ammo Box Crate"
 	desc = "Contains a 100-round hollow point ammo box for refilling .22 LR weapons."
 	contains = list(/obj/item/storage/box/ammo/c22lr/hp)
-	cost = 600
+	cost = 310
 
 /datum/supply_pack/ammo/c22lr_ap
 	name = ".22 LR AP Ammo Box Crate"
 	desc = "Contains a 100-round armour piercing ammo box for refilling .22 LR weapons."
 	contains = list(/obj/item/storage/box/ammo/c22lr/ap)
-	cost = 600
+	cost = 310
 
 
 /* 9mm */
@@ -38,19 +38,19 @@
 	name = "9mm Ammo Box Crate"
 	desc = "Contains a 60-round 9mm box for pistols and SMGs such as the Commander or Saber."
 	contains = list(/obj/item/storage/box/ammo/c9mm)
-	cost = 200
+	cost = 200 //6 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c9mmap_ammo_box
 	name = "9mm AP Ammo Box Crate"
 	desc = "Contains a 60-round 9mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c9mm_ap)
-	cost = 400
+	cost = 250
 
 /datum/supply_pack/ammo/c9mmhp_ammo_box
 	name = "9mm HP Ammo Box Crate"
 	desc = "Contains a 60-round 9mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c9mm_hp)
-	cost = 400
+	cost = 250
 
 /datum/supply_pack/ammo/c9mmrubber_ammo_box
 	name = "9mm Rubber Ammo Box Crate"
@@ -63,7 +63,7 @@
 /datum/supply_pack/ammo/c38
 	name = ".38 Ammo Boxes Crate"
 	desc = "Contains two 50 round ammo boxes for refilling .38 weapons."
-	cost = 250
+	cost = 250 //8 ammo efficiency at 20 damage
 	contains = list(/obj/item/storage/box/ammo/c38,
 					/obj/item/storage/box/ammo/c38)
 	crate_name = "ammo crate"
@@ -74,25 +74,25 @@
 	name = "10mm Ammo Box Crate"
 	desc = "Contains a 48-round 10mm box for pistols and SMGs like the Ringneck or the SkM-44(k)."
 	contains = list(/obj/item/storage/box/ammo/c10mm)
-	cost = 250
+	cost = 210 //5.7 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/c10mmap_ammo_box
 	name = "10mm AP Ammo Box Crate"
 	desc = "Contains a 48-round 10mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c10mm_ap)
-	cost = 500
+	cost = 260
 
 /datum/supply_pack/ammo/c10mmhp_ammo_box
 	name = "10mm HP Ammo Box Crate"
 	desc = "Contains a 48-round 10mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c10mm_hp)
-	cost = 500
+	cost = 260
 
 /datum/supply_pack/ammo/c10mmrubber_ammo_box
 	name = "10mm Rubber Ammo Box Crate"
 	desc = "Contains a 48-round 10mm box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c10mm_rubber)
-	cost = 250
+	cost = 210
 
 /* .45 */
 
@@ -100,25 +100,25 @@
 	name = ".45 Ammo Box Crate"
 	desc = "Contains a 48-round .45 box for pistols and SMGs like the Candor or the C-20r."
 	contains = list(/obj/item/storage/box/ammo/c45)
-	cost = 250
+	cost = 210 //5.7 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/c45ap_ammo_box
 	name = ".45 AP Ammo Box Crate"
 	desc = "Contains a 48-round .45 box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c45_ap)
-	cost = 500
+	cost = 262
 
 /datum/supply_pack/ammo/c45hp_ammo_box
 	name = ".45 HP Ammo Box Crate"
 	desc = "Contains a 48-round .45 box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c45_hp)
-	cost = 500
+	cost = 262
 
 /datum/supply_pack/ammo/c45mmrubber_ammo_box
 	name = ".45 Rubber Ammo Box Crate"
 	desc = "Contains a 48-round .45 box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c45_rubber)
-	cost = 250
+	cost = 210
 
 /* .357 */
 
@@ -126,19 +126,19 @@
 	name = ".357 Ammo Box Crate"
 	desc = "Contains a 48-round .357 box for revolvers such as the Scarborough Revolver and the HP Firebrand."
 	contains = list(/obj/item/storage/box/ammo/a357)
-	cost = 250
+	cost = 257 //5.6 ammo efficiency at 30 damage //TTD: boost this to 300 if revolvers get 35 damage
 
 /datum/supply_pack/ammo/a357hp_ammo_box
 	name = ".357 HP Ammo Box Crate"
 	desc = "Contains a 48-round .357 box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a357_hp)
-	cost = 500
+	cost = 321 //375 at 35 base
 
 /datum/supply_pack/ammo/a357match_ammo_box
 	name = ".357 Match Ammo Box Crate"
 	desc = "Contains a 48-round .357 match box for better performance against armor."
 	contains = list(/obj/item/storage/box/ammo/a357_match)
-	cost = 500
+	cost = 321 // 375 at 35 base
 
 /* .44 */
 
@@ -146,19 +146,19 @@
 	name = ".44 Roumain Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain ammo for revolvers such as the Shadow and Montagne."
 	contains = list(/obj/item/storage/box/ammo/a44roum)
-	cost = 250
+	cost = 214 //5.6 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/a44roum_rubber
 	name = ".44 Roumain Rubber Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain ammo loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/a44roum_rubber)
-	cost = 250
+	cost = 214
 
 /datum/supply_pack/ammo/a44roum_hp
 	name = ".44 Roumain Hollow Point Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a44roum_hp)
-	cost = 500
+	cost = 267
 
 /* 4.6x30 */
 
@@ -166,19 +166,19 @@
 	name = "4.6x30mm Ammo Box Crate"
 	desc = "Contains an 80-round 4.6x30mm box for PDWs such as the WT-550."
 	contains = list(/obj/item/storage/box/ammo/c46x30mm)
-	cost = 250
+	cost = 296 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c46x30mm_ap
 	name = "4.6x30mm Armour Piercing Ammo Box Crate"
 	desc = "Contains a 80-round 4.6x30mm armour piercing box for PDWs such as the WT-550."
 	contains = list(/obj/item/storage/box/ammo/c46x30mm/ap)
-	cost = 500
+	cost = 370
 
 /datum/supply_pack/ammo/c46x30mm_hp
 	name = "4.6x30mm Hollow Point Ammo Box Crate"
 	desc = "Contains a 80-round 4.6x30mm hollow point box for PDWs such as the WT-550."
 	contains = list(/obj/item/storage/box/ammo/c46x30mm/hp)
-	cost = 500
+	cost = 370
 
 
 /* 5.7x39 */
@@ -190,7 +190,7 @@
 		/obj/item/storage/box/ammo/c57x39,
 		/obj/item/storage/box/ammo/c57x39,
 	)
-	cost = 350
+	cost = 355 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c57x39mm_ap
 	name = "5.7x39mm Armour Piercing Ammo Box Crate"
@@ -199,7 +199,7 @@
 		/obj/item/storage/box/ammo/c57x39/ap,
 		/obj/item/storage/box/ammo/c57x39/ap,
 	)
-	cost = 700
+	cost = 443
 
 /datum/supply_pack/ammo/c57x39mm_hp
 	name = "5.7x39mm Hollow Point Ammo Box Crate"
@@ -208,32 +208,32 @@
 		/obj/item/storage/box/ammo/c57x39/hp,
 		/obj/item/storage/box/ammo/c57x39/hp,
 	)
-	cost = 700
+	cost = 443
 
 /* 12 Gauge */
 
 /datum/supply_pack/ammo/buckshot
 	name = "Buckshot Crate"
 	desc = "Contains a box of 32 buckshot shells for use in lethal persuasion."
-	cost = 500
+	cost = 520 //6.4 ammo efficiency at 104 damage. Yes we are counting point blank.
 	contains = list(/obj/item/storage/box/ammo/a12g_buckshot)
 
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains a box of 32 slug shells for use in lethal persuasion."
-	cost = 500
+	cost = 220 //5.81 ammo efficiency at 40 damage
 	contains = list(/obj/item/storage/box/ammo/a12g_slug)
 
 /datum/supply_pack/ammo/blank_shells
 	name = "Blank Shell Crate"
 	desc = "Contains a box of blank shells."
-	cost = 500
+	cost = 220
 	contains = list(/obj/item/storage/box/ammo/a12g_blank)
 
 /datum/supply_pack/ammo/rubbershot
 	name = "Rubbershot Crate"
 	desc = "Contains a box of 32 12 gauge rubbershot shells. Perfect for crowd control and training."
-	cost = 500
+	cost = 520
 	contains = list(/obj/item/storage/box/ammo/a12g_rubbershot)
 
 /datum/supply_pack/ammo/techshells
@@ -248,59 +248,53 @@
 	name = ".45-70 Ammo Box Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition."
 	contains = list(/obj/item/storage/box/ammo/a4570)
-	cost = 300
+	cost = 192 //5.6 ammo efficiency at 45 damage
 
 /datum/supply_pack/ammo/a4570_box/match
 	name = ".45-70 Match Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition, that travels faster, pierces armour better, and ricochets off targets."
 	contains = list(/obj/item/storage/box/ammo/a4570_match)
-	cost = 400
+	cost = 384
 
 /* 7.62 */
 
 /datum/supply_pack/ammo/a762_ammo_box
 	name = "7.62x40mm CLIP Ammo Box Crate"
-	desc = "Contains two 60-round 7.62x40mm CLIP boxes for the SKM rifles."
-	contains = list(/obj/item/storage/box/ammo/a762_40,
-					/obj/item/storage/box/ammo/a762_40)
-	cost = 500
+	desc = "Contains one 60-round 7.62x40mm CLIP boxes for the SKM rifles."
+	contains = list(/obj/item/storage/box/ammo/a762_40)
+	cost = 360 //5 ammo efficiency at 30 damage
 
 /datum/supply_pack/ammo/a762_ap
 	name = "7.62x40mm CLIP Armour Piercing Ammo Box Crate"
-	desc = "Contains two 60-round 7.62x40mm CLIP Armour Piercing boxes for the SKM rifles."
-	contains = list(/obj/item/storage/box/ammo/a762_40/ap,
-					/obj/item/storage/box/ammo/a762_40/ap)
-	cost = 1000
+	desc = "Contains one 60-round 7.62x40mm CLIP Armour Piercing boxes for the SKM rifles."
+	contains = list(/obj/item/storage/box/ammo/a762_40/ap)
+	cost = 450
 
 /datum/supply_pack/ammo/a762_hp
 	name = "7.62x40mm CLIP Hollow Point Ammo Box Crate"
-	desc = "Contains two 60-round 7.62x40mm CLIP Hollow Point boxes for the SKM rifles."
-	contains = list(/obj/item/storage/box/ammo/a762_40/hp,
-					/obj/item/storage/box/ammo/a762_40/hp)
-	cost = 1000
+	desc = "Contains one 60-round 7.62x40mm CLIP Hollow Point boxes for the SKM rifles."
+	contains = list(/obj/item/storage/box/ammo/a762_40/hp)
+	cost = 450
 
 /* 5.56 */
 
 /datum/supply_pack/ammo/a556_ammo_box
 	name = "5.56x42mm CLIP Ammo Box Crate"
-	desc = "Contains two 60-round 5.56x42mm CLIP boxes for most newer rifles."
-	contains = list(/obj/item/storage/box/ammo/a556_42,
-					/obj/item/storage/box/ammo/a556_42)
-	cost = 450
+	desc = "Contains one 60-round 5.56x42mm CLIP boxes for most newer rifles."
+	contains = list(/obj/item/storage/box/ammo/a556_42)
+	cost = 300 //5 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/a556_ap
 	name = "5.56x42mm CLIP Armour Piercing Ammo Box Crate"
-	desc = "Contains two 60-round 5.56x42mm CLIP Armour Piercing boxes for most newer rifles."
-	contains = list(/obj/item/storage/box/ammo/a556_42/ap,
-					/obj/item/storage/box/ammo/a556_42/ap)
-	cost = 900
+	desc = "Contains one 60-round 5.56x42mm CLIP Armour Piercing boxes for most newer rifles."
+	contains = list(/obj/item/storage/box/ammo/a556_42/ap)
+	cost = 375
 
 /datum/supply_pack/ammo/a556_hp
 	name = "5.56x42mm CLIP Hollow Point Ammo Box Crate"
-	desc = "Contains two 60-round 5.56x42mm CLIP Hollow Point boxes for most newer rifles."
-	contains = list(/obj/item/storage/box/ammo/a556_42/hp,
-					/obj/item/storage/box/ammo/a556_42/hp)
-	cost = 900
+	desc = "Contains one 60-round 5.56x42mm CLIP Hollow Point boxes for most newer rifles."
+	contains = list(/obj/item/storage/box/ammo/a556_42/hp)
+	cost = 375
 
 /* 5.56 caseless */
 
@@ -308,34 +302,33 @@
 	name = "5.56 Caseless Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless box for SolGov sidearms like the Pistole C."
 	contains = list(/obj/item/storage/box/ammo/c556mm)
-	cost = 250
+	cost = 168 //3.84 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c556mmHITPap_ammo_box
 	name = "5.56 caseless AP Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless boxloaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c556mm_ap)
-	cost = 500
+	cost = 210
 
 /datum/supply_pack/ammo/c556mmhitphp_ammo_box
 	name = "5.56 Caseless HP Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c556mm_hp)
-	cost = 500
+	cost = 210
 
 /datum/supply_pack/ammo/c556HITPrubber_ammo_box
 	name = "5.56 Caseless Rubber Ammo Box Crate"
 	desc = "Contains a 48-round 5.56 caseless box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c556mm_rubber)
-	cost = 250
+	cost = 168
 
 /* .299 */
 
 /datum/supply_pack/ammo/c299
 	name = ".299 Eoehoma Caseless Ammo Box Crate"
-	desc = "Contains two 60-round boxes of .299 Caseless ammo from the defunct Eoehoma. Used for the E-40 Hybrid Rifle."
-	contains = list(/obj/item/storage/box/ammo/c299,
-					/obj/item/storage/box/ammo/c299)
-	cost = 400
+	desc = "Contains one 60-round boxes of .299 Caseless ammo from the defunct Eoehoma. Used for the E-40 Hybrid Rifle."
+	contains = list(/obj/item/storage/box/ammo/c299)
+	cost = 222 //5.4 ammo efficiency at 20 damage
 
 /* 8x50 */
 
@@ -343,19 +336,19 @@
 	name = "8x50mm Ammo Box Crate"
 	desc = "Contains a 40-round 8x50mm ammo box for rifles such as the Illestren."
 	contains = list(/obj/item/storage/box/ammo/a8_50r)
-	cost = 250
+	cost = 291 //4.8 ammo efficiency at 35 damage
 
 /datum/supply_pack/ammo/c8x50mm_boxhp_boxcrate
 	name = "8x50mm Hollow Point Crate"
 	desc = "Contains a 40-round 8x50mm ammo box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/hp)
-	cost = 500
+	cost = 363
 
 /datum/supply_pack/ammo/c8x50mm_tracbox
 	name = "8x50mm Tracker Crate"
 	desc = "Contains a 30-round 8x50mm ammo box loaded with tracker ammo, great for sustained hunts."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/trac)
-	cost = 500
+	cost = 363
 
 
 /* .300 */
@@ -364,13 +357,13 @@
 	name = ".300 Ammo Box Crate"
 	desc = "Contains a twenty-round .300 Magnum ammo box for sniper rifles such as the HP Scout."
 	contains = list(/obj/item/storage/box/ammo/a300)
-	cost = 400
+	cost = 200 //4 ammo efficiency at 40 damage
 
 /datum/supply_pack/ammo/a300_trac
 	name = ".300 Trac Ammo Box Crate"
 	desc = "Contains a ten-round .300 TRAC ammo box for sniper rifles such as the HP Scout."
 	contains = list(/obj/item/storage/box/ammo/a300/trac)
-	cost = 600
+	cost = 250
 
 
 /* .308 */
@@ -379,19 +372,19 @@
 	name = "308 Ammo Box Crate"
 	desc = "Contains a thirty-round .308 box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308)
-	cost = 250
+	cost = 187 //4.8 ammo efficiency at 30 damage
 
 /datum/supply_pack/ammo/a308_ap
 	name = "308 Armour Piercing Ammo Box Crate"
 	desc = "Contains a thirty-round .308 armour piercing box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/ap)
-	cost = 500
+	cost = 233
 
 /datum/supply_pack/ammo/a308_hp
 	name = "308 Hollow Point Ammo Box Crate"
 	desc = "Contains a thirty-round .308 hollow point box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/hp)
-	cost = 500
+	cost = 233
 
 /* 6.5 */
 
@@ -399,13 +392,13 @@
 	name = "6.5x57mm CLIP Ammo Box Crate"
 	desc = "Contains a twenty-round 6.5x57mm CLIP ammo box for various sniper rifles such as the CM-F90 and the Boomslang series."
 	contains = list(/obj/item/storage/box/ammo/a65clip)
-	cost = 400
+	cost = 200 //4 ammo efficiency at 40 damage
 
 /datum/supply_pack/ammo/a65clip_trackers
 	name = "6.5x57mm CLIP Tracker Shell Crate"
 	desc = "Contains a 10-round 6.5x57mm CLIP tracker box for various sniper rifles such as the CM-F90 and the Boomslang series."
 	contains = list(/obj/item/storage/box/ammo/a65clip/trac)
-	cost = 600
+	cost = 250
 
 /* 8x58 */
 
@@ -413,7 +406,7 @@
 	name = "8x58mm Ammo Box Crate"
 	desc = "Contains a twenty-round 8x58 ammo box for Solarian-manufactured sniper rifles, such as the SSG-69."
 	contains = list(/obj/item/storage/box/ammo/a858)
-	cost = 400
+	cost = 200 //4 ammo efficiency at 40 damage
 
 /* .50 BMG */
 
@@ -421,7 +414,7 @@
 	name = ".50 BMG Ammo Box Crate"
 	desc = "Contains a twenty-round .50 BMG ammo box for the Taipan Anti-Material Rifle. Make them count, they aren't cheap."
 	contains = list(/obj/item/storage/box/ammo/a50box)
-	cost = 1000
+	cost = 1000 //1.4 ammo efficiency at 70 damage. Yes, 70.
 
 
 /* ferro pellets */
@@ -430,13 +423,13 @@
 	name = "Ferromagnetic Pellet Box Crate"
 	desc = "Contains a 48-round ferromagnetic pellet ammo box for gauss guns such as the Claris."
 	contains = list(/obj/item/storage/box/ammo/ferropellet)
-	cost = 250
+	cost = 210 //5.7 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/hcpellets
 	name = "High Conductivity Pellet Box Crate"
 	desc = "Contains a 48-round high conductivity pellet ammo box for gauss guns such as the Claris."
 	contains = list(/obj/item/storage/box/ammo/ferropellet/hc)
-	cost = 500
+	cost = 262
 
 /* ferroslugs */
 
@@ -444,13 +437,13 @@
 	name = "Ferromagnetic Slug Box Crate"
 	desc = "Contains a twenty-round ferromagnetic slug for gauss guns such as the Model-H."
 	contains = list(/obj/item/storage/box/ammo/ferroslug)
-	cost = 250
+	cost = 175 //5.7 ammo efficiency at 50 damage
 
 /datum/supply_pack/ammo/hcslugs
 	name = "High Conductivity Slug Box Crate"
 	desc = "Contains a twenty-round high conductivity slug for gauss guns such as the Model-H."
 	contains = list(/obj/item/storage/box/ammo/ferroslug/hc)
-	cost = 500
+	cost = 218
 
 /* ferro lances */
 
@@ -458,10 +451,10 @@
 	name = "Ferromagnetic Lance Box Crate"
 	desc = "Contains a 48-round box for high-powered gauss guns such as the GAR assault rifle."
 	contains = list(/obj/item/storage/box/ammo/ferrolance)
-	cost = 250
+	cost = 288 //5 ammo efficiency at 30 damage
 
 /datum/supply_pack/ammo/ferrolanceboxcrate
 	name = "High Conductivity Lance Box Crate"
 	desc = "Contains a 48-round box for high-powered gauss guns such as the GAR assault rifle."
 	contains = list(/obj/item/storage/box/ammo/ferrolance/hc)
-	cost = 500
+	cost = 360

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -106,13 +106,13 @@
 	name = ".45 AP Ammo Box Crate"
 	desc = "Contains a 48-round .45 box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c45_ap)
-	cost = 262
+	cost = 260
 
 /datum/supply_pack/ammo/c45hp_ammo_box
 	name = ".45 HP Ammo Box Crate"
 	desc = "Contains a 48-round .45 box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c45_hp)
-	cost = 262
+	cost = 260
 
 /datum/supply_pack/ammo/c45mmrubber_ammo_box
 	name = ".45 Rubber Ammo Box Crate"
@@ -126,19 +126,19 @@
 	name = ".357 Ammo Box Crate"
 	desc = "Contains a 48-round .357 box for revolvers such as the Scarborough Revolver and the HP Firebrand."
 	contains = list(/obj/item/storage/box/ammo/a357)
-	cost = 257 //5.6 ammo efficiency at 30 damage //TTD: boost this to 300 if revolvers get 35 damage
+	cost = 255 //5.6 ammo efficiency at 30 damage //TTD: boost this to 300 if revolvers get 35 damage
 
 /datum/supply_pack/ammo/a357hp_ammo_box
 	name = ".357 HP Ammo Box Crate"
 	desc = "Contains a 48-round .357 box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a357_hp)
-	cost = 321 //375 at 35 base
+	cost = 320 //375 at 35 base
 
 /datum/supply_pack/ammo/a357match_ammo_box
 	name = ".357 Match Ammo Box Crate"
 	desc = "Contains a 48-round .357 match box for better performance against armor."
 	contains = list(/obj/item/storage/box/ammo/a357_match)
-	cost = 321 // 375 at 35 base
+	cost = 320 // 375 at 35 base
 
 /* .44 */
 
@@ -146,19 +146,19 @@
 	name = ".44 Roumain Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain ammo for revolvers such as the Shadow and Montagne."
 	contains = list(/obj/item/storage/box/ammo/a44roum)
-	cost = 214 //5.6 ammo efficiency at 25 damage
+	cost = 210 //5.6 ammo efficiency at 25 damage
 
 /datum/supply_pack/ammo/a44roum_rubber
 	name = ".44 Roumain Rubber Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain ammo loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/a44roum_rubber)
-	cost = 214
+	cost = 210
 
 /datum/supply_pack/ammo/a44roum_hp
 	name = ".44 Roumain Hollow Point Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a44roum_hp)
-	cost = 267
+	cost = 265
 
 /* 4.6x30 */
 
@@ -166,7 +166,7 @@
 	name = "4.6x30mm Ammo Box Crate"
 	desc = "Contains an 80-round 4.6x30mm box for PDWs such as the WT-550."
 	contains = list(/obj/item/storage/box/ammo/c46x30mm)
-	cost = 296 //5.4 ammo efficiency at 20 damage
+	cost = 295 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c46x30mm_ap
 	name = "4.6x30mm Armour Piercing Ammo Box Crate"
@@ -187,7 +187,7 @@
 	name = "5.7x39mm Ammo Box Crate"
 	desc = "Contains one 80-round 5.7x39mm box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39)
-	cost = 296 //5.4 ammo efficiency at 20 damage
+	cost = 295 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c57x39mm_ap
 	name = "5.7x39mm Armour Piercing Ammo Box Crate"
@@ -212,7 +212,7 @@
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains a box of 32 slug shells for use in lethal persuasion."
-	cost = 228 //5.6 ammo efficiency at 40 damage
+	cost = 225 //5.6 ammo efficiency at 40 damage
 	contains = list(/obj/item/storage/box/ammo/a12g_slug)
 
 /datum/supply_pack/ammo/blank_shells
@@ -239,13 +239,13 @@
 	name = ".45-70 Ammo Box Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition."
 	contains = list(/obj/item/storage/box/ammo/a4570)
-	cost = 192 //5.6 ammo efficiency at 45 damage
+	cost = 190 //5.6 ammo efficiency at 45 damage
 
 /datum/supply_pack/ammo/a4570_box/match
 	name = ".45-70 Match Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition, that travels faster, pierces armour better, and ricochets off targets."
 	contains = list(/obj/item/storage/box/ammo/a4570_match)
-	cost = 384
+	cost = 380
 
 /* 7.62 */
 
@@ -293,25 +293,25 @@
 	name = "5.56 Caseless Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless box for SolGov sidearms like the Pistole C."
 	contains = list(/obj/item/storage/box/ammo/c556mm)
-	cost = 168 //5.7 ammo efficiency at 20 damage
+	cost = 165 //5.7 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c556mmHITPap_ammo_box
 	name = "5.56 caseless AP Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless boxloaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c556mm_ap)
-	cost = 210
+	cost = 205
 
 /datum/supply_pack/ammo/c556mmhitphp_ammo_box
 	name = "5.56 Caseless HP Ammo Box Crate"
 	desc = "Contains a 48-round 5.56mm caseless box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c556mm_hp)
-	cost = 210
+	cost = 205
 
 /datum/supply_pack/ammo/c556HITPrubber_ammo_box
 	name = "5.56 Caseless Rubber Ammo Box Crate"
 	desc = "Contains a 48-round 5.56 caseless box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c556mm_rubber)
-	cost = 168
+	cost = 165
 
 /* .299 */
 
@@ -319,7 +319,7 @@
 	name = ".299 Eoehoma Caseless Ammo Box Crate"
 	desc = "Contains one 60-round box of .299 Caseless ammo from the defunct Eoehoma. Used for the E-40 Hybrid Rifle."
 	contains = list(/obj/item/storage/box/ammo/c299)
-	cost = 222 //5.4 ammo efficiency at 20 damage
+	cost = 220 //5.4 ammo efficiency at 20 damage
 
 /* 8x50 */
 
@@ -327,19 +327,19 @@
 	name = "8x50mm Ammo Box Crate"
 	desc = "Contains a 40-round 8x50mm ammo box for rifles such as the Illestren."
 	contains = list(/obj/item/storage/box/ammo/a8_50r)
-	cost = 291 //4.8 ammo efficiency at 35 damage //TTD 37 damage 308 cr DMR buff
+	cost = 290 //4.8 ammo efficiency at 35 damage //TTD 37 damage 308 cr DMR buff
 
 /datum/supply_pack/ammo/c8x50mm_boxhp_boxcrate
 	name = "8x50mm Hollow Point Crate"
 	desc = "Contains a 40-round 8x50mm ammo box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/hp)
-	cost = 363 //TTD 385
+	cost = 360 //TTD 385
 
 /datum/supply_pack/ammo/c8x50mm_tracbox
 	name = "8x50mm Tracker Crate"
 	desc = "Contains a 30-round 8x50mm ammo box loaded with tracker ammo, great for sustained hunts."
 	contains = list(/obj/item/storage/box/ammo/a8_50r/trac)
-	cost = 363 //TTD 385
+	cost = 360 //TTD 385
 
 
 /* .300 */
@@ -354,7 +354,7 @@
 	name = ".300 Trac Ammo Box Crate"
 	desc = "Contains a ten-round .300 TRAC ammo box for sniper rifles such as the HP Scout."
 	contains = list(/obj/item/storage/box/ammo/a300/trac)
-	cost = 250 //TTD 312
+	cost = 250 //TTD 310
 
 
 /* .308 */
@@ -363,19 +363,19 @@
 	name = "308 Ammo Box Crate"
 	desc = "Contains a thirty-round .308 box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308)
-	cost = 187 //4.8 ammo efficiency at 30 damage //TTD 35 damage 218 cr DMR buff
+	cost = 185 //4.8 ammo efficiency at 30 damage //TTD 35 damage 215 cr DMR buff
 
 /datum/supply_pack/ammo/a308_ap
 	name = "308 Armour Piercing Ammo Box Crate"
 	desc = "Contains a thirty-round .308 armour piercing box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/ap)
-	cost = 233 //TTD 272
+	cost = 230 //TTD 270
 
 /datum/supply_pack/ammo/a308_hp
 	name = "308 Hollow Point Ammo Box Crate"
 	desc = "Contains a thirty-round .308 hollow point box for DMRs such as the SsG-04 and CM-GAL-S."
 	contains = list(/obj/item/storage/box/ammo/a308/hp)
-	cost = 233 //TTD 272
+	cost = 230 //TTD 270
 
 /* 6.5 */
 
@@ -420,7 +420,7 @@
 	name = "High Conductivity Pellet Box Crate"
 	desc = "Contains a 48-round high conductivity pellet ammo box for gauss guns such as the Claris."
 	contains = list(/obj/item/storage/box/ammo/ferropellet/hc)
-	cost = 262
+	cost = 260
 
 /* ferroslugs */
 
@@ -434,7 +434,7 @@
 	name = "High Conductivity Slug Box Crate"
 	desc = "Contains a twenty-round high conductivity slug for gauss guns such as the Model-H."
 	contains = list(/obj/item/storage/box/ammo/ferroslug/hc)
-	cost = 218
+	cost = 215
 
 /* ferro lances */
 
@@ -442,7 +442,7 @@
 	name = "Ferromagnetic Lance Box Crate"
 	desc = "Contains a 48-round box for high-powered gauss guns such as the GAR assault rifle."
 	contains = list(/obj/item/storage/box/ammo/ferrolance)
-	cost = 288 //5 ammo efficiency at 30 damage
+	cost = 285 //5 ammo efficiency at 30 damage
 
 /datum/supply_pack/ammo/ferrolanceboxcrate
 	name = "High Conductivity Lance Box Crate"

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -185,21 +185,21 @@
 
 /datum/supply_pack/ammo/c57x39mm_boxcrate
 	name = "5.7x39mm Ammo Box Crate"
-	desc = "Contains one 48-round 5.7x39mm box for PDWs such as the Sidewinder."
+	desc = "Contains one 80-round 5.7x39mm box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39)
-	cost = 177 //5.4 ammo efficiency at 20 damage
+	cost = 296 //5.4 ammo efficiency at 20 damage
 
 /datum/supply_pack/ammo/c57x39mm_ap
 	name = "5.7x39mm Armour Piercing Ammo Box Crate"
-	desc = "Contains one 48-round 5.7x39mm box for PDWs such as the Sidewinder."
+	desc = "Contains one 80-round 5.7x39mm box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39/ap)
-	cost = 221
+	cost = 370
 
 /datum/supply_pack/ammo/c57x39mm_hp
 	name = "5.7x39mm Hollow Point Ammo Box Crate"
-	desc = "Contains one 48-round 5.7x39mm Hollow Point box for PDWs such as the Sidewinder."
+	desc = "Contains one 80-round 5.7x39mm Hollow Point box for PDWs such as the Sidewinder."
 	contains = list(/obj/item/storage/box/ammo/c57x39/hp)
-	cost = 221
+	cost = 370
 
 /* 12 Gauge */
 
@@ -212,7 +212,7 @@
 /datum/supply_pack/ammo/slugs
 	name = "Shotgun Slug Crate"
 	desc = "Contains a box of 32 slug shells for use in lethal persuasion."
-	cost = 221 //5.6 ammo efficiency at 40 damage
+	cost = 228 //5.6 ammo efficiency at 40 damage
 	contains = list(/obj/item/storage/box/ammo/a12g_slug)
 
 /datum/supply_pack/ammo/blank_shells

--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_smg_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_smg_stacks.dm
@@ -115,6 +115,7 @@
 // 5.7x39mm (Asp and Sidewinder)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c57x39
+	max_ammo = 20
 	ammo_type = /obj/item/ammo_casing/c57x39mm
 
 /obj/item/storage/box/ammo/c57x39


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ammo costs modified according to The List in the gun balance thread, making most guns significantly cheaper to maintain. Except assault rifles.

Ammo crates with two boxes in them now carry one box unless they are .38 so the prices aren't in the thousands for a single refill. You'll still be buying thousands of credits for refills but you'll be able to do partials for less.

Current damage/cr for each weapon type:
buckshot: 6.4 (nerf)
slug: 5.6 (buff)
pistol (low AP, moderate damage): 5.7-6 (buff)
PDW (moderate AP, moderate damage, high speed): 5.4 (nerf)
revolver: 5.6 (buff)
assault rifle (above moderate damage, moderate AP, high capacity, high speed): 5 (nerf)
DMR (high damage, high AP, low capacity): 4.8 (buff)
sniper (highest damage, high AP, low capacity): 4 (buff)

.22lr and .38 are currently unchanged due to being budget calibers, both at ~8 efficiency

## Why It's Good For The Game

I sure do love using guns that AREN'T automatics!!!

## Changelog

:cl:
balance: ammo costs have been modified Slightly. Most of them are significantly cheaper.
balance: Rifle ammo crates with two boxes now only have one box, so the cost to refill one is manageable.
balance: Specialist ammo costs cut from 100% premium to 25% premium. Now you might actually use them for something that isn't a bit!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
