### PR TITLE
Adds buckles to toilets

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -5,6 +5,8 @@
 	icon_state = "toilet00"
 	density = FALSE
 	anchored = TRUE
+	can_buckle = TRUE
+	buckle_lying = 0
 	var/open = FALSE			//if the lid is up
 	var/cistern = 0			//if the cistern bit is open
 	var/w_items = 0			//the combined w_class of all the items in the cistern
@@ -126,6 +128,20 @@
 		to_chat(user, span_notice("You fill [RG] from [src]. Gross."))
 	else
 		return ..()
+
+/obj/structure/toilet/proc/handle_layer()
+	if(has_buckled_mobs() && dir == NORTH)
+		layer = ABOVE_MOB_LAYER
+	else
+		layer = OBJ_LAYER
+
+/obj/structure/toilet/post_buckle_mob(mob/living/M)
+	. = ..()
+	handle_layer()
+
+/obj/structure/toilet/post_unbuckle_mob()
+	. = ..()
+	handle_layer()
 
 /obj/structure/toilet/secret
 	var/obj/item/secret


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets you buckle to a toilet like you would a chair. That's about it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being vaguely chair-shaped and nominally rated for microgravity operations, the toilet _should_ have a set of buckles for securing yourself to the throne in-case you need to use it while the gravity is out, and more practically as a way of preventing yourself from embarrassingly falling over during takeoff.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Following a review of shipbuilding standards, all toilets are now equipped with the same set of buckles that chairs have.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
