### PR TITLE
Dynamic mission objectives can now be spawned in containers

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
@@ -77,7 +77,8 @@
 /obj/item/stock_parts/cell/gun/upgraded,
 /obj/structure/safe,
 /obj/effect/landmark/mission_poi/main{
-	type_to_spawn = /obj/item/documents/nanotrasen
+	type_to_spawn = /obj/item/documents/nanotrasen;
+	spawn_in_containter = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/ruin/lavaland/factory/manager_office)

--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -6726,7 +6726,8 @@
 /obj/effect/mob_spawn/human/corpse/pgf/captain,
 /obj/item/storage/belt/sabre/pgf,
 /obj/effect/landmark/mission_poi/main{
-	already_spawned = 1
+	already_spawned = 1;
+	spawn_in_containter = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/space/pgf_wreck/cargo)

--- a/code/modules/missions/landmark.dm
+++ b/code/modules/missions/landmark.dm
@@ -17,7 +17,7 @@
 	var/mission_index = 1
 	///Prefered over the passed one, used for varediting primarly.
 	var/type_to_spawn
-	///checks for containters on the turf for this to put into. For if we haven't already spawned the thing.
+	///checks for containters on the turf for this to put into, or if prespawned check container for the object
 	var/spawn_in_containter = FALSE
 
 
@@ -72,7 +72,12 @@
 		if(istype(prespawned_item, type_to_spawn))
 			return prespawned_item
 	for(var/atom/movable/item_in_poi as anything in get_turf(src))
-		if(istype(item_in_poi, type_to_spawn))
+		if(spawn_in_containter)
+			if(is_type_in_list(item_in_poi, VALID_POI_CONTAINERS))
+				for(var/atom/movable/item_in_container as anything in item_in_poi.contents)
+					if(istype(item_in_container, type_to_spawn))
+						return item_in_container
+		else if(istype(item_in_poi, type_to_spawn))
 			return item_in_poi
 
 /obj/effect/landmark/mission_poi/proc/get_container()

--- a/code/modules/missions/landmark.dm
+++ b/code/modules/missions/landmark.dm
@@ -1,3 +1,5 @@
+#define VALID_POI_CONTAINERS list(/obj/structure/closet,/obj/structure/safe,/obj/structure/cabinet)
+
 /obj/effect/landmark/mission_poi
 	name = "mission poi"
 	icon = 'icons/effects/mission_poi.dmi'
@@ -7,12 +9,17 @@
 	var/use_count = 1
 	///Assume the item we want is included in the map and we simple have to return it
 	var/already_spawned = FALSE
+	///if the object we're looking for is in a certain kind of container that we need to look for
+	var/object_container
 	///Grabbed as apart of late init to ensure that the item of intrest cant move
 	var/datum/weakref/prespawned_weakref
 	///Only needed if you have multipe missiosn that would otherwise use the same poi's
 	var/mission_index = 1
 	///Prefered over the passed one, used for varediting primarly.
 	var/type_to_spawn
+	///checks for containters on the turf for this to put into. For if we haven't already spawned the thing.
+	var/spawn_in_containter = FALSE
+
 
 /obj/effect/landmark/mission_poi/Initialize(mapload)
 	. = ..()
@@ -45,7 +52,13 @@
 		item_of_interest = search_poi()
 		if(!item_of_interest)
 			CRASH("[src] is meant to have its item prespawned but could not find it on its tile.")
-	else //Spawn the item
+	else if(spawn_in_containter)//Spawn the item
+		var/poi_container = get_container()
+		if(poi_container)
+			item_of_interest = new type_to_spawn(poi_container)
+		else
+			CRASH("[src] is meant to have a container to be spawn inside but could not find one on its tile.")
+	else
 		item_of_interest = new type_to_spawn(loc)
 	// We dont have an item to return
 	if(!istype(item_of_interest))
@@ -61,6 +74,11 @@
 	for(var/atom/movable/item_in_poi as anything in get_turf(src))
 		if(istype(item_in_poi, type_to_spawn))
 			return item_in_poi
+
+/obj/effect/landmark/mission_poi/proc/get_container()
+	for(var/atom/movable/container as anything in get_turf(src))
+		if(is_type_in_list(container,VALID_POI_CONTAINERS))
+			return container
 
 /obj/effect/landmark/mission_poi/main
 	name = "mission focus"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title.

Dynamic mission landmarks can now be set to spawn their items inside containers(or be marked a pre-existing one if already spawned in a container)

Fixes the ruin mission on Wrecked Factory and Scrap Station.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Having your secret documents spawn on top of the locked safe is bad I think.

## Changelog

:cl:
add: Dynamic mission objectives can now properly start inside containers
fix: Wrecked Factory and Scrapstation retrieval missions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
