### PR TITLE
Update cybersun_nimbus.dmm

### DIFF
--- a/_maps/shuttles/cybersun/cybersun_nimbus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_nimbus.dmm
@@ -2089,7 +2089,6 @@
 	dir = 1
 	},
 /obj/structure/curtain/cloth/fancy,
-/obj/structure/rack,
 /obj/structure/sign/poster/contraband/cybersun{
 	pixel_x = -28
 	},


### PR DESCRIPTION


:cl:
fix: removes a random rack event from the nimbus
/:cl:
