### PR TITLE
short scope gives minimum recoil

### DIFF
--- a/code/game/objects/items/attachments/short_scope.dm
+++ b/code/game/objects/items/attachments/short_scope.dm
@@ -9,6 +9,7 @@
 	size_mod = 0
 	var/zoom_mod = 6
 	var/zoom_out_mod = 2
+	var/min_recoil_mod = 0.1
 	var/aim_slowdown_mod = 0.2
 
 
@@ -16,11 +17,13 @@
 	. = ..()
 	gun.zoom_amt = zoom_mod
 	gun.zoom_out_amt = zoom_out_mod
+	gun.min_recoil_aimed = min_recoil_mod
 	gun.aimed_wield_slowdown += aim_slowdown_mod
 
 /obj/item/attachment/scope/remove_attachment(obj/item/gun/gun, mob/user)
 	. = ..()
 	gun.zoom_amt = initial(gun.zoom_amt)
 	gun.zoom_out_amt = initial(gun.zoom_out_amt)
+	gun.min_recoil_aimed = initial(gun.min_recoil_aimed)
 	gun.aimed_wield_slowdown = initial(gun.aimed_wield_slowdown)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds 0.1 minimum aimed recoil to the short scope (same as the long scope unfortunately) since they are generally applicable to assault weapons

## Why It's Good For The Game

THE 0 recoil skm in question:

## Changelog

:cl:
balance: short scopes now have minimum recoil, similar to long scopes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
