### PR TITLE
Woodsman zoom and Vickland ghost scope slot fix

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -1106,7 +1106,6 @@ EMPTY_GUN_HELPER(shotgun/doublebarrel/beacon)
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1,
-		ATTACHMENT_SLOT_SCOPE = 1
 	)
 
 	slot_offsets = list(

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -266,6 +266,7 @@ EMPTY_GUN_HELPER(automatic/m12_sporter/mod)
 	recoil_unwielded = 6
 	fire_delay = 0.75 SECONDS
 	wield_delay = 1.15 SECONDS //a little longer and less wieldy than other DMRs
+	zoom_out_amt = 2
 
 	can_be_sawn_off = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds 2 tiles of zoom for Woodsman and removes broken Vickland's scope slot

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now Woodsman have the same zoom as other DMRs and Vickalnd doesn't have a disorienting scope slot

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed missing zoom_out_amt = 2 of Woodsman, removed attachment scope slot of Vickland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
