### PR TITLE
Minor tweaks to the overmap inspect

### DIFF
--- a/code/modules/overmap/overmap_inspect.dm
+++ b/code/modules/overmap/overmap_inspect.dm
@@ -10,8 +10,8 @@
 
 /datum/overmap/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
-	//if(!check_rights(R_DEBUG))
-	//	return
+	if(!check_rights(R_DEBUG))
+		return
 	if(user.client)
 		var/datum/overmap_inspect/overmap_inspect = new(src, user)
 		overmap_inspect.ui_interact(user)

--- a/tgui/packages/tgui/interfaces/OvermapInspect/index.tsx
+++ b/tgui/packages/tgui/interfaces/OvermapInspect/index.tsx
@@ -9,6 +9,8 @@ import {
 } from '../../components';
 import { Window } from '../../layouts';
 
+import { decodeHtmlEntities } from 'common/string';
+
 export type OvermapData = {
   admin_rights: Boolean;
   ref: string;
@@ -54,7 +56,9 @@ export const OvermapInspect = (props, context) => {
               /Y
               <AnimatedNumber value={y} />
             </LabeledList.Item>
-            <LabeledList.Item label="Information">{desc}</LabeledList.Item>
+            <LabeledList.Item label="Information">
+              {decodeHtmlEntities(desc)}
+            </LabeledList.Item>
             {dockedTo.ref && (
               <LabeledList.Item label="Docked To">
                 <Box>
@@ -90,7 +94,7 @@ export const OvermapInspect = (props, context) => {
               </LabeledList.Item>
             )}
             {admin_rights ? (
-              <Box>
+              <>
                 <LabeledList.Item label="Active Missions">
                   {data.active_ruin_missions?.map((mission) => (
                     <Box key={mission.ref}>
@@ -119,7 +123,7 @@ export const OvermapInspect = (props, context) => {
                     </Box>
                   ))}
                 </LabeledList.Item>
-              </Box>
+              </>
             ) : null}
           </LabeledList>
         </Section>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Only admins can open it again, was really only meant as a stop gap measure. Ill implement a ship button for this behavior post om5.
Properly formatted, ideally prevents 
![image](https://github.com/user-attachments/assets/34a0959d-e46d-43ac-ae0f-a351089ac5a1)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It was never really meant to players, and not ugly ui is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Players go no longer open the overmap inspector, it was designed for admins
fix: Overmap inspect is now formated better and santizes desc html
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
