### PR TITLE
Exosuit radio fix

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -16,6 +16,9 @@
 #define MODE_L_HAND "left hand"
 #define MODE_KEY_L_HAND "l"
 
+#define MODE_EXOSUIT "exosuit"
+#define MODE_KEY_EXOSUIT "z"
+
 #define MODE_INTERCOM "intercom"
 #define MODE_KEY_INTERCOM "i"
 #define MODE_TOKEN_INTERCOM ":i"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -140,6 +140,7 @@
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
 
 /obj/item/radio/mech //this has to go somewhere
+	canhear_range = 0
 
 /obj/mecha/Initialize()
 	. = ..()
@@ -305,7 +306,6 @@
 	radio.name = "[src] radio"
 	radio.icon = icon
 	radio.icon_state = icon_state
-	radio.subspace_transmission = TRUE
 
 /obj/mecha/proc/can_use(mob/user)
 	if(user != occupant)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Location
 	MODE_KEY_R_HAND = MODE_R_HAND,
 	MODE_KEY_L_HAND = MODE_L_HAND,
+	MODE_KEY_EXOSUIT = MODE_EXOSUIT,
 	MODE_KEY_INTERCOM = MODE_INTERCOM,
 
 	// Department
@@ -394,6 +395,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			for(var/obj/item/l_hand in get_held_items_for_side(LEFT_HANDS, all = TRUE))
 				if (l_hand)
 					return l_hand.talk_into(src, message, , spans, language, message_mods)
+				return ITALICS | REDUCE_RANGE
+
+		if(MODE_EXOSUIT)
+			var/obj/mecha/exo = get_atom_on_turf(src, /obj/mecha)
+			if(ismecha(exo) && exo.radio)
+				exo.radio.talk_into(src, message, , spans, language, message_mods)
 				return ITALICS | REDUCE_RANGE
 
 		if(MODE_INTERCOM)


### PR DESCRIPTION
## About The Pull Request

Fixes exosuit radios not working, and adds the ability to talk into them directly with .z

## Why It's Good For The Game

Fixes a long-standing oversight that makes exosuit radios unusable + minor QOL to not have to toggle the speaker every time you use them

## Changelog

:cl:
fix: Fixed exosuit radios being unusable
add: Exosuit radios can be talked into directly using .z
/:cl: