### PR TITLE
Replace a statbrowser verb call with send message

### DIFF
--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -803,7 +803,7 @@ if (!current_tab) {
 }
 
 window.onload = function () {
-	Byond.command("Update-Verbs");
+	Byond.sendMessage("Update-Verbs");
 };
 
 Byond.subscribeTo('update_spells', function (payload) {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/pull/68151
fixes #3909, fixes #1011 thats an old one.

Seems like it completely fixes it for some people but fix-chat works first try for everyone else.
![image](https://github.com/user-attachments/assets/bda94b84-ff5b-4a5c-b1e2-37e81cd9d04b)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ive been told this fixes fancy chat not loading
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: removes a stray verb call from the status tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
