### PR TITLE
fixes safes being unsawable

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -81,8 +81,6 @@ FLOOR SAFES
 /obj/structure/safe/deconstruct_act(mob/living/user, obj/item/tool)
 	if(open)
 		return FALSE
-	if(..())
-		return TRUE
 	user.visible_message(
 		span_warning("[user] begin to cut through the lock of \the [src]."),
 		span_notice("You start cutting trough the lock of [src]."),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #4654
Removes a parent call that always fails bc safes are indestructible when trying to destruct the safe (done before doing any saw attempt stuff)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: saws can now saw safes again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
