### PR TITLE
Frontiersman heavies use slugs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -217,7 +217,7 @@
 	projectilesound = 'sound/weapons/gun/hmg/shredder.ogg'
 	rapid = 5
 	rapid_fire_delay = 2
-	casingtype = /obj/item/ammo_casing/shotgun/buckshot
+	casingtype = /obj/item/ammo_casing/shotgun
 	r_hand = /obj/item/gun/ballistic/automatic/hmg/shredder
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/ranged/trooper/heavy
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes frontiersman heavies quite a bit more threatening- and more true to their weapon's supposed role as a "heavy machine gun"- by firing slugs instead of buckshot.

## Why It's Good For The Game

shredder was always intended to do this; makes for a much more intimidating encounter that isn't countered as easily by the intended counter to buckshot (medium armor)

## Changelog

:cl:
balance: Frontiersman heavies now use slugs in their Shredders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
