### PR TITLE
Decreases Drying Time on Concrete Floor

### DIFF
--- a/code/game/turfs/open/floor/conc_floor.dm
+++ b/code/game/turfs/open/floor/conc_floor.dm
@@ -13,7 +13,7 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
 	var/smash_time = 3 SECONDS
-	var/time_to_harden = 50 SECONDS
+	var/time_to_harden = 20 SECONDS
 	// fraction ranging from 0 to 1 -- 0 is fully soft, 1 is fully hardened
 	// don't change this in subtypes unless you want them to spawn in soft on maps
 	var/harden_lvl = 1
@@ -234,7 +234,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_FLOOR_HEXACRETE)
 
 	smash_time = 8 SECONDS
-	time_to_harden = 80 SECONDS
+	time_to_harden = 40 SECONDS
 	// so that you can remove the overlays
 	shape_types = list(/turf/open/floor/concrete/reinforced)
 


### PR DESCRIPTION
## About The Pull Request

Roughly halves the drying time for concrete and hexacrete floors. Walls are unchanged.

## Why It's Good For The Game

It's multiple stages and it takes a really, really long time compared to the walls. 

## Changelog

:cl:
balance: Concrete and Hexacrete floors take roughly half the time to proceed to the next drying stage
/:cl: