### PR TITLE
IPC balance change

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -4,7 +4,7 @@
 	sexes = FALSE
 	species_age_min = 0
 	species_age_max = 300
-	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,TRAIT_EASYDISMEMBER,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH,NO_BONES) //all of these + whatever we inherit from the real species
+	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,TRAIT_EASYDISMEMBER,NOZOMBIE,MUTCOLORS,NOHUSK,NOMOUTH,NO_BONES) //all of these + whatever we inherit from the real species
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_LIMBATTACHMENT, TRAIT_METALLIC)
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
 	mutantbrain = /obj/item/organ/brain/mmi_holder/posibrain
@@ -49,7 +49,8 @@
 	/// The last screen used when the IPC died.
 	var/saved_screen
 	var/datum/action/innate/change_screen/change_screen
-	var/has_screen = TRUE //do we have a screen. Used to determine if we mess with the screen or not
+	/// Used to determine if the frame has a screen or not
+	var/has_screen = TRUE
 
 /datum/species/ipc/random_name(unique)
 	var/ipc_name = "[pick(GLOB.posibrain_names)]-[rand(100, 999)]"
@@ -216,15 +217,6 @@
 
 	H.visible_message("<span class='notice'>[H] unplugs from the [target].</span>", "<span class='notice'>You unplug from the [target].</span>")
 	return
-
-/datum/species/ipc/spec_life(mob/living/carbon/human/H)
-	. = ..()
-	if(H.health <= HEALTH_THRESHOLD_CRIT && H.stat != DEAD) // So they die eventually instead of being stuck in crit limbo.
-		H.adjustFireLoss(6) // After BODYTYPE_ROBOTIC resistance this is ~2/second
-		if(prob(5))
-			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
-			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
-
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
 	if(has_screen)

--- a/code/modules/surgery/ipc_revive.dm
+++ b/code/modules/surgery/ipc_revive.dm
@@ -27,7 +27,7 @@
 		/obj/item/shockpaddles = 80,
 		/obj/item/melee/baton = 50,
 		/obj/item/gun/energy = 30)
-	time = 60
+	time = 3.5 SECONDS
 
 /datum/surgery_step/revive/ipc/tool_check(mob/user, obj/item/tool)
 	. = ..()

--- a/code/modules/surgery/ipc_revive.dm
+++ b/code/modules/surgery/ipc_revive.dm
@@ -20,7 +20,7 @@
 		return FALSE
 	return isipc(target)
 
-/datum/surgery_step/revive/ipc //TODO: make ipcs not auto revive, to make this surgery actually do something.
+/datum/surgery_step/revive/ipc
 	name = "reboot electronics"
 	implements = list(
 		/obj/item/inducer = 100,
@@ -35,5 +35,3 @@
 		var/obj/item/inducer/I = tool
 		if(I.cantbeused(user))
 			return FALSE
-
-

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -3,8 +3,8 @@
 	name = "unscrew shell"
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
-		TOOL_SCALPEL 			= 75, // med borgs could try to unscrew shell with scalpel
-		/obj/item/melee/knife/kitchen	= 50,
+		TOOL_SCALPEL 			= 75,
+		/obj/item/melee/knife	= 50,
 		/obj/item				= 10)
 	time = 2.4 SECONDS
 	preop_sound = 'sound/items/screwdriver.ogg'
@@ -28,7 +28,7 @@
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
 		TOOL_SCALPEL 			= 75,
-		/obj/item/melee/knife/kitchen	= 50,
+		/obj/item/melee/knife	= 50,
 		/obj/item				= 10)
 	time = 2.4 SECONDS
 	preop_sound = 'sound/items/screwdriver.ogg'
@@ -50,8 +50,7 @@
 /datum/surgery_step/prepare_electronics
 	name = "prepare electronics"
 	implements = list(
-		TOOL_MULTITOOL = 100,
-		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
+		TOOL_MULTITOOL = 100,)
 	time = 2.4 SECONDS
 	preop_sound = 'sound/items/tape_flip.ogg'
 	success_sound = 'sound/items/taperecorder_close.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes IPCs dying in crit.

Removes IPCs auto-reviving on reaching low damage. This will probably mean if you get stuck in crit somewhere, you'll never die. But you can always manually succumb so this is fine. It also causes issues with some other stuff, and nullifies the surgery that exists for it.
Wiki purposes, the surgery is:
1. Unscrew Shell (Screwdriver 100%, Scalpel 75%, Knife Subtype 50%, any item 10%)
2. Open Hatch (Hand)
3. Prepare Electronics (Multitool 100%)
4. Revive (Inducer 100%, Shockpaddles 80%, Baton subtype 50%, Energy gun subtype 30%)
5. Close Hatch (Hand)
6. Screw Shell (Same as step 1)

Slight tweaks to the surgery in the diffs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
balance: IPCs no longer die rapidly in critical condition
balance: IPCs no longer auto-revive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
