### PR TITLE
This mission no longer spawns a naked man

### DIFF
--- a/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
@@ -2547,7 +2547,9 @@
 	pixel_x = -4
 	},
 /obj/effect/mob_spawn/human/corpse/inteq/vanguard/tradepost,
-/obj/effect/landmark/mission_poi/main,
+/obj/effect/landmark/mission_poi/main{
+	already_spawned = 1
+	},
 /turf/open/floor/wood/walnut,
 /area/ruin/wasteplanet/tradepost/center)
 "Cq" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This landmark did not have already spawned set so it spawns a naked man
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missions now work properly
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: the wasteplanet tradepost vangaurd mission now properly works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
