### PR TITLE
ion thruster > ion thruster board for selling

### DIFF
--- a/code/modules/cargo/exports/scraping.dm
+++ b/code/modules/cargo/exports/scraping.dm
@@ -35,8 +35,8 @@
 
 /datum/export/thruster_ion
 	cost = 500
-	unit_name = "ion thruster"
-	export_types = list(/obj/machinery/power/shuttle/engine/electric)
+	unit_name = "ion thruster board"
+	export_types = list(/obj/item/circuitboard/machine/shuttle/engine/electric)
 
 //Computer Tablets and Parts
 /datum/export/modular_part


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ion thrusters aren't picked up by the selling pad because they are anchored and you can't unanchor them
also rebuilding them on the pad sounds tedious

## Changelog

:cl:
balance: ion thrusters are now sold as boards instead of the whole machine, and can actually be sold now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
