### PR TITLE
Indie deckhand outfit tweaks

### DIFF
--- a/_maps/configs/independent_corona.json
+++ b/_maps/configs/independent_corona.json
@@ -28,7 +28,7 @@
 			"slots": 1
 		},
 		"Deckhand": {
-			"outfit": "/datum/outfit/job/independent/assistant",
+			"outfit": "/datum/outfit/job/independent/assistant/fancy",
 			"slots": 2
 		}
 	},

--- a/_maps/configs/independent_falmouth.json
+++ b/_maps/configs/independent_falmouth.json
@@ -35,7 +35,7 @@
 			"slots": 1
 		},
 		"Deckhand": {
-			"outfit": "/datum/outfit/job/independent/assistant",
+			"outfit": "/datum/outfit/job/independent/assistant/cheap",
 			"slots": 2
 		}
 	},

--- a/_maps/configs/independent_junker.json
+++ b/_maps/configs/independent_junker.json
@@ -17,7 +17,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Assistant": {
-			"outfit": "/datum/outfit/job/independent/assistant/cheap",
+			"outfit": "/datum/outfit/job/assistant",
 			"slots": 4
 		}
 	},

--- a/_maps/configs/independent_junker.json
+++ b/_maps/configs/independent_junker.json
@@ -17,7 +17,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Assistant": {
-			"outfit": "/datum/outfit/job/assistant",
+			"outfit": "/datum/outfit/job/assistant/cheap",
 			"slots": 4
 		}
 	},

--- a/_maps/configs/independent_junker.json
+++ b/_maps/configs/independent_junker.json
@@ -17,7 +17,7 @@
 	"limit": 1,
 	"job_slots": {
 		"Assistant": {
-			"outfit": "/datum/outfit/job/assistant/cheap",
+			"outfit": "/datum/outfit/job/independent/assistant/cheap",
 			"slots": 4
 		}
 	},

--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -32,7 +32,7 @@
 			"slots": 1
 		},
 		"Deckhand": {
-			"outfit": "/datum/outfit/job/independent/assistant",
+			"outfit": "/datum/outfit/job/independent/assistant/cheap",
 			"slots": 1
 		}
 	},

--- a/_maps/configs/independent_shetland.json
+++ b/_maps/configs/independent_shetland.json
@@ -44,7 +44,7 @@
 			"slots": 1
 		},
 		"Deckhand": {
-			"outfit": "/datum/outfit/job/independent/assistant",
+			"outfit": "/datum/outfit/job/independent/assistant/cheap",
 			"slots": 3
 		}
 	},

--- a/code/modules/clothing/outfits/factions/independent.dm
+++ b/code/modules/clothing/outfits/factions/independent.dm
@@ -13,6 +13,7 @@
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 
+	uniform = /obj/item/clothing/under/color/black
 	shoes = /obj/item/clothing/shoes/sneakers/black
 
 /datum/outfit/job/independent/assistant/waiter
@@ -26,6 +27,11 @@
 	l_pocket = /obj/item/lighter
 	r_pocket = /obj/item/reagent_containers/glass/rag
 
+/datum/outfit/job/independent/assistant/cheap //for Miskilamo ships
+	name = "Independent - Assistant (Low Budget)"
+
+	uniform = /obj/item/clothing/under/utility
+
 /datum/outfit/job/independent/assistant/waiter/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
@@ -33,7 +39,7 @@
 	var/obj/item/card/id/W = H.get_idcard()
 	W.access += list(ACCESS_KITCHEN)
 
-/datum/outfit/job/independent/assistant/fancy
+/datum/outfit/job/independent/assistant/fancy //for ISF ships
 	name = "Independent - Assistant (Fancy)"
 
 	shoes = /obj/item/clothing/shoes/laceup


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It always irked me that every deckhand spawns with `A somewhat uncomfortable suit designed to be as cheap as possible to manufacture.`

Now, instead, most indies start with a much more neutral black jumpsuit. The utility jumpsuit is, however, preserved for a `/cheap` variant that, similarly to how the Captain outfit does it, is to be used on Miskilamo ships.
Also, makes the Corona use the `/fancy` outfit added with the Ivory.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
add: Deckhands on non-Miskilamo ships now start with a black jumpsuit instead of a utility one. Corona deckhands also got fancier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
