### PR TITLE
removes lava lake biome from lava worlds

### DIFF
--- a/code/datums/mapgen/planetary/LavaGenerator.dm
+++ b/code/datums/mapgen/planetary/LavaGenerator.dm
@@ -285,7 +285,3 @@
 		/obj/structure/flora/ash/tall_shroom = 2,
 	)
 
-/datum/biome/cave/lavaland/lava
-	open_turf_types = list(/turf/open/lava/smooth/lava_land_surface = 1)
-	feature_spawn_chance = 1
-	feature_spawn_list = list(/obj/structure/flora/rock/pile/lava = 1)


### PR DESCRIPTION
## About The Pull Request

removes the lava lake biome from lava worlds. lava still generates but not in extremely laggy oceans that you can possibly spawn in the middle of

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/0e04be20-9ca7-4126-9082-5d201cdacf61)

## Changelog

:cl:
del: Removed lava lake biome from lavaworld generation
/:cl: