### PR TITLE
touches up background radiation (on waste worlds)

### DIFF
--- a/code/game/objects/effects/radiation.dm
+++ b/code/game/objects/effects/radiation.dm
@@ -3,34 +3,49 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "radiation"
 	invisibility = INVISIBILITY_ABSTRACT
+	anchored = TRUE
+	///Radiation pulse intensity
 	var/rad_power = 33
-	var/rad_range = 1 // !Range mod = rad dropoff speed
-	var/rad_spread = 6 // Range of nearby atoms to radiate
+	/// !Range mod = rad dropoff speed
+	var/rad_range = 1
+	/// Range of nearby atoms to radiate
+	var/rad_spread = 6
+	/// Probability per open turf in view to make a rad pulse there
 	var/rad_prob = 10
 	COOLDOWN_DECLARE(pulse_cooldown)
+	/// Delay between radiation pulses
 	var/rad_delay = 2 SECONDS
 
 /obj/effect/radiation/Initialize()
-	START_PROCESSING(SSobj, src)
 	. = ..()
+	START_PROCESSING(SSobj, src)
 
-/obj/effect/radiation/process(seconds_per_tick)
+/obj/effect/radiation/process()
 	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
-		return ..()
+		return
 
 	var/player_in_range = FALSE
-	for(var/mob/living/L in range(rad_spread))
-		if(L.client)
+	for(var/mob/living/living in range(rad_spread, loc))
+		if(living.client)
 			player_in_range = TRUE
 			break
 	if(!player_in_range)
-		return ..()
+		return
 	COOLDOWN_START(src, pulse_cooldown, rad_delay)
-	for(var/obj/O in range(rad_spread, src))
-		if(prob(rad_prob))
-			radiation_pulse(O, rad_power, rad_range)
+	for(var/turf/open/open_turf in view(rad_spread, src))
+		if(!prob(rad_prob))
+			continue
+		radiation_pulse(rad_impact_loc(open_turf), rad_power, rad_range)
 
-	..()
+/// Cast a line to target and if blocked, returns the turf before the blocking turf. Otherwise returns target turf
+/obj/effect/radiation/proc/rad_impact_loc(turf/target)
+	var/list/turfs = get_line(loc, target)
+	for(var/i=1 to length(turfs))
+		var/turf/turf = turfs[i]
+		if(!turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = src))
+			continue
+		return turfs[max(i-1, 1)] // Prevents trying to access index 0
+	return target
 
 /obj/effect/radiation/waste
 	rad_power = 33


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

bg radiation effects can no longer randomly decide to affect you through walls and blocking them with radiation insulation (walls, windows) is more effective
also anchors them

oh yeah and also makes them actually work

## Why It's Good For The Game

them affecting ignoring walls and such is bad jank
fixes #4405

## Changelog

:cl:
fix: background radiation (on waste worlds) may no longer decide to ignore obstructions and also actually works now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
