### PR TITLE
reverts ex_act nerf for obj

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -55,15 +55,15 @@
 	if(QDELETED(src))
 		return
 	if(target == src)
-		take_damage(INFINITY, BRUTE, "bomb", 0)
+		take_damage(INFINITY, BRUTE, BOMB, 0)
 		return
 	switch(severity)
-		if(1)
-			take_damage(rand(220, 330), BRUTE, "bomb", 0)
-		if(2)
-			take_damage(rand(120, 180), BRUTE, "bomb", 0)
-		if(3)
-			take_damage(rand(20, 80), BRUTE, "bomb", 0)
+		if(EXPLODE_DEVASTATE)
+			take_damage(rand(1000, 2000), BRUTE, BOMB, 0)
+		if(EXPLODE_HEAVY)
+			take_damage(rand(100, 250), BRUTE, BOMB, 0)
+		if(EXPLODE_LIGHT)
+			take_damage(rand(10, 90), BRUTE, BOMB, 0)
 
 /obj/bullet_act(obj/projectile/hitting_projectile)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts the num tweaks of ex_act of om5. Until i am convinced that it was good for the game.
also some defines
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
tbd. I think shrinking the range of the rand of the light and heavy create more "perdictable" rings around explosions
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: devastating explosions should kill everything again.
balance: light and heavy explosions now have a wider range again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
