### PR TITLE
Smoke from chemical grenades is now transparent by default

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -229,8 +229,13 @@
 /////////////////////////////////////////////
 
 /obj/effect/particle_effect/smoke/chem
+
 	lifetime = 10
 
+/obj/effect/particle_effect/smoke/chem/thin
+	alpha = 100
+	opaque = FALSE
+	opaque = TRUE
 
 /obj/effect/particle_effect/smoke/chem/process(seconds_per_tick)
 	if(..())
@@ -320,6 +325,8 @@
 	if(S.amount)
 		S.spread_smoke() //calling process right now so the smoke immediately attacks mobs.
 
+/datum/effect_system/smoke_spread/chem/dense
+	effect_type = /obj/effect/particle_effect/smoke/chem/dense
 
 /////////////////////////////////////////////
 // Transparent smoke

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -325,8 +325,8 @@
 	if(S.amount)
 		S.spread_smoke() //calling process right now so the smoke immediately attacks mobs.
 
-/datum/effect_system/smoke_spread/chem/dense
-	effect_type = /obj/effect/particle_effect/smoke/chem/dense
+/datum/effect_system/smoke_spread/chem/thin
+	effect_type = /obj/effect/particle_effect/smoke/chem/thin
 
 /////////////////////////////////////////////
 // Transparent smoke

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -155,6 +155,14 @@
 	color = "#C8C8C8"
 	taste_description = "smoke"
 
+/datum/reagent/dense_smoke_powder
+	name = "Dense Smoke Powder"
+	description = "Makes a large cloud of thick smoke that can carry reagents."
+	category = "Pyrotechnics"
+	reagent_state = LIQUID
+	color = "#C8C8C8"
+	taste_description = "smoke"
+
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"
 	description = "Makes a deafening noise."

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -329,7 +329,7 @@
 	holder.remove_reagent(/datum/reagent/smoke_powder, created_volume*3)
 	var/smoke_radius = round(sqrt(created_volume * 1.5), 1)
 	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/smoke_spread/chem/S = new
+	var/datum/effect_system/smoke_spread/chem/thin/S = new
 	S.attach(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, TRUE, -3)
 	if(S)
@@ -344,6 +344,27 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	var/smoke_radius = round(sqrt(created_volume / 2), 1)
+	var/datum/effect_system/smoke_spread/chem/thin/S = new
+	S.attach(location)
+	playsound(location, 'sound/effects/smoke.ogg', 50, TRUE, -3)
+	if(S)
+		S.set_up(holder, smoke_radius, location, 0)
+		S.start()
+	if(holder && holder.my_atom)
+		holder.clear_reagents()
+
+/datum/chemical_reaction/dense_smoke_powder
+	results = list(/datum/reagent/dense_smoke_powder = 4)
+	required_reagents = list(/datum/reagent/smoke_powder = 3, /datum/reagent/carbon = 1)
+
+/datum/chemical_reaction/dense_smoke_powder_smoke
+	required_reagents = list(/datum/reagent/dense_smoke_powder = 1)
+	required_temp = 374
+	mob_react = FALSE
+
+/datum/chemical_reaction/dense_smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	var/smoke_radius = round(sqrt(created_volume / 2), 1)
 	var/datum/effect_system/smoke_spread/chem/S = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

easier to use smoke for moving reagents without completely making it impossible to see!!!
you can make thick smoke by adding carbon to mixed smoke powder (3 powder, 1 carbon = 4 dense smoke powder), which is as unteneable as it used to be

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Dense smoke powder reagent, functions the same as normal smoke but you can't see through it. 3 smoke powder + 1 carbon for 4 units
balance: chemical grenade smoke is by-default transparent enough to see through!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
