### PR TITLE
Minor mission fix for Wrecked Factory

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
@@ -5052,7 +5052,7 @@
 	},
 /obj/effect/landmark/mission_poi/main{
 	mission_index = 2;
-	type_to_spawn = /obj/item/clothing/accessory/medal/gold/captain;
+	type_to_spawn = /obj/item/clothing/accessory/medal/gold/heroism;
 	already_spawned = 1
 	},
 /turf/open/floor/wood,


### PR DESCRIPTION
## About The Pull Request

Before the war medal retrieval mission was marked for you to retrieve the captains medal, and not the exceptional heroism medal, so for people who only checked the name and not the description itself would later realize they grabbed the wrong medal.

## Why It's Good For The Game

Small fix towards a ruin contract

## Changelog

:cl:
fix: The "Retrieve War Medal" contract will now have you retrieve the proper medal
/:cl: