### PR TITLE
Buffs Woodsman's rate of fire

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -264,7 +264,7 @@ EMPTY_GUN_HELPER(automatic/m12_sporter/mod)
 	spread_unwielded = 20
 	recoil = 1.25
 	recoil_unwielded = 6
-	fire_delay = 0.75 SECONDS
+	fire_delay = 0.5 SECONDS
 	wield_delay = 1.15 SECONDS //a little longer and less wieldy than other DMRs
 
 	can_be_sawn_off = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Woodsman's fire delay has been buffed from 0.75 to 0.5 SEC. This is still slower than every other semi-automatic DMR, but it should mean Woodsman doesn't actually get beat out by the Illestren in rate of fire anymore.

## Why It's Good For The Game

the premium semi-automatic 8mm rifle should probably be actually better than the ancient dirt cheap bolt-action.

## Changelog

:cl:
balance: Buffed rate of fire on Woodsman hunting rifle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
