### PR TITLE
Stops players from getting a check_rights message from examining overmaps

### DIFF
--- a/code/modules/overmap/overmap_inspect.dm
+++ b/code/modules/overmap/overmap_inspect.dm
@@ -10,7 +10,7 @@
 
 /datum/overmap/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG, FALSE))
 		return
 	if(user.client)
 		var/datum/overmap_inspect/overmap_inspect = new(src, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
players should not see that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: players no longer get a admin message when you examine a overmap token
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
