### PR TITLE
Fixes runtime with admin AI interact on certain machines

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -979,6 +979,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			client.images -= stored_t_ray_images
 
 /mob/dead/observer/proc/has_ship_access() //prevents runtime with admin AI interact
-	if (isAdminGhostAI(usr))
+	if (isAdminGhostAI(src))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -979,6 +979,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			client.images -= stored_t_ray_images
 
 /mob/dead/observer/proc/has_ship_access() //prevents runtime with admin AI interact
-	if (src.has_unlimited_silicon_privilege)
+	if (isAdminGhostAI(usr))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -977,3 +977,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			client.images += t_ray_images
 		else
 			client.images -= stored_t_ray_images
+
+/mob/dead/observer/proc/has_ship_access() //prevents runtime with admin AI interact
+	if (src.has_unlimited_silicon_privilege)
+		return TRUE
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the proc mob/dead/observer/has_ship_access() which just calls isAdminGhostAI. 
Prevents undefined proc runtime when check_ship_ai_access calls has_ship_access(ship) on observers.
This otherwise doesn't impact normal ghost functionality.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
runtime bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
admin: Admin AI interact should no longer cause runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
