### PR TITLE
Removes Landmines from most planetgen (for real)

### DIFF
--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -151,7 +151,6 @@
 		/obj/structure/flora/ausbushes/ywflowers/hell = 1,
 		/obj/structure/flora/ausbushes/grassybush/hell = 4,
 		/obj/structure/flora/firebush = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	flora_spawn_chance = 15
 

--- a/code/datums/mapgen/planetary/RockGenerator.dm
+++ b/code/datums/mapgen/planetary/RockGenerator.dm
@@ -101,7 +101,6 @@
 		/obj/structure/flora/tree/cactus = 8,
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/ash/garden/arid = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 	mob_spawn_list = list(
@@ -136,7 +135,6 @@
 		/obj/structure/flora/ash/cacti = 2,
 		/obj/structure/flora/grass/rockplanet/dead = 8,
 		/obj/structure/flora/ash/garden/arid = 1,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/cave/rock
@@ -148,7 +146,6 @@
 		/obj/structure/flora/rock/pile/rockplanet = 8,
 		/obj/structure/flora/ash/fern = 4,
 		/obj/structure/flora/ash/puce = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	feature_spawn_chance = 0.5
 	feature_spawn_list = list(

--- a/code/datums/mapgen/planetary/SnowGenerator.dm
+++ b/code/datums/mapgen/planetary/SnowGenerator.dm
@@ -140,7 +140,6 @@
 		/obj/structure/flora/ausbushes/ppflowers = 2,
 		/obj/structure/flora/ausbushes/lavendergrass = 2,
 		/obj/structure/flora/ash/garden/frigid = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 
 /datum/biome/snow/forest
@@ -244,7 +243,6 @@
 		/obj/structure/flora/ash/stem_shroom = 2,
 		/obj/structure/flora/ash/puce = 2,
 		/obj/structure/flora/ash/garden/frigid = 2,
-		/obj/item/mine/pressure/explosive/rusty/live = 1,
 	)
 	closed_turf_types = list(
 		/turf/closed/mineral/random/snow = 1


### PR DESCRIPTION
## About The Pull Request

Says on the tin (radworlds still have them)

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/8dd02328-70be-48e4-9611-f664e8ee941e)

Pretty sure the pr that decreased the spawn ended up just putting them in more places. I still don't think dynamic mission bounty contracts justifies keeping them as planetgen if they keep spewing out like this. You can go to a waste world if you really want the trickle pay of landmine defusal when they're a 50% chance to explode

## Changelog

:cl:
balance: Landmine bounties have depleted landmine spawns on all but wasteworlds, entirely. For real, this time.
/:cl: