### PR TITLE
Atomizes Cargo Even Further

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -62,7 +62,7 @@
 
 /datum/supply_pack/ammo/c38
 	name = ".38 Ammo Boxes Crate"
-	desc = "Contains two 50 round ammo boxes for refilling .38 weapons."
+	desc = "Contains a 50 round ammo box for refilling .38 weapons."
 	cost = 125 //8 ammo efficiency at 20 damage
 	contains = list(/obj/item/storage/box/ammo/c38)
 	crate_name = "ammo crate"

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -63,9 +63,8 @@
 /datum/supply_pack/ammo/c38
 	name = ".38 Ammo Boxes Crate"
 	desc = "Contains two 50 round ammo boxes for refilling .38 weapons."
-	cost = 250 //8 ammo efficiency at 20 damage
-	contains = list(/obj/item/storage/box/ammo/c38,
-					/obj/item/storage/box/ammo/c38)
+	cost = 125 //8 ammo efficiency at 20 damage
+	contains = list(/obj/item/storage/box/ammo/c38)
 	crate_name = "ammo crate"
 
 /* 10x22mm */

--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -218,9 +218,8 @@
 /datum/supply_pack/civilian/noslipfloor
 	name = "High-traction Floor Tiles"
 	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floortiles!"
-	cost = 1000
-	contains = list(/obj/item/stack/tile/noslip/thirty,
-					/obj/item/stack/tile/noslip/thirty)
+	cost = 500
+	contains = list(/obj/item/stack/tile/noslip/thirty)
 	crate_name = "high-traction floor tiles crate"
 
 /datum/supply_pack/civilian/jukebox

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -22,10 +22,9 @@
 
 /datum/supply_pack/emergency/plasmaman_tank
 	name = "Phorid Internals Crate"
-	desc = "Contains two Phorid belt tanks, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
-	cost = 100
-	contains = list(/obj/item/tank/internals/plasmaman/belt/full,
-					/obj/item/tank/internals/plasmaman/belt/full)
+	desc = "Contains a Phorid belt tank, for when you just can't bear to refill a normal tank with plasma. Plasma canisters sold separately."
+	cost = 50
+	contains = list(/obj/item/tank/internals/plasmaman/belt/full)
 	crate_name = "phorid internals crate"
 
 /datum/supply_pack/emergency/plasmaman_suit
@@ -62,32 +61,24 @@
 
 /datum/supply_pack/emergency/radiation
 	name = "Radiation Protection Crate"
-	desc = "Survive nuclear wars and overclocked engines alike with two sets of radiation suits. Each set contains a helmet, suit, and Geiger counter. Comes with a glass of vodka and two Night of Fire commemorative shot glasses."
-	cost = 2500
+	desc = "Survive nuclear wars and overclocked engines alike with this radiation suit. Contains a helmet, suit, and Geiger counter. Comes with a glass of vodka and Night of Fire commemorative shot glass."
+	cost = 1250
 	contains = list(/obj/item/clothing/head/radiation,
-					/obj/item/clothing/head/radiation,
 					/obj/item/clothing/suit/radiation,
-					/obj/item/clothing/suit/radiation,
-					/obj/item/geiger_counter,
 					/obj/item/geiger_counter,
 					/obj/item/reagent_containers/food/drinks/bottle/vodka,
-					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative,
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
 
 /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
-	desc = "This crate holds 2 full bio suits, 2 pairs of latex gloves, and a pair of spaceacillin syringes. Offers excellent protection from diseases and acid attacks alike."
-	cost = 2500
+	desc = "This crate holds one full bio suit, a pair of latex gloves, a biohazard bag, and a spaceacillin syringe. Offers excellent protection from diseases and acid attacks alike."
+	cost = 1250
 	contains = list(/obj/item/clothing/head/bio_hood,
-					/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/suit/bio_suit,
-					/obj/item/clothing/suit/bio_suit,
-					/obj/item/clothing/gloves/color/latex,
 					/obj/item/clothing/gloves/color/latex,
 					/obj/item/storage/bag/bio,
-					/obj/item/reagent_containers/syringe/antiviral,
 					/obj/item/reagent_containers/syringe/antiviral)
 	crate_name = "bio suit crate"
 	crate_type = /obj/structure/closet/crate/science

--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -6,28 +6,22 @@
 
 /datum/supply_pack/exploration/lava
 	name = "Lava Exploration Kit"
-	desc = "Contains 60 lavaproof rods, two pocket extinguishers and goggles to protect yourself from the heat."
-	cost = 500
+	desc = "Contains 30 lavaproof rods, a pocket extinguisher, and goggles to protect yourself from the heat."
+	cost = 250
 	contains = list(
 		/obj/item/extinguisher/mini,
-		/obj/item/extinguisher/mini,
 		/obj/item/clothing/glasses/heat,
-		/obj/item/clothing/glasses/heat,
-		/obj/item/stack/rods/lava/thirty,
 		/obj/item/stack/rods/lava/thirty,
 	)
 	crate_name = "Lava Exploration Kit"
 
 /datum/supply_pack/exploration/ice
 	name = "Ice Exploration Kit"
-	desc = "Contains 2 sets of winter clothes and ice hiking boots, along with goggles to protect eyes from the cold."
-	cost = 500
+	desc = "Contains a set of winter clothes and ice hiking boots, along with goggles to protect eyes from the cold."
+	cost = 250
 	contains = list(
 		/obj/item/clothing/glasses/cold,
-		/obj/item/clothing/glasses/cold,
 		/obj/item/clothing/suit/hooded/wintercoat,
-		/obj/item/clothing/suit/hooded/wintercoat,
-		/obj/item/clothing/shoes/winterboots/ice_boots,
 		/obj/item/clothing/shoes/winterboots/ice_boots,
 	)
 	crate_name = "Ice Exploration Kit"
@@ -39,10 +33,9 @@
 
 /datum/supply_pack/exploration/lavaproof_rods
 	name ="Lavaproof Rods Crate"
-	desc = "Contains 60 lavaproof rods for safely traversing molten pits."
-	cost = 200
+	desc = "Contains 30 lavaproof rods for safely traversing molten pits."
+	cost = 100
 	contains = list(
-		/obj/item/stack/rods/lava/thirty,
 		/obj/item/stack/rods/lava/thirty,
 		)
 	crate_name = "Lavaproof Rod Crate"
@@ -89,12 +82,9 @@
 
 /datum/supply_pack/exploration/flares
 	name = "Flare Supply Pack"
-	desc = "Contains 4 boxes of flares (28 total)! Great for lighting things up."
-	cost = 100
+	desc = "Contains a box of flares (7 total)! Great for lighting things up."
+	cost = 25
 	contains = list(
-		/obj/item/storage/box/flares,
-		/obj/item/storage/box/flares,
-		/obj/item/storage/box/flares,
 		/obj/item/storage/box/flares,
 	)
 

--- a/code/modules/cargo/packs/fishing.dm
+++ b/code/modules/cargo/packs/fishing.dm
@@ -15,22 +15,16 @@
 
 /datum/supply_pack/fish/fishstasis
 	name = "Fish Stasis Kit Supply Crate"
-	desc = "Contains four stasis cases meant to keep fish alive during transportation."
-	cost = 1000
-	contains = list(/obj/item/storage/fish_case,
-					/obj/item/storage/fish_case,
-					/obj/item/storage/fish_case,
-					/obj/item/storage/fish_case)
+	desc = "Contains a stasis case meant to keep fish alive during transportation."
+	cost = 250
+	contains = list(/obj/item/storage/fish_case)
 	crate_name = "stasis case crate"
 
 /datum/supply_pack/fish/premiumworms
 	name = "High Quality Worm Pack"
 	desc = "A selection of the system's finest worms, guaranteed to lure in only the largest of fish."
-	cost = 1000
-	contains = list(/obj/item/bait_can/worm/premium,
-					/obj/item/bait_can/worm/premium,
-					/obj/item/bait_can/worm/premium,
-					/obj/item/bait_can/worm/premium)
+	cost = 250
+	contains = list(/obj/item/bait_can/worm/premium)
 	crate_name = "premium worm crate"
 
 /datum/supply_pack/fish/masterworkpole
@@ -52,9 +46,8 @@
 /datum/supply_pack/fish/fishinglines
 	name = "Fishing Line Pack"
 	desc = "Contains the necessary fishing lines for catching more exotic fish."
-	cost = 1000
-	contains = list(/obj/item/storage/box/fishing_lines,
-					/obj/item/storage/box/fishing_lines) //Comes with two boxes on account of these being more necessary than the hooks
+	cost = 500
+	contains = list(/obj/item/storage/box/fishing_lines)
 	crate_name = "fishing line crate"
 	crate_type = /obj/structure/closet/crate/wooden
 

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -39,7 +39,7 @@
 	name = "Ration Crate"
 	desc = "One standard issue ration pack. For your inner jarhead."
 	cost = 80
-	contains = list(/obj/effect/spawner/random/food_or_drink/ration,
+	contains = list(/obj/effect/spawner/random/food_or_drink/ration)
 	crate_name = "ration crate"
 	crate_type = /obj/structure/closet/crate
 

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -37,14 +37,9 @@
 
 /datum/supply_pack/food/ration
 	name = "Ration Crate"
-	desc = "6 standard issue rations. For your inner jarhead."
-	cost = 500
+	desc = "One standard issue ration pack. For your inner jarhead."
+	cost = 80
 	contains = list(/obj/effect/spawner/random/food_or_drink/ration,
-					/obj/effect/spawner/random/food_or_drink/ration,
-					/obj/effect/spawner/random/food_or_drink/ration,
-					/obj/effect/spawner/random/food_or_drink/ration,
-					/obj/effect/spawner/random/food_or_drink/ration,
-					/obj/effect/spawner/random/food_or_drink/ration)
 	crate_name = "ration crate"
 	crate_type = /obj/structure/closet/crate
 
@@ -185,11 +180,8 @@
 /datum/supply_pack/food/sugar
 	name = "Sugar Crate"
 	desc = "A crate with a few bags of sugar. Good for cake shops and amateur chemists."
-	cost = 150
-	contains = list(/obj/item/reagent_containers/condiment/sugar,
-					/obj/item/reagent_containers/condiment/sugar,
-					/obj/item/reagent_containers/condiment/sugar
-	)
+	cost = 50
+	contains = list(/obj/item/reagent_containers/condiment/sugar)
 	crate_name = "sugar crate"
 	crate_type = /obj/structure/closet/crate
 
@@ -245,14 +237,9 @@
 
 /datum/supply_pack/food/ethanol
 	name = "Ethanol Crate"
-	desc = "Five small bottles of ethanol for the aspiring botanist or amateur chemist."
-	cost = 500
-	contains = list(/obj/item/reagent_containers/glass/bottle/ethanol,
-					/obj/item/reagent_containers/glass/bottle/ethanol,
-					/obj/item/reagent_containers/glass/bottle/ethanol,
-					/obj/item/reagent_containers/glass/bottle/ethanol,
-					/obj/item/reagent_containers/glass/bottle/ethanol
-					)
+	desc = "Contains one small bottle of ethanol for the aspiring botanist or amateur chemist."
+	cost = 100
+	contains = list(/obj/item/reagent_containers/glass/bottle/ethanol)
 	crate_name = "gardening crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
@@ -312,11 +299,9 @@
 
 /datum/supply_pack/food/beekeeping_suits
 	name = "Beekeeper Suit Crate"
-	desc = "Bee business booming? Better be benevolent and boost botany by bestowing bi-Beekeeper-suits! Contains two beekeeper suits and matching headwear."
+	desc = "Bee business booming? Better be benevolent and boost botany by bestowing a bodacious-Beekeeper-suit! Contains one beekeeper suit and matching headwear."
 	cost = 500
 	contains = list(/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/suit/beekeeper_suit,
-					/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit)
 	crate_name = "beekeeper suit crate"
 	crate_type = /obj/structure/closet/crate/hydroponics

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -8,11 +8,9 @@
 
 /datum/supply_pack/machinery/lightbulbs
 	name = "Replacement Lights"
-	desc = "May the light of Aether shine upon this sector! Or at least, the light of forty two light tubes and twenty one light bulbs."
-	cost = 500
-	contains = list(/obj/item/storage/box/lights/mixed,
-					/obj/item/storage/box/lights/mixed,
-					/obj/item/storage/box/lights/mixed)
+	desc = "May the light of Aether shine upon this sector! Or at least, the light of fourteen light tubes and seven light bulbs."
+	cost = 100
+	contains = list(/obj/item/storage/box/lights/mixed)
 	crate_name = "replacement lights"
 	crate_type = /obj/structure/closet/crate
 
@@ -122,13 +120,9 @@
 
 /datum/supply_pack/machinery/power
 	name = "Power Cell Crate"
-	desc = "Looking for power overwhelming? Look no further. Contains five high-voltage power cells."
-	cost = 1500 //it should be a bit more expensive for a full ship recharge
-	contains = list(/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high)
+	desc = "Looking for power overwhelming? Look no further. Contains one high-voltage power cell."
+	cost = 300 //it should be a bit more expensive for a full ship recharge
+	contains = list(/obj/item/stock_parts/cell/high)
 	crate_name = "power cell crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -231,10 +225,9 @@
 
 /datum/supply_pack/machinery/breach_shield_gen
 	name = "Anti-breach Shield Projector Crate"
-	desc = "Hull breaches again? Say no more with the Nanotrasen Anti-Breach Shield Projector! Uses forcefield technology to keep the air in, and the space out. Contains two shield projectors."
-	cost = 2500
-	contains = list(/obj/machinery/shieldgen,
-					/obj/machinery/shieldgen)
+	desc = "Hull breaches again? Say no more with the Nanotrasen Anti-Breach Shield Projector! Uses forcefield technology to keep the air in, and the space out. Contains one shield projector."
+	cost = 1250
+	contains = list(/obj/machinery/shieldgen)
 	crate_name = "anti-breach shield projector crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	no_bundle = TRUE
@@ -373,22 +366,17 @@
 
 /datum/supply_pack/machinery/collector
 	name = "Radiation Collector Crate"
-	desc = "Contains three radiation collectors. Put that radiation to work on something other than your DNA!"
-	cost = 3000
-	contains = list(/obj/machinery/power/rad_collector,
-					/obj/machinery/power/rad_collector,
-					/obj/machinery/power/rad_collector)
+	desc = "Contains one radiation collector. Put that radiation to work on something other than your DNA!"
+	cost = 1000
+	contains = list(/obj/machinery/power/rad_collector)
 	crate_name = "collector crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/machinery/tesla_coils
 	name = "Tesla Coil Crate"
-	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation, this pack of four Tesla coils can do it all!"
-	cost = 2500
-	contains = list(/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil)
+	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation, this Tesla coil can do it all!"
+	cost = 625
+	contains = list(/obj/machinery/power/tesla_coil)
 	crate_name = "tesla coil crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -398,10 +386,9 @@
 
 /datum/supply_pack/machinery/emitter
 	name = "Emitter Crate"
-	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains two high-powered energy emitters."
-	cost = 3000
-	contains = list(/obj/machinery/power/emitter,
-					/obj/machinery/power/emitter)
+	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains one high-powered energy emitter."
+	cost = 1500
+	contains = list(/obj/machinery/power/emitter)
 	crate_name = "emitter crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -416,12 +403,9 @@
 
 /datum/supply_pack/machinery/grounding_rods
 	name = "Grounding Rod Crate"
-	desc = "Four grounding rods guaranteed to keep any uppity tesla's lightning under control."
-	cost = 1750
-	contains = list(/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod)
+	desc = "Contains one grounding rod guaranteed to keep any uppity tesla's lightning under control."
+	cost = 450
+	contains = list(/obj/machinery/power/grounding_rod)
 	crate_name = "grounding rod crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -46,7 +46,6 @@ Build Your Own Suit
 		/obj/item/mecha_parts/part/odysseus_head,
 		/obj/item/mecha_parts/part/odysseus_torso,
 		/obj/item/mecha_parts/part/odysseus_left_arm,
-		/obj/item/mecha_parts/part/odysseus_left_arm,
 		/obj/item/mecha_parts/part/odysseus_right_arm,
 		/obj/item/mecha_parts/part/odysseus_left_leg,
 		/obj/item/mecha_parts/part/odysseus_right_leg,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -303,7 +303,7 @@
 /datum/supply_pack/medical/vials/sal_vial
 	name = "SalGlu Vial Crate"
 	desc = "Contains one spare SalGlu Solution vial, for usage in a Hypospray."
-	cost = 600
+	cost = 300
 	contains = list(
 		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/salclu)
 	crate_name = "SalGlu vial crate"
@@ -311,7 +311,7 @@
 /datum/supply_pack/medical/vials/chit_vial
 	name = "Chitosan Vial Crate"
 	desc = "Contains one spare Chitosan vial, for usage in a Hypospray."
-	cost = 600
+	cost = 300
 	contains = list(
 		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/chitosan)
 	crate_name = "chitosan vial crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -214,12 +214,10 @@
 
 /datum/supply_pack/medical/vials/empty_vial
 	name = "Empty Vial Crate"
-	desc = "Contains 2 empty hypospray vials, for usage in a Hypospray."
+	desc = "Contains one empty hypospray vial, for usage in a Hypospray."
 	cost = 200
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/vial/small,
-		/obj/item/reagent_containers/glass/bottle/vial/small
-	)
+		/obj/item/reagent_containers/glass/bottle/vial/small)
 	crate_name = "empty vial crate"
 
 /datum/supply_pack/medical/vials/bica_vial
@@ -296,30 +294,24 @@
 
 /datum/supply_pack/medical/vials/erp_vial
 	name = "Radiation Purgant Vial Crate"
-	desc = "Contains 2 spare radiation purgant vials, for usage in a Hypospray."
-	cost = 600
+	desc = "Contains one spare radiation purgant vial, for usage in a Hypospray."
+	cost = 300
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/erp,
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/erp
-	)
+		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/erp)
 	crate_name = "radiation purgant vial crate"
 
 /datum/supply_pack/medical/vials/sal_vial
 	name = "SalGlu Vial Crate"
-	desc = "Contains 2 spare SalGlu Solution vials, for usage in a Hypospray."
+	desc = "Contains one spare SalGlu Solution vial, for usage in a Hypospray."
 	cost = 600
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/salclu,
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/salclu
-	)
+		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/salclu)
 	crate_name = "SalGlu vial crate"
 
 /datum/supply_pack/medical/vials/chit_vial
 	name = "Chitosan Vial Crate"
-	desc = "Contains 2 spare Chitosan vials, for usage in a Hypospray."
+	desc = "Contains one spare Chitosan vial, for usage in a Hypospray."
 	cost = 600
 	contains = list(
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/chitosan,
-		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/chitosan
-	)
+		/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/chitosan)
 	crate_name = "chitosan vial crate"

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -14,12 +14,9 @@
 
 /datum/supply_pack/sec_supply/securitybarriers
 	name = "Security Barrier Grenades"
-	desc = "Halt the opposition with four Security Barrier grenades."
-	contains = list(/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier)
-	cost = 500
+	desc = "Halt the opposition with one Security Barrier grenade."
+	contains = list(/obj/item/grenade/barrier)
+	cost = 125
 	crate_name = "security barriers crate"
 
 /datum/supply_pack/sec_supply/empty_sandbags
@@ -38,23 +35,23 @@
 
 /datum/supply_pack/sec_supply/flashbangs
 	name = "Flashbangs Crate"
-	desc = "Contains seven flashbangs for use in door breaching and riot control."
-	cost = 750
-	contains = list(/obj/item/storage/box/flashbangs)
+	desc = "Contains one flashbang for use in door breaching and riot control."
+	cost = 100
+	contains = list(/obj/item/grenade/flashbang)
 	crate_name = "flashbangs crate"
 
 /datum/supply_pack/sec_supply/smokebombs
-	name = "Smoke Grenades Crate"
-	desc = "Contains seven smoke grenades for screening unit movements and signalling."
-	cost = 500
-	contains = list(/obj/item/storage/box/smokebombs)
+	name = "Smoke Grenade Crate"
+	desc = "Contains one smoke grenade for screening unit movements and signaling."
+	cost = 70
+	contains = list(/obj/item/grenade/smokebomb)
 	crate_name = "smoke grenades crate"
 
 /datum/supply_pack/sec_supply/teargas
 	name = "Teargas Grenades Crate"
-	desc = "Contains seven teargas grenades for use in crowd dispersion and riot control."
-	cost = 750
-	contains = list(/obj/item/storage/box/teargas)
+	desc = "Contains one teargas grenade for use in crowd dispersion and riot control."
+	cost = 100
+	contains = list(/obj/item/grenade/chem_grenade/teargas)
 	crate_name = "teargas grenades crate"
 
 /datum/supply_pack/sec_supply/camera_console
@@ -129,29 +126,24 @@
 	crate_name = "riot shield crate"
 
 /datum/supply_pack/sec_supply/survknives
-	name = "Survival Knives Crate"
-	desc = "Contains three sharpened survival knives. Each knife guaranteed to fit snugly inside any galactic-standard boot."
-	cost = 350
-	contains = list(/obj/item/melee/knife/survival,
-					/obj/item/melee/knife/survival,
-					/obj/item/melee/knife/survival)
+	name = "Survival Knife Crate"
+	desc = "Contains one sharpened survival knife. Guaranteed to fit snugly inside any galactic-standard boot."
+	cost = 120
+	contains = list(/obj/item/melee/knife/survival)
 	crate_name = "survival knife crate"
 
 /datum/supply_pack/sec_supply/machete
 	name = "Stamped Steel Machete Crate"
-	desc = "Contains two mass produced machetes. A perfect choice for crews on a budget."
-	cost = 500
-	contains = list(/obj/item/melee/sword/mass,
-					/obj/item/melee/sword/mass)
+	desc = "Contains one mass produced machete. A perfect choice for crews on a budget."
+	cost = 250
+	contains = list(/obj/item/melee/sword/mass)
 	crate_name = "machete crate"
 
 /datum/supply_pack/sec_supply/combatknives
-	name = "Combat Knives Crate"
-	desc = "Contains three high quality combat knives. For the sharper, and meaner, crew."
-	cost = 1000
-	contains = list(/obj/item/melee/knife/combat,
-					/obj/item/melee/knife/combat,
-					/obj/item/melee/knife/combat)
+	name = "Combat Knife Crate"
+	desc = "Contains one high quality combat knife. For the sharper, and meaner, crew."
+	cost = 350
+	contains = list(/obj/item/melee/knife/combat)
 	crate_name = "combat knife crate"
 
 /datum/supply_pack/sec_supply/flamethrower
@@ -166,10 +158,9 @@
 
 /datum/supply_pack/sec_supply/frag_grenade
 	name = "Frag Grenade Crate"
-	desc = "Contains two fragmentation grenades. Better not let it go off in your hands."
-	cost = 500
-	contains = list(/obj/item/grenade/frag,
-					/obj/item/grenade/frag)
+	desc = "Contains one fragmentation grenade. Better not let it go off in your hands."
+	cost = 250
+	contains = list(/obj/item/grenade/frag)
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
@@ -195,12 +186,9 @@
 
 /datum/supply_pack/sec_supply/pepper_spray
 	name = "Pepper Spray Crate"
-	desc = "Contains four pepper spray cans, for self defense on a budget."
-	cost = 250
-	contains = list(/obj/item/reagent_containers/spray/pepper,
-					/obj/item/reagent_containers/spray/pepper,
-					/obj/item/reagent_containers/spray/pepper,
-					/obj/item/reagent_containers/spray/pepper)
+	desc = "Contains one pepper spray can, for self defense on a budget."
+	cost = 60
+	contains = list(/obj/item/reagent_containers/spray/pepper)
 	crate_name = "pepper spray crate"
 
 /*
@@ -209,9 +197,9 @@
 
 /datum/supply_pack/sec_supply/stingpack
 	name = "Stingbang Grenade Pack"
-	desc = "Contains five \"stingbang\" grenades, perfect for stopping riots and playing morally unthinkable pranks."
-	cost = 750
-	contains = list(/obj/item/storage/box/stingbangs)
+	desc = "Contains one \"stingbang\" grenade, perfect for stopping riots and playing morally unthinkable pranks."
+	cost = 150
+	contains = list(/obj/item/grenade/stingbang)
 	crate_name = "stingbang grenade pack crate"
 
 /datum/supply_pack/sec_supply/baton
@@ -223,12 +211,9 @@
 
 /datum/supply_pack/sec_supply/claymore
 	name = "C-10 Claymore Crate"
-	desc = "Four motion-activated directional mines, perfect for ambushing enemy infantry. Still debatably legal to sell!"
-	cost = 3000
+	desc = "Contains one motion-activated directional mine, perfect for ambushing enemy infantry. Still debatably legal to sell!"
+	cost = 750
 	contains = list(/obj/item/paper/fluff/claymore,
-					/obj/item/mine/directional/claymore,
-					/obj/item/mine/directional/claymore,
-					/obj/item/mine/directional/claymore,
 					/obj/item/mine/directional/claymore)
 	crate_name = "C-10 Claymore crate"
 

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -13,7 +13,7 @@
 	crate_name = "holster crate"
 
 /datum/supply_pack/sec_supply/securitybarriers
-	name = "Security Barrier Grenades"
+	name = "Security Barrier Grenade"
 	desc = "Halt the opposition with one Security Barrier grenade."
 	contains = list(/obj/item/grenade/barrier)
 	cost = 125
@@ -34,7 +34,7 @@
 	crate_name = "maintenance kit crate"
 
 /datum/supply_pack/sec_supply/flashbangs
-	name = "Flashbangs Crate"
+	name = "Flashbang Crate"
 	desc = "Contains one flashbang for use in door breaching and riot control."
 	cost = 100
 	contains = list(/obj/item/grenade/flashbang)
@@ -48,7 +48,7 @@
 	crate_name = "smoke grenades crate"
 
 /datum/supply_pack/sec_supply/teargas
-	name = "Teargas Grenades Crate"
+	name = "Teargas Grenade Crate"
 	desc = "Contains one teargas grenade for use in crowd dispersion and riot control."
 	cost = 100
 	contains = list(/obj/item/grenade/chem_grenade/teargas)
@@ -196,7 +196,7 @@
 */
 
 /datum/supply_pack/sec_supply/stingpack
-	name = "Stingbang Grenade Pack"
+	name = "Stingbang Grenade"
 	desc = "Contains one \"stingbang\" grenade, perfect for stopping riots and playing morally unthinkable pranks."
 	cost = 150
 	contains = list(/obj/item/grenade/stingbang)

--- a/code/modules/cargo/packs/spacesuits.dm
+++ b/code/modules/cargo/packs/spacesuits.dm
@@ -8,11 +8,9 @@
 
 /datum/supply_pack/spacesuits/spacesuit
 	name = "Space Suit Crate"
-	desc = "Contains two basic space suits. Although the technology is centuries old, it should protect you from the vacuum of space."
-	cost = 500 //changed the suit type to be the one without pockets, making it more consistent with the rest of the EVA suits available
+	desc = "Contains one basic space suit. Although the technology is centuries old, it should protect you from the vacuum of space."
+	cost = 250 //changed the suit type to be the one without pockets, making it more consistent with the rest of the EVA suits available
 	contains = list(/obj/item/clothing/suit/space/eva,
-					/obj/item/clothing/suit/space/eva,
-					/obj/item/clothing/head/helmet/space/eva,
 					/obj/item/clothing/head/helmet/space/eva)
 
 /datum/supply_pack/spacesuits/pilot_spacesuit

--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -31,12 +31,9 @@
 
 /datum/supply_pack/tools/engigear
 	name = "Engineering Gear Crate"
-	desc = "Contains three toolbelts and 2 sets of meson goggles."
-	cost = 750
+	desc = "Contains one toolbelt and a set of meson goggles."
+	cost = 250
 	contains = list(/obj/item/storage/belt/utility,
-					/obj/item/storage/belt/utility,
-					/obj/item/storage/belt/utility,
-					/obj/item/clothing/glasses/meson/engine,
 					/obj/item/clothing/glasses/meson/engine)
 	crate_name = "engineering gear crate"
 
@@ -71,14 +68,11 @@
 
 /datum/supply_pack/tools/mining
 	name = "Basic Mining Crate"
-	desc = "Contains two pickaxes, two ore bags, and two manual mining scanners."
-	cost = 500 //cheaper to send your legions to war (mining) (also you can just print all this asides the scanners so what's the point anyway)
+	desc = "Contains one miniature pickaxe, an ore bag, and a manual mining scanner."
+	cost = 250 //cheaper to send your legions to war (mining) (also you can just print all this asides the scanners so what's the point anyway)
 	contains = list(
-		/obj/item/pickaxe,
 		/obj/item/pickaxe/mini,
 		/obj/item/storage/bag/ore,
-		/obj/item/storage/bag/ore,
-		/obj/item/mining_scanner,
 		/obj/item/mining_scanner)
 	crate_name = "basic mining crate"
 	faction = /datum/faction/nt/ns_logi

--- a/code/modules/cargo/packs/trickwine.dm
+++ b/code/modules/cargo/packs/trickwine.dm
@@ -5,62 +5,32 @@
 	faction_locked = TRUE
 
 /datum/supply_pack/food/trickwine/ashwine
-	name = "4 bottles of vintage Ashwine"
-	desc = "Trickwines shipped directly from illestern factories. A good replacement for underequipped Roumain ships. Cheaper due to the ease of production and important in ritual."
-	cost = 1500
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine
-		)
+	name = "Bottle of vintage Ashwine"
+	desc = "Trickwine shipped directly from illestern factories. A good replacement for underequipped Roumain ships. Cheaper due to the ease of production and importance in ritual."
+	cost = 375
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine)
 
 /datum/supply_pack/food/trickwine/icewine
-	name = "4 bottles of vintage Icewine"
-	cost = 2000
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine
-		)
+	name = "Bottle of vintage Icewine"
+	cost = 500
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine)
 
 /datum/supply_pack/food/trickwine/shockwine
-	name = "4 bottles of vintage Lightnings' Blessing"
-	cost = 2000
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine
-		)
+	name = "Bottle of vintage Lightnings' Blessing"
+	cost = 500
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine)
 
 /datum/supply_pack/food/trickwine/heartwine
-	name = "4 bottles of vintage Hearthflame"
-	cost = 2000
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine
-		)
+	name = "Bottle of vintage Hearthflame"
+	cost = 500
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine)
 
 /datum/supply_pack/food/trickwine/forcewine
-	name = "4 bottles of vintage Forcewine"
-	cost = 2000
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine
-		)
+	name = "Bottle of vintage Forcewine"
+	cost = 500
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine)
 
 /datum/supply_pack/food/trickwine/prismwine
-	name = "4 bottles of vintage Prismwine"
-	cost = 2000
-	contains = list(
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine,
-			/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine
-		)
+	name = "Bottle of vintage Prismwine"
+	cost = 500
+	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine)


### PR DESCRIPTION
## About The Pull Request

Atomizes yet more cargo crates. Some prices have been rounded up and down to avoid fractions, but the total credit difference is minimal.

## Why It's Good For The Game

With the advent of https://github.com/shiptest-ss13/Shiptest/pull/4402 being merged, cheap crates won't bring on the issue of dropping 20,000 crates on the conveyer line, which means further atomization of cargo crates can provide players with more precise control of the number of items they purchase.

## Changelog

:cl:
balance: Atomizes many cargo crates. This means many cargo purchases will be contain less duplicate items, but with lower proportional prices!
/:cl: