### PR TITLE
fix ore veins having null ores if they can pick more than they have access to

### DIFF
--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 			var/picked = pick_weight(ore_list)
 			vein_contents.Add(picked)
 			ore_list.Remove(picked)
-			if(!LAZYLEN(ore_list)
+			if(!LAZYLEN(ore_list))
 				break
 	GLOB.ore_veins += src
 

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -76,6 +76,8 @@ GLOBAL_LIST_EMPTY(ore_veins)
 			var/picked = pick_weight(ore_list)
 			vein_contents.Add(picked)
 			ore_list.Remove(picked)
+			if(!LAZYLEN(ore_list)
+				break
 	GLOB.ore_veins += src
 
 /obj/structure/vein/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

awawa

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: ore veins will no longer have extractable amounts of NOTHING
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
