### PR TITLE
Removes/locks behind SRM remaining tribal weapon crafting recipes.

### DIFF
--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -261,9 +261,20 @@
 
 /datum/crafting_recipe/bonespear
 	name = "Bone Spear"
+	always_availible = FALSE
 	result = /obj/item/melee/spear/bone
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/sinew = 1)
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/boneaxe
+	name = "Bone Axe"
+	always_availible = FALSE
+	result = /obj/item/melee/axe/bone
+	time = 50
+	reqs = list(/obj/item/stack/sheet/bone = 6,
+				/obj/item/stack/sheet/sinew = 3)
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -259,6 +259,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/* Kept for SRM use */
 /datum/crafting_recipe/bonespear
 	name = "Bone Spear"
 	always_availible = FALSE

--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -267,21 +267,3 @@
 				/obj/item/stack/sheet/sinew = 1)
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
-
-/datum/crafting_recipe/boneaxe
-	name = "Bone Axe"
-	result = /obj/item/melee/axe/bone
-	time = 50
-	reqs = list(/obj/item/stack/sheet/bone = 6,
-				/obj/item/stack/sheet/sinew = 3)
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
-/datum/crafting_recipe/bonesword
-	name = "Bone Sword"
-	result = /obj/item/melee/sword/bone
-	time = 40
-	reqs = list(/obj/item/stack/sheet/bone = 3,
-				/obj/item/stack/sheet/sinew = 2)
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON

--- a/code/modules/clothing/outfits/factions/roumain.dm
+++ b/code/modules/clothing/outfits/factions/roumain.dm
@@ -10,6 +10,12 @@
 	if(visualsOnly)
 		return
 	H.faction |= list(FACTION_PLAYER_ROUMAIN)
+	var/list/crafting_recipe_types = list(
+		/datum/crafting_recipe/bonespear,
+		/datum/crafting_recipe/boneaxe
+	)
+	for(var/crafting_recipe_type in crafting_recipe_types)
+		H.mind.teach_crafting_recipe(crafting_recipe_type)
 
 // Assistant
 

--- a/code/modules/clothing/outfits/factions/roumain.dm
+++ b/code/modules/clothing/outfits/factions/roumain.dm
@@ -14,8 +14,9 @@
 		/datum/crafting_recipe/bonespear,
 		/datum/crafting_recipe/boneaxe
 	)
-	for(var/crafting_recipe_type in crafting_recipe_types)
-		H.mind.teach_crafting_recipe(crafting_recipe_type)
+	if(H.mind)
+		for(var/crafting_recipe_type in crafting_recipe_types)
+			H.mind.teach_crafting_recipe(crafting_recipe_type)
 
 // Assistant
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I kept the Sword, the Axe and the Spear in #3296, because there were no other melee weapons available. I think the machettes and combat knives that are now in cargo satisfy it, so I am:
- Removing the bone sword.
- Locking the bone spear and the bone axe behind being an SRM role
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
del: Bone axe and bone sword are no longer craftable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
