### PR TITLE
EHF Beacon doesn't need to be anchored to insert/remove ID

### DIFF
--- a/code/game/machinery/planet_beacon.dm
+++ b/code/game/machinery/planet_beacon.dm
@@ -51,7 +51,7 @@
 
 /obj/machinery/power/planet_beacon/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/card/id))
-		if(!inserted_id || state != BEACON_UNANCHORED)
+		if(!inserted_id)
 			inserted_id = item
 			item.forceMove(src)
 			update_icon()
@@ -129,13 +129,12 @@
 
 /obj/machinery/power/planet_beacon/AltClick(mob/user)
 	..()
-	if(state != BEACON_UNANCHORED)
-		if(inserted_id)
-			try_put_in_hand(inserted_id, user)
-			inserted_id = null
-			update_icon()
-			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-			return
+	if(inserted_id)
+		try_put_in_hand(inserted_id, user)
+		inserted_id = null
+		update_icon()
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+		return
 
 /obj/machinery/power/planet_beacon/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #4458

Removes a check for the EHF Beacon to be anchored before inserting/removing IDs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't know why I put that check in there in the first place, but you can reach your ID without needing to anchor the beacon now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: IDs can be inserted/removed from unanchoredEHFs beaconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
