### PR TITLE
Microtarget with barrel is no longer bulky

### DIFF
--- a/code/game/objects/items/attachments/m17_barrel.dm
+++ b/code/game/objects/items/attachments/m17_barrel.dm
@@ -4,7 +4,7 @@
 	icon_state = "m17_barrel"
 
 	slot = ATTACHMENT_SLOT_MUZZLE
-	spread_mod = -40
+	spread_mod = -30
 	size_mod = 1
 	pixel_shift_x = 1
 	pixel_shift_y = 1

--- a/code/game/objects/items/attachments/m17_barrel.dm
+++ b/code/game/objects/items/attachments/m17_barrel.dm
@@ -5,6 +5,6 @@
 
 	slot = ATTACHMENT_SLOT_MUZZLE
 	spread_mod = -40
-	size_mod = 2
+	size_mod = 1
 	pixel_shift_x = 1
 	pixel_shift_y = 1

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -27,8 +27,8 @@
 
 	w_class = WEIGHT_CLASS_SMALL
 
-	spread = 25
-	spread_unwielded = 45
+	spread = 15
+	spread_unwielded = 35
 	recoil = -2
 	recoil_unwielded = -2
 


### PR DESCRIPTION
## About The Pull Request

With barrel it is now normal instead of bulky. Still small with barrel off

Also decreases spread

## Why It's Good For The Game

You can put it in your holster I guess. Theres no way This Fucking Thing is the same size as a full-sized rifle.

With the barrel off it is also more inaccurate than the E11. It is still really bad, like Spitter levels of bad.

## Changelog

:cl:
balance: Microtarget with barrel is now Normal-sized instead of Bulky
balance: Decrease Microtarget spread
/:cl: