### PR TITLE
update airbase turrets

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_bombed_starport.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_bombed_starport.dmm
@@ -2504,9 +2504,8 @@
 /obj/structure/barricade/security{
 	layer = 2.89
 	},
-/obj/machinery/porta_turret/ship/syndicate/heavy/starport{
-	dir = 10;
-	lethal = 1
+/obj/machinery/porta_turret/ruin/ramzi/heavy{
+	dir = 10
 	},
 /turf/open/floor/concrete/reinforced/jungleplanet/lit,
 /area/ruin/jungle/airbase/turrets)
@@ -3580,9 +3579,8 @@
 /obj/structure/barricade/security{
 	layer = 2.89
 	},
-/obj/machinery/porta_turret/ship/syndicate/heavy/starport{
-	dir = 6;
-	lethal = 1
+/obj/machinery/porta_turret/ruin/ramzi/heavy{
+	dir = 6
 	},
 /turf/open/floor/concrete/reinforced/jungleplanet/lit,
 /area/ruin/jungle/airbase/turrets)
@@ -6833,9 +6831,8 @@
 /obj/structure/barricade/security{
 	layer = 2.89
 	},
-/obj/machinery/porta_turret/ship/syndicate/heavy/starport{
-	dir = 9;
-	lethal = 1
+/obj/machinery/porta_turret/ruin/ramzi/heavy{
+	dir = 9
 	},
 /turf/open/floor/concrete/reinforced/jungleplanet/lit,
 /area/ruin/jungle/airbase/turrets)
@@ -12094,9 +12091,8 @@
 /obj/structure/barricade/security{
 	layer = 2.89
 	},
-/obj/machinery/porta_turret/ship/syndicate/heavy/starport{
-	dir = 5;
-	lethal = 1
+/obj/machinery/porta_turret/ruin/ramzi/heavy{
+	dir = 5
 	},
 /turf/open/floor/concrete/reinforced/jungleplanet/lit,
 /area/ruin/jungle/airbase/turrets)
@@ -17345,7 +17341,7 @@ bY
 uX
 uX
 bp
-kX
+pw
 BM
 eO
 "}

--- a/_maps/shuttles/syndicate/syndicate_twinkleshine.dmm
+++ b/_maps/shuttles/syndicate/syndicate_twinkleshine.dmm
@@ -20,9 +20,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "ae" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
+/obj/machinery/power/shuttle/engine/fueled/plasma,
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "ag" = (
@@ -194,9 +192,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater,
 /obj/machinery/door/poddoor/shutters{
 	id = "twinkle_engines";
 	dir = 4
@@ -1482,9 +1478,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
 "iJ" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater,
 /obj/machinery/door/window/eastright{
 	name = "Engine Access"
 	},
@@ -1554,15 +1548,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
-"iX" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 10;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/engineering/atmospherics)
 "iZ" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
 	dir = 1
@@ -2180,15 +2165,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
-"ms" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 9;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/engineering/atmospherics)
 "mt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 8
@@ -2259,9 +2235,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "mW" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater,
 /obj/machinery/door/window/eastright{
 	name = "Engine Access"
 	},
@@ -2968,7 +2942,6 @@
 	req_access = list(150)
 	},
 /obj/docking_port/mobile{
-	can_move_docking_ports = 1;
 	name = "Twink Bay";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -3634,15 +3607,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
-"vd" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 5;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/hallway/port)
 "vl" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
@@ -3915,9 +3879,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
+/obj/machinery/power/smes/shuttle/precharged,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -5642,8 +5604,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 20;
-	pixel_y = 0
+	pixel_x = 20
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
@@ -6629,8 +6590,7 @@
 	pixel_x = -6
 	},
 /obj/structure/sign/poster/contraband/syndiemoth{
-	pixel_x = -32;
-	desc = "A Syndicate-commissioned poster that uses Syndie Moth(TM?) to tell the viewer to keep the nuclear authentication disk unsecured. It's signed by 'AspEv'."
+	pixel_x = -32
 	},
 /obj/item/toy/balloon/syndicate,
 /obj/effect/turf_decal/techfloor/orange{
@@ -6639,9 +6599,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
 "LX" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 4
-	},
+/obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -6695,15 +6653,6 @@
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
-"Mr" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 6;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/hallway/starboard)
 "Mw" = (
 /obj/effect/turf_decal/industrial/caution/red,
 /obj/effect/decal/cleanable/shreds{
@@ -6875,9 +6824,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
+/obj/machinery/power/smes/shuttle/precharged,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -7415,9 +7362,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
+/obj/machinery/power/smes/shuttle/precharged,
 /obj/machinery/door/poddoor/shutters{
 	id = "twinkle_engines";
 	dir = 4
@@ -7961,15 +7906,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
-"TH" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 9;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/crew/canteen)
 "TI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8404,15 +8340,6 @@
 	rad_insulation = 0
 	},
 /area/ship/crew/cryo)
-"We" = (
-/obj/machinery/porta_turret/ship/syndicate/heavy{
-	dir = 10;
-	id = "twink_grid"
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
-	rad_insulation = 0
-	},
-/area/ship/security)
 "Wj" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
@@ -8843,7 +8770,6 @@
 /area/ship/bridge)
 "YI" = (
 /obj/structure/sign/poster/contraband/m90{
-	icon_state = "poster-m90";
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -9122,7 +9048,7 @@ mp
 mp
 mp
 mp
-ms
+FR
 ae
 LX
 FR
@@ -9142,7 +9068,7 @@ FR
 FR
 LX
 ae
-iX
+FR
 mp
 mp
 mp
@@ -9641,7 +9567,7 @@ mp
 mp
 "}
 (17,1,1) = {"
-TH
+xj
 xj
 xj
 xj
@@ -9673,7 +9599,7 @@ kT
 Bj
 Bj
 Bj
-We
+Bj
 "}
 (18,1,1) = {"
 xj
@@ -10380,7 +10306,7 @@ mp
 mp
 mp
 mp
-vd
+NE
 NE
 NE
 NE
@@ -10404,7 +10330,7 @@ lx
 xB
 xB
 xB
-Mr
+xB
 mp
 mp
 mp

--- a/code/modules/ruins/jungleplanet_ruin_code/airbase.dm
+++ b/code/modules/ruins/jungleplanet_ruin_code/airbase.dm
@@ -30,9 +30,3 @@
 		/obj/item/stack/sheet/metal/five = 10,
 		/obj/item/stack/sheet/plasteel/five = 30,
 	)
-
-/obj/machinery/porta_turret/ship/syndicate/heavy/starport
-	faction = list(FACTION_SYNDICATE, "turret")
-	turret_flags = TURRET_FLAG_HOSTILE
-	req_ship_access = FALSE
-	turret_respects_id = FALSE


### PR DESCRIPTION
puts heavy ramzi turrets on the syndicate airbase because the turrets they were previously subtyped off don't exist any more.

## Changelog

:cl:
fix: the syndicate coalition has retroactively installed the correct turrets on their old abandoned airbase.
/:cl:

