### PR TITLE
changes the frontie distillery turret to a spitter turret

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_distillery.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_distillery.dmm
@@ -765,7 +765,7 @@
 /area/ruin/rockplanet/distillery/office)
 "ir" = (
 /obj/structure/cable/yellow,
-/obj/machinery/porta_turret/ship/weak,
+/obj/machinery/porta_turret/ruin/frontiersmen,
 /turf/open/floor/plating/asteroid/rockplanet/cracked/lit,
 /area/ruin/rockplanet/distillery/office)
 "iy" = (


### PR DESCRIPTION
## About The Pull Request



## Why It's Good For The Game

also makes the turret not get killed by the guy at the front

## Changelog

:cl:
fix: Frontie distillery turret is now a spitter and is no longer destroyed by the fronties
/:cl: