### PR TITLE
38 trickwine fix

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/ammo.dm
@@ -286,7 +286,7 @@
 /datum/blackmarket_item/ammo/c38hotshot
 	name = ".38 Hearth Ammo Box"
 	desc = "We got our ship cook to marinade some .38 in some hearthflame we pocketed off some hunters. It'll cook your targets to a nice well done."
-	item = /obj/item/ammo_box/c38/hotshot
+	item = /obj/item/storage/box/ammo/c38_hotshot
 
 	price_min = 300
 	price_max = 500
@@ -297,7 +297,7 @@
 /datum/blackmarket_item/ammo/c38iceblox
 	name = ".38 Chilled Ammo Box"
 	desc = "One of our runners accidentally spilled some .38 into a fucking pristine wine of ice shipment. It'll freeze your targets faster than our runner froze solid outside for making a mess."
-	item = /obj/item/ammo_box/c38/iceblox
+	item = /obj/item/storage/box/ammo/c38_iceblox
 
 	price_min = 300
 	price_max = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

.38 black market trickwine ammo now comes in boxes instead of speedloaders

## Why It's Good For The Game

yes

## Changelog

:cl:
fix: .38 black market trickwine ammo now comes in boxes instead of speedloaders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
