### PR TITLE
Fixes some turning in jank

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
@@ -2538,6 +2538,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/mission_poi/main/blackbox,
+/obj/machinery/blackbox_recorder,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface/lit,
 /area/ruin/unpowered/crashed_starwalker)
 "PH" = (

--- a/code/datums/ruins/beachplanet.dm
+++ b/code/datums/ruins/beachplanet.dm
@@ -60,6 +60,6 @@
 	faction = /datum/faction/independent
 	value = 1750
 	mission_limit = 1
-	required_item = /obj/item/storage/bottles/moonshine/sealed
+	setpiece_item = /obj/item/storage/bottles/moonshine/sealed
 	specific_item = FALSE
 	required_count = 3

--- a/code/modules/missions/dynamic/_dynamic.dm
+++ b/code/modules/missions/dynamic/_dynamic.dm
@@ -68,13 +68,12 @@
 	return
 
 /datum/mission/ruin/can_turn_in(atom/movable/item_to_check)
-	if(istype(required_item))
-		if(specific_item)
-			if(istype(item_to_check, required_item))
-				return TRUE
-		else
-			if(istype(item_to_check, required_item.type))
-				return TRUE
+	if(istype(required_item) && specific_item)
+		if(item_to_check == required_item)
+			return TRUE
+	else
+		if(istype(item_to_check, required_item.type) || istype(item_to_check, setpiece_item))
+			return TRUE
 
 /datum/mission/ruin/get_tgui_info(list/items_on_pad = list())
 	. = ..()

--- a/code/modules/missions/dynamic/_dynamic.dm
+++ b/code/modules/missions/dynamic/_dynamic.dm
@@ -72,7 +72,9 @@
 		if(item_to_check == required_item)
 			return TRUE
 	else
-		if(istype(item_to_check, required_item.type) || istype(item_to_check, setpiece_item))
+		if(istype(item_to_check, setpiece_item))
+			return TRUE
+		else if(istype(required_item) && istype(item_to_check, required_item.type))
 			return TRUE
 
 /datum/mission/ruin/get_tgui_info(list/items_on_pad = list())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Primarly, allows you to acctually turn in quests that are "non-specific" and prevent you from turning in generic items when its specific (IE qdeling yourself from a body recovery mission
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I was told to fix this a few days ago i was just very distracted
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: booze missions should work better now
fix: you cant turn yourself in for missions
fix: crashed starwalker now spawns its blackbox recorder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
