### PR TITLE
Makes the crew percentage not 0

### DIFF
--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -465,7 +465,7 @@ SUBSYSTEM_DEF(overmap)
 	var/counted_ships = 0
 	for(var/datum/overmap/ship/controlled/ship_datum in controlled_ships)
 		var/slot_count = 0
-		if(!ship_datum.source_template || ship_datum.source_template.category != "subshuttles")
+		if(!ship_datum.source_template || ship_datum.source_template.category == "subshuttles")
 			continue
 		for(var/job_slot in ship_datum.source_template.job_slots)
 			slot_count += ship_datum.source_template.job_slots[job_slot]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make Auto shop locking skip if its a SHUTTLE. not if its anything BUT a shuttle.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes auto ship locking acctually work
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: ship locking works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
