### PR TITLE
alloys cant be sold

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -30,6 +30,14 @@
 
 	return round(amount/MINERAL_MATERIAL_AMOUNT)
 
+/datum/export/material/applies_to(obj/O, apply_elastic = TRUE)
+	. = ..()
+	if(!isitem(O))
+		return FALSE
+	var/obj/item/I = O
+	if(length(I.custom_materials) > 1)
+		return FALSE
+
 // - Material exports.
 // Prices have been heavily nerfed from the original values; mining is boring, so it shouldn't be a good way to make money.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
if a sheet has more then one material it cannot be sold

https://github.com/user-attachments/assets/8bc274ee-d1c6-4f10-8638-a9f95208b2e8


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
prevents a very annoying issue where you sell an alloy and only recive the value of one of its materials. Autolathes can pull these apart very easily and the dang outpost dont want no dang premixed materials they can do that themselves
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: prevents you from selling material alloy sheets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
