### PR TITLE
Adds Pet to the Mudskipper

### DIFF
--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -159,6 +159,13 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
+/obj/structure/bed/dogbed{
+	name = "Kitty's Bed"
+	},
+/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck{
+	name = "Kitty";
+	faction = list("neutral")
+	},
 /turf/open/floor/carpet,
 /area/ship/crew)
 "dT" = (

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -162,7 +162,7 @@
 /obj/structure/bed/dogbed{
 	name = "Kitty's Bed"
 	},
-/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck{
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen{
 	name = "Kitty";
 	faction = list("neutral")
 	},

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -1,7 +1,7 @@
 //Gutlunches, passive mods that devour blood and gibs
 /mob/living/simple_animal/hostile/asteroid/gutlunch
 	name = "gutlunch"
-	desc = "A scavenger that eats raw meat, often found alongside ash walkers. Produces a thick, nutritious milk."
+	desc = "A scavenger that eats raw meat. Produces a thick, nutritious milk."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "gutlunch"
 	icon_living = "gutlunch"


### PR DESCRIPTION
## About The Pull Request

Adds guthen to the mudskipper, with a bed in the crew dorm. Her name is Kitty.

Also removes the Ashwalker reference in their description.

## Why It's Good For The Game

They're really cute. Like really cute. I also think it's funny to put the bottomfeeder detritivore on the bottomfeeder scrapper ship.

I remember hearing some concern about them being associated with ashwalker slop but I guarantee you 99% of tg players don't even know these guys exist. They're also really cute.

Like they're really really cute.

## Changelog

:cl:
add: Added guthen pet and bed to the Mudskipper in the crew dorm
/:cl: