### PR TITLE
replaces the mercury jellysandwich with a jellysandwich cherry

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_mercury.dmm
+++ b/_maps/shuttles/syndicate/syndicate_mercury.dmm
@@ -3042,10 +3042,6 @@
 /area/ship/bridge)
 "Ua" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/jellysandwich{
-	pixel_x = 0;
-	pixel_y = 8
-	},
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -6;
 	pixel_y = -6
@@ -3053,6 +3049,11 @@
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 6;
 	pixel_y = -6
+	},
+/obj/item/reagent_containers/food/snacks/jellysandwich/cherry{
+	pixel_x = 0;
+	pixel_y = 8;
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)


### PR DESCRIPTION
## About The Pull Request

says

## Why It's Good For The Game

The base jellysandwich is not actually obtainable and cannot be eaten because it has no reagents. This one does.

## Changelog

:cl:
fix: Mercury jellysandwich can now be eaten
/:cl: