### PR TITLE
Minor Ramzi simplemob description fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -343,7 +343,7 @@
 
 /mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/smg
 	name = "Ramzi Clique Shock Trooper"
-	desc = "Night-black armor traces the silhouette of a soldier equaled by precious few. Their Sidewinder tracks you perfectly, a staccato bark of .45 already in its throat."
+	desc = "Night-black armor traces the silhouette of a soldier equaled by precious few. Their Sidewinder tracks you perfectly, a staccato bark of 5.7 already in its throat."
 	icon_state = "syndicate_stormtrooper_smg"
 	icon_living = "syndicate_stormtrooper_smg"
 	armor_base = /obj/item/clothing/suit/space/hardsuit/syndi


### PR DESCRIPTION
## About The Pull Request

This fixes the description of the Ramzi Shock Trooper to have the proper caliber of the Sidewinder (5.7) instead of the caliber of the Cobra (45)

## Why It's Good For The Game

Just a minor description change all in all

## Changelog

:cl:
spellcheck: Swaps the caliber mentioned in Ramzi Shock Troopers description
/:cl: