### PR TITLE
broadcast cameras notify entertainment monitors they're broadcasting now

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -380,7 +380,7 @@
 	desc = "A screen displaying various entertainment channels. I hope they have that new Gezenan sitcom on this."
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment_blank"
-	network = list("thunder")
+	network = list("IntraNet")
 	density = FALSE
 	circuit = null
 	interaction_flags_atom = NONE  // interact() is called by BigClick()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -397,13 +397,9 @@
 
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, interact), usr)
 
-/obj/machinery/computer/security/telescreen/entertainment/proc/notify(on)
+/obj/machinery/computer/security/telescreen/entertainment/proc/notify(on, string="helloooo please tell coders if you see me")
 	if(on && icon_state == icon_state_off)
-		say(pick(
-			"Feats of bravery live now at the thunderdome!",
-			"Two enter, one leaves! Tune in now!",
-			"Violence like you've never seen it before!",
-			"Spears! Camera! Action! LIVE NOW!"))
+		say(string)
 		icon_state = icon_state_on
 	else
 		icon_state = icon_state_off

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -171,7 +171,7 @@
 	var/obj/item/radio/broadcast/radio
 	var/mob/listeningTo
 	actions_types = list(/datum/action/item_action/toggle_radio)
-	var/detect_time = -1
+	COOLDOWN_DECLARE(broadcast_announcement)
 
 /obj/item/bodycamera/broadcast_camera/Initialize()
 	. = ..()
@@ -244,7 +244,7 @@
 
 /obj/item/bodycamera/broadcast_camera/AltClick(mob/user)
 	. = ..()
-	if(status && world.time > detect_time + 20 SECONDS)
+	if(status && COOLDOWN_FINISHED(src, broadcast_announcement))
 		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
 			TV.notify(TRUE, "[c_tag] is now live on [network]!")
-			detect_time = world.time
+			COOLDOWN_START(src, broadcast_announcement, 20 seconds)

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -246,5 +246,5 @@
 	. = ..()
 	if(status && world.time > detect_time + 20 SECONDS)
 		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
-			TV.notify(TRUE, "[c_tag] is now live on IntraNet!")
+			TV.notify(TRUE, "[c_tag] is now live on [network]!")
 			detect_time = world.time

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -167,7 +167,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	view_range = 5
 	can_transmit_across_z_levels = TRUE
-	network = list("thunder")
+	network = list("IntraNet")
 	var/obj/item/radio/broadcast/radio
 	var/mob/listeningTo
 	actions_types = list(/datum/action/item_action/toggle_radio)

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -247,4 +247,4 @@
 	if(status && COOLDOWN_FINISHED(src, broadcast_announcement))
 		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
 			TV.notify(TRUE, "[c_tag] is now live on [network]!")
-			COOLDOWN_START(src, broadcast_announcement, 20 seconds)
+			COOLDOWN_START(src, broadcast_announcement, 20 SECONDS)

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -171,6 +171,7 @@
 	var/obj/item/radio/broadcast/radio
 	var/mob/listeningTo
 	actions_types = list(/datum/action/item_action/toggle_radio)
+	var/detect_time = -1
 
 /obj/item/bodycamera/broadcast_camera/Initialize()
 	. = ..()
@@ -181,6 +182,7 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
 	RegisterSignal(radio, COMSIG_RADIO_NEW_FREQUENCY, PROC_REF(adjust_name))
 	c_tag = "Broadcast Camera - Unlabeled"
+
 
 /obj/item/bodycamera/broadcast_camera/Destroy()
 	listeningTo = null
@@ -239,3 +241,10 @@
 	user.visible_message(span_notice("[user] lowers [src]."), span_notice("You lower [src], reducing it's view."))
 	item_state = "broadcast"
 	view_range = 3
+
+/obj/item/bodycamera/broadcast_camera/AltClick(mob/user)
+	. = ..()
+	if(status && world.time > detect_time + 20 SECONDS)
+		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
+			TV.notify(TRUE, "[c_tag] is now live on IntraNet!")
+			detect_time = world.time


### PR DESCRIPTION

## Changelog

:cl:
add: entertainment monitors now tell you when someone starts their livestream. don't miss today's episode of the scrapper show!
/:cl: