### PR TITLE
Language Icons in Runechat

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -16,6 +16,8 @@
 #define CHAT_MESSAGE_MAX_LENGTH 110
 /// Maximum precision of float before rounding errors occur (in this context)
 #define CHAT_LAYER_Z_STEP 0.0001
+/// The dimensions to scale language icons in the message
+#define CHAT_LANGUAGE_ICON_SIZE 9
 /// The number of z-layer 'slices' usable by the chat message layering
 #define CHAT_LAYER_MAX_Z (CHAT_LAYER_MAX - CHAT_LAYER) / CHAT_LAYER_Z_STEP
 /// Macro from Lummox used to get height from a MeasureText proc
@@ -56,8 +58,9 @@
  * * owner - The mob that owns this overlay, only this mob will be able to view it
  * * extra_classes - Extra classes to apply to the span that holds the text
  * * lifespan - The lifespan of the message in deciseconds
+ * * message_language - The language of the message, passed to generate_image to display its icon
  */
-/datum/chatmessage/New(text, atom/target, mob/owner, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN)
+/datum/chatmessage/New(text, atom/target, mob/owner, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN, datum/language/message_language)
 	. = ..()
 	if (!istype(target))
 		CRASH("Invalid target given for chatmessage")
@@ -65,7 +68,7 @@
 		stack_trace("/datum/chatmessage created with [isnull(owner) ? "null" : "invalid"] mob owner")
 		qdel(src)
 		return
-	INVOKE_ASYNC(src, PROC_REF(generate_image), text, target, owner, extra_classes, lifespan)
+	INVOKE_ASYNC(src, PROC_REF(generate_image), text, target, owner, extra_classes, lifespan, message_language)
 
 /datum/chatmessage/Destroy()
 	if (owned_by)
@@ -95,8 +98,9 @@
  * * owner - The mob that owns this overlay, only this mob will be able to view it
  * * extra_classes - Extra classes to apply to the span that holds the text
  * * lifespan - The lifespan of the message in deciseconds
+ * * message_language - The language (if any) that the message is in
  */
-/datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
+/datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan, datum/language/message_language)
 	// Register client who owns this message
 	owned_by = owner.client
 	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, PROC_REF(on_parent_qdel))
@@ -136,6 +140,12 @@
 	else if("looc" in extra_classes)
 		var/image/r_icon = image('icons/UI_Icons/chat/chat_icons.dmi', icon_state = "looc")
 		text =  "\icon[r_icon]&nbsp;[text]"
+
+	var/datum/language/language = GLOB.language_datum_instances[message_language]
+	if(language?.display_icon(owner))
+		var/icon/l_icon = icon(language.icon, icon_state = language.icon_state)
+		l_icon.Scale(CHAT_LANGUAGE_ICON_SIZE, CHAT_LANGUAGE_ICON_SIZE)
+		text = "\icon[l_icon]&nbsp;[text]"
 
 	var/tgt_color = target.chat_color
 	if("looc" in extra_classes)
@@ -234,7 +244,7 @@
 	else if(runechat_flags & LOOC_MESSAGE)
 		new /datum/chatmessage(raw_message, speaker, src, list("looc", "italics"))
 	else
-		new /datum/chatmessage(lang_treat(speaker, message_language, raw_message, spans, null, TRUE), speaker, src, spans)
+		new /datum/chatmessage(lang_treat(speaker, message_language, raw_message, spans, null, TRUE), speaker, src, spans, message_language = message_language)
 
 
 // Tweak these defines to change the available color ranges


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Language icons are now prepended to runechat messages when they would also be shown in the chat log. The icons are scaled from their regular icons, with antialiasing.

![image](https://github.com/user-attachments/assets/05f37161-0048-4e18-a760-6a0fe10f8e3e) ![image](https://github.com/user-attachments/assets/98d81704-ee8c-445a-b94c-c591b06504ca)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to tell what language someone, or yourself, is speaking without needing to look at the chat log.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added language icons to runechat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
