### PR TITLE
Fixed melee weapons not applying armor penetration to objects, or being affected by exosuit directional armor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -152,7 +152,7 @@
 	else
 		total_force = (attacking_item.force)
 
-	var/damage = take_damage(total_force, attacking_item.damtype, "melee", 1)
+	var/damage = take_damage(total_force, attacking_item.damtype, "melee", TRUE, get_dir(user, src), attacking_item.armour_penetration)
 
 	var/damage_verb = "hit"
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -43,7 +43,7 @@
 				break
 
 	if(attack_dir)
-		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(src))
+		var/facing_modifier = get_armour_facing(abs(dir2angle(attack_dir) - dir2angle(dir)))
 		booster_damage_modifier /= facing_modifier
 		booster_deflection_modifier *= facing_modifier
 	if(prob(deflect_chance * booster_deflection_modifier))


### PR DESCRIPTION

## About The Pull Request

Fixes an oversight causing melee weapons to not take armor penetration into account when damaging objects, and another causing them to ignore exosuit directional armor.

## Why It's Good For The Game

fix

## Changelog

:cl:
fix: Fixed melee weapons not applying armor penetration when damaging objects
fix: Fixed exosuit directional armor not working
/:cl: