### PR TITLE
Colorblind people can't see wire colors

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -288,6 +288,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Granted by prismwine, reflects lasers
 #define TRAIT_REFLECTIVE "reflective"
 #define TRAIT_HEARING_SENSITIVE "hearing_sensitive"
+/// You can't see color!
+#define TRAIT_COLORBLIND "colorblind"
 
 /* Traits for ventcrawling.
  * Both give access to ventcrawling, but *_NUDE requires the user to be

--- a/code/datums/traits/neutral/monochromatic.dm
+++ b/code/datums/traits/neutral/monochromatic.dm
@@ -9,4 +9,4 @@
 
 /datum/quirk/monochromatic/remove()
 	if(quirk_holder)
-		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+		quirk_holder.remove_client_colour(/datum/client_colour/monochrome/blind/permanent)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -259,15 +259,17 @@
 	else if(user.is_holding_item_of_type(/obj/item/areaeditor/blueprints) && !randomize)
 		reveal_wires = TRUE
 
+	var/colorblind = HAS_TRAIT(user, TRAIT_COLORBLIND) || HAS_TRAIT(user, TRAIT_BLIND)
 	for(var/color in colors)
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
+			"wire" = ((reveal_wires && !is_dud_color(color) && !colorblind) ? get_wire(color) : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))
 	data["wires"] = payload
 	data["status"] = get_status()
+	data["colorblind"] = colorblind
 	return data
 
 /datum/wires/ui_act(action, params)

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -200,6 +200,14 @@
 /datum/client_colour/monochrome/blind/permanent //For the permanently colorblind
 	priority = PRIORITY_ABSOLUTE
 
+/datum/client_colour/monochrome/New(mob/_owner)
+	. = ..()
+	ADD_TRAIT(_owner, TRAIT_COLORBLIND, REF(src))
+
+/datum/client_colour/monochrome/Destroy()
+	REMOVE_TRAIT(owner, TRAIT_COLORBLIND, REF(src))
+	return ..()
+
 /datum/client_colour/bloodlust
 	priority = PRIORITY_ABSOLUTE // Only anger.
 	colour = list(0,0,0,0,0,0,0,0,0,1,0,0) //pure red.

--- a/tgui/packages/tgui/interfaces/Wires.js
+++ b/tgui/packages/tgui/interfaces/Wires.js
@@ -6,6 +6,7 @@ export const Wires = (props, context) => {
   const { act, data } = useBackend(context);
   const wires = data.wires || [];
   const statuses = data.status || [];
+  const colorblind = data.colorblind;
   return (
     <Window width={350} height={150 + wires.length * 30}>
       <Window.Content>
@@ -15,9 +16,9 @@ export const Wires = (props, context) => {
               <LabeledList.Item
                 key={wire.color}
                 className="candystripe"
-                label={wire.color}
-                labelColor={wire.color}
-                color={wire.color}
+                label={colorblind ? 'grey' : wire.color}
+                labelColor={colorblind ? 'grey' : wire.color}
+                color={colorblind ? 'grey' : wire.color}
                 buttons={
                   <>
                     <Button


### PR DESCRIPTION
## About The Pull Request

Being fully colorblind (or just regular blind) prevents being able to distinguish wires by color.

![image](https://github.com/user-attachments/assets/ef2d29bc-5822-456b-886d-e51496c38c4c)

Also fixes monochromacy effects not being removed properly when you lose the quirk.

## Why It's Good For The Game

It's funny, makes sense, and can be easily overcome by distinguishing wires by order instead of color.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Being unable to see color prevents being able to see the color of wires
fix: Fixed monochromacy's effects not being removed when losing the quirk
/:cl:
