### PR TITLE
Scoopable Goliath Pups and Derecho touch-ups

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
@@ -848,16 +848,11 @@
 /obj/item/gun/energy/plasmacutter{
 	pixel_y = 15
 	},
-/obj/item/screwdriver/power{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/crowbar/power{
-	pixel_x = -9;
-	pixel_y = -1
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/gear_pack/anglegrinder{
+	pixel_y = 3
+	},
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "hf" = (
@@ -984,6 +979,13 @@
 /obj/item/ammo_box/magazine/m12g_bulldog/empty,
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/ammo/c10mm{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/obj/item/gun_maint_kit,
+/obj/item/gun_maint_kit,
+/obj/item/gun_maint_kit,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "iy" = (
@@ -3524,6 +3526,10 @@
 /obj/item/melee/sledgehammer/gorlex{
 	pixel_x = 5
 	},
+/obj/item/pinpointer/mineral{
+	pixel_x = 5;
+	pixel_y = -3
+	},
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "DD" = (
@@ -5858,6 +5864,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/item/storage/guncase/pistol/a357,
 /obj/machinery/light/small/directional/east,
+/obj/item/storage/belt/military/assault,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "Yq" = (

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -135,6 +135,9 @@
 	tame_chance = 5
 	bonus_tame_chance = 15
 
+/mob/living/simple_animal/hostile/asteroid/goliath/pup/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_HOLDABLE, INNATE_TRAIT)
 
 //Lavaland Goliath
 /mob/living/simple_animal/hostile/asteroid/goliath/beast


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a 10mm ammo box, and three weapon refurbishment kits to the Derecho. It also removes the hand drill and jaws of life from the wrecker's equipment room and replaces it with an angle grinder pack, and a mineral vein scanner. The Captain's locker is also given an assault belt.

This PR also makes goliath pups, and by extension, David the goliath pup, scoopable.

![image](https://github.com/user-attachments/assets/521b640e-b68a-47f6-a2ff-991bd108cd00)

## Why It's Good For The Game

Adding a 10mm ammo box allows the Foreman to be able to load their weapon without having to buy a box of ammo roundstart. Weapon refurbishment kits make sense for a ship that may be expected to use their weapons frequently, I think. The hand drill and jaws of life from the wrecker equipment room was replaced with an angle grinder because I felt that they don't serve as much help for salvaging as an angle grinder would. I'm a little unsure about this change, though, so if it may be better to keep the tools, I would be happy to bring them back. I do still think that an angle grinder would be helpful for this ship, regardless. A mineral scanner was added because I can see this ship primarily conducting drill surveys when it's not scrapping, and this would help facilitate that, or to at least encourage it. An assault belt was added to the Captain's locker because it can be helpful to have one to hold equipment to help manage your crew in, rather than having to rely on one's bag.

Goliath pups were made scoopable because I thought it would be nice to be able to do. While goliaths are cow sized, I can see a pup being small enough to be carried around.

## Changelog

:cl:
add: Added a 10mm ammo box, three weapon refurbishment kits, an angle grinder, a mineral vein scanner, and an assault belt to the Derecho
add: Added goliath pup scooping
del: Removed wrecker power tools from the Derecho
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
