### PR TITLE
Additional Engineering Tools on the Cargo Market

### DIFF
--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -151,11 +151,10 @@
 
 /datum/supply_pack/tools/jaws_of_life
 	name = "Jaws of Life"
-	desc = "Contains a single 'Jaws of Life', rescue equipment that doubles as both prying and cutting."
+	desc = "Contains a single 'Jaws of Life', rescue equipment that doubles for both prying and cutting tools."
 	cost = 850
 	contains = list(/obj/item/crowbar/power)
 	crate_name = "jaws of life crate"
-
 
 /datum/supply_pack/tools/plasmacutter
 	name = "Plasmacutter Crate"

--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -142,20 +142,6 @@
 	contains = list(/obj/item/weldingtool/electric)
 	crate_name = "electric welder crate"
 
-/datum/supply_pack/tools/hand_drill
-	name = "Hand Drill"
-	desc = "Contains a single hand drill, with replacable drillbits for both screwing and wrenching."
-	cost = 850
-	contains = list(/obj/item/screwdriver/power)
-	crate_name = "hand drill crate"
-
-/datum/supply_pack/tools/jaws_of_life
-	name = "Jaws of Life"
-	desc = "Contains a single 'Jaws of Life', rescue equipment that doubles for both prying and cutting tools."
-	cost = 850
-	contains = list(/obj/item/crowbar/power)
-	crate_name = "jaws of life crate"
-
 /datum/supply_pack/tools/plasmacutter
 	name = "Plasmacutter Crate"
 	desc = "Contains a plasmacutter, capable of rapidly breaking down hull."

--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -98,10 +98,18 @@
 
 /datum/supply_pack/tools/insulated_gloves
 	name = "Insulated Gloves Crate"
-	desc = "The backbone of modern society. Barely ever ordered for actual engineering. Contains a pair of insulated gloves."
+	desc = "The backbone of modern society. Contains a pair of insulated gloves."
 	cost = 750
 	contains = list(/obj/item/clothing/gloves/color/yellow)
 	crate_name = "insulated gloves crate"
+
+/datum/supply_pack/tools/inducer
+	name = "Inducer Crate"
+	desc = "An electromagnetic induction charging device, used for both field engineering/recharging and reactivation of Positronics. Not suitable for cooking."
+	cost = 750
+	contains = list(/obj/item/inducer)
+	crate_name = "inducer crate"
+	faction = /datum/faction/nt
 
 /datum/supply_pack/tools/jetpack
 	name = "Jetpack Crate"
@@ -133,6 +141,21 @@
 	cost = 850
 	contains = list(/obj/item/weldingtool/electric)
 	crate_name = "electric welder crate"
+
+/datum/supply_pack/tools/hand_drill
+	name = "Hand Drill"
+	desc = "Contains a single hand drill, with replacable drillbits for both screwing and wrenching."
+	cost = 850
+	contains = list(/obj/item/screwdriver/power)
+	crate_name = "hand drill crate"
+
+/datum/supply_pack/tools/jaws_of_life
+	name = "Jaws of Life"
+	desc = "Contains a single 'Jaws of Life', rescue equipment that doubles as both prying and cutting."
+	cost = 850
+	contains = list(/obj/item/crowbar/power)
+	crate_name = "jaws of life crate"
+
 
 /datum/supply_pack/tools/plasmacutter
 	name = "Plasmacutter Crate"


### PR DESCRIPTION
## About The Pull Request

Adds Inducers (for the upcoming #4421 PR) to cargo

Also removes a reference to greytiding.

## Why It's Good For The Game

We're going to need inducers to be available if IPCs require rebooting, so this makes them purchasable in the event of an IPC's deactivation.

## Changelog

:cl:
add: Additional tool in cargo: Inducers.
/:cl:
