### PR TITLE
Removes the `central maint` area from the Scarab.

### DIFF
--- a/_maps/shuttles/independent/independent_scarab.dmm
+++ b/_maps/shuttles/independent/independent_scarab.dmm
@@ -73,7 +73,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/cargo)
 "aL" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -628,7 +628,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/cargo)
 "ir" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -751,9 +751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew)
-"jA" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/maintenance/central)
 "jC" = (
 /obj/machinery/conveyor{
 	id = "scarab_conveyor"
@@ -762,7 +759,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/cargo)
 "jG" = (
 /obj/machinery/power/smes/shuttle/precharged,
 /obj/structure/cable{
@@ -1739,9 +1736,6 @@
 	dir = 4
 	},
 /obj/structure/railing/corner,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "tL" = (
@@ -1797,7 +1791,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ship/maintenance/central)
+/area/ship/cargo)
 "uG" = (
 /obj/machinery/door/airlock/public/glass{
 	req_ship_access = 1
@@ -2404,9 +2398,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Cg" = (
@@ -2596,9 +2587,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
@@ -3417,12 +3405,8 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/green{
-	icon_state = "0-1"
-	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/cargo)
 "NS" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -3633,9 +3617,6 @@
 /area/ship/crew)
 "QE" = (
 /obj/effect/decal/cleanable/oil/streak,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "QJ" = (
@@ -4633,8 +4614,8 @@ Qb
 oJ
 rC
 iZ
-jA
-jA
+iZ
+iZ
 UB
 UB
 iV
@@ -4714,7 +4695,7 @@ kl
 jj
 IL
 iZ
-jA
+iZ
 uC
 UB
 MD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
It was needed so crates don't drop into the unreachable smeltery. However, crates now spawn in the hangar so it's no longer needed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Removed an unneeded area from the Scarab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
