### PR TITLE
rad foam buff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2662,6 +2662,12 @@
 		M.ExtinguishMob()
 	..()
 
+
+/datum/reagent/anti_radiation_foam/on_mob_life(mob/living/carbon/M)
+	M.radiation = M.radiation - rand(max(M.radiation * 0.97, M.radiation))
+	..()
+	. = 1
+
 /datum/reagent/sulfur_dioxide
 	name = "Sulfur Dioxide"
 	description = "A transparent gas produced by geological activity and burning certain fuels."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2658,7 +2658,7 @@
 
 /datum/reagent/anti_radiation_foam/expose_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method in list(TOUCH, VAPOR))
-		M.radiation = M.radiation - rand(max(M.radiation * 0.1, 0)) //get the hose
+		M.radiation = M.radiation - rand(max(M.radiation * 0.07, 0)) //get the hose
 		M.ExtinguishMob()
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2658,13 +2658,13 @@
 
 /datum/reagent/anti_radiation_foam/expose_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method in list(TOUCH, VAPOR))
-		M.radiation = M.radiation - rand(max(M.radiation * 0.95, M.radiation)) //get the hose
+		M.radiation = M.radiation - rand(max(M.radiation * 0.1, 0)) //get the hose
 		M.ExtinguishMob()
 	..()
 
 
 /datum/reagent/anti_radiation_foam/on_mob_life(mob/living/carbon/M)
-	M.radiation = M.radiation - rand(max(M.radiation * 0.97, M.radiation))
+	M.radiation = M.radiation - rand(max(M.radiation * 0.03, 0))
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2662,13 +2662,6 @@
 		M.ExtinguishMob()
 	..()
 
-
-/datum/reagent/anti_radiation_foam/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(0.5, 200)
-	M.adjust_disgust(4)
-	..()
-	. = 1
-
 /datum/reagent/sulfur_dioxide
 	name = "Sulfur Dioxide"
 	description = "A transparent gas produced by geological activity and burning certain fuels."


### PR DESCRIPTION
## Why It's Good For The Game
the fun anti rad spraydown was less effective than just letting the radiation exit naturally
## Changelog

:cl:
balance: anti-rad foam no longer sends you to disgust/toxinloss hell when you use it to remove rads
/:cl: