### PR TITLE
Reduces E11 spread by half + Black Market price decrease

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/weapons.dm
@@ -140,8 +140,8 @@
 	desc = "Look. I'll be straight with you. These guns are awful. But, they are cheap if you're that desperate."
 	item = /obj/item/gun/energy/e_gun/e11
 
-	price_min = 250
-	price_max = 750
+	price_min = 200
+	price_max = 400
 	stock = 5
 	availability_prob = 60
 

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
@@ -31,9 +31,9 @@
 
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/eoehoma)
 	ammo_x_offset = 0
-	spread = 60
-	spread_unwielded = 100
-	dual_wield_spread = 100
+	spread = 30
+	spread_unwielded = 50
+	dual_wield_spread = 50
 	shaded_charge = TRUE
 	manufacturer = MANUFACTURER_EOEHOMA
 

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
@@ -32,8 +32,8 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/eoehoma)
 	ammo_x_offset = 0
 	spread = 30
-	spread_unwielded = 50
-	dual_wield_spread = 50
+	spread_unwielded = 40
+	dual_wield_spread = 40
 	shaded_charge = TRUE
 	manufacturer = MANUFACTURER_EOEHOMA
 


### PR DESCRIPTION
## About The Pull Request

Reduces E11 spread from 60 to 30. Halved the dual wield and unwielded spread as well.

Also decreases the max cost for the E11 in the black market.

## Why It's Good For The Game

There was talk about making the E11 at least semi-usable instead of actually worthless. It is still the least accurate gun in the game by several magnitudes, but you can probably hit someone within a single tile of you.

## Changelog

:cl:
balance: Halved E11 spread and decreased the max cost for the E11 in the black market
/:cl: