### PR TITLE
Do AI dream of electric sheep?

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -165,10 +165,9 @@
 		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
-	if(prob(20))
-		if(carbon_owner)
-			carbon_owner.handle_dreams()
-		if(prob(10) && owner.health > owner.crit_threshold)
+	if(prob(20) && carbon_owner?.client)
+		carbon_owner.handle_dreams()
+		if(prob(10) && carbon_owner.client && owner.health > owner.crit_threshold)
 			owner.emote("snore")
 
 /atom/movable/screen/alert/status_effect/asleep

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -167,7 +167,7 @@
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20) && carbon_owner?.client)
 		carbon_owner.handle_dreams()
-		if(prob(10) && carbon_owner.client && owner.health > owner.crit_threshold)
+		if(prob(10) && owner.health > owner.crit_threshold)
 			owner.emote("snore")
 
 /atom/movable/screen/alert/status_effect/asleep


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability for mobs without a client to dream and snore
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Message spam and background bullshit for handling dreams 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: AI no longer dream of electric sheep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
