### PR TITLE
Minor cargo fix

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -594,7 +594,7 @@
 	name = "CM-24 Surplus Stockpile Rifle"
 	desc = "Contains a higher-powered rifle chambered in 7.62x40 CLIP based on the SKM-24 platform, formerly the main service rifle of the CMM. This one has been pulled from reservist stockpiles."
 	cost = 5000
-	contains = list(/obj/item/storage/guncase/cm82)
+	contains = list(/obj/item/storage/guncase/cm24)
 	crate_name = "rifle crate"
 	faction = /datum/faction/clip
 	faction_discount = 0


### PR DESCRIPTION
## About The Pull Request

Swaps the delivered item in the CM-24 pack from the CM-82 to the correct path of CM-24

## Why It's Good For The Game

Gun? Just a really minor fix for CLIP factional so they get their SKM instead of whatever the 82 is

## Changelog

:cl:
fix: The CM-24 is now properly delivered when ordered
/:cl: