### PR TITLE
Furnaces are 10x as fast at refining

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -1,5 +1,5 @@
 /// Smelt amount per second
-#define SMELT_AMOUNT 5
+#define SMELT_AMOUNT 50
 
 /**********************Mineral processing unit console**************************/
 


### PR DESCRIPTION
## About The Pull Request

Furnaces are 10x as fast at refining materials.

## Why It's Good For The Game

I spoke with a few people and I was told by multiple people that it was genuinely faster to blow up the refinery and get their ore than it was to actually refine it, and multiple occasions people missed jump or all sorts of other things while they waited for minerals to refine. The UI is also abysmal to have to work with it for so long, even being close to notoriously buggy. This makes the smelteries a lot more usable.

## Changelog

:cl:
balance: You can now smelt 10x as fast at furnaces.
/:cl: