### PR TITLE
Tweaks rifle and sniper ammo

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -31,8 +31,8 @@
 
 /obj/projectile/bullet/a8_50r
 	name = "8x50mmR bullet"
-	damage = 35
-	armour_penetration = 40
+	damage = 37
+	armour_penetration = 30
 	speed = BULLET_SPEED_RIFLE
 	bullet_identifier = "large bullet"
 
@@ -45,7 +45,7 @@
 /obj/projectile/bullet/a8_50r/match
 	name = "8x50mmR match bullet"
 	damage = 40
-	armour_penetration = 30
+	armour_penetration = 27
 	speed_mod = BULLET_SPEED_AP_MOD
 	ricochets_max = 4
 	ricochet_chance = 80
@@ -93,7 +93,7 @@
 
 /obj/projectile/bullet/a308
 	name = ".308 bullet"
-	damage = 30
+	damage = 35
 	armour_penetration = 40
 	speed = BULLET_SPEED_RIFLE
 	bullet_identifier = "large bullet"
@@ -106,7 +106,7 @@
 
 /obj/projectile/bullet/a308/ap
 	name = ".308 armor piercing bullet"
-	damage = 27
+	damage = 32
 	armour_penetration = 60
 	speed_mod = BULLET_SPEED_AP_MOD
 

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -72,8 +72,9 @@
 
 /obj/projectile/bullet/a858
 	name = "8x58mm caseless bullet"
-	damage = 40
-	armour_penetration = 45
+	damage = 45
+	stamina = 10
+	armour_penetration = 50
 	speed = BULLET_SPEED_SNIPER
 	bullet_identifier = "huge bullet"
 
@@ -87,7 +88,7 @@
 
 /obj/projectile/bullet/a300
 	name = ".300 Magnum bullet"
-	damage = 45
+	damage = 50
 	stamina = 10
 	armour_penetration = 40
 	speed = BULLET_SPEED_RIFLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes some tweaks to DMR and sniper ammo. Importantly, this allows .308 and .300 to break a couple damage thresholds.

- 8mm Illestren: 35->37 base damage, 40->30 AP
- 8mm Illestren Match: 30->27 AP.
- .308: 30->35 base damage
- .308 AP: 27->32 damage
- 8x58mm Caseless: 40->45 dam, 0->10 stamina, 45->50 AP
- .300: 45 -> 50 dam

## Why It's Good For The Game

.308 was the only DMR round with 4 shots to crit. 8mm Caseless was almost completely unused and easily the worst of the three sniper cartridges (tied for worst damage with no stamina side effect), on top of the only weapon that uses it being exceedingly rare to begin with. .300 goes to a 2 shot kill because it's .300 and the scout fires so slowly that it still takes forever to make those 2 shots.

## Changelog

:cl:
balance: Buffed damage on .308, 8mm Illestren, 8x58mm Caseless, and .300. Nerfed 8mm Illestren AP factor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
