### PR TITLE
Cable healing on mechanical limbs no longer does structure damage

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -544,7 +544,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [parse_zone(affecting.body_zone)].</span>", "<span class='notice'>You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [parse_zone(affecting.body_zone)].</span>")
 			if(!do_after(user, 0.5 SECONDS, H))
 				return
-		if(item_heal_robotic(H, user, 0, 15, integrity_loss = 5))
+		if(item_heal_robotic(H, user, 0, 15))
 			use(1)
 		return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IPCs take burn damage while in crit (and a lot of it) to the point cables are the only reliable way to get them out, meaning options are either
1: hope they have enough structure left to heal out of crit and not have the healing stall then die anyway
2: wait for the IPC to die, then heal them either with repair machinery or stacks & structure repair that won't be immediately undone by damage from crit

Structure is still dealt by healing via welding tool (most damage you take will generally be brute damage anyways)

## Why It's Good For The Game

"just let them die lol" generally shouldnt be the strat for medical stuff I think

## Changelog

:cl:
balance: healing mechanical limbs with cables no longer deals structure damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
