### PR TITLE
Replaces the HBG-7 on the crying sun with the unscoped version.

### DIFF
--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -240,6 +240,10 @@
 /obj/effect/turf_decal/corner/opaque/purple/border{
 	dir = 1
 	},
+/obj/item/binoculars{
+	pixel_x = 6;
+	pixel_y = -8
+	},
 /turf/open/floor/vault,
 /area/ship/security/armory)
 "bU" = (

--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -741,14 +741,14 @@
 "gx" = (
 /obj/structure/rack,
 /obj/machinery/light/directional/west,
-/obj/item/gun/energy/kalix/pgf/heavy/sniper{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/corner/opaque/neutral/full,
 /obj/item/gun/energy/kalix/pgf/medium{
 	pixel_y = -4;
 	pixel_x = -2
+	},
+/obj/item/gun/energy/kalix/pgf/heavy{
+	pixel_x = 0;
+	pixel_y = 5
 	},
 /turf/open/floor/vault,
 /area/ship/security/armory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Says in the title.
![image](https://github.com/user-attachments/assets/5be96000-cce3-43c2-b8e3-aa147a670110)

## Why It's Good For The Game

This guns already insanely strong and basically an ERT weapon, they can go without doming people across the map with it

## Changelog

:cl:
balance: Replaces the HBG7 with the unscoped version on the crying sun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
