### PR TITLE
Nerfs the SAW-80's spread and recoil

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -759,9 +759,11 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra)
 
 	burst_delay = 0.08 SECONDS
 	fire_delay = 0.08 SECONDS
-	spread = 6
-	spread_unwielded = 20
-	wield_slowdown = SAW_SLOWDOWN //better than the lmgs since it doesnt have a bipod, still not ideal
+	spread = 7
+	spread_unwielded = 25
+	recoil = 2
+	recoil_unwielded = 4
+	wield_slowdown = SAW_SLOWDOWN
 	wield_delay = 0.9 SECONDS //ditto
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS


### PR DESCRIPTION
## About The Pull Request

Increases the SAW-80's spread slightly and gives it some hefty recoil

## Why It's Good For The Game

It's just straight better than the default hydra. You literally just need to hold down the left mouse button and walk forward and you will see success. 

## Changelog

:cl:
balance: SAW has mildly adjusted spread and has some hefty recoil now
/:cl: