### PR TITLE
Shotgun Ammo Adjustments

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -218,13 +218,13 @@
 /datum/supply_pack/ammo/blank_shells
 	name = "Blank Shell Crate"
 	desc = "Contains a box of blank shells."
-	cost = 220
+	cost = 110
 	contains = list(/obj/item/storage/box/ammo/a12g_blank)
 
 /datum/supply_pack/ammo/rubbershot
 	name = "Rubbershot Crate"
 	desc = "Contains a box of 32 12 gauge rubbershot shells. Perfect for crowd control and training."
-	cost = 520
+	cost = 300
 	contains = list(/obj/item/storage/box/ammo/a12g_rubbershot)
 
 /datum/supply_pack/ammo/techshells

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -206,7 +206,7 @@
 /datum/supply_pack/ammo/buckshot
 	name = "Buckshot Crate"
 	desc = "Contains a box of 32 buckshot shells for use in lethal persuasion."
-	cost = 520 //6.4 ammo efficiency at 104 damage. Yes we are counting point blank.
+	cost = 350
 	contains = list(/obj/item/storage/box/ammo/a12g_buckshot)
 
 /datum/supply_pack/ammo/slugs

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -224,7 +224,7 @@
 /datum/supply_pack/ammo/rubbershot
 	name = "Rubbershot Crate"
 	desc = "Contains a box of 32 12 gauge rubbershot shells. Perfect for crowd control and training."
-	cost = 300
+	cost = 350
 	contains = list(/obj/item/storage/box/ammo/a12g_rubbershot)
 
 /datum/supply_pack/ammo/techshells

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -60,8 +60,8 @@
 	custom_materials = list(/datum/material/iron=250)
 
 /obj/item/ammo_casing/shotgun/improvised
-	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	name = "surplus buckshot shell"
+	desc = "A makeshift shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvised"
 	projectile_type = /obj/projectile/bullet/pellet/improvised
 	custom_materials = list(/datum/material/iron=250)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/slug
 	name = "12g shotgun slug"
 	damage = 40
-	armour_penetration = -10
+	armour_penetration = 0
 	speed = BULLET_SPEED_SHOTGUN
 	bullet_identifier = "large slug"
 
@@ -72,7 +72,7 @@
 	var/ap_dropoff_cutoff = -50
 
 	icon_state = "pellet"
-	armour_penetration = -30
+	armour_penetration = -20
 	speed = BULLET_SPEED_SHOTGUN
 	bullet_identifier = "pellet"
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -72,7 +72,7 @@
 	var/ap_dropoff_cutoff = -50
 
 	icon_state = "pellet"
-	armour_penetration = -20
+	armour_penetration = -30
 	speed = BULLET_SPEED_SHOTGUN
 	bullet_identifier = "pellet"
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -69,10 +69,10 @@
 	var/tile_dropoff_stamina = 1.5 //As above
 
 	var/ap_dropoff = 5
-	var/ap_dropoff_cutoff = -50
+	var/ap_dropoff_cutoff = -35
 
 	icon_state = "pellet"
-	armour_penetration = -30
+	armour_penetration = -20
 	speed = BULLET_SPEED_SHOTGUN
 	bullet_identifier = "pellet"
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -904,7 +904,7 @@
 	name = "surplus buckshot"
 	id = "buckshot-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 2500)
+	materials = list(/datum/material/iron = 5000)
 	build_path = /obj/item/ammo_casing/shotgun/improvised
 	category = list("initial", "Security", "Ammo")
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -900,6 +900,14 @@
 	build_path = /obj/item/storage/box/ammo/c556mm_surplus
 	category = list("initial", "Security", "Ammo")
 
+/datum/design/buckshot_surplus
+	name = "surplus buckshot"
+	id = "buckshot-surplus"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 2500)
+	build_path = /obj/item/ammo_casing/shotgun/improvised
+	category = list("initial", "Security", "Ammo")
+
 /datum/design/ammo_can
 	name = "Ammo Can"
 	id = "ammo-can"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Buckshot costs 350 from 520, a bit more expensive than a rifle round.
Rubbershot now costs 350 from 520
Shotgun blanks cost 110 from 220.
Shotgun slugs are now armor neutral.
Improvised shotgun ammo can now be printed in the autolathe directly for 5000 cm^3 of metal per casing. (2 sheets and a half)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Buckshot is currently overpriced and does not feel great to use for the cost. It's based around the ideal situation of pointblank against an unarmored target. Against fauna, that's fine. Against opponents with guns, that's becomes much less feasible as they tend to be armored (simple mob or player) and the increasing lethality of other rounds like rifles makes moving into close range much more dangerous. I feel it's much more reasonable for them to be priced on par with rifle rounds like 8x50 and other specialist ammo.

Reduces the cost of blanks as well, because I don't think it's reasonable for them to cost almost as much as actual ammo.

Makes slugs AP neutral to reflect the fact the desc says they're supposed to have better penetration.

Makes improvised shotgun ammo autolathe printable for QoL. You need an autolathe anyways to make cable coil for improvised buckshot, so it makes things a bit more efficient.
## Changelog

:cl:
add: Improvised buckshot can be autolathe printed
balance: buckshot costs 350.
balance: Rubbershot costs 350
balance:  Blanks costs 110.
balance: Shotgun slugs have 0 AP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
