### PR TITLE
Adds additional say verbs to tongues

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -2,6 +2,11 @@
 	var/obj/item/organ/tongue/T = src.getorganslot(ORGAN_SLOT_TONGUE)
 	if(T)
 		verb_say = T.say_mod
+		verb_ask = T.ask_mod
+		verb_exclaim = T.exclaim_mod
+		verb_whisper = T.whisper_mod
+		verb_sing = T.sing_mod
+		verb_yell = T.yell_mod
 	if(slurring)
 		return "slurs"
 	else

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -7,6 +7,11 @@
 	attack_verb = list("licked", "slobbered", "slapped", "frenched", "tongued")
 	var/list/languages_possible
 	var/say_mod = "says"
+	var/ask_mod = "asks"
+	var/exclaim_mod = "exclaims"
+	var/whisper_mod = "whispers"
+	var/sing_mod = "sings"
+	var/yell_mod = "yells"
 	var/taste_sensitivity = 15 // lower is more sensitive.
 	var/modifies_speech = FALSE
 	var/static/list/languages_possible_base = typecacheof(list(
@@ -125,6 +130,9 @@
 	organ_flags = NONE
 	icon_state = "tonguerobot"
 	say_mod = "states"
+	ask_mod = "queries"
+	exclaim_mod = "declares"
+	yell_mod = "alarms"
 	attack_verb = list("beeped", "booped")
 	modifies_speech = TRUE
 	taste_sensitivity = 25 // not as good as an organic tongue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds more say verbs to tongues, letting species -- whose speaking habits are mostly controlled through their tongue -- have unique exclaim(!), yell(!!), ask(?), whisper(#), and sing(%) verbs.
Gives IPCs a set of unique speaking verbs, letting them query, declare, and alarm like their silicon brethren.

(please give me more verbs to add to other species)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's weird that IPC don't query in the first place. Also provides more flexibility when deciding how each species should speak.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: IPCs and FBPs now query, declare, and alarm like other silicons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
