### PR TITLE
Gives some enemies guaranteed drops on their guns

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
@@ -491,7 +491,9 @@
 /area/ruin/powered)
 "PQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/mob/living/simple_animal/hostile/human/frontier/ranged/trooper,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper{
+	weapon_drop_chance = 100
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/powered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
@@ -2361,7 +2361,8 @@
 	on_aggro_say = list("I'll kill all you Ramzi scum! COME AND GET SOME!", "I'll kill every last one of you Ramzi bastards!", "Finally got the nerve to finish me off you scum sucking Ramzi assholes...  YOU WON'T GET ME TOO YOU BASTARDS!!");
 	speak_emote = list("rants","screams","sobs");
 	verb_exclaim = "rants";
-	verb_yell = "rants"
+	verb_yell = "rants";
+	weapon_drop_chance = 100
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/carpet/blue,
@@ -2537,7 +2538,7 @@
 /area/ruin/lavaland/factory/warehouse)
 "yq" = (
 /obj/structure/displaycase/noalert{
-	start_showpiece_type = /obj/item/gun/energy/e_gun/hades
+	open = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/ruin/lavaland/factory/manager_office)

--- a/_maps/RandomRuins/RockRuins/rockplanet_distillery.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_distillery.dmm
@@ -4379,7 +4379,9 @@
 	pixel_y = 24;
 	specialfunctions = 4
 	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals{
+	weapon_drop_chance = 100
+	},
 /obj/effect/landmark/mission_poi/main/kill{
 	already_spawned = 1;
 	type_to_spawn = /mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some ruins relied on non-neutered enemies having a 100% drop chance for certain loot drops. This got removed when a mostly-global drop chance was applied to simplehumans making it significantly easier to have 20 of them only maybe drop 1 gun
Specifically:
The frontie commander in distillery now drops their mauler 100% of the time so the magazines on the table are useful
The frontie shotgunner in abandoned village (remember that one? Me neither) now drops their shotgun 100% of the time so the slugs in the safe aren't just paperweights
The manager in wrecked factory now uses the hades that was in the display case, instead of having a second one they manifested out of sheer hatred for ramzi.

This is a COOL TRICK you can use to turn an enemy into a loot drop at the same time

## Why It's Good For The Game

My loot.....

## Changelog

:cl:
balance: certain enemies at the end of ruins are now significantly more likely to drop their guns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
