### PR TITLE
Adds (placebo) prescription pills to general loadout

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -507,14 +507,10 @@
 	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/pill/starlight(src)
 
-/obj/item/storage/pill_bottle/water
-	name = "bottle of water pills"
-	desc = "Contains pills that hold water. Refreshing!"
-
-/obj/item/storage/pill_bottle/water/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/pill/water(src)
-
-/obj/item/storage/pill_bottle/water/loadout
+/obj/item/storage/pill_bottle/placebatol
 	name = "bottle of prescription pills"
 	desc = "Contains pills as prescribed. A tag reads: \"NO MEDICINAL EFFECT\"."
+
+/obj/item/storage/pill_bottle/placebatol/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/placebatol(src)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -506,3 +506,15 @@
 /obj/item/storage/pill_bottle/starlight/PopulateContents()
 	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/pill/starlight(src)
+
+/obj/item/storage/pill_bottle/water
+	name = "bottle of water pills"
+	desc = "Contains pills that hold water. Refreshing!"
+
+/obj/item/storage/pill_bottle/water/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/water(src)
+
+/obj/item/storage/pill_bottle/water/loadout
+	name = "bottle of prescription pills"
+	desc = "Contains pills as prescribed. A tag reads: \"NO MEDICINAL EFFECT\"."

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -221,8 +221,8 @@
 
 /datum/gear/prescription_pills
 	display_name = "prescription pills"
-	path = /obj/item/storage/pill_bottle/water/loadout
+	path = /obj/item/storage/pill_bottle/placebatol
 
 /datum/gear/prescription_injector
 	display_name = "prescription injector"
-	path = /obj/item/reagent_containers/hypospray/medipen/water/loadout
+	path = /obj/item/reagent_containers/hypospray/medipen/placebatol

--- a/code/modules/client/loadout/loadout_general.dm
+++ b/code/modules/client/loadout/loadout_general.dm
@@ -218,3 +218,11 @@
 /datum/gear/spraycan
 	display_name = "spraycan"
 	path = /obj/item/toy/crayon/spraycan
+
+/datum/gear/prescription_pills
+	display_name = "prescription pills"
+	path = /obj/item/storage/pill_bottle/water/loadout
+
+/datum/gear/prescription_injector
+	display_name = "prescription injector"
+	path = /obj/item/reagent_containers/hypospray/medipen/water/loadout

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -659,6 +659,6 @@
 	taste_description = "sugar" //effectively a sugar pill, but sugar actually has a use
 
 /datum/reagent/drug/placebatol/on_mob_life(mob/living/carbon/M)
-	if(prob(4))
+	if(prob(3))
 		to_chat(M, span_notice("[pick("You feel better.", "You feel normal.", "You feel stable.")]")) //normal pills
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -659,6 +659,6 @@
 	taste_description = "sugar" //effectively a sugar pill, but sugar actually has a use
 
 /datum/reagent/drug/placebatol/on_mob_life(mob/living/carbon/M)
-	..()
-	if(prob(2))
+	if(prob(4))
 		to_chat(M, span_notice("[pick("You feel better.", "You feel normal.", "You feel stable.")]")) //normal pills
+	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -649,3 +649,16 @@
 	metabolization_rate = 0.2
 	vision_trait = TRAIT_GOOD_CHEMICAL_NIGHTVISION
 	taste_description = "sulpheric sweetness"
+
+/datum/reagent/drug/placebatol
+	name = "Placebatol"
+	description = "An odorless, colorless, powdery substance that's sometimes prescribed. May not actually do anything...?"
+	reagent_state = SOLID
+	color = "#f5f5f0"
+	metabolization_rate = REAGENTS_METABOLISM * 0.25
+	taste_description = "sugar" //effectively a sugar pill, but sugar actually has a use
+
+/datum/reagent/drug/placebatol/on_mob_life(mob/living/carbon/M)
+	..()
+	if(prob(2))
+		to_chat(M, span_notice("[pick("You feel better.", "You feel normal.", "You feel stable.")]")) //normal pills

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -373,7 +373,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/placebatol
 	name = "prescription medipen"
-	desc = "An injector filled with some prescribed substance. A tag reads: \"NO MEDICINAL EFFECT\"."
+	desc = "An injector filled with some prescribed substance."
 	list_reagents = list(/datum/reagent/drug/placebatol = 15)
 	volume = 15
 	amount_per_transfer_from_this = 15

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -371,6 +371,17 @@
 	base_icon_state = "syndipen"
 	item_state = "syndipen"
 
+/obj/item/reagent_containers/hypospray/medipen/water
+	name = "water injector"
+	desc = "An injector filled with water."
+	list_reagents = list(/datum/reagent/water = 15)
+	volume = 15
+	amount_per_transfer_from_this = 15
+
+/obj/item/reagent_containers/hypospray/medipen/water/loadout
+	name = "prescription medipen"
+	desc = "An injector filled with some prescribed substance. A tag reads: \"NO MEDICINAL EFFECT\"."
+
 //A vial-loaded hypospray. Cartridge-based!
 /obj/item/hypospray/mkii
 	name = "hypospray mk.II"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -371,16 +371,12 @@
 	base_icon_state = "syndipen"
 	item_state = "syndipen"
 
-/obj/item/reagent_containers/hypospray/medipen/water
-	name = "water injector"
-	desc = "An injector filled with water."
-	list_reagents = list(/datum/reagent/water = 15)
-	volume = 15
-	amount_per_transfer_from_this = 15
-
-/obj/item/reagent_containers/hypospray/medipen/water/loadout
+/obj/item/reagent_containers/hypospray/medipen/placebatol
 	name = "prescription medipen"
 	desc = "An injector filled with some prescribed substance. A tag reads: \"NO MEDICINAL EFFECT\"."
+	list_reagents = list(/datum/reagent/drug/placebatol = 15)
+	volume = 15
+	amount_per_transfer_from_this = 15
 
 //A vial-loaded hypospray. Cartridge-based!
 /obj/item/hypospray/mkii

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -329,8 +329,8 @@ WS End */
 	icon_state = "sprayer"
 	list_reagents = list(/datum/reagent/medicine/rhigoxane = 100)
 
-/obj/item/reagent_containers/pill/water
-	name = "clear pill"
-	desc = "A gel-like capsule filled with some watery fluid."
-	icon_state = "pill3"
-	list_reagents = list(/datum/reagent/water = 10)
+/obj/item/reagent_containers/pill/placebatol
+	name = "prescription pill"
+	desc = "A pill composed of a white, powdery substance. Take as prescribed."
+	icon_state = "pill9"
+	list_reagents = list(/datum/reagent/drug/placebatol = 10)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -328,3 +328,9 @@ WS End */
 	desc = "A medical spray bottle.This one contains rhigoxane, it is used to treat burns and cool down temperature if applied with spray."
 	icon_state = "sprayer"
 	list_reagents = list(/datum/reagent/medicine/rhigoxane = 100)
+
+/obj/item/reagent_containers/pill/water
+	name = "clear pill"
+	desc = "A gel-like capsule filled with some watery fluid."
+	icon_state = "pill3"
+	list_reagents = list(/datum/reagent/water = 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a bottle of prescription pills and a prescription autoinjector to loadout. They don't do anything aside from putting a message in your chat saying you feel better, but you can use them for flavor if you'd like.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was asked as a low-impact solution to some players wanting to roleplay their blorbos taking medicine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Prescription pills added to loadout! Filled with placebatol, they do almost nothing, but are good for flavoring your character.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
