### PR TITLE
Sarathi no longer take toxin damage from welding fuel

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -66,6 +66,11 @@
 		internal_lighter = new
 		internal_lighter.Grant(C)
 
+/datum/species/lizard/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	if(chem.type == /datum/reagent/fuel)
+		return TRUE
+	return ..()
+
 /datum/action/innate/liz_lighter
 	name = "Ignite"
 	desc = "(Requires you to drink welding fuel beforehand)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a species chem check for welding fuel on lizards so they don't Die while doing radical pyrotechnics
This also prevents it from metabolizing out currently since it's spent to use the ignite ability but that can be returned if necessary

## Why It's Good For The Game

ough. im gonna vomit. i did the funny thing.

## Changelog

:cl:
balance: sarathi no longer take toxin damage from welding fuel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
