### PR TITLE
Removes redundent signal for ship moving

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_overmap.dm
+++ b/code/__DEFINES/dcs/signals/signals_overmap.dm
@@ -4,8 +4,6 @@
 #define COMSIG_OVERMAP_MOVED "overmap_moved"
 /// From overmap move_overmaps(): (datum/overmap, old_x, old_y)
 #define COMSIG_OVERMAP_MOVE_SYSTEMS "overmap_moved_systems"
-/// From overmap Move(): (datum/overmap)
-#define COMSIG_OVERMAP_MOVE_SELF "overmap_move_self"
 /// From overmap Dock(): (datum/overmap)
 #define COMSIG_OVERMAP_DOCK "overmap_dock"
 /// From overmap Undock(): (datum/overmap)

--- a/code/modules/overmap/_overmap_datum.dm
+++ b/code/modules/overmap/_overmap_datum.dm
@@ -196,7 +196,6 @@
 	// Updates the token with the new position.
 	token.abstract_move(OVERMAP_TOKEN_TURF(x, y, current_overmap))
 	SEND_SIGNAL(src, COMSIG_OVERMAP_MOVED, old_x, old_y)
-	SEND_SIGNAL(src, COMSIG_OVERMAP_MOVE_SELF, src)
 	return TRUE
 
 /**

--- a/code/modules/overmap/objects/jump_point.dm
+++ b/code/modules/overmap/objects/jump_point.dm
@@ -55,7 +55,7 @@
 		if(INTERACTION_OVERMAP_JUMPTO)
 			if(tgui_alert(user, "Do you want to bluespace jump to [destination.current_overmap.name]? Your ship will NOT be removed from the round and you will have to stay near [name] doing this.", "Jump Confirmation", list("Yes", "No")) != "Yes")
 				return
-			RegisterSignal(interactor, COMSIG_OVERMAP_MOVE_SELF, PROC_REF(ship_moved))
+			RegisterSignal(interactor, COMSIG_OVERMAP_MOVED, PROC_REF(ship_moved))
 			RegisterSignal(interactor, COMSIG_OVERMAP_MOVE_SYSTEMS, PROC_REF(ship_jumped))
 			SEND_SIGNAL(interactor, COMSIG_OVERMAP_CALIBRATE_JUMP, destination.current_overmap, destination.x, destination.y)
 
@@ -70,10 +70,10 @@
 		if(locate(interactor) in current_overmap.overmap_container[checked_coords["x"]][checked_coords["y"]])
 			return
 	SEND_SIGNAL(interactor, COMSIG_OVERMAP_CANCEL_JUMP)
-	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVE_SELF)
+	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVED)
 	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVE_SYSTEMS)
 
 
 /datum/overmap/jump_point/proc/ship_jumped(datum/overmap/interactor)
-	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVE_SELF)
+	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVED)
 	UnregisterSignal(interactor, COMSIG_OVERMAP_MOVE_SYSTEMS)

--- a/code/modules/overmap/ships/ship_datum.dm
+++ b/code/modules/overmap/ships/ship_datum.dm
@@ -40,10 +40,13 @@
 	///Is this ship hidden? If true we hide the ships name/class on the token.
 	var/hidden = FALSE
 
+	var/registered_to_docked = FALSE
+
 /datum/overmap/ship/Initialize(position, system_spawned_in, ...)
 	. = ..()
 	if(docked_to)
 		RegisterSignal(docked_to, COMSIG_OVERMAP_MOVED, PROC_REF(on_docked_to_moved))
+		registered_to_docked = TRUE
 
 /datum/overmap/ship/Destroy()
 	if(movement_callback_id)
@@ -52,11 +55,13 @@
 
 /datum/overmap/ship/complete_dock(datum/overmap/dock_target, datum/docking_ticket/ticket)
 	. = ..()
-	// override prevents runtime on controlled ship init due to docking after initializing at a position
-	RegisterSignal(dock_target, COMSIG_OVERMAP_MOVED, PROC_REF(on_docked_to_moved), override = TRUE)
+	if(!registered_to_docked)
+		RegisterSignal(dock_target, COMSIG_OVERMAP_MOVED, PROC_REF(on_docked_to_moved))
+		registered_to_docked = TRUE
 
 /datum/overmap/ship/complete_undock()
 	UnregisterSignal(docked_to, COMSIG_OVERMAP_MOVED)
+	registered_to_docked = FALSE
 	. = ..()
 
 /datum/overmap/ship/Undock(force = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes COSMIG_OVERMAP_MOVED_SELF as you can just register to COSMIG_OVERMAP_MOVED and it was not even being registered to itself, a small fix to ships to prevent them double registering to there docked target

Tested local and docking, jumping, and canceling jump all work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
you should not have to signals that do the same thing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: Removes redundent signal for ship moving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
