### PR TITLE
industrial drills require class 4 veins again

### DIFF
--- a/code/modules/missions/dynamic/signaled.dm
+++ b/code/modules/missions/dynamic/signaled.dm
@@ -76,7 +76,7 @@
 /obj/machinery/drill/mission/ruin
 	name = "industrial grade mining drill"
 	desc = "A large scale laser drill. It's able to mine vast amounts of minerals from near-surface ore pockets, this one is designed for mining outposts."
-	mission_class = 3
+	mission_class = 4
 	num_wanted = 10
 
 /obj/item/drill_readout


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ruin drill and veins are meant to be class 4 as they pay out more and currently come with extra defenses for the main one I've seen ran.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unintended revert of original behavoir.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: industrial drills now require class 4 veins again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
