### PR TITLE
Remaps The Ivory

### DIFF
--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,26 +1,49 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"ao" = (
-/obj/structure/dresser{
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/item/storage/guncase/pistol/pistolec{
-	pixel_y = 10
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1;
+	icon_state = "computer-left"
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = -30
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"ao" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "cabinet";
+	name = "captain's wardobe";
+	req_access_txt = "20";
+	close_sound = 'sound/machines/wooden_closet_close.ogg';
+	open_sound = 'sound/machines/wooden_closet_open.ogg';
+	desc = "It's a card-locked cabinet.";
+	anchored = 1
 	},
+/obj/item/storage/backpack/satchel/cap,
+/obj/item/storage/backpack/captain,
+/obj/item/clothing/under/rank/command/captain,
+/obj/item/clothing/under/rank/command/captain/skirt,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13;
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/jacket/miljacket,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/caphat,
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/attachment/sling,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 20
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -32,11 +55,11 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "au" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
 "aL" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -88,52 +111,6 @@
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/starboard)
 "aZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/slime/pet{
-	colour = "cerulean";
-	icon_living = "cerulean baby slime";
-	icon_state = "cerulean baby slime";
-	icon_dead = "cerulean baby slime dead";
-	faction = list("neutral");
-	mood = "aslime-:3";
-	name = "Searle";
-	pass_flags = 4;
-	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
-	speak_emote = list("blorbles", "bounces around happily", "purrs");
-	speak_chance = 1;
-	density = 0;
-	can_buckle = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"ba" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"bv" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"cg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -143,14 +120,54 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_steel_grid{
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"ba" = (
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"bw" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"cg" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -230,7 +247,20 @@
 /obj/item/reagent_containers/food/snacks/grown/tea/astra{
 	dry = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"cZ" = (
+/obj/structure/chair/sofa/grey/right{
+	dir = 4
+	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "dm" = (
 /obj/structure/table/chem{
@@ -244,12 +274,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"dJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "ed" = (
 /obj/item/storage/secure/safe{
 	dir = 1;
@@ -357,14 +381,12 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eM" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "fa" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -389,67 +411,35 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "fg" = (
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
-	},
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/obj/item/attachment/bayonet{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
+	color = "#D2BC9D"
 	},
-/obj/item/gun/ballistic/revolver/shadow/empty{
-	pixel_y = -2
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
-"fi" = (
-/obj/item/clothing/under/suit/roumain,
-/obj/item/clothing/suit/armor/roumain,
-/obj/item/clothing/head/cowboy/sec/roumain,
-/obj/item/flashlight/lantern,
-/obj/structure/closet/secure_closet/hunter{
-	name = "guide's locker"
-	},
-/obj/item/clothing/shoes/cowboy/black,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/shoes/combat,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/accessory/waistcoat/roumain,
-/obj/item/disk/holodisk/roumain,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/machinery/light_switch{
 	dir = 1;
-	color = "#543C30"
+	pixel_x = 11;
+	pixel_y = -19
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -8
-	},
-/obj/item/storage/box/ammo/a44roum,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -507,6 +497,32 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
+"gN" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/crew/crewtwo)
+"gO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "gP" = (
 /obj/structure/chair/handrail{
 	dir = 4
@@ -539,27 +555,76 @@
 	layer = 2.89;
 	pixel_x = 23
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/directional/north{
+	pixel_x = 5
+	},
+/obj/machinery/button/door{
+	pixel_y = 22;
+	pixel_x = -9;
+	name = "door lock";
+	id = "i_b";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "hO" = (
-/obj/structure/railing/thick/corner{
-	dir = 1
+/obj/structure/cabinet/m23{
+	dir = 4;
+	pixel_x = -21
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"hQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/structure/bed/double{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 10;
-	layer = 2.030
+/obj/item/bedsheet/double{
+	dir = 4;
+	icon_state = "double_sheetrd"
 	},
-/obj/effect/turf_decal/techfloor{
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"hR" = (
+/obj/structure/dresser{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/sign/painting/library{
+	pixel_x = -30
+	},
+/obj/item/storage/guncase/pistol/ringneck{
+	pixel_y = 8
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"ii" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -567,6 +632,7 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/industrial/hatch,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/patterned/grid{
 	color = "#777777"
 	},
@@ -613,34 +679,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"jt" = (
-/obj/structure/cabinet/m23{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/bed/double{
-	dir = 4
-	},
-/obj/item/bedsheet/double{
-	dir = 4;
-	icon_state = "double_sheetrd"
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
 "jv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
+"jJ" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "jL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
@@ -655,24 +712,21 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
 /area/ship/crew/dorm/captain)
-"kn" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "kr" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/area/ship/cargo)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -685,16 +739,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engines/port)
-"kF" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew)
 "kR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -803,23 +847,22 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "mB" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
-	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "nj" = (
 /obj/machinery/washing_machine{
 	pixel_y = 9;
@@ -845,39 +888,30 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/structure/closet/cabinet{
-	anchored = 1
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
 	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 1
 	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm)
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "nL" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -887,11 +921,20 @@
 	dir = 1;
 	id = "ivory_bridge";
 	name = "shutter control";
-	pixel_y = -20;
-	pixel_x = -1
+	pixel_y = -22;
+	pixel_x = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_y = -22;
+	pixel_x = -10;
+	name = "bathroom door override";
+	id = "i_b";
+	specialfunctions = 4;
+	normaldoorcontrol = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
@@ -926,52 +969,27 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/cargo)
 "oP" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "oU" = (
 /obj/machinery/jukebox/boombox{
 	pixel_x = -4;
@@ -988,46 +1006,26 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "pa" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "pl" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
 	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/structure/sign/painting/library{
+	pixel_x = 30
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -1057,30 +1055,52 @@
 /area/ship/bridge)
 "qb" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
+/turf/open/floor/plasteel/stairs/wood/maple/left{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew/crewtwo)
+/area/ship/crew)
 "qm" = (
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"qo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
 "qp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
+	},
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "qx" = (
 /obj/effect/turf_decal/isf_small{
 	dir = 8
@@ -1103,11 +1123,11 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/structure/railing/thick/corner{
+	dir = 4
 	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "qM" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -1123,28 +1143,6 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
-"rv" = (
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"rJ" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "rP" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative{
@@ -1234,6 +1232,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
+"sJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "tj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -1259,13 +1267,48 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 5;
-	layer = 2.030
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"tS" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/obj/item/melee/knife/hunting{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "tT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -1299,28 +1342,44 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "uz" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
 	},
-/turf/open/floor/plasteel/stairs/wood/maple/left{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/area/ship/crew)
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "uG" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/computer/cryopod/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
-"uS" = (
-/obj/machinery/computer/cargo{
-	icon_state = "computer-right";
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "uU" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -1357,35 +1416,67 @@
 	color = "#777777"
 	},
 /area/ship/cargo)
-"vJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+"vE" = (
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
+	},
+/obj/item/melee/spear/bone,
+/obj/item/melee/knife/hunting{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
+	dir = 9;
+	color = "#543C30"
 	},
-/obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"vO" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/item/gun/ballistic/revolver/shadow/empty{
+	pixel_y = -2
 	},
-/area/ship/cargo)
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"vJ" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "vS" = (
-/obj/structure/chair/sofa/grey/right{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
+"wc" = (
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1514,18 +1605,26 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"yP" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "zf" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engines/starboard)
@@ -1593,6 +1692,12 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/port)
+"zY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Ab" = (
 /obj/docking_port/stationary{
 	width = 30;
@@ -1645,20 +1750,25 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "AX" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Be" = (
 /obj/structure/railing/thick,
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"Bg" = (
-/obj/structure/railing/thick/corner,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Bw" = (
@@ -1674,12 +1784,21 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "BM" = (
-/obj/machinery/door/airlock/external/glass{
-	dir = 4
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "BP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1714,75 +1833,52 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "Cc" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east{
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	pixel_y = 11;
+	pixel_x = 22;
+	dir = 8;
+	id = "my_dumb_gay_windows";
+	name = "shutter control"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "Cl" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "CU" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/melee/knife/survival{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Dk" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/crewtwo)
 "Dm" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only{
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"Dq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"Dq" = (
-/turf/open/floor/grass/ship/jungle,
-/area/ship/crew/crewtwo)
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1804,24 +1900,34 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
 "Ey" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "EC" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/corner{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/mob/living/simple_animal/slime/pet{
+	colour = "cerulean";
+	icon_living = "cerulean baby slime";
+	icon_state = "cerulean baby slime";
+	icon_dead = "cerulean baby slime dead";
+	faction = list("neutral");
+	mood = "aslime-:3";
+	name = "Searle";
+	pass_flags = 4;
+	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
+	speak_emote = list("blorbles", "bounces around happily", "purrs");
+	speak_chance = 1;
+	density = 0;
+	can_buckle = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1835,22 +1941,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"Fm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
 "Fr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -1862,39 +1952,12 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"FL" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
-	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "Gc" = (
 /obj/structure/railing/thick/corner{
 	dir = 8
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"Gf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_captains";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -1929,21 +1992,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"GF" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
 "Hd" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
@@ -1978,20 +2026,12 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "HB" = (
-/obj/structure/closet/crate{
-	name = "glowstick crate"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
 	},
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/effect/mapping_helpers/crate_shelve,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "HK" = (
 /obj/structure/chair/stool/bar{
@@ -2004,18 +2044,18 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "HQ" = (
-/obj/structure/chair/sofa/grey/left{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "HV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engines/starboard)
 "Id" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 10;
 	layer = 2.030
@@ -2042,30 +2082,15 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/crew)
 "IR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "Jw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2086,6 +2111,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"JI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "JT" = (
 /obj/structure/railing{
 	dir = 4
@@ -2096,21 +2131,11 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JY" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
-	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/borderfloorblack{
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2130,16 +2155,6 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/ship/dirt/dark,
-/area/ship/crew/crewtwo)
-"Ko" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/ship/crew/crewtwo)
 "KE" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2166,30 +2181,29 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"Li" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
 "Ls" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"Mt" = (
-/obj/structure/railing/thick/corner{
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Mx" = (
 /obj/structure/closet/wall/directional/west{
 	name = "janitorial supplies";
@@ -2247,18 +2261,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"Og" = (
+/obj/structure/railing/thick/corner{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Op" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -2268,21 +2277,21 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/bridge)
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "OA" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/area/ship/crew/dorm/captain)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2311,18 +2320,6 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"Qy" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 10
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
 "QG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -2334,24 +2331,34 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/cargo)
-"QI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/bridge)
 "QQ" = (
-/obj/structure/railing/thick,
-/obj/docking_port/mobile{
-	port_direction = 4;
-	preferred_direction = 4;
-	name = "Ivory-class"
+/obj/item/clothing/under/suit/roumain,
+/obj/item/clothing/suit/armor/roumain,
+/obj/item/clothing/head/cowboy/sec/roumain,
+/obj/item/flashlight/lantern,
+/obj/structure/closet/secure_closet/hunter{
+	name = "guide's locker"
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/item/clothing/shoes/cowboy/black,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/accessory/waistcoat/roumain,
+/obj/item/disk/holodisk/roumain,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/a44roum,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "Rs" = (
 /obj/structure/closet/emcloset/wall/directional/north{
 	populate = 0;
@@ -2399,6 +2406,15 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
+"Su" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Sz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -2428,6 +2444,15 @@
 	color = "#792f27"
 	},
 /area/ship/crew/dorm/captain)
+"SP" = (
+/obj/structure/railing/thick,
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "SV" = (
 /obj/structure/table,
 /obj/item/folder/yellow{
@@ -2448,10 +2473,34 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/public{
-	name = "Bathroom"
+	name = "Bathroom";
+	id_tag = "i_b"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew)
+"Tb" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
 "TP" = (
 /obj/structure/table/glass,
 /obj/item/toy/cards/deck/syndicate{
@@ -2465,106 +2514,51 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "UM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"UQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/item/storage/box/flares,
+/obj/item/storage/box/flares,
+/obj/item/storage/box/flares,
+/obj/item/storage/box/flares,
+/obj/item/storage/box/flares,
+/obj/item/storage/box/flares,
+/obj/structure/closet/crate{
+	name = "Dr. Flare's Magnificent Lighting Solution"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Vj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
-"Vt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"VO" = (
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
+"VR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
-"VO" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
-	},
-/area/ship/cargo)
 "VS" = (
 /obj/effect/turf_decal/isf_small/left{
 	dir = 8
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
-"Wc" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
 "Wg" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "captain's wardobe";
-	req_access_txt = "20";
-	close_sound = 'sound/machines/wooden_closet_close.ogg';
-	open_sound = 'sound/machines/wooden_closet_open.ogg';
-	desc = "It's a card-locked cabinet.";
-	anchored = 1
+/obj/machinery/computer/cargo{
+	icon_state = "computer-right";
+	dir = 8
 	},
-/obj/item/storage/backpack/satchel/cap,
-/obj/item/storage/backpack/captain,
-/obj/item/clothing/under/rank/command/captain,
-/obj/item/clothing/under/rank/command/captain/skirt,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13;
-	pixel_x = -6
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/item/clothing/suit/jacket/miljacket,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/caphat,
-/obj/item/clothing/shoes/jackboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/attachment/sling,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 20
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Wt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -2586,6 +2580,22 @@
 /obj/effect/turf_decal/industrial/hatch,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/dorm)
+"WH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/starboard)
 "WL" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass/ship/jungle,
@@ -2604,66 +2614,92 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1;
-	icon_state = "computer-left"
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "Xr" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "XC" = (
-/obj/structure/railing/corner{
-	dir = 1
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/patterned/external,
 /area/ship/external/dark)
 "XJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"XM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/structure/chair/handrail{
 	dir = 4
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/engine/hull,
 /area/ship/engineering/engines/starboard)
-"XM" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"XX" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
+"XP" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Yu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/area/ship/crew)
+"XX" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
+"Yu" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -2717,11 +2753,11 @@ hB
 hB
 tj
 iy
-Ls
+XC
 hB
 Ab
 hB
-EC
+pa
 iy
 tj
 hB
@@ -2744,7 +2780,7 @@ mp
 sv
 Hd
 mh
-XC
+wc
 iy
 iy
 Ue
@@ -2767,7 +2803,7 @@ go
 VS
 qx
 AF
-kr
+eM
 iy
 iy
 iC
@@ -2809,12 +2845,12 @@ zW
 zW
 lc
 cq
-rJ
+XJ
 xo
 NO
 DL
 eA
-FL
+mB
 HV
 zV
 zV
@@ -2824,7 +2860,7 @@ hB
 hB
 "}
 (7,1,1) = {"
-Mt
+qL
 Ue
 aR
 lc
@@ -2832,37 +2868,37 @@ sE
 GE
 lc
 SV
-AX
-Id
+Su
+fx
 tm
-tJ
 HB
-ba
+UM
+oP
 HV
 fa
 sf
 HV
 zf
 Ue
-Bg
+CU
 "}
 (8,1,1) = {"
 gQ
 iC
 lc
-Li
+Xe
 OX
-pl
+qp
 lc
 DK
 JT
-hQ
+Id
 tm
 Fr
 eK
-Cc
+ii
 HV
-oP
+bw
 pC
 wh
 HV
@@ -2873,7 +2909,7 @@ Be
 gQ
 iC
 lc
-mB
+vJ
 Pr
 kB
 qH
@@ -2883,36 +2919,36 @@ mz
 aQ
 QG
 lT
-ac
+hQ
 wV
 tq
 lS
-yH
+Cc
 HV
-au
-QQ
+zY
+SP
 "}
 (10,1,1) = {"
-hO
+Og
 iC
 lc
-OA
+cg
 sA
 es
 lc
+kr
 iq
-VO
 vo
-cg
+AX
 qm
 uU
-vO
+ox
 HV
-BM
 jv
+WH
 HV
 HV
-dJ
+JY
 Gc
 "}
 (11,1,1) = {"
@@ -2932,9 +2968,9 @@ iy
 iy
 HV
 Rs
-GF
+tJ
 eI
-Ey
+XM
 bv
 hB
 "}
@@ -2952,10 +2988,10 @@ Bw
 Ar
 qM
 Mx
-Qy
+jJ
 Ef
 Ef
-XJ
+Dq
 zf
 iC
 Ue
@@ -2968,15 +3004,15 @@ hB
 hB
 hB
 yg
-XM
-fx
+au
+Dm
 as
 HK
-Vt
-rv
+aZ
+ba
 Gs
 lo
-vS
+cZ
 yg
 hB
 hB
@@ -2995,8 +3031,8 @@ KU
 Cl
 as
 aL
-aZ
-rv
+EC
+ba
 fs
 NU
 op
@@ -3015,11 +3051,11 @@ hB
 hB
 yg
 xq
-fx
+Dm
 as
 HK
 Ss
-UM
+HQ
 Xr
 TP
 rP
@@ -3042,10 +3078,10 @@ aP
 og
 zk
 BP
-Yu
+VR
 YX
 jg
-HQ
+pl
 yg
 hB
 hB
@@ -3065,7 +3101,7 @@ jV
 jV
 cC
 wO
-uz
+qb
 cC
 cC
 cC
@@ -3091,7 +3127,7 @@ kR
 KE
 SX
 Av
-Wc
+Yu
 cC
 hB
 hB
@@ -3108,13 +3144,13 @@ hB
 jV
 WC
 jZ
-nI
+uz
 cC
 tT
-vJ
+sJ
 cC
 hN
-kF
+XX
 cC
 hB
 hB
@@ -3133,8 +3169,8 @@ jV
 jV
 jV
 cC
-ox
-Dm
+Ls
+fg
 cC
 cC
 cC
@@ -3156,12 +3192,12 @@ yC
 gc
 NG
 eu
-pa
+XP
 Af
 jL
-Wg
-jt
 ao
+hO
+hR
 vg
 iC
 iC
@@ -3174,17 +3210,17 @@ hB
 hB
 iC
 RJ
-Dq
-Dq
+VO
+VO
 sn
 NG
 nj
-Fm
+Op
 PT
 cC
 ef
+vS
 kj
-qL
 vg
 iC
 hB
@@ -3200,14 +3236,14 @@ RJ
 yA
 WL
 Ca
-qb
+gN
 Fc
-IR
+nI
 Wt
 Iu
-UQ
-qp
-eM
+IR
+Ey
+OA
 vg
 iC
 hB
@@ -3219,19 +3255,19 @@ hB
 hB
 hB
 Ue
-Ko
+gO
 RJ
-fg
-fi
+vE
+QQ
 NG
 fK
-Op
+Tb
 fK
 cC
-CU
+tS
 SF
 vg
-Gf
+JI
 Ue
 hB
 hB
@@ -3273,7 +3309,7 @@ Jw
 kX
 yz
 rf
-XX
+yH
 HA
 hB
 hB
@@ -3295,8 +3331,8 @@ HA
 iT
 YF
 ui
-QI
-Xe
+qo
+ac
 HA
 iC
 hB
@@ -3316,9 +3352,9 @@ hB
 Ue
 pZ
 HA
-kn
-JY
-uS
+yP
+BM
+Wg
 HA
 pZ
 Ue

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -864,14 +864,14 @@
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_y = 8;
-	pixel_x = -10
+	pixel_x = -7
 	},
 /obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 9;
-	pixel_x = -4
+	pixel_y = 1;
+	pixel_x = -7
 	},
 /obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -10;
+	pixel_x = -14;
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/patterned/brushed,
@@ -1026,10 +1026,27 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "qp" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/melee/knife/hunting{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/obj/item/pen/fountain/captain,
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -1257,7 +1274,9 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew)
 "uc" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/obj/structure/chair/comfy/purple{
+	dir = 1
+	},
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -2401,29 +2420,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "RG" = (
-/obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
-	},
 /obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
-	},
-/obj/item/melee/knife/hunting{
-	pixel_x = 6;
-	pixel_y = -1
-	},
+/obj/structure/chair/sofa/blue/corpo/right/directional/west,
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -2458,9 +2460,6 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "SF" = (
-/obj/structure/chair/comfy/purple{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	pixel_x = 20;
 	dir = 8;
@@ -2474,6 +2473,7 @@
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 15
 	},
+/obj/structure/chair/sofa/blue/corpo/left/directional/west,
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -2522,13 +2522,10 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "UM" = (
-/obj/effect/mapping_helpers/crate_shelve,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1;
 	color = "#FFFFFF"
 	},
-/obj/item/storage/box/flares,
-/obj/item/storage/box/flares,
 /obj/item/storage/box/flares,
 /obj/item/storage/box/flares,
 /obj/item/storage/box/flares,

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -344,7 +344,6 @@
 	req_access_txt = "1"
 	},
 /obj/item/storage/box/ammo/a8_50r,
-/obj/item/storage/box/ammo/c556mm,
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/industrial/warning{
@@ -353,6 +352,7 @@
 	},
 /obj/item/ammo_box/magazine/m23/empty,
 /obj/item/ammo_box/magazine/m23/empty,
+/obj/item/storage/box/ammo/c10mm,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eI" = (

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,20 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 9
 	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "ao" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "cabinet";
@@ -55,10 +45,7 @@
 	},
 /area/ship/crew/dorm/captain)
 "as" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
-	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "au" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -145,53 +132,56 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "ba" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
-"bv" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"bH" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 10;
-	layer = 2.030
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"cg" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/slime/pet{
+	colour = "cerulean";
+	icon_living = "cerulean baby slime";
+	icon_state = "cerulean baby slime";
+	icon_dead = "cerulean baby slime dead";
+	faction = list("neutral");
+	mood = "aslime-:3";
+	name = "Searle";
+	pass_flags = 4;
+	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
+	speak_emote = list("blorbles", "bounces around happily", "purrs");
+	speak_chance = 1;
+	density = 0;
+	can_buckle = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"bv" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
 	dir = 1
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
+"cg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -365,32 +355,13 @@
 /obj/item/ammo_box/magazine/m23/empty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
-"eB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
 "eI" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "eK" = (
 /obj/structure/railing{
 	dir = 4
@@ -414,16 +385,28 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "my_dumb_gay_windows";
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/area/ship/bridge)
 "fa" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -448,42 +431,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "fg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/slime/pet{
-	colour = "cerulean";
-	icon_living = "cerulean baby slime";
-	icon_state = "cerulean baby slime";
-	icon_dead = "cerulean baby slime dead";
-	faction = list("neutral");
-	mood = "aslime-:3";
-	name = "Searle";
-	pass_flags = 4;
-	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
-	speak_emote = list("blorbles", "bounces around happily", "purrs");
-	speak_chance = 1;
-	density = 0;
-	can_buckle = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/wood/maple/left{
-	dir = 4
-	},
-/area/ship/crew)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -559,9 +518,29 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"hs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "hB" = (
 /turf/template_noop,
 /area/template_noop)
+"hC" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1;
+	icon_state = "computer-left"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "hN" = (
 /obj/structure/sink{
 	dir = 8;
@@ -587,37 +566,33 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "hO" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/corner{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"hQ" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"hU" = (
-/obj/structure/railing/thick/corner{
-	dir = 1
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"hQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/industrial/hatch,
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/patterned/grid{
 	color = "#777777"
 	},
@@ -685,30 +660,27 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/railing/thick/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/bridge)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "kr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/plating,
+/area/ship/engineering/engines/starboard)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -757,6 +729,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"lr" = (
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "lS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -794,6 +770,16 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/cargo)
+"lZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "mh" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -829,13 +815,15 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "mB" = (
-/obj/structure/railing{
-	dir = 10
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
 "nj" = (
 /obj/machinery/washing_machine{
 	pixel_y = 9;
@@ -861,30 +849,33 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
+/obj/structure/table/chem{
+	name = "kitchen counter"
 	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/item/cutting_board{
+	pixel_y = 1;
+	anchored = 1;
+	pixel_x = 7
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/item/melee/knife/kitchen{
+	pixel_y = 2;
+	pixel_x = 4
 	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
+/obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 8;
+	pixel_x = -10
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
 "nL" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -942,41 +933,17 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
 "oP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "oU" = (
 /obj/machinery/jukebox/boombox{
 	pixel_x = -4;
@@ -992,30 +959,24 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"oZ" = (
-/obj/structure/chair/sofa/grey/right{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
+"pa" = (
+/obj/structure/dresser{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/structure/sign/painting/library{
+	pixel_x = -30
 	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"pa" = (
-/turf/open/floor/carpet/royalblack,
+/obj/item/storage/guncase/pistol/ringneck{
+	pixel_y = 8
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
 /area/ship/crew/dorm/captain)
 "pl" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -1033,16 +994,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
-"pX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/wood/maple,
-/area/ship/crew)
 "pZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -1053,11 +1004,21 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
+"qa" = (
+/obj/structure/railing/thick,
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "qb" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "qm" = (
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 9
@@ -1065,15 +1026,36 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "qp" = (
-/obj/structure/railing/thick/corner,
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "qx" = (
 /obj/effect/turf_decal/isf_small{
 	dir = 8
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
+"qA" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "qH" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1090,23 +1072,16 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
-	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/area/ship/cargo)
 "qM" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -1122,40 +1097,6 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
-"rv" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
-	},
-/obj/item/cutting_board{
-	pixel_y = 1;
-	anchored = 1;
-	pixel_x = 7
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 2;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 8;
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 9;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"rM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
 "rP" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative{
@@ -1245,6 +1186,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
+"sU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/crewtwo)
 "tj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -1270,28 +1227,18 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
 	},
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
-	},
-/obj/item/gun/ballistic/revolver/shadow/empty{
-	pixel_y = -2
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "tT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -1309,6 +1256,12 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
+"uc" = (
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "ui" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1325,20 +1278,22 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "uz" = (
-/obj/structure/cable/green{
-	icon_state = "4-9"
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-10"
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 6
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
 	},
 /obj/effect/turf_decal/techfloor{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "uG" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/computer/cryopod/directional/north,
@@ -1381,22 +1336,29 @@
 	},
 /area/ship/cargo)
 "vJ" = (
-/obj/structure/chair/stool/bar{
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "vS" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/obj/structure/chair/handrail{
+/obj/structure/chair/sofa/grey/right{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/engines/starboard)
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1461,16 +1423,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/crew/ccommons)
-"yw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
 "yz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1513,15 +1465,33 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/item/clothing/under/suit/roumain,
+/obj/item/clothing/suit/armor/roumain,
+/obj/item/clothing/head/cowboy/sec/roumain,
+/obj/item/flashlight/lantern,
+/obj/structure/closet/secure_closet/hunter{
+	name = "guide's locker"
 	},
-/obj/machinery/modular_computer/console/preset/command{
+/obj/item/clothing/shoes/cowboy/black,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/accessory/waistcoat/roumain,
+/obj/item/disk/holodisk/roumain,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1;
-	icon_state = "computer-left"
+	color = "#543C30"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/a44roum,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "zf" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engines/starboard)
@@ -1566,6 +1536,25 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"zA" = (
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "zV" = (
 /obj/machinery/power/smes/shuttle,
@@ -1634,20 +1623,19 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
-"Ax" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
+"AA" = (
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
@@ -1657,72 +1645,19 @@
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
-"AG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "my_dumb_gay_windows";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/starboard)
-"AL" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
 "AX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Be" = (
 /obj/structure/railing/thick,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"Br" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 10
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
 "Bw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random/trash/deluxe_garbage,
@@ -1735,12 +1670,21 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
+"BC" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "BM" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
+/obj/machinery/computer/cargo{
+	icon_state = "computer-right";
+	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "BP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1775,40 +1719,103 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "Cc" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "Cl" = (
-/obj/structure/chair/stool,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"CU" = (
-/obj/structure/railing/thick/corner{
+"Cn" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"CU" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Dk" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/crewtwo)
 "Dm" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
 "Dq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_captains";
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1826,39 +1833,63 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"DN" = (
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
 "Ef" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
-"El" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew)
 "Ey" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
 	},
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "EC" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"EZ" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1870,28 +1901,8 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"Fh" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
@@ -1906,22 +1917,19 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"FJ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "Gc" = (
 /obj/structure/railing/thick/corner{
 	dir = 8
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"Gq" = (
-/obj/machinery/computer/cargo{
-	icon_state = "computer-right";
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -1998,22 +2006,44 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "HK" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
-	},
-/obj/machinery/shower{
+/obj/structure/chair/stool/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
-"HQ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
+"HQ" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"HT" = (
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
+	},
+/obj/item/melee/spear/bone,
+/obj/item/melee/knife/hunting{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
+	},
+/obj/item/gun/ballistic/revolver/shadow/empty{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "HV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engines/starboard)
@@ -2031,36 +2061,29 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Iu" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
+/turf/open/floor/wood/maple,
 /area/ship/crew)
 "IR" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "Jw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2091,14 +2114,15 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JY" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2145,21 +2169,30 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "Ls" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/structure/chair/handrail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
+"Mo" = (
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "Mx" = (
 /obj/structure/closet/wall/directional/west{
 	name = "janitorial supplies";
@@ -2194,27 +2227,45 @@
 "NG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/crewtwo)
-"NH" = (
-/turf/open/floor/grass/ship/jungle,
-/area/ship/crew/crewtwo)
+"NI" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "NO" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
+/obj/structure/cable/green{
+	icon_state = "4-9"
 	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
+/obj/structure/cable/green{
+	icon_state = "4-10"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 6
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "NU" = (
 /obj/structure/table/glass,
@@ -2225,46 +2276,35 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "Op" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/closet/cabinet{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm)
-"OA" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"OA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2286,31 +2326,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"Pu" = (
-/obj/structure/chair/sofa/grey/left{
-	dir = 8
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"PG" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "PT" = (
 /obj/structure/closet/firecloset/wall/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -2318,34 +2333,6 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"QD" = (
-/obj/item/clothing/under/suit/roumain,
-/obj/item/clothing/suit/armor/roumain,
-/obj/item/clothing/head/cowboy/sec/roumain,
-/obj/item/flashlight/lantern,
-/obj/structure/closet/secure_closet/hunter{
-	name = "guide's locker"
-	},
-/obj/item/clothing/shoes/cowboy/black,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/shoes/combat,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/accessory/waistcoat/roumain,
-/obj/item/disk/holodisk/roumain,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -8
-	},
-/obj/item/storage/box/ammo/a44roum,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
 "QG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -2358,22 +2345,35 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "QQ" = (
-/obj/structure/railing/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/handrail{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/techfloor{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Rd" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Rs" = (
 /obj/structure/closet/emcloset/wall/directional/north{
 	populate = 0;
@@ -2400,6 +2400,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
+"RG" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/obj/item/melee/knife/hunting{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "RJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -2409,16 +2437,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/crew/crewtwo)
-"Sh" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
-	},
-/area/ship/cargo)
 "Ss" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -2497,6 +2515,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"UK" = (
+/obj/structure/railing/thick/corner{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "UM" = (
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/effect/turf_decal/industrial/warning{
@@ -2518,28 +2542,15 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
 "VO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/bridge)
+/area/ship/engineering/engines/port)
 "VS" = (
 /obj/effect/turf_decal/isf_small/left{
 	dir = 8
@@ -2547,20 +2558,13 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "Wg" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/wood/maple/left{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
+/area/ship/crew)
 "Wt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -2572,6 +2576,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
 "WC" = (
@@ -2600,54 +2607,18 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
-/obj/structure/dresser{
-	dir = 1
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = -30
-	},
-/obj/item/storage/guncase/pistol/ringneck{
-	pixel_y = 8
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"Xr" = (
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"XC" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"XF" = (
-/obj/machinery/power/smes/engineering,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	color = "#FFFFFF"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
-"XJ" = (
-/obj/structure/railing/thick,
-/obj/docking_port/mobile{
-	port_direction = 4;
-	preferred_direction = 4;
-	name = "Ivory-class"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"XM" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Xg" = (
 /obj/structure/cabinet/m23{
 	dir = 4;
 	pixel_x = -21
@@ -2663,43 +2634,78 @@
 	color = "#792f27"
 	},
 /area/ship/crew/dorm/captain)
-"XX" = (
-/turf/open/floor/plasteel/patterned/brushed,
+"Xr" = (
+/turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"Yq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+"XC" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
+"XJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"XM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
+"XX" = (
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Yu" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
 	},
-/obj/item/melee/knife/hunting{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -2753,11 +2759,11 @@ hB
 hB
 tj
 iy
-mB
+IR
 hB
 Ab
 hB
-hO
+EZ
 iy
 tj
 hB
@@ -2780,7 +2786,7 @@ mp
 sv
 Hd
 mh
-QQ
+uz
 iy
 iy
 Ue
@@ -2803,7 +2809,7 @@ go
 VS
 qx
 AF
-OA
+eI
 iy
 iy
 iC
@@ -2845,12 +2851,12 @@ zW
 zW
 lc
 cq
-NO
+zA
 xo
-uz
+NO
 DL
 eA
-Ax
+Ey
 HV
 zV
 zV
@@ -2860,7 +2866,7 @@ hB
 hB
 "}
 (7,1,1) = {"
-CU
+kj
 Ue
 aR
 lc
@@ -2868,27 +2874,27 @@ sE
 GE
 lc
 SV
-pl
-bH
+AX
+JY
 tm
 HB
 UM
-IR
+CU
 HV
 fa
 sf
 HV
 zf
 Ue
-qp
+lr
 "}
 (8,1,1) = {"
 gQ
 iC
 lc
-XF
+VO
 OX
-nI
+Yu
 lc
 DK
 JT
@@ -2896,9 +2902,9 @@ Id
 tm
 Fr
 eK
-PG
+AA
 HV
-ox
+Cn
 pC
 wh
 HV
@@ -2909,7 +2915,7 @@ Be
 gQ
 iC
 lc
-qL
+Mo
 Pr
 kB
 qH
@@ -2919,36 +2925,36 @@ mz
 aQ
 QG
 lT
-oP
+Xe
 wV
 tq
 lS
 au
 HV
-BM
-XJ
+hO
+qa
 "}
 (10,1,1) = {"
-hU
+UK
 iC
 lc
-EC
+tJ
 sA
 es
 lc
-Sh
 iq
+qL
 vo
-AX
+QQ
 qm
 uU
-Ey
+FJ
 HV
 jv
-AG
+kr
 HV
 HV
-Yq
+qb
 Gc
 "}
 (11,1,1) = {"
@@ -2968,10 +2974,10 @@ iy
 iy
 HV
 Rs
-Wg
-qb
-vS
-Cc
+Dq
+BC
+Ls
+ac
 hB
 "}
 (12,1,1) = {"
@@ -2988,10 +2994,10 @@ Bw
 Ar
 qM
 Mx
-Br
+Rd
 Ef
 Ef
-eM
+XM
 zf
 iC
 Ue
@@ -3005,14 +3011,14 @@ hB
 hB
 yg
 xq
-XX
-as
-vJ
-aZ
+Cl
 HQ
+HK
+aZ
+as
 Gs
 lo
-oZ
+vS
 yg
 hB
 hB
@@ -3028,11 +3034,11 @@ hB
 hB
 yg
 KU
-Cl
-as
-aL
-fg
+Dm
 HQ
+aL
+ba
+as
 fs
 NU
 op
@@ -3050,12 +3056,12 @@ hB
 hB
 hB
 yg
-rv
-XX
-as
-vJ
+nI
+Cl
+HQ
+HK
 Ss
-rM
+fx
 Xr
 TP
 rP
@@ -3078,10 +3084,10 @@ aP
 og
 zk
 BP
-hQ
+OA
 YX
 jg
-Pu
+DN
 yg
 hB
 hB
@@ -3101,7 +3107,7 @@ jV
 jV
 cC
 wO
-fx
+Wg
 cC
 cC
 cC
@@ -3127,7 +3133,7 @@ kR
 KE
 SX
 Av
-HK
+XC
 cC
 hB
 hB
@@ -3144,13 +3150,13 @@ hB
 jV
 WC
 jZ
-Op
+Cc
 cC
 tT
-pX
+XJ
 cC
 hN
-El
+mB
 cC
 hB
 hB
@@ -3169,8 +3175,8 @@ jV
 jV
 jV
 cC
-Fh
-AL
+Op
+qA
 cC
 cC
 cC
@@ -3192,12 +3198,12 @@ yC
 gc
 NG
 eu
-Ls
+bv
 Af
 jL
 ao
-XM
-Xe
+Xg
+pa
 vg
 iC
 iC
@@ -3210,17 +3216,17 @@ hB
 hB
 iC
 RJ
-NH
-NH
+fg
+fg
 sn
 NG
 nj
-kr
+Iu
 PT
 cC
 ef
-pa
-Dm
+oP
+uc
 vg
 iC
 hB
@@ -3236,14 +3242,14 @@ RJ
 yA
 WL
 Ca
-eI
+sU
 Fc
-cg
+NI
 Wt
-Iu
-eB
-ba
-JY
+hQ
+hs
+pl
+qp
 vg
 iC
 hB
@@ -3255,19 +3261,19 @@ hB
 hB
 hB
 Ue
-yw
+cg
 RJ
-tJ
-QD
+HT
+yH
 NG
 fK
-VO
+eM
 fK
 cC
-Yu
+RG
 SF
 vg
-Dq
+lZ
 Ue
 hB
 hB
@@ -3309,7 +3315,7 @@ Jw
 kX
 yz
 rf
-XC
+vJ
 HA
 hB
 hB
@@ -3331,8 +3337,8 @@ HA
 iT
 YF
 ui
-kj
-yH
+ox
+hC
 HA
 iC
 hB
@@ -3352,9 +3358,9 @@ hB
 Ue
 pZ
 HA
-bv
-ac
-Gq
+XX
+EC
+BM
 HA
 pZ
 Ue

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,7 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "ao" = (
 /obj/structure/dresser{
 	dir = 1
@@ -17,41 +26,33 @@
 	},
 /area/ship/crew/dorm/captain)
 "as" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
 	},
-/obj/item/melee/knife/survival{
-	pixel_x = 6;
-	pixel_y = -1
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "au" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 5;
-	layer = 2.030
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "aL" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -103,33 +104,6 @@
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/starboard)
 "aZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"ba" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
-"bv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -154,19 +128,38 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
-"cg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+"ba" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
+"bv" = (
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"bK" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"cg" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -287,6 +280,45 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/captain)
+"eg" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "cabinet";
+	name = "captain's wardobe";
+	req_access_txt = "20";
+	close_sound = 'sound/machines/wooden_closet_close.ogg';
+	open_sound = 'sound/machines/wooden_closet_open.ogg';
+	desc = "It's a card-locked cabinet.";
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel/cap,
+/obj/item/storage/backpack/captain,
+/obj/item/clothing/under/rank/command/captain,
+/obj/item/clothing/under/rank/command/captain/skirt,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13;
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/jacket/miljacket,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/caphat,
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/attachment/sling,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 20
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "es" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/light_switch{
@@ -322,60 +354,54 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/crew)
 "eA" = (
-/obj/effect/turf_decal/borderfloorblack{
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
 	dir = 1
 	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1;
-	icon_state = "computer-left"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "eI" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"eK" = (
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
-"eK" = (
-/obj/structure/railing/thick/corner{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "eM" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/computer/cargo{
+	icon_state = "computer-right";
 	dir = 8
 	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "fa" = (
 /obj/machinery/power/terminal{
@@ -400,29 +426,57 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
-"fg" = (
+"ff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"fg" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
-"fT" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "gb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -513,27 +567,43 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "hO" = (
-/obj/structure/railing/thick,
-/obj/docking_port/mobile{
-	port_direction = 4;
-	preferred_direction = 4;
-	name = "Ivory-class"
+/obj/structure/railing/thick/corner{
+	dir = 1
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"hP" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "hQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/item/clothing/under/suit/roumain,
+/obj/item/clothing/suit/armor/roumain,
+/obj/item/clothing/head/cowboy/sec/roumain,
+/obj/item/flashlight/lantern,
+/obj/structure/closet/secure_closet/hunter{
+	name = "guide's locker"
 	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 10;
-	layer = 2.030
+/obj/item/clothing/shoes/cowboy/black,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/accessory/waistcoat/roumain,
+/obj/item/disk/holodisk/roumain,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -8
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -550,6 +620,16 @@
 "iC" = (
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"iI" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "iT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax/indie{
@@ -574,6 +654,17 @@
 	color = "#555555"
 	},
 /area/ship/bridge)
+"iV" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "jg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/chair/sofa/grey/right{
@@ -585,10 +676,6 @@
 	layer = 3.01
 	},
 /turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"jr" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "jv" = (
 /obj/structure/grille,
@@ -616,35 +703,42 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/obj/structure/window{
+/obj/effect/turf_decal/corner_steel_grid{
 	dir = 4
 	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
+/obj/effect/turf_decal/techfloor{
+	dir = 10
 	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "kr" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
-	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/borderfloorblack{
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -765,44 +859,11 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "mB" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"mI" = (
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"mY" = (
-/obj/item/clothing/under/suit/roumain,
-/obj/item/clothing/suit/armor/roumain,
-/obj/item/clothing/head/cowboy/sec/roumain,
-/obj/item/flashlight/lantern,
-/obj/structure/closet/secure_closet/hunter{
-	name = "guide's locker"
-	},
-/obj/item/clothing/shoes/cowboy/black,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/shoes/combat,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/accessory/waistcoat/roumain,
-/obj/item/disk/holodisk/roumain,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -8
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "nj" = (
 /obj/machinery/washing_machine{
 	pixel_y = 9;
@@ -828,30 +889,18 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/item/gun/ballistic/shotgun/flamingarrow/absolution/factory,
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
 	},
-/obj/item/attachment/bayonet{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "nL" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -900,15 +949,46 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/techfloor{
+/obj/structure/cabinet/m23{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/double{
+	dir = 4;
+	icon_state = "double_sheetrd"
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"oL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"oN" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "oP" = (
-/turf/open/floor/grass/ship/jungle,
-/area/ship/crew/crewtwo)
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
 "oU" = (
 /obj/machinery/jukebox/boombox{
 	pixel_x = -4;
@@ -925,29 +1005,27 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "pa" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"pl" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 4
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"pl" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -976,27 +1054,29 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "qb" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
 	},
-/area/ship/crew/dorm/captain)
-"qk" = (
-/obj/structure/cabinet/m23{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 4;
-	pixel_x = -21
+	piping_layer = 4
 	},
-/obj/structure/bed/double{
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/item/bedsheet/double{
-	dir = 4;
-	icon_state = "double_sheetrd"
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/area/ship/crew/dorm/captain)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "qm" = (
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 9
@@ -1004,11 +1084,15 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "qp" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "qx" = (
 /obj/effect/turf_decal/isf_small{
 	dir = 8
@@ -1031,15 +1115,28 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
 "qM" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -1063,24 +1160,22 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"rT" = (
-/obj/machinery/power/terminal{
-	dir = 8
+"sc" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
 	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/crew/crewtwo)
 "sf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
@@ -1110,16 +1205,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
-"sg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 4
+"si" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
 	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "sn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9;
@@ -1197,15 +1290,15 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/machinery/computer/cargo{
-	icon_state = "computer-right";
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "tT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -1238,19 +1331,29 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
-"uq" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "uz" = (
-/obj/structure/railing/thick/corner,
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "uG" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/computer/cryopod/directional/north,
@@ -1292,81 +1395,45 @@
 	color = "#777777"
 	},
 /area/ship/cargo)
-"vB" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
-	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
-"vJ" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/closet/cabinet{
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm)
-"vS" = (
-/obj/machinery/door/firedoor/border_only{
+"vu" = (
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
+"vJ" = (
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
+	},
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"vS" = (
+/obj/structure/railing/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1495,13 +1562,14 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/wood/maple/left{
-	dir = 4
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/area/ship/crew)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "zf" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engines/starboard)
@@ -1642,6 +1710,18 @@
 /obj/structure/railing/thick,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"Bo" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Bw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random/trash/deluxe_garbage,
@@ -1695,70 +1775,61 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "Cc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_captains";
-	dir = 4
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
 /area/ship/crew/dorm/captain)
 "Cl" = (
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
+"Cy" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "CU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"Dk" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/crewtwo)
-"Dm" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"Dq" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
 	},
 /obj/effect/turf_decal/industrial/warning{
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
+"Dk" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/crewtwo)
+"Dm" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"Dq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/wood/maple/left{
+	dir = 4
+	},
+/area/ship/crew)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1786,39 +1857,35 @@
 /obj/item/ammo_box/magazine/m23/empty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
-"DX" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
 "Ef" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
 "Ey" = (
-/obj/structure/railing{
-	dir = 10
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
 	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "EC" = (
-/obj/structure/railing/thick/corner{
-	dir = 1
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
+"EP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1832,46 +1899,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"Fn" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "Fr" = (
-/obj/structure/railing{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/closet/crate/internals,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/effect/mapping_helpers/crate_shelve,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Gc" = (
 /obj/structure/railing/thick/corner{
@@ -1879,13 +1916,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"Go" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -1989,6 +2019,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engines/starboard)
 "Id" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 10;
 	layer = 2.030
@@ -2015,42 +2048,12 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/crew)
 "IR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/bridge)
-"IZ" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Jv" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/cargo)
 "Jw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2081,16 +2084,30 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 5;
-	layer = 2.030
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"JZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2137,21 +2154,22 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "Ls" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Mx" = (
 /obj/structure/closet/wall/directional/west{
 	name = "janitorial supplies";
@@ -2210,20 +2228,27 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "Op" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
-"OA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1;
+	icon_state = "computer-left"
 	},
-/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"OA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/crew/ccommons)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2245,22 +2270,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"PG" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+"PO" = (
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "PT" = (
 /obj/structure/closet/firecloset/wall/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -2268,18 +2281,6 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"Qh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
 "QG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -2292,14 +2293,33 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "QQ" = (
-/obj/structure/chair/sofa/grey/left{
-	dir = 8
+/obj/structure/chair/sofa/grey/right{
+	dir = 4
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"Rm" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Rs" = (
 /obj/structure/closet/emcloset/wall/directional/north{
 	populate = 0;
@@ -2400,16 +2420,12 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew)
-"Tb" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = 3
+"TO" = (
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew)
+/area/ship/crew/dorm/captain)
 "TP" = (
 /obj/structure/table/glass,
 /obj/item/toy/cards/deck/syndicate{
@@ -2423,96 +2439,30 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "UM" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "captain's wardobe";
-	req_access_txt = "20";
-	close_sound = 'sound/machines/wooden_closet_close.ogg';
-	open_sound = 'sound/machines/wooden_closet_open.ogg';
-	desc = "It's a card-locked cabinet.";
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel/cap,
-/obj/item/storage/backpack/captain,
-/obj/item/clothing/under/rank/command/captain,
-/obj/item/clothing/under/rank/command/captain/skirt,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13;
-	pixel_x = -6
-	},
-/obj/item/clothing/suit/jacket/miljacket,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/caphat,
-/obj/item/clothing/shoes/jackboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/attachment/sling,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 20
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"UR" = (
-/obj/structure/chair/sofa/grey/right{
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
+"UX" = (
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Vj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
-"Vt" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
-"Vu" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
-	},
-/area/ship/cargo)
 "VO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "VS" = (
 /obj/effect/turf_decal/isf_small/left{
 	dir = 8
@@ -2520,25 +2470,37 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "Wg" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
-"Wo" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/obj/structure/chair/handrail{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"Wk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Wt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -2578,67 +2540,87 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/railing/thin{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 10
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Xr" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "XC" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/area/ship/cargo)
-"XJ" = (
-/obj/structure/railing{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/techfloor/corner{
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"XJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
 "XM" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "XX" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
 	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
 "Yu" = (
-/obj/machinery/power/smes/engineering,
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
+	},
+/obj/item/melee/spear/bone,
+/obj/item/melee/knife/hunting{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/attachment/bayonet{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/obj/item/gun/ballistic/revolver/shadow/empty{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -2646,6 +2628,40 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
+"YV" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "YX" = (
 /obj/machinery/button/door{
 	pixel_x = 20;
@@ -2659,29 +2675,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"Zh" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+"ZV" = (
+/obj/structure/railing/thick,
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 
 (1,1,1) = {"
 hB
@@ -2715,11 +2717,11 @@ hB
 hB
 tj
 iy
-Ey
+Cy
 hB
 Ab
 hB
-XJ
+cg
 iy
 tj
 hB
@@ -2742,7 +2744,7 @@ mp
 sv
 Hd
 mh
-pa
+vu
 iy
 iy
 Ue
@@ -2765,7 +2767,7 @@ go
 VS
 qx
 AF
-ox
+fg
 iy
 iy
 iC
@@ -2807,12 +2809,12 @@ zW
 zW
 lc
 cq
-Fn
+CU
 xo
 NO
-mB
+kj
 DL
-eI
+Ls
 HV
 zV
 zV
@@ -2822,7 +2824,7 @@ hB
 hB
 "}
 (7,1,1) = {"
-eK
+vS
 Ue
 aR
 lc
@@ -2830,37 +2832,37 @@ sE
 GE
 lc
 SV
-Dq
-Id
+yH
+bK
 tm
-au
+si
 HB
-Dm
+pl
 HV
 fa
 sf
 HV
 zf
 Ue
-uz
+PO
 "}
 (8,1,1) = {"
 gQ
 iC
 lc
-Yu
+iI
 OX
-vB
+fx
 lc
 DK
 JT
-hQ
+Id
 tm
-JY
 Fr
-PG
+eK
+UX
 HV
-Vt
+qb
 pC
 wh
 HV
@@ -2871,7 +2873,7 @@ Be
 gQ
 iC
 lc
-rT
+as
 Pr
 kB
 qH
@@ -2881,36 +2883,36 @@ mz
 aQ
 QG
 lT
-Qh
+ff
 wV
 tq
 lS
-cg
+nI
 HV
-qp
-hO
+Xe
+ZV
 "}
 (10,1,1) = {"
-EC
+hO
 iC
 lc
-Wg
+Ey
 sA
 es
 lc
 iq
-XC
+iV
 vo
 AX
 qm
 uU
-Vu
+IR
 HV
 BM
 jv
 HV
 HV
-fT
+Dm
 Gc
 "}
 (11,1,1) = {"
@@ -2930,10 +2932,10 @@ iy
 iy
 HV
 Rs
-ba
-Op
-Wo
-VO
+JY
+hP
+XJ
+mB
 hB
 "}
 (12,1,1) = {"
@@ -2950,10 +2952,10 @@ Bw
 Ar
 qM
 Mx
-Xe
+Bo
 Ef
 Ef
-pl
+ba
 zf
 iC
 Ue
@@ -2970,11 +2972,11 @@ XM
 Cl
 HQ
 HK
-aZ
-mI
+OA
+bv
 Gs
 lo
-UR
+QQ
 yg
 hB
 hB
@@ -2990,11 +2992,11 @@ hB
 hB
 yg
 KU
-jr
+eI
 HQ
 aL
+aZ
 bv
-mI
 fs
 NU
 op
@@ -3017,7 +3019,7 @@ Cl
 HQ
 HK
 Ss
-fx
+oL
 Xr
 TP
 rP
@@ -3040,10 +3042,10 @@ aP
 og
 zk
 BP
-Go
+pa
 YX
 jg
-QQ
+EC
 yg
 hB
 hB
@@ -3063,7 +3065,7 @@ jV
 jV
 cC
 wO
-yH
+Dq
 cC
 cC
 cC
@@ -3089,7 +3091,7 @@ kR
 KE
 SX
 Av
-kj
+eA
 cC
 hB
 hB
@@ -3106,13 +3108,13 @@ hB
 jV
 WC
 jZ
-vJ
+YV
 cC
 tT
-OA
+tJ
 cC
 hN
-Tb
+oP
 cC
 hB
 hB
@@ -3131,8 +3133,8 @@ jV
 jV
 jV
 cC
-Zh
-DX
+uz
+Rm
 cC
 cC
 cC
@@ -3154,11 +3156,11 @@ yC
 gc
 NG
 eu
-Jv
+Wg
 Af
 jL
-UM
-qk
+eg
+ox
 ao
 vg
 iC
@@ -3172,17 +3174,17 @@ hB
 hB
 iC
 RJ
-oP
-oP
+UM
+UM
 sn
 NG
 nj
-Ls
+Wk
 PT
 cC
 ef
-ac
-qb
+VO
+TO
 vg
 iC
 hB
@@ -3198,14 +3200,14 @@ RJ
 yA
 WL
 Ca
-vS
+sc
 Fc
-CU
+XC
 Wt
 Iu
-qL
-fg
-XX
+au
+EP
+Cc
 vg
 iC
 hB
@@ -3217,19 +3219,19 @@ hB
 hB
 hB
 Ue
-sg
+qp
 RJ
-nI
-mY
+Yu
+hQ
 NG
 fK
-eM
+qL
 fK
 cC
-as
+kr
 SF
 vg
-Cc
+JZ
 Ue
 hB
 hB
@@ -3271,7 +3273,7 @@ Jw
 kX
 yz
 rf
-IZ
+ac
 HA
 hB
 hB
@@ -3293,8 +3295,8 @@ HA
 iT
 YF
 ui
-IR
-eA
+XX
+Op
 HA
 iC
 hB
@@ -3314,9 +3316,9 @@ hB
 Ue
 pZ
 HA
-uq
-kr
-tJ
+oN
+vJ
+eM
 HA
 pZ
 Ue

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,12 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
+	},
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
+	},
 /obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1;
-	icon_state = "computer-left"
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "ao" = (
@@ -55,11 +61,27 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "au" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east{
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	pixel_y = 11;
+	pixel_x = 22;
+	dir = 8;
+	id = "my_dumb_gay_windows";
+	name = "shutter control"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "aL" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -123,51 +145,53 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "ba" = (
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "bv" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 9
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"bw" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"bH" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"cg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
-"cg" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -249,18 +273,6 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"cZ" = (
-/obj/structure/chair/sofa/grey/right{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "dm" = (
 /obj/structure/table/chem{
@@ -353,11 +365,32 @@
 /obj/item/ammo_box/magazine/m23/empty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
+"eB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "eI" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/crew/crewtwo)
 "eK" = (
 /obj/structure/railing{
 	dir = 4
@@ -381,12 +414,16 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eM" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "fa" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -411,35 +448,42 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "fg" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/slime/pet{
+	colour = "cerulean";
+	icon_living = "cerulean baby slime";
+	icon_state = "cerulean baby slime";
+	icon_dead = "cerulean baby slime dead";
+	faction = list("neutral");
+	mood = "aslime-:3";
+	name = "Searle";
+	pass_flags = 4;
+	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
+	speak_emote = list("blorbles", "bounces around happily", "purrs");
+	speak_chance = 1;
+	density = 0;
+	can_buckle = 1
+	},
 /turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/crew/ccommons)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 10;
-	layer = 2.030
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/turf/open/floor/plasteel/stairs/wood/maple/left{
+	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/crew)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -497,32 +541,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
-"gN" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew/crewtwo)
-"gO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
 "gP" = (
 /obj/structure/chair/handrail{
 	dir = 4
@@ -569,63 +587,30 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "hO" = (
-/obj/structure/cabinet/m23{
-	dir = 4;
-	pixel_x = -21
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/structure/bed/double{
+/obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/item/bedsheet/double{
-	dir = 4;
-	icon_state = "double_sheetrd"
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"hQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"hR" = (
-/obj/structure/dresser{
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = -30
-	},
-/obj/item/storage/guncase/pistol/ringneck{
-	pixel_y = 8
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"ii" = (
-/obj/structure/railing{
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
+"hQ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"hU" = (
+/obj/structure/railing/thick/corner{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -663,7 +648,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/stairs{
-	dir = 8;
+	dir = 4;
 	color = "#555555"
 	},
 /area/ship/bridge)
@@ -686,18 +671,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
-"jJ" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 10
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
 "jL" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
@@ -712,21 +685,30 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/area/ship/crew/dorm/captain)
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
 "kr" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -847,22 +829,13 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "mB" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "nj" = (
 /obj/machinery/washing_machine{
 	pixel_y = 9;
@@ -888,30 +861,30 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
+	},
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "nL" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -969,26 +942,40 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
 	},
-/area/ship/cargo)
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "oP" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "oU" = (
 /obj/machinery/jukebox/boombox{
@@ -1005,27 +992,30 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"pa" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/corner{
+"oZ" = (
+/obj/structure/chair/sofa/grey/right{
 	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/structure/railing/thin/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"pl" = (
-/obj/structure/chair/sofa/grey/left{
-	dir = 8
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"pa" = (
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
+"pl" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -1043,6 +1033,16 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
+"pX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "pZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -1054,53 +1054,20 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "qb" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/wood/maple/left{
-	dir = 4
-	},
-/area/ship/crew)
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "qm" = (
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"qo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/bridge)
 "qp" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
-	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "qx" = (
 /obj/effect/turf_decal/isf_small{
 	dir = 8
@@ -1123,11 +1090,23 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/structure/railing/thick/corner{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "qM" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -1143,6 +1122,40 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
+"rv" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/obj/item/cutting_board{
+	pixel_y = 1;
+	anchored = 1;
+	pixel_x = 7
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_y = 2;
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 8;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"rM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "rP" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative{
@@ -1232,16 +1245,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"sJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/wood/maple,
-/area/ship/crew)
 "tj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -1267,48 +1270,28 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
-"tS" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
-	},
+/obj/item/melee/spear/bone,
 /obj/item/melee/knife/hunting{
-	pixel_x = 6;
-	pixel_y = -1
+	pixel_x = 8;
+	pixel_y = -5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/area/ship/crew/dorm/captain)
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
+	},
+/obj/item/gun/ballistic/revolver/shadow/empty{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "tT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -1342,39 +1325,20 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "uz" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
+/obj/structure/cable/green{
+	icon_state = "4-9"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "4-10"
 	},
-/obj/structure/closet/cabinet{
-	anchored = 1
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 6
 	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
+/obj/effect/turf_decal/techfloor{
+	dir = 8
 	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "uG" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/computer/cryopod/directional/north,
@@ -1416,67 +1380,23 @@
 	color = "#777777"
 	},
 /area/ship/cargo)
-"vE" = (
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
-	},
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
+"vJ" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
+	color = "#D2BC9D";
+	dir = 1
 	},
-/obj/item/gun/ballistic/revolver/shadow/empty{
-	pixel_y = -2
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
-"vJ" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
-	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "vS" = (
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
-"wc" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
 /obj/structure/chair/handrail{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1527,31 +1447,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "xq" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
-	},
-/obj/item/cutting_board{
-	pixel_y = 1;
-	anchored = 1;
-	pixel_x = 7
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 2;
-	pixel_x = 4
-	},
+/obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 8;
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 9;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -10;
-	pixel_y = 5
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "yg" = (
@@ -1563,6 +1461,16 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/crew/ccommons)
+"yw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "yz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1605,23 +1513,12 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
-	},
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"yP" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+	dir = 1;
+	icon_state = "computer-left"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -1692,12 +1589,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/port)
-"zY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "Ab" = (
 /obj/docking_port/stationary{
 	width = 30;
@@ -1743,12 +1634,61 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
+"Ax" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
+	},
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "AF" = (
 /obj/effect/turf_decal/isf_small/right{
 	dir = 8
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
+"AG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "my_dumb_gay_windows";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/starboard)
+"AL" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1771,6 +1711,18 @@
 /obj/structure/railing/thick,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"Br" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Bw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random/trash/deluxe_garbage,
@@ -1784,21 +1736,11 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "BM" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
 	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "BP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1833,52 +1775,40 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "Cc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east{
-	pixel_y = -4
-	},
-/obj/machinery/button/door{
-	pixel_y = 11;
-	pixel_x = 22;
-	dir = 8;
-	id = "my_dumb_gay_windows";
-	name = "shutter control"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Cl" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "CU" = (
-/obj/structure/railing/thick/corner,
+/obj/structure/railing/thick/corner{
+	dir = 4
+	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Dk" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/crewtwo)
 "Dm" = (
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "Dq" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
+/obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "my_dumb_gay_windows";
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1899,35 +1829,36 @@
 "Ef" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
+"El" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
 "Ey" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "EC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
 	},
-/mob/living/simple_animal/slime/pet{
-	colour = "cerulean";
-	icon_living = "cerulean baby slime";
-	icon_state = "cerulean baby slime";
-	icon_dead = "cerulean baby slime dead";
-	faction = list("neutral");
-	mood = "aslime-:3";
-	name = "Searle";
-	pass_flags = 4;
-	desc = "A blue gelatinous blob commonly known as Searle. It seems happy!";
-	speak_emote = list("blorbles", "bounces around happily", "purrs");
-	speak_chance = 1;
-	density = 0;
-	can_buckle = 1
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1939,6 +1870,29 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"Fh" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
 "Fr" = (
@@ -1958,6 +1912,16 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"Gq" = (
+/obj/machinery/computer/cargo{
+	icon_state = "computer-right";
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -2034,19 +1998,20 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "HK" = (
-/obj/structure/chair/stool/bar{
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "HQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "HV" = (
@@ -2082,15 +2047,20 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/crew)
 "IR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Jw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2111,16 +2081,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"JI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_captains";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
 "JT" = (
 /obj/structure/railing{
 	dir = 4
@@ -2131,11 +2091,14 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JY" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 8
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2182,25 +2145,18 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "Ls" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
 	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
@@ -2238,20 +2194,27 @@
 "NG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/crewtwo)
+"NH" = (
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
 "NO" = (
-/obj/structure/cable/green{
-	icon_state = "4-9"
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-10"
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 6
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "NU" = (
 /obj/structure/table/glass,
@@ -2261,37 +2224,47 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"Og" = (
-/obj/structure/railing/thick/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "Op" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/closet/cabinet{
+	anchored = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "OA" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2313,6 +2286,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
+"Pu" = (
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
+"PG" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "PT" = (
 /obj/structure/closet/firecloset/wall/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -2320,18 +2318,7 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
-"QG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"QQ" = (
+"QD" = (
 /obj/item/clothing/under/suit/roumain,
 /obj/item/clothing/suit/armor/roumain,
 /obj/item/clothing/head/cowboy/sec/roumain,
@@ -2359,6 +2346,34 @@
 /obj/item/storage/box/ammo/a44roum,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
+"QG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"QQ" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "Rs" = (
 /obj/structure/closet/emcloset/wall/directional/north{
 	populate = 0;
@@ -2394,6 +2409,16 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/crew/crewtwo)
+"Sh" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "Ss" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -2406,15 +2431,6 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
-"Su" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "Sz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -2444,15 +2460,6 @@
 	color = "#792f27"
 	},
 /area/ship/crew/dorm/captain)
-"SP" = (
-/obj/structure/railing/thick,
-/obj/docking_port/mobile{
-	port_direction = 4;
-	preferred_direction = 4;
-	name = "Ivory-class"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "SV" = (
 /obj/structure/table,
 /obj/item/folder/yellow{
@@ -2478,29 +2485,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew)
-"Tb" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/bridge)
 "TP" = (
 /obj/structure/table/glass,
 /obj/item/toy/cards/deck/syndicate{
@@ -2534,15 +2518,28 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
 "VO" = (
-/turf/open/floor/grass/ship/jungle,
-/area/ship/crew/crewtwo)
-"VR" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
 "VS" = (
 /obj/effect/turf_decal/isf_small/left{
 	dir = 8
@@ -2550,15 +2547,20 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "Wg" = (
-/obj/machinery/computer/cargo{
-	icon_state = "computer-right";
-	dir = 8
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "Wt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -2580,22 +2582,6 @@
 /obj/effect/turf_decal/industrial/hatch,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/dorm)
-"WH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "my_dumb_gay_windows";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/starboard)
 "WL" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass/ship/jungle,
@@ -2614,6 +2600,35 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
+/obj/structure/dresser{
+	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = -30
+	},
+/obj/item/storage/guncase/pistol/ringneck{
+	pixel_y = 8
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"Xr" = (
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
+"XC" = (
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"XF" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2623,83 +2638,68 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
-"Xr" = (
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"XC" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
 "XJ" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"XM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/obj/structure/chair/handrail{
-	dir = 4
+/obj/structure/railing/thick,
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
 	},
 /turf/open/floor/engine/hull,
-/area/ship/engineering/engines/starboard)
-"XP" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/area/ship/external/dark)
+"XM" = (
+/obj/structure/cabinet/m23{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/bed/double{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/item/bedsheet/double{
+	dir = 4;
+	icon_state = "double_sheetrd"
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/crew/dorm/captain)
 "XX" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = 3
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"Yq" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Yu" = (
-/obj/structure/window{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/obj/machinery/shower{
-	dir = 1
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/obj/item/melee/knife/hunting{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -2753,11 +2753,11 @@ hB
 hB
 tj
 iy
-XC
+mB
 hB
 Ab
 hB
-pa
+hO
 iy
 tj
 hB
@@ -2780,7 +2780,7 @@ mp
 sv
 Hd
 mh
-wc
+QQ
 iy
 iy
 Ue
@@ -2803,7 +2803,7 @@ go
 VS
 qx
 AF
-eM
+OA
 iy
 iy
 iC
@@ -2845,12 +2845,12 @@ zW
 zW
 lc
 cq
-XJ
-xo
 NO
+xo
+uz
 DL
 eA
-mB
+Ax
 HV
 zV
 zV
@@ -2860,7 +2860,7 @@ hB
 hB
 "}
 (7,1,1) = {"
-qL
+CU
 Ue
 aR
 lc
@@ -2868,27 +2868,27 @@ sE
 GE
 lc
 SV
-Su
-fx
+pl
+bH
 tm
 HB
 UM
-oP
+IR
 HV
 fa
 sf
 HV
 zf
 Ue
-CU
+qp
 "}
 (8,1,1) = {"
 gQ
 iC
 lc
-Xe
+XF
 OX
-qp
+nI
 lc
 DK
 JT
@@ -2896,9 +2896,9 @@ Id
 tm
 Fr
 eK
-ii
+PG
 HV
-bw
+ox
 pC
 wh
 HV
@@ -2909,7 +2909,7 @@ Be
 gQ
 iC
 lc
-vJ
+qL
 Pr
 kB
 qH
@@ -2919,36 +2919,36 @@ mz
 aQ
 QG
 lT
-hQ
+oP
 wV
 tq
 lS
-Cc
+au
 HV
-zY
-SP
+BM
+XJ
 "}
 (10,1,1) = {"
-Og
+hU
 iC
 lc
-cg
+EC
 sA
 es
 lc
-kr
+Sh
 iq
 vo
 AX
 qm
 uU
-ox
+Ey
 HV
 jv
-WH
+AG
 HV
 HV
-JY
+Yq
 Gc
 "}
 (11,1,1) = {"
@@ -2968,10 +2968,10 @@ iy
 iy
 HV
 Rs
-tJ
-eI
-XM
-bv
+Wg
+qb
+vS
+Cc
 hB
 "}
 (12,1,1) = {"
@@ -2988,10 +2988,10 @@ Bw
 Ar
 qM
 Mx
-jJ
+Br
 Ef
 Ef
-Dq
+eM
 zf
 iC
 Ue
@@ -3004,15 +3004,15 @@ hB
 hB
 hB
 yg
-au
-Dm
+xq
+XX
 as
-HK
+vJ
 aZ
-ba
+HQ
 Gs
 lo
-cZ
+oZ
 yg
 hB
 hB
@@ -3031,8 +3031,8 @@ KU
 Cl
 as
 aL
-EC
-ba
+fg
+HQ
 fs
 NU
 op
@@ -3050,12 +3050,12 @@ hB
 hB
 hB
 yg
-xq
-Dm
+rv
+XX
 as
-HK
+vJ
 Ss
-HQ
+rM
 Xr
 TP
 rP
@@ -3078,10 +3078,10 @@ aP
 og
 zk
 BP
-VR
+hQ
 YX
 jg
-pl
+Pu
 yg
 hB
 hB
@@ -3101,7 +3101,7 @@ jV
 jV
 cC
 wO
-qb
+fx
 cC
 cC
 cC
@@ -3127,7 +3127,7 @@ kR
 KE
 SX
 Av
-Yu
+HK
 cC
 hB
 hB
@@ -3144,13 +3144,13 @@ hB
 jV
 WC
 jZ
-uz
+Op
 cC
 tT
-sJ
+pX
 cC
 hN
-XX
+El
 cC
 hB
 hB
@@ -3169,8 +3169,8 @@ jV
 jV
 jV
 cC
-Ls
-fg
+Fh
+AL
 cC
 cC
 cC
@@ -3192,12 +3192,12 @@ yC
 gc
 NG
 eu
-XP
+Ls
 Af
 jL
 ao
-hO
-hR
+XM
+Xe
 vg
 iC
 iC
@@ -3210,17 +3210,17 @@ hB
 hB
 iC
 RJ
-VO
-VO
+NH
+NH
 sn
 NG
 nj
-Op
+kr
 PT
 cC
 ef
-vS
-kj
+pa
+Dm
 vg
 iC
 hB
@@ -3236,14 +3236,14 @@ RJ
 yA
 WL
 Ca
-gN
+eI
 Fc
-nI
+cg
 Wt
 Iu
-IR
-Ey
-OA
+eB
+ba
+JY
 vg
 iC
 hB
@@ -3255,19 +3255,19 @@ hB
 hB
 hB
 Ue
-gO
+yw
 RJ
-vE
-QQ
+tJ
+QD
 NG
 fK
-Tb
+VO
 fK
 cC
-tS
+Yu
 SF
 vg
-JI
+Dq
 Ue
 hB
 hB
@@ -3309,7 +3309,7 @@ Jw
 kX
 yz
 rf
-yH
+XC
 HA
 hB
 hB
@@ -3331,8 +3331,8 @@ HA
 iT
 YF
 ui
-qo
-ac
+kj
+yH
 HA
 iC
 hB
@@ -3352,9 +3352,9 @@ hB
 Ue
 pZ
 HA
-yP
-BM
-Wg
+bv
+ac
+Gq
 HA
 pZ
 Ue

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -40,7 +40,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
@@ -115,6 +114,7 @@
 	dir = 1;
 	color = "#FFFFFF"
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "cg" = (
@@ -122,11 +122,11 @@
 	name = "kitchen counter"
 	},
 /obj/machinery/microwave{
-	pixel_y = 8;
-	pixel_x = 1;
-	layer = 3.22
+	pixel_y = 6;
+	pixel_x = 1
 	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "ci" = (
@@ -151,7 +151,6 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
@@ -254,7 +253,6 @@
 	color = "#D5A66E"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 2;
 	color = "#D5A66E"
 	},
 /turf/open/floor/wood/birch,
@@ -272,6 +270,7 @@
 /obj/item/stack/sheet/mineral/titanium/five,
 /obj/item/stack/sheet/metal/five,
 /obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eI" = (
@@ -304,7 +303,6 @@
 	color = "#D5A66E"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 2;
 	color = "#D5A66E"
 	},
 /turf/open/floor/wood/birch,
@@ -392,7 +390,6 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/tech/grid,
@@ -498,6 +495,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/corner/transparent/white/full,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew)
 "hO" = (
@@ -575,8 +573,7 @@
 "jL" = (
 /obj/structure/cabinet/m23{
 	dir = 4;
-	pixel_x = -21;
-	pixel_y = 0
+	pixel_x = -21
 	},
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
@@ -661,7 +658,6 @@
 /area/ship/engineering/engines/port)
 "kR" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 2;
 	color = "#D5A66E"
 	},
 /turf/open/floor/wood/birch,
@@ -711,7 +707,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -767,12 +762,22 @@
 	},
 /obj/item/cutting_board{
 	pixel_y = 1;
-	anchored = 1
+	anchored = 1;
+	pixel_x = 7
 	},
 /obj/item/melee/knife/kitchen{
-	pixel_y = 2
+	pixel_y = 2;
+	pixel_x = 4
 	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 8;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 9;
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "nj" = (
@@ -821,7 +826,6 @@
 /obj/item/stack/sheet/mineral/uranium/ten,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/tech/grid,
@@ -892,7 +896,6 @@
 	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 0;
 	pixel_x = 10
 	},
 /obj/item/kitchen/rollingpin{
@@ -902,15 +905,14 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "oP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 2
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "oU" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -1025,6 +1027,9 @@
 	icon_state = "1-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines/port)
 "qx" = (
@@ -1050,9 +1055,11 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/machinery/newscaster/directional/east,
 /obj/structure/chair/sofa/grey/left{
 	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 30
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
@@ -1412,8 +1419,7 @@
 	pixel_x = -20;
 	dir = 4;
 	id = "ivory_guides";
-	name = "shutter control";
-	pixel_y = 0
+	name = "shutter control"
 	},
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = 12
@@ -1537,7 +1543,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light_switch{
-	dir = 2;
 	pixel_x = 12;
 	pixel_y = 20
 	},
@@ -1640,6 +1645,7 @@
 /obj/machinery/firealarm/directional/south{
 	pixel_x = -8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood/maple,
 /area/ship/crew/crewtwo)
 "Cc" = (
@@ -1668,7 +1674,6 @@
 /area/ship/crew/crewtwo)
 "Dm" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	pixel_x = 11;
 	pixel_y = 20
 	},
@@ -1985,9 +1990,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "Kk" = (
@@ -2016,7 +2021,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/public{
-	dir = 2;
 	name = "Bathroom"
 	},
 /turf/open/floor/plasteel/patterned/ridged,
@@ -2040,6 +2044,7 @@
 /obj/structure/railing/thin{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood/birch,
 /area/ship/crew/ccommons)
 "NG" = (
@@ -2077,7 +2082,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#FFFFFF"
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
@@ -2156,11 +2160,11 @@
 /obj/structure/chair/sofa/grey/right{
 	dir = 4
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = -30
-	},
 /obj/structure/railing/thin/corner{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
@@ -2175,7 +2179,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/end{
-	dir = 2;
 	color = "#555555"
 	},
 /turf/open/floor/plasteel/tech,
@@ -2327,6 +2330,7 @@
 	pixel_x = 6;
 	pixel_y = -1
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
@@ -2391,6 +2395,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/airalarm/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "XM" = (
@@ -2702,7 +2707,7 @@ es
 lc
 iq
 iq
-iq
+oP
 vo
 AX
 qm
@@ -3023,7 +3028,7 @@ hB
 hB
 hB
 hB
-oP
+RJ
 RJ
 kr
 Ca

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -3,6 +3,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "ao" = (
@@ -156,6 +157,12 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
+"bc" = (
+/obj/structure/marker_beacon{
+	picked_color = "Burgundy"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "bv" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -189,6 +196,12 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/port)
+"cj" = (
+/obj/structure/marker_beacon{
+	picked_color = "Lime"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "cq" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2776,7 +2789,7 @@ hB
 hB
 hB
 hB
-Ue
+cj
 iy
 iy
 mp
@@ -2786,7 +2799,7 @@ mh
 uz
 iy
 iy
-Ue
+bc
 hB
 hB
 hB
@@ -2864,7 +2877,7 @@ hB
 "}
 (7,1,1) = {"
 kj
-Ue
+cj
 aR
 lc
 sE
@@ -2882,12 +2895,12 @@ fa
 sf
 HV
 zf
-Ue
+bc
 lr
 "}
 (8,1,1) = {"
 gQ
-iC
+Ue
 lc
 VO
 OX
@@ -2905,7 +2918,7 @@ Cn
 pC
 wh
 HV
-iC
+Ue
 Be
 "}
 (9,1,1) = {"
@@ -2956,7 +2969,7 @@ Gc
 "}
 (11,1,1) = {"
 hB
-iC
+Ue
 aR
 lc
 cD
@@ -2979,7 +2992,7 @@ hB
 "}
 (12,1,1) = {"
 hB
-Ue
+cj
 iC
 aR
 lc
@@ -2997,7 +3010,7 @@ Ef
 XM
 zf
 iC
-Ue
+bc
 hB
 "}
 (13,1,1) = {"
@@ -3164,7 +3177,7 @@ hB
 (20,1,1) = {"
 hB
 hB
-Ue
+cj
 iC
 NG
 jV
@@ -3180,7 +3193,7 @@ cC
 cC
 jL
 iC
-Ue
+bc
 hB
 hB
 "}
@@ -3188,7 +3201,7 @@ hB
 hB
 hB
 iC
-iC
+Ue
 RJ
 Kk
 yC
@@ -3234,7 +3247,7 @@ hB
 hB
 hB
 hB
-iC
+Ue
 RJ
 yA
 WL
@@ -3257,7 +3270,7 @@ hB
 hB
 hB
 hB
-Ue
+cj
 cg
 RJ
 HT
@@ -3271,7 +3284,7 @@ RG
 SF
 vg
 lZ
-Ue
+bc
 hB
 hB
 hB
@@ -3352,7 +3365,7 @@ hB
 hB
 hB
 hB
-Ue
+cj
 pZ
 HA
 XX
@@ -3360,7 +3373,7 @@ EC
 BM
 HA
 pZ
-Ue
+bc
 hB
 hB
 hB

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,16 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/chair/handrail,
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "ao" = (
 /obj/structure/dresser{
 	dir = 1
@@ -26,25 +17,119 @@
 	},
 /area/ship/crew/dorm/captain)
 "as" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"au" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"aL" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
+	color = "#D2BC9D";
+	dir = 1
 	},
-/turf/open/floor/wood/birch,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
-"au" = (
-/obj/structure/railing{
+"aP" = (
+/obj/machinery/light/directional/east,
+/obj/structure/sink/kitchen{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"aR" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/engineering/engines/port)
+"aW" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
+"aZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"aL" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"ba" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"bv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67,44 +152,9 @@
 	density = 0;
 	can_buckle = 1
 	},
-/turf/open/floor/wood/birch,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
-"aP" = (
-/obj/machinery/door/window/southright{
-	req_ship_access = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"aQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
-"aR" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering/engines/port)
-"aW" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/engines/starboard)
-"aZ" = (
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"ba" = (
-/obj/effect/landmark/start/assistant,
-/turf/template_noop,
-/area/template_noop)
-"bv" = (
+"cg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -117,18 +167,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
-"cg" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
-	},
-/obj/machinery/microwave{
-	pixel_y = 6;
-	pixel_x = 1
-	},
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -137,22 +175,10 @@
 /turf/open/floor/engine/hull,
 /area/ship/engineering/engines/port)
 "cq" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/machinery/airalarm/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "cC" = (
@@ -170,159 +196,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "cT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/jukebox/boombox{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/item/toy/seashell{
-	pixel_y = 2;
-	pixel_x = 8
-	},
-/turf/open/floor/light,
-/area/ship/crew/ccommons)
-"dm" = (
-/obj/machinery/light/directional/east,
-/obj/structure/sink/kitchen{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"ed" = (
-/obj/machinery/holopad/emergency/command,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/bridge)
-"ef" = (
-/obj/structure/bed/double{
-	dir = 4
-	},
-/obj/item/bedsheet/double{
-	dir = 4;
-	icon_state = "double_sheetrd"
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"es" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
-"eu" = (
-/obj/structure/closet/firecloset/wall/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew)
-"eA" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
-	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"eI" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/chair/handrail,
-/obj/structure/sign/directions/evac{
-	pixel_y = 20;
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew)
-"eK" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"eM" = (
 /obj/structure/closet/secure_closet/freezer{
 	name = "fridge";
 	storage_capacity = 35;
@@ -352,15 +225,158 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage,
 /obj/item/reagent_containers/food/snacks/grown/onion,
 /obj/item/reagent_containers/food/snacks/grown/vanillapod,
-/obj/item/reagent_containers/food/snacks/grown/tea/astra,
-/obj/item/reagent_containers/food/snacks/grown/tea/astra,
-/obj/item/reagent_containers/food/snacks/grown/tea/astra,
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/reagent_containers/food/snacks/grown/coffee,
-/obj/item/reagent_containers/food/snacks/grown/coffee,
-/obj/item/reagent_containers/food/snacks/grown/coffee,
+/obj/item/reagent_containers/food/snacks/grown/coffee{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/coffee{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/coffee{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/coffee{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/tea/astra{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/tea/astra{
+	dry = 1
+	},
+/obj/item/reagent_containers/food/snacks/grown/tea/astra{
+	dry = 1
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
+"dm" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/obj/machinery/microwave{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"ed" = (
+/obj/item/storage/secure/safe{
+	dir = 1;
+	pixel_y = 31;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
+"ef" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
+"es" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
+"eu" = (
+/obj/structure/bedsheetbin{
+	pixel_x = -3;
+	pixel_y = 7;
+	layer = 2.91
+	},
+/obj/structure/dresser,
+/obj/item/desk_flag/trans{
+	pixel_y = 15;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/crew)
+"eA" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1;
+	icon_state = "computer-left"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"eI" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
+	},
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"eK" = (
+/obj/structure/railing/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"eM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
 "fa" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -385,31 +401,28 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "fg" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/obj/machinery/door/airlock/external{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
+"fT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "gb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -435,11 +448,8 @@
 /turf/open/floor/grass/ship/jungle,
 /area/ship/crew/crewtwo)
 "go" = (
-/obj/effect/turf_decal/isf_small/left{
-	dir = 8;
-	color = "#000000"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one/external,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
 /area/ship/external/dark)
 "gE" = (
 /obj/machinery/door/firedoor,
@@ -457,28 +467,27 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "gI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/newscaster/security_unit/directional/west{
+	pixel_y = -14
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
+"gP" = (
 /obj/structure/chair/handrail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/purple,
-/area/ship/crew/dorm)
-"gP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "gQ" = (
 /obj/structure/railing/thick{
@@ -490,41 +499,50 @@
 /turf/template_noop,
 /area/template_noop)
 "hN" = (
-/obj/machinery/washing_machine{
-	pixel_x = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 13;
+	pixel_y = -1
 	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/corner/transparent/white/full,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/mirror{
+	pixel_y = -1;
+	layer = 2.89;
+	pixel_x = 23
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "hO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/fax/indie{
-	pixel_y = 7;
-	layer = 3.22
-	},
-/obj/effect/turf_decal/corner/opaque/black/half,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/turf/open/floor/light,
-/area/ship/bridge)
-"hQ" = (
-/obj/machinery/light/floor,
 /obj/structure/railing/thick,
-/obj/structure/railing/thick/corner{
-	pixel_x = -27
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"hQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
 /area/ship/cargo)
 "iy" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -533,18 +551,28 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "iT" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/fax/indie{
+	pixel_y = 7;
+	layer = 3.22
 	},
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 8
-	},
-/turf/open/floor/light,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "iU" = (
-/obj/effect/turf_decal/borderfloorblack,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/tech,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 8;
+	color = "#555555"
+	},
 /area/ship/bridge)
 "jg" = (
 /obj/machinery/light/directional/east,
@@ -557,6 +585,10 @@
 	layer = 3.01
 	},
 /turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
+"jr" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "jv" = (
 /obj/structure/grille,
@@ -571,79 +603,48 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "jL" = (
-/obj/structure/cabinet/m23{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
 "jV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm)
 "jZ" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/closet/cabinet{
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/purple,
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/railing/thin,
+/turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "kr" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 1;
-	color = "#543C30"
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
 	},
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
 	},
-/obj/item/gun/ballistic/shotgun/flamingarrow/absolution/factory,
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/item/attachment/bayonet{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/crewtwo)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -657,25 +658,28 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/port)
 "kR" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/open/floor/wood/birch,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
 /area/ship/crew)
 "kX" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 4
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "lc" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -701,105 +705,116 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "lT" = (
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/closet/crate/wooden{
+	name = "fishing crate"
+	},
+/obj/item/book/fish_catalog,
+/obj/item/storage/fish_case,
+/obj/item/storage/fish_case,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/item/storage/fish_case,
+/obj/item/storage/fish_case,
+/obj/item/storage/toolbox/fishing,
+/obj/item/storage/toolbox/fishing,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "mh" = (
 /obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"mp" = (
-/obj/structure/railing/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
 	color = "#FFFFFF"
 	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"mp" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/chair/handrail,
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/patterned/external,
 /area/ship/external/dark)
 "mz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
-"mB" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
-	},
-/obj/item/cutting_board{
-	pixel_y = 1;
-	anchored = 1;
-	pixel_x = 7
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 2;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 8;
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 9;
-	pixel_x = -4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"nj" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood/end{
-	color = "#D5A66E";
 	dir = 4
 	},
-/turf/open/floor/wood/birch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"mB" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"mI" = (
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"mY" = (
+/obj/item/clothing/under/suit/roumain,
+/obj/item/clothing/suit/armor/roumain,
+/obj/item/clothing/head/cowboy/sec/roumain,
+/obj/item/flashlight/lantern,
+/obj/structure/closet/secure_closet/hunter{
+	name = "guide's locker"
+	},
+/obj/item/clothing/shoes/cowboy/black,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/accessory/waistcoat/roumain,
+/obj/item/disk/holodisk/roumain,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -8
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"nj" = (
+/obj/machinery/washing_machine{
+	pixel_y = 9;
+	pixel_x = -9;
+	should_we_be_dense = 0
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = 5;
+	pixel_y = 18
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/crew)
 "ny" = (
 /obj/machinery/power/ship_gravity,
@@ -813,69 +828,68 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
+/obj/item/gun/ballistic/shotgun/flamingarrow/absolution/factory,
+/obj/item/melee/spear/bone,
+/obj/item/melee/knife/hunting{
+	pixel_x = 8;
+	pixel_y = -5
 	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
-	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
-"nL" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
-	},
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
-	},
-/obj/structure/chair/handrail,
-/turf/open/floor/light,
-/area/ship/bridge)
-"of" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew)
-"og" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_y = -12;
-	pixel_x = 20
+/obj/item/attachment/bayonet{
+	pixel_y = 5;
+	pixel_x = -6
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 5;
-	color = "#D5A66E"
+	dir = 9;
+	color = "#543C30"
 	},
-/obj/item/kirbyplants/random{
-	pixel_y = 20;
-	pixel_x = 10
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"nL" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/open/floor/wood/birch,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/button/door{
+	dir = 1;
+	id = "ivory_bridge";
+	name = "shutter control";
+	pixel_y = -20;
+	pixel_x = -1
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
+"of" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"og" = (
+/obj/machinery/door/window/southright{
+	req_ship_access = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "op" = (
 /obj/structure/table/glass,
@@ -886,80 +900,54 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
+"oP" = (
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
+"oU" = (
+/obj/machinery/jukebox/boombox{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/item/toy/seashell{
+	pixel_y = 2;
+	pixel_x = 8
+	},
 /obj/structure/table/chem{
 	name = "kitchen counter"
 	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 17;
-	pixel_x = -7;
-	layer = 3.22
-	},
-/obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/item/reagent_containers/glass/rag{
-	pixel_x = 10
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_y = 3;
-	pixel_x = 6
-	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"oP" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"oU" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#D5A66E"
-	},
-/obj/structure/closet/crate/bin{
-	pixel_x = -7;
-	density = 0;
-	pixel_y = 19
-	},
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/obj/item/cigbutt/cigarbutt,
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
 "pa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
 	},
-/obj/machinery/button/door{
-	dir = 1;
-	id = "ivory_bridge";
-	name = "shutter control";
-	pixel_y = -20;
-	pixel_x = -1
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/stairs{
-	dir = 8;
-	color = "#555555"
-	},
-/area/ship/bridge)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "pl" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/computer/cryopod/directional/north,
-/obj/effect/turf_decal/corner/opaque/black/diagonal{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/dorm)
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -988,56 +976,44 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "qb" = (
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"qk" = (
+/obj/structure/cabinet/m23{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/double{
+	dir = 4;
+	icon_state = "double_sheetrd"
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"qm" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"qp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"qm" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_y = 11;
-	pixel_x = 20
-	},
-/obj/structure/closet/firecloset/full,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"qp" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
-	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
 "qx" = (
-/obj/effect/turf_decal/isf_small/right{
-	dir = 8;
-	color = "#000000"
+/obj/effect/turf_decal/isf_small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/cargo_one/external,
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "qH" = (
 /obj/machinery/door/firedoor/border_only{
@@ -1055,47 +1031,29 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/structure/chair/sofa/grey/left{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
+"qM" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 8
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"qM" = (
-/obj/structure/closet/wall/directional/west{
-	name = "janitorial supplies";
-	pixel_y = -2
-	},
-/obj/item/storage/fancy/candle_box,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/pushbroom,
-/obj/item/storage/bag/trash,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_y = 11;
-	pixel_x = -20
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#D5A66E"
-	},
-/obj/structure/railing/thin/corner,
-/turf/open/floor/wood/birch,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "rf" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
+/obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 1
 	},
-/obj/machinery/computer/secure_data{
-	dir = 1;
-	icon_state = "computer-left";
-	layer = 3.01
-	},
-/obj/structure/chair/handrail,
-/turf/open/floor/light,
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "rP" = (
 /obj/structure/table/glass,
@@ -1105,6 +1063,24 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"rT" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "sf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
@@ -1134,29 +1110,35 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
+"sg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "sn" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8;
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
 	color = "#543C30"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/open/floor/wood/maple,
+/turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "sv" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
 	color = "#FFFFFF"
 	},
-/obj/effect/turf_decal/industrial/caution/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/external,
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "sA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1194,10 +1176,11 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
 "tm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "tq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1214,85 +1197,80 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"tT" = (
-/obj/structure/dresser{
-	dir = 8;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6;
-	color = "#D5A66E"
-	},
-/obj/structure/bedsheetbin{
-	pixel_x = 5;
-	pixel_y = 7;
-	layer = 2.91
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew)
-"ui" = (
 /obj/machinery/computer/cargo{
 	icon_state = "computer-right";
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/black/half{
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 8
 	},
-/turf/open/floor/light,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"tT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"ui" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
+"uq" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "uz" = (
-/obj/structure/closet/emcloset/wall/directional/north{
-	populate = 0;
-	pixel_x = 4
-	},
-/obj/item/clothing/suit/space/fragile{
-	pixel_y = 17;
-	pixel_x = 5
-	},
-/obj/item/clothing/head/helmet/space/fragile{
-	pixel_y = 25;
-	pixel_x = 7
-	},
-/obj/item/clothing/mask/breath{
-	pixel_y = 19;
-	pixel_x = -2
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_y = 12
-	},
-/obj/machinery/advanced_airlock_controller/directional/east,
-/obj/machinery/light/small/directional/north{
-	pixel_x = -10
-	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 1;
-	color = "#555555"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engines/starboard)
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "uG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/newscaster/security_unit/directional/west{
-	pixel_y = -14
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/door/window/southleft,
+/obj/machinery/computer/cryopod/directional/north,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "uU" = (
-/obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_y = 11;
+	pixel_x = 20
+	},
+/obj/structure/closet/firecloset/full,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
 /area/ship/cargo)
 "vg" = (
 /obj/structure/grille,
@@ -1304,33 +1282,91 @@
 /turf/open/floor/plating,
 /area/ship/crew/dorm/captain)
 "vo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/area/ship/cargo)
+"vB" = (
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
+	},
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "vJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20;
+	pixel_x = -12
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
+"vS" = (
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"vS" = (
-/obj/effect/landmark/start/security_officer,
-/turf/template_noop,
-/area/template_noop)
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/crew/crewtwo)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1342,10 +1378,19 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "wO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/stairs/wood/birch/left{
+/turf/open/floor/plasteel/stairs/wood/maple/right{
 	dir = 4
 	},
 /area/ship/crew)
@@ -1365,19 +1410,38 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/starboard)
 "xo" = (
-/obj/structure/cable/green{
-	icon_state = "4-9"
+/obj/effect/turf_decal/corner_steel_grid,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-10"
-	},
-/obj/effect/turf_decal/industrial/loading/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "xq" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/obj/item/cutting_board{
+	pixel_y = 1;
+	anchored = 1;
+	pixel_x = 7
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_y = 2;
+	pixel_x = 4
+	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 8;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -10;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "yg" = (
@@ -1390,13 +1454,17 @@
 /turf/open/floor/plating,
 /area/ship/crew/ccommons)
 "yz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/borderfloorblack{
-	dir = 6
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "yA" = (
 /obj/structure/bed{
@@ -1427,28 +1495,47 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/structure/sink{
-	pixel_y = 19
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/structure/mirror{
-	pixel_y = 28;
-	layer = 2.89
+/turf/open/floor/plasteel/stairs/wood/maple/left{
+	dir = 4
 	},
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/corner/transparent/white/full,
-/obj/machinery/newscaster/directional/east{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew)
 "zf" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engines/starboard)
 "zk" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_y = -12;
+	pixel_x = 20
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 20;
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"zv" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4;
+	name = "Cargo Bay"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1456,29 +1543,9 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#D5A66E"
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"zv" = (
-/obj/machinery/door/airlock/mining/glass{
-	dir = 4;
-	name = "Cargo Bay"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "zV" = (
 /obj/machinery/power/smes/shuttle,
@@ -1512,79 +1579,13 @@
 /turf/template_noop,
 /area/template_noop)
 "Af" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "captain's wardobe";
-	req_access_txt = "20";
-	close_sound = 'sound/machines/wooden_closet_close.ogg';
-	open_sound = 'sound/machines/wooden_closet_open.ogg';
-	desc = "It's a card-locked cabinet.";
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel/cap,
-/obj/item/storage/backpack/captain,
-/obj/item/clothing/under/rank/command/captain,
-/obj/item/clothing/under/rank/command/captain/skirt,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13;
-	pixel_x = -6
-	},
-/obj/item/clothing/suit/jacket/miljacket,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/caphat,
-/obj/item/clothing/head/trapper,
-/obj/item/clothing/shoes/jackboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/attachment/sling,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 20
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"Ar" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#D5A66E"
+	color = "#D2BC9D"
 	},
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"Av" = (
-/obj/structure/catwalk/over/plated_catwalk/white,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/noslip,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood/maple,
 /area/ship/crew)
-"AF" = (
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"AX" = (
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
-"Be" = (
-/obj/structure/railing/thick,
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"Bw" = (
+"Ar" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1595,10 +1596,63 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#D5A66E"
+	color = "#D2BC9D";
+	dir = 8
 	},
-/turf/open/floor/wood/birch,
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"Av" = (
+/obj/structure/closet/wall/directional/west,
+/obj/item/towel{
+	pixel_y = -3;
+	pixel_x = -5
+	},
+/obj/item/towel{
+	pixel_y = -3;
+	pixel_x = 6
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
+"AF" = (
+/obj/effect/turf_decal/isf_small/right{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"AX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Be" = (
+/obj/structure/railing/thick,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"Bw" = (
+/obj/machinery/light/directional/west,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/obj/item/cigbutt/cigarbutt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "BM" = (
 /obj/machinery/door/airlock/external/glass{
@@ -1608,100 +1662,103 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "BP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#D5A66E"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"Ca" = (
-/obj/item/clothing/under/suit/roumain,
-/obj/item/clothing/suit/armor/roumain,
-/obj/item/clothing/head/cowboy/sec/roumain,
-/obj/item/flashlight/lantern,
-/obj/structure/closet/secure_closet/hunter{
-	name = "guide's locker"
-	},
-/obj/item/clothing/shoes/cowboy/black,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/shoes/combat,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/accessory/waistcoat/roumain,
-/obj/item/disk/holodisk/roumain,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6;
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -8
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood/maple,
-/area/ship/crew/crewtwo)
-"Cc" = (
-/obj/machinery/light/floor,
-/obj/structure/railing/thick{
-	dir = 1
-	},
-/obj/structure/railing/thick/corner{
-	dir = 4;
-	pixel_x = -27
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"Cl" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/light,
-/area/ship/crew/ccommons)
-"CU" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"Dk" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/crewtwo)
-"Dm" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"Ca" = (
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"Cc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"Cl" = (
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"CU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"Dk" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/crewtwo)
+"Dm" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Dq" = (
-/obj/structure/railing{
-	dir = 9
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1729,64 +1786,71 @@
 /obj/item/ammo_box/magazine/m23/empty,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
+"DX" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Ef" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
 "Ey" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#D5A66E"
-	},
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 23;
-	pixel_x = 7
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew)
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "EC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/structure/railing/thick/corner{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Fc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/chair/handrail{
 	dir = 8
 	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/maple,
 /area/ship/crew)
+"Fn" = (
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Fr" = (
 /obj/structure/railing{
 	dir = 4
@@ -1815,6 +1879,13 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"Go" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -1850,30 +1921,29 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
 "Hd" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
 	color = "#FFFFFF"
 	},
-/turf/open/floor/plasteel/patterned/external,
+/obj/effect/turf_decal/industrial/caution/red{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "Hm" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/chair/handrail{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Dormitory"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "HA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -1900,36 +1970,33 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "HK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"HQ" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#D5A66E"
+	color = "#D2BC9D";
+	dir = 1
 	},
-/turf/open/floor/wood/birch,
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"HQ" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "HV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engines/starboard)
 "Id" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Iu" = (
 /obj/machinery/door/firedoor/border_only{
@@ -1948,53 +2015,82 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/crew)
 "IR" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
 	},
-/obj/machinery/door/airlock/mining/glass{
-	dir = 4;
-	name = "Cargo Bay"
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
+"IZ" = (
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Jv" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/cargo)
-"Jw" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/tech,
-/area/ship/bridge)
-"JT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
-"JY" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"Jw" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/stamp/captain{
+	pixel_x = 8;
+	pixel_y = 9;
+	layer = 3.01
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/folder/blue{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"JT" = (
+/obj/structure/railing{
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	color = "#FFFFFF"
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"JY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2016,58 +2112,94 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "KE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public{
-	name = "Bathroom"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
+/turf/open/floor/wood/maple,
 /area/ship/crew)
 "KU" = (
+/obj/structure/table/chem{
+	name = "kitchen counter"
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 17;
+	pixel_x = -7;
+	layer = 3.22
+	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/structure/chair/stool,
-/obj/machinery/holopad/emergency/bar,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 10
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_y = 3;
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "Ls" = (
-/obj/effect/landmark/start/captain,
-/turf/template_noop,
-/area/template_noop)
-"Mx" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10;
-	color = "#D5A66E"
-	},
-/obj/structure/railing/thin{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/wood/birch,
-/area/ship/crew/ccommons)
-"NG" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
+/turf/open/floor/wood/maple,
 /area/ship/crew)
-"NO" = (
-/obj/effect/turf_decal/industrial/loading/white{
-	dir = 4
+"Mx" = (
+/obj/structure/closet/wall/directional/west{
+	name = "janitorial supplies";
+	pixel_y = -2
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/item/storage/fancy/candle_box,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/mop,
+/obj/item/pushbroom,
+/obj/item/storage/bag/trash{
+	pixel_y = -7
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = 11;
+	pixel_x = -20
+	},
+/obj/structure/railing/thin/corner,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"NG" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"NO" = (
+/obj/structure/cable/green{
+	icon_state = "4-9"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 6
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "NU" = (
 /obj/structure/table/glass,
@@ -2078,26 +2210,20 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "Op" = (
-/obj/structure/chair/office/dark{
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
+"OA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"OA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/cargo)
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2119,69 +2245,86 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"PT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"QG" = (
-/obj/structure/chair/handrail{
+"PG" = (
+/obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"PT" = (
+/obj/structure/closet/firecloset/wall/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"Qh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/structure/closet/crate/wooden{
-	name = "fishing crate"
-	},
-/obj/item/book/fish_catalog,
-/obj/item/storage/fish_case,
-/obj/item/storage/fish_case,
-/obj/effect/mapping_helpers/crate_shelve,
-/obj/item/storage/fish_case,
-/obj/item/storage/fish_case,
-/obj/item/storage/toolbox/fishing,
-/obj/item/storage/toolbox/fishing,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
-"QQ" = (
-/obj/structure/chair/sofa/grey/right{
+"QG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/railing/thin/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"QQ" = (
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 30
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "Rs" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/structure/closet/emcloset/wall/directional/north{
+	populate = 0;
+	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+/obj/item/clothing/suit/space/fragile{
+	pixel_y = 17;
+	pixel_x = 5
 	},
-/obj/structure/chair/handrail{
-	dir = 4
+/obj/item/clothing/head/helmet/space/fragile{
+	pixel_y = 25;
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/siding/white/end{
-	color = "#555555"
+/obj/item/clothing/mask/breath{
+	pixel_y = 19;
+	pixel_x = -2
 	},
-/turf/open/floor/plasteel/tech,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_y = 12
+	},
+/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/light/small/directional/north{
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
 "RJ" = (
 /obj/structure/grille,
@@ -2193,10 +2336,16 @@
 /turf/open/floor/plating,
 /area/ship/crew/crewtwo)
 "Ss" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/wood/birch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "Sz" = (
 /obj/machinery/door/firedoor,
@@ -2242,18 +2391,24 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "SX" = (
-/obj/structure/closet/wall/directional/west,
-/obj/item/towel{
-	pixel_y = -3;
-	pixel_x = -5
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/item/towel{
-	pixel_y = -3;
-	pixel_x = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public{
+	name = "Bathroom"
 	},
-/obj/item/soap/deluxe,
-/obj/effect/turf_decal/corner/transparent/white/full,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"Tb" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
 "TP" = (
 /obj/structure/table/glass,
@@ -2268,194 +2423,228 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "UM" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/structure/closet/secure_closet{
+	icon_state = "cabinet";
+	name = "captain's wardobe";
+	req_access_txt = "20";
+	close_sound = 'sound/machines/wooden_closet_close.ogg';
+	open_sound = 'sound/machines/wooden_closet_open.ogg';
+	desc = "It's a card-locked cabinet.";
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel/cap,
+/obj/item/storage/backpack/captain,
+/obj/item/clothing/under/rank/command/captain,
+/obj/item/clothing/under/rank/command/captain/skirt,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13;
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/jacket/miljacket,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/caphat,
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/attachment/sling,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 20
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
+"UR" = (
+/obj/structure/chair/sofa/grey/right{
+	dir = 4
+	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
 "Vj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
+"Vt" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
+"Vu" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "VO" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"VS" = (
+/obj/effect/turf_decal/isf_small/left{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"Wg" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
+"Wo" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
+"Wt" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"WC" = (
 /obj/machinery/cryopod{
 	dir = 8
 	},
 /obj/structure/window,
 /obj/effect/turf_decal/industrial/hatch,
-/obj/effect/turf_decal/siding/white{
-	dir = 8;
-	color = "#555555"
-	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/dorm)
-"VS" = (
-/obj/effect/turf_decal/isf_small{
-	dir = 8;
-	color = "#000000"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one/external,
-/area/ship/external/dark)
-"Wg" = (
-/obj/effect/landmark/start/station_engineer,
-/turf/template_noop,
-/area/template_noop)
-"Wt" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/glasses/sunglasses/big{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/melee/knife/survival{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"WC" = (
-/obj/effect/spawner/bunk_bed,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/railing/thin,
-/turf/open/floor/carpet/purple,
 /area/ship/crew/dorm)
 "WL" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass/ship/jungle,
 /area/ship/crew/crewtwo)
 "WP" = (
-/obj/structure/chair/handrail{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
 	},
-/obj/item/storage/secure/safe{
-	dir = 8;
-	pixel_x = -31;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/bridge)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "Xr" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "XC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/wood/birch/right{
-	dir = 4
-	},
-/area/ship/crew)
-"XJ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/airalarm/directional/north,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
+"XJ" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "XM" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "XX" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 7
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/item/stamp/captain{
-	pixel_x = 8;
-	pixel_y = 9;
-	layer = 3.01
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/obj/item/pen/fountain/captain,
-/obj/item/folder/blue{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/corner/opaque/black/half,
-/obj/machinery/power/apc/auto_name/directional/west,
+/area/ship/crew/dorm/captain)
+"Yu" = (
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/structure/chair/handrail{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/turf/open/floor/light,
-/area/ship/bridge)
-"Yu" = (
-/obj/docking_port/mobile{
-	dir = 2;
-	launch_status = 0;
-	port_direction = 8;
-	preferred_direction = 4;
-	name = "ivory dock"
-	},
-/obj/structure/railing/thick/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "YF" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 5
 	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 8
-	},
-/turf/open/floor/light,
+/turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "YX" = (
 /obj/machinery/button/door{
@@ -2470,6 +2659,29 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"Zh" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 
 (1,1,1) = {"
 hB
@@ -2479,7 +2691,6 @@ hB
 hB
 hB
 hB
-hB
 iy
 hB
 hB
@@ -2494,7 +2705,6 @@ hB
 hB
 hB
 hB
-Ls
 "}
 (2,1,1) = {"
 hB
@@ -2503,14 +2713,13 @@ hB
 hB
 hB
 hB
-hB
 tj
 iy
-CU
+Ey
 hB
 Ab
 hB
-Dq
+XJ
 iy
 tj
 hB
@@ -2519,7 +2728,6 @@ hB
 hB
 hB
 hB
-vS
 "}
 (3,1,1) = {"
 hB
@@ -2527,15 +2735,14 @@ hB
 hB
 hB
 hB
-hB
 Ue
 iy
 iy
-ac
 mp
 sv
 Hd
 mh
+pa
 iy
 iy
 Ue
@@ -2544,7 +2751,6 @@ hB
 hB
 hB
 hB
-Wg
 "}
 (4,1,1) = {"
 hB
@@ -2552,15 +2758,14 @@ hB
 hB
 hB
 hB
-hB
 iC
 iy
 iy
-kj
 go
 VS
 qx
 AF
+ox
 iy
 iy
 iC
@@ -2569,10 +2774,8 @@ hB
 hB
 hB
 hB
-ba
 "}
 (5,1,1) = {"
-Cc
 hB
 hB
 hB
@@ -2594,136 +2797,124 @@ hB
 hB
 hB
 hB
-hQ
 "}
 (6,1,1) = {"
-gQ
-iC
+hB
 hB
 hB
 aR
 zW
 zW
 lc
-XJ
 cq
-NO
+Fn
 xo
 NO
+mB
 DL
-eA
+eI
 HV
 zV
 zV
 zf
 hB
 hB
-iC
-Be
+hB
 "}
 (7,1,1) = {"
-gQ
-iC
-iC
+eK
+Ue
 aR
 lc
 sE
 GE
 lc
 SV
-Op
-AX
+Dq
 Id
-AX
+tm
+au
 HB
-UM
+Dm
 HV
 fa
 sf
 HV
 zf
-iC
-iC
-Be
+Ue
+uz
 "}
 (8,1,1) = {"
-Yu
-iC
+gQ
 iC
 lc
-fg
+Yu
 OX
-qp
+vB
 lc
 DK
-au
 JT
-Id
+hQ
 tm
+JY
 Fr
-eK
+PG
 HV
-Dm
+Vt
 pC
 wh
 HV
 iC
-iC
-Gc
+Be
 "}
 (9,1,1) = {"
-iC
-iC
+gQ
 iC
 lc
-nI
+rT
 Pr
 kB
 qH
-OA
 WP
 gP
 mz
 aQ
 QG
 lT
+Qh
 wV
 tq
 lS
-bv
+cg
 HV
-iC
-iC
-iC
+qp
+hO
 "}
 (10,1,1) = {"
-Ue
-iC
+EC
 iC
 lc
-JY
+Wg
 sA
 es
 lc
 iq
-iq
-oP
+XC
 vo
 AX
 qm
 uU
+Vu
 HV
 BM
 jv
 HV
 HV
-iC
-iC
-Ue
+fT
+Gc
 "}
 (11,1,1) = {"
 hB
-iC
 iC
 aR
 lc
@@ -2733,66 +2924,61 @@ lc
 iy
 iy
 iy
-IR
 zv
 iy
 iy
+iy
 HV
-uz
 Rs
-HV
-zf
-iC
-iC
+ba
+Op
+Wo
+VO
 hB
 "}
 (12,1,1) = {"
 hB
-iC
 Ue
 iC
 aR
 lc
 Ef
 Ef
-eM
 cT
 oU
 Bw
 Ar
 qM
 Mx
+Xe
 Ef
 Ef
-fx
+pl
 zf
 iC
 Ue
-iC
 hB
 "}
 (13,1,1) = {"
 hB
 hB
-iC
-iC
-iC
-iC
+hB
+hB
+hB
 yg
 XM
-xq
 Cl
-as
+HQ
 HK
 aZ
+mI
 Gs
 lo
-QQ
+UR
 yg
-tJ
-iC
-iC
-iC
+hB
+hB
+hB
 hB
 hB
 "}
@@ -2800,23 +2986,21 @@ hB
 hB
 hB
 hB
-iC
-iC
-iC
+hB
+hB
 yg
-ox
 KU
-Cl
+jr
 HQ
 aL
-aZ
+bv
+mI
 fs
 NU
 op
 yg
-tJ
-iC
-iC
+hB
+hB
 hB
 hB
 hB
@@ -2826,21 +3010,19 @@ hB
 hB
 hB
 hB
-Ue
-iC
+hB
 yg
-mB
 xq
 Cl
-as
-vJ
+HQ
+HK
 Ss
+fx
 Xr
 TP
 rP
 yg
-qb
-Ue
+hB
 hB
 hB
 hB
@@ -2852,19 +3034,17 @@ hB
 hB
 hB
 hB
-hB
 yg
-cg
 dm
 aP
 og
 zk
 BP
+Go
 YX
 jg
-qL
+QQ
 yg
-hB
 hB
 hB
 hB
@@ -2877,19 +3057,17 @@ hB
 hB
 hB
 hB
-hB
 jV
 jV
 jV
 jV
 cC
-XC
 wO
+yH
 cC
 cC
 cC
 cC
-hB
 hB
 hB
 hB
@@ -2902,9 +3080,7 @@ hB
 hB
 hB
 hB
-hB
 jV
-pl
 uG
 gI
 Hm
@@ -2913,8 +3089,8 @@ kR
 KE
 SX
 Av
+kj
 cC
-hB
 hB
 hB
 hB
@@ -2927,19 +3103,17 @@ hB
 hB
 hB
 hB
-hB
 jV
-VO
 WC
 jZ
+vJ
 cC
-Ey
 tT
+OA
 cC
-yH
 hN
+Tb
 cC
-hB
 hB
 hB
 hB
@@ -2949,50 +3123,46 @@ hB
 (20,1,1) = {"
 hB
 hB
-hB
-hB
-hB
-hB
+Ue
+iC
+NG
 jV
 jV
 jV
 jV
 cC
-eI
+Zh
+DX
 cC
 cC
 cC
 cC
-cC
-hB
-hB
-hB
-hB
+jL
+iC
+Ue
 hB
 hB
 "}
 (21,1,1) = {"
 hB
 hB
-hB
-hB
-hB
-hB
+iC
+iC
 RJ
 Kk
 yC
 gc
-cC
+NG
 eu
-cC
+Jv
 Af
 jL
+UM
+qk
 ao
 vg
-hB
-hB
-hB
-hB
+iC
+iC
 hB
 hB
 "}
@@ -3000,23 +3170,21 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
+iC
 RJ
-yA
-WL
+oP
+oP
 sn
 NG
 nj
-Iu
+Ls
 PT
-EC
+cC
 ef
+ac
+qb
 vg
-hB
-hB
-hB
+iC
 hB
 hB
 hB
@@ -3025,23 +3193,21 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
+iC
 RJ
-RJ
-kr
+yA
+WL
 Ca
-cC
+vS
 Fc
-cC
+CU
 Wt
-SF
+Iu
+qL
+fg
+XX
 vg
-vg
-hB
-hB
-hB
+iC
 hB
 hB
 hB
@@ -3050,23 +3216,21 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-hB
-Dk
+Ue
+sg
+RJ
+nI
+mY
+NG
 fK
+eM
 fK
-fK
-pa
-fK
-fK
-fK
-Vj
-hB
-hB
-hB
-hB
+cC
+as
+SF
+vg
+Cc
+Ue
 hB
 hB
 hB
@@ -3077,19 +3241,17 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-HA
-XX
-Xe
+Dk
+Dk
+fK
+fK
 ed
 iU
 nL
-HA
-hB
-hB
-hB
+fK
+fK
+fK
+Vj
 hB
 hB
 hB
@@ -3104,15 +3266,13 @@ hB
 hB
 hB
 hB
-hB
 HA
-hO
 Jw
 kX
 yz
 rf
+IZ
 HA
-hB
 hB
 hB
 hB
@@ -3128,17 +3288,15 @@ hB
 hB
 hB
 hB
-hB
-hB
+iC
 HA
-pZ
 iT
 YF
 ui
-pZ
+IR
+eA
 HA
-hB
-hB
+iC
 hB
 hB
 hB
@@ -3153,15 +3311,36 @@ hB
 hB
 hB
 hB
+Ue
+pZ
+HA
+uq
+kr
+tJ
+HA
+pZ
+Ue
 hB
 hB
 hB
-pZ
-pZ
-pZ
-pZ
-pZ
 hB
+hB
+hB
+"}
+(29,1,1) = {"
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+pZ
+pZ
+pZ
+pZ
+pZ
 hB
 hB
 hB

--- a/_maps/shuttles/independent/independent_ivory.dmm
+++ b/_maps/shuttles/independent/independent_ivory.dmm
@@ -1,16 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer-right";
-	layer = 3.01
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/cargo)
 "ao" = (
 /obj/structure/dresser{
 	dir = 1
@@ -26,33 +26,17 @@
 	},
 /area/ship/crew/dorm/captain)
 "as" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/structure/table/chem{
+	name = "kitchen counter"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/structure/closet/crate/radiation{
-	name = "fuel crate";
-	anchored = 1
-	},
-/obj/item/stack/sheet/mineral/uranium/ten,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
 "au" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "aL" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -129,37 +113,44 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "ba" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/exo,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor,
+/obj/item/pickaxe/drill,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
+"cg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
-"bv" = (
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"bK" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 10;
-	layer = 2.030
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/techfloor{
-	dir = 1
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"cg" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
 "ci" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -253,6 +244,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
+"dJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "ed" = (
 /obj/item/storage/secure/safe{
 	dir = 1;
@@ -279,45 +276,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
-"eg" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "captain's wardobe";
-	req_access_txt = "20";
-	close_sound = 'sound/machines/wooden_closet_close.ogg';
-	open_sound = 'sound/machines/wooden_closet_open.ogg';
-	desc = "It's a card-locked cabinet.";
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel/cap,
-/obj/item/storage/backpack/captain,
-/obj/item/clothing/under/rank/command/captain,
-/obj/item/clothing/under/rank/command/captain/skirt,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13;
-	pixel_x = -6
-	},
-/obj/item/clothing/suit/jacket/miljacket,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/caphat,
-/obj/item/clothing/shoes/jackboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/attachment/sling,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 20
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
 /area/ship/crew/dorm/captain)
 "es" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -354,23 +312,28 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/crew)
 "eA" = (
-/obj/structure/window{
-	dir = 4
+/obj/structure/closet/crate/secure/plasma{
+	name = "ammo crate";
+	desc = "A secure ammo crate.";
+	req_access_txt = "1"
 	},
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain,
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9
+/obj/item/storage/box/ammo/a8_50r,
+/obj/item/storage/box/ammo/c556mm,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	color = "#FFFFFF"
 	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
+/obj/item/ammo_box/magazine/m23/empty,
+/obj/item/ammo_box/magazine/m23/empty,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "eI" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "eK" = (
 /obj/structure/railing{
 	dir = 4
@@ -394,15 +357,14 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "eM" = (
-/obj/machinery/computer/cargo{
-	icon_state = "computer-right";
-	dir = 8
+/obj/structure/chair/sofa/blue/corpo/right/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/area/ship/crew/dorm/captain)
 "fa" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -426,54 +388,68 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
-"ff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/cargo)
 "fg" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/structure/closet/secure_closet/armorycage{
+	name = "weapon locker";
+	req_access = list(1)
 	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
+/obj/item/melee/spear/bone,
+/obj/item/melee/knife/hunting{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/attachment/bayonet{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
+	},
+/obj/item/gun/ballistic/revolver/shadow/empty{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"fi" = (
+/obj/item/clothing/under/suit/roumain,
+/obj/item/clothing/suit/armor/roumain,
+/obj/item/clothing/head/cowboy/sec/roumain,
+/obj/item/flashlight/lantern,
+/obj/structure/closet/secure_closet/hunter{
+	name = "guide's locker"
+	},
+/obj/item/clothing/shoes/cowboy/black,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/accessory/waistcoat/roumain,
+/obj/item/disk/holodisk/roumain,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/a44roum,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "fs" = (
 /obj/structure/chair/sofa/grey/left,
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "fx" = (
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "mechanic's locker";
-	req_access_txt = "11"
-	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/under/rank/engineering/engineer,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/weldhat/dblue,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/welding{
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engines/port)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
 "fK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -572,38 +548,19 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"hP" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
 "hQ" = (
-/obj/item/clothing/under/suit/roumain,
-/obj/item/clothing/suit/armor/roumain,
-/obj/item/clothing/head/cowboy/sec/roumain,
-/obj/item/flashlight/lantern,
-/obj/structure/closet/secure_closet/hunter{
-	name = "guide's locker"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/item/clothing/shoes/cowboy/black,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/shoes/combat,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/accessory/waistcoat/roumain,
-/obj/item/disk/holodisk/roumain,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10;
+	layer = 2.030
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -8
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "iq" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -620,16 +577,6 @@
 "iC" = (
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"iI" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
 "iT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax/indie{
@@ -654,17 +601,6 @@
 	color = "#555555"
 	},
 /area/ship/bridge)
-"iV" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/industrial/hatch,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
-	},
-/area/ship/cargo)
 "jg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/chair/sofa/grey/right{
@@ -677,6 +613,22 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
+"jt" = (
+/obj/structure/cabinet/m23{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/double{
+	dir = 4;
+	icon_state = "double_sheetrd"
+	},
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
+	},
+/area/ship/crew/dorm/captain)
 "jv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -703,42 +655,24 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm)
 "kj" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"kr" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
+"kn" = (
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/item/pen/fountain/captain,
-/obj/item/clothing/mask/vape/cigar{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/melee/knife/survival{
-	pixel_x = 6;
-	pixel_y = -1
-	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"kr" = (
 /obj/item/radio/intercom/directional/east,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11;
-	pixel_x = -5
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -751,6 +685,16 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engines/port)
+"kF" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew)
 "kR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -859,11 +803,23 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "mB" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 9
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/crate/radiation{
+	name = "fuel crate";
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/uranium/ten,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "nj" = (
 /obj/machinery/washing_machine{
 	pixel_y = 9;
@@ -889,18 +845,39 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/port)
 "nI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/light_switch{
 	dir = 1;
-	color = "#FFFFFF"
+	pixel_y = -20;
+	pixel_x = -12
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/white,
+/obj/item/clothing/under/dress/skirt/pinafore,
+/obj/item/clothing/under/dress/skirt/color,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/accessory/waistcoat,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm)
 "nL" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -949,46 +926,52 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "ox" = (
-/obj/structure/cabinet/m23{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/bed/double{
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/item/bedsheet/double{
-	dir = 4;
-	icon_state = "double_sheetrd"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
-"oL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
-"oN" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"oP" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew)
+"oP" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "oU" = (
 /obj/machinery/jukebox/boombox{
 	pixel_x = -4;
@@ -1005,27 +988,46 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "pa" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
 /turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/area/ship/crew)
 "pl" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/pickaxe/drill,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "mechanic's locker";
+	req_access_txt = "11"
+	},
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/under/rank/engineering/engineer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/head/hardhat/weldhat/dblue,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engines/port)
 "pC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -1054,29 +1056,21 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "qb" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 4;
-	piping_layer = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Guide's Quarters";
+	req_access_txt = "1"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ship/crew/crewtwo)
 "qm" = (
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 9
@@ -1084,15 +1078,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "qp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_guides";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "qx" = (
 /obj/effect/turf_decal/isf_small{
 	dir = 8
@@ -1115,28 +1103,11 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/engineering/engines/port)
 "qL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/chair/sofa/blue/corpo/left/directional/north,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command{
-	dir = 4;
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/bridge)
+/area/ship/crew/dorm/captain)
 "qM" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -1152,6 +1123,28 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
+"rv" = (
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"rJ" = (
+/obj/machinery/button/door{
+	pixel_x = -20;
+	dir = 4;
+	pixel_y = -8;
+	id = "ivory_cargo";
+	name = "blast door control"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	id = "ivory_holo";
+	pixel_x = -19;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "rP" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/commemorative{
@@ -1160,22 +1153,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"sc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Guide's Quarters";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/crew/crewtwo)
 "sf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
@@ -1205,14 +1182,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)
-"si" = (
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 5;
-	layer = 2.030
-	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
 "sn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9;
@@ -1290,15 +1259,13 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "tJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5;
+	layer = 2.030
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
-	},
-/obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "tT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -1332,33 +1299,28 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "uz" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/wood/maple/left{
 	dir = 4
 	},
-/turf/open/floor/wood/maple,
 /area/ship/crew)
 "uG" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/computer/cryopod/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
+"uS" = (
+/obj/machinery/computer/cargo{
+	icon_state = "computer-right";
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "uU" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -1395,45 +1357,35 @@
 	color = "#777777"
 	},
 /area/ship/cargo)
-"vu" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#FFFFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
 "vJ" = (
-/obj/machinery/computer/helm{
-	icon_state = "computer-left";
-	dir = 8;
-	layer = 3.01
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_y = 13
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
 	},
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+/obj/structure/closet/emcloset/wall/directional/south,
+/turf/open/floor/wood/maple,
+/area/ship/crew)
+"vO" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/industrial/hatch,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/area/ship/cargo)
 "vS" = (
-/obj/structure/railing/thick/corner{
+/obj/structure/chair/sofa/grey/right{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/turf/open/floor/carpet/black,
+/area/ship/crew/ccommons)
 "wh" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1562,14 +1514,18 @@
 /turf/open/floor/ship/dirt/dark,
 /area/ship/crew/crewtwo)
 "yH" = (
-/obj/structure/chair/office/dark{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/industrial/warning{
+	dir = 1;
 	color = "#FFFFFF"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/starboard)
 "zf" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engines/starboard)
@@ -1689,39 +1645,22 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "AX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner_steel_grid{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "Be" = (
 /obj/structure/railing/thick,
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
-"Bo" = (
-/obj/machinery/vending/cigarette,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 10
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+"Bg" = (
+/obj/structure/railing/thick/corner,
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Bw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random/trash/deluxe_garbage,
@@ -1775,61 +1714,75 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/crewtwo)
 "Cc" = (
-/obj/structure/chair/sofa/blue/corpo/right/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/splint,
+/obj/item/storage/firstaid/advanced,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/roller,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"Cl" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/ccommons)
+"CU" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen/fountain/captain,
+/obj/item/clothing/mask/vape/cigar{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11;
+	pixel_x = -5
 	},
 /turf/open/floor/suns/hatch{
 	color = "#792f27"
 	},
 /area/ship/crew/dorm/captain)
-"Cl" = (
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/ccommons)
-"Cy" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/external,
-/area/ship/external/dark)
-"CU" = (
-/obj/machinery/button/door{
-	pixel_x = -20;
-	dir = 4;
-	pixel_y = -8;
-	id = "ivory_cargo";
-	name = "blast door control"
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 4;
-	id = "ivory_holo";
-	pixel_x = -19;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
 "Dk" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/crewtwo)
 "Dm" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 8
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"Dq" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/structure/cable/green,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/wood/maple/left{
 	dir = 4
 	},
+/turf/open/floor/wood/maple,
 /area/ship/crew)
+"Dq" = (
+/turf/open/floor/grass/ship/jungle,
+/area/ship/crew/crewtwo)
 "DK" = (
 /obj/structure/railing{
 	dir = 4
@@ -1839,53 +1792,36 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "DL" = (
-/obj/structure/closet/crate/secure/plasma{
-	name = "ammo crate";
-	desc = "A secure ammo crate.";
-	req_access_txt = "1"
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 4
 	},
-/obj/item/storage/box/ammo/a357,
-/obj/item/storage/box/ammo/a8_50r,
-/obj/item/storage/box/ammo/c556mm,
-/obj/effect/mapping_helpers/crate_shelve,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1;
-	color = "#FFFFFF"
+/obj/effect/turf_decal/techfloor{
+	dir = 10
 	},
-/obj/item/ammo_box/magazine/m23/empty,
-/obj/item/ammo_box/magazine/m23/empty,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Ef" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/ccommons)
 "Ey" = (
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/structure/chair/handrail{
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	color = "#FFFFFF"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engines/port)
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engines/starboard)
 "EC" = (
-/obj/structure/chair/sofa/grey/left{
-	dir = 8
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = 30
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"EP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1899,6 +1835,22 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/maple,
 /area/ship/crew)
+"Fm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Fr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -1910,12 +1862,39 @@
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"FL" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
+	},
+/obj/item/stack/sheet/plastic/five,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/mineral/titanium/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Gc" = (
 /obj/structure/railing/thick/corner{
 	dir = 8
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
+"Gf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_captains";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "Gs" = (
 /obj/structure/chair/sofa/grey/corner{
 	dir = 4
@@ -1950,6 +1929,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
+"GF" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engines/starboard)
 "Hd" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
@@ -2010,18 +2004,18 @@
 /turf/open/floor/wood/maple,
 /area/ship/crew/ccommons)
 "HQ" = (
-/obj/structure/table/chem{
-	name = "kitchen counter"
+/obj/structure/chair/sofa/grey/left{
+	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "HV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engines/starboard)
 "Id" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/corner_steel_grid{
 	dir = 10;
 	layer = 2.030
@@ -2048,12 +2042,30 @@
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/crew)
 "IR" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/industrial/hatch,
-/turf/open/floor/plasteel/patterned/grid{
-	color = "#777777"
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/area/ship/cargo)
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew)
 "Jw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -2084,30 +2096,21 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "JY" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/machinery/computer/helm{
+	icon_state = "computer-left";
+	dir = 8;
+	layer = 3.01
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_y = 13
 	},
-/obj/structure/chair/handrail{
-	dir = 4
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/engineering/engines/starboard)
-"JZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ivory_captains";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Kk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine{
@@ -2127,6 +2130,16 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/ship/dirt/dark,
+/area/ship/crew/crewtwo)
+"Ko" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ivory_guides";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
 /area/ship/crew/crewtwo)
 "KE" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2153,23 +2166,30 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
-"Ls" = (
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
+"Li" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/mineral/wood/twentyfive,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/mineral/titanium/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
+"Ls" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
+"Mt" = (
+/obj/structure/railing/thick/corner{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Mx" = (
 /obj/structure/closet/wall/directional/west{
 	name = "janitorial supplies";
@@ -2228,16 +2248,17 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "Op" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1;
-	icon_state = "computer-left"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"OA" = (
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -2247,8 +2268,21 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew/ccommons)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
+"OA" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	color = "#FFFFFF"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engines/port)
 "OX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2270,10 +2304,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/port)
-"PO" = (
-/obj/structure/railing/thick/corner,
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 "PT" = (
 /obj/structure/closet/firecloset/wall/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -2281,6 +2311,18 @@
 	},
 /turf/open/floor/wood/maple,
 /area/ship/crew)
+"Qy" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "QG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -2292,34 +2334,24 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/cargo)
-"QQ" = (
-/obj/structure/chair/sofa/grey/right{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
+"QI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
 	},
-/turf/open/floor/carpet/black,
-/area/ship/crew/ccommons)
-"Rm" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D"
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/bridge)
+"QQ" = (
+/obj/structure/railing/thick,
+/obj/docking_port/mobile{
+	port_direction = 4;
+	preferred_direction = 4;
+	name = "Ivory-class"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/turf/open/floor/engine/hull,
+/area/ship/external/dark)
 "Rs" = (
 /obj/structure/closet/emcloset/wall/directional/north{
 	populate = 0;
@@ -2420,12 +2452,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew)
-"TO" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#792f27"
-	},
-/area/ship/crew/dorm/captain)
 "TP" = (
 /obj/structure/table/glass,
 /obj/item/toy/cards/deck/syndicate{
@@ -2439,68 +2465,106 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "UM" = (
-/turf/open/floor/grass/ship/jungle,
-/area/ship/crew/crewtwo)
-"UX" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/medical,
-/obj/item/stack/medical/splint,
-/obj/item/storage/firstaid/advanced,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/roller,
-/obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
+"UQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ship/crew/dorm/captain)
 "Vj" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/captain)
+"Vt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "VO" = (
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm/captain)
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/industrial/hatch,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/patterned/grid{
+	color = "#777777"
+	},
+/area/ship/cargo)
 "VS" = (
 /obj/effect/turf_decal/isf_small/left{
 	dir = 8
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
+"Wc" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "Wg" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "cabinet";
+	name = "captain's wardobe";
+	req_access_txt = "20";
+	close_sound = 'sound/machines/wooden_closet_close.ogg';
+	open_sound = 'sound/machines/wooden_closet_open.ogg';
+	desc = "It's a card-locked cabinet.";
+	anchored = 1
+	},
+/obj/item/storage/backpack/satchel/cap,
+/obj/item/storage/backpack/captain,
+/obj/item/clothing/under/rank/command/captain,
+/obj/item/clothing/under/rank/command/captain/skirt,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13;
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/jacket/miljacket,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/caphat,
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/attachment/sling,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/light/directional/west,
+/turf/open/floor/suns/hatch{
+	color = "#792f27"
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"Wk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 1
-	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
+/area/ship/crew/dorm/captain)
 "Wt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
@@ -2540,45 +2604,41 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Xe" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1;
+	icon_state = "computer-left"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
 "Xr" = (
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
 "XC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D2BC9D";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#D2BC9D";
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/maple,
-/area/ship/crew)
-"XJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer4,
+/obj/machinery/light/directional/south,
 /obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	color = "#FFFFFF";
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/external,
+/area/ship/external/dark)
+"XJ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "XM" = (
 /obj/machinery/vending/boozeomat,
@@ -2586,41 +2646,24 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/ccommons)
 "XX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer-right";
+	layer = 3.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "Yu" = (
-/obj/structure/closet/secure_closet/armorycage{
-	name = "weapon locker";
-	req_access = list(1)
-	},
-/obj/item/melee/spear/bone,
-/obj/item/melee/knife/hunting{
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/obj/item/attachment/bayonet{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 9;
-	color = "#543C30"
+	color = "#D2BC9D";
+	dir = 4
 	},
-/obj/item/gun/ballistic/revolver/shadow/empty{
-	pixel_y = -2
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/turf/open/floor/wood/maple,
+/area/ship/crew/ccommons)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -2628,40 +2671,6 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
-"YV" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -20;
-	pixel_x = -12
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/closet/cabinet{
-	anchored = 1
-	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/pants/white,
-/obj/item/clothing/under/dress/skirt/pinafore,
-/obj/item/clothing/under/dress/skirt/color,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/painting/library{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -13
-	},
-/obj/item/clothing/gloves/color/white{
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/ship/crew/dorm)
 "YX" = (
 /obj/machinery/button/door{
 	pixel_x = 20;
@@ -2675,15 +2684,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/ship/crew/ccommons)
-"ZV" = (
-/obj/structure/railing/thick,
-/obj/docking_port/mobile{
-	port_direction = 4;
-	preferred_direction = 4;
-	name = "Ivory-class"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
 
 (1,1,1) = {"
 hB
@@ -2717,11 +2717,11 @@ hB
 hB
 tj
 iy
-Cy
+Ls
 hB
 Ab
 hB
-cg
+EC
 iy
 tj
 hB
@@ -2744,7 +2744,7 @@ mp
 sv
 Hd
 mh
-vu
+XC
 iy
 iy
 Ue
@@ -2767,7 +2767,7 @@ go
 VS
 qx
 AF
-fg
+kr
 iy
 iy
 iC
@@ -2809,12 +2809,12 @@ zW
 zW
 lc
 cq
-CU
+rJ
 xo
 NO
-kj
 DL
-Ls
+eA
+FL
 HV
 zV
 zV
@@ -2824,7 +2824,7 @@ hB
 hB
 "}
 (7,1,1) = {"
-vS
+Mt
 Ue
 aR
 lc
@@ -2832,37 +2832,37 @@ sE
 GE
 lc
 SV
-yH
-bK
+AX
+Id
 tm
-si
+tJ
 HB
-pl
+ba
 HV
 fa
 sf
 HV
 zf
 Ue
-PO
+Bg
 "}
 (8,1,1) = {"
 gQ
 iC
 lc
-iI
+Li
 OX
-fx
+pl
 lc
 DK
 JT
-Id
+hQ
 tm
 Fr
 eK
-UX
+Cc
 HV
-qb
+oP
 pC
 wh
 HV
@@ -2873,7 +2873,7 @@ Be
 gQ
 iC
 lc
-as
+mB
 Pr
 kB
 qH
@@ -2883,36 +2883,36 @@ mz
 aQ
 QG
 lT
-ff
+ac
 wV
 tq
 lS
-nI
+yH
 HV
-Xe
-ZV
+au
+QQ
 "}
 (10,1,1) = {"
 hO
 iC
 lc
-Ey
+OA
 sA
 es
 lc
 iq
-iV
+VO
 vo
-AX
+cg
 qm
 uU
-IR
+vO
 HV
 BM
 jv
 HV
 HV
-Dm
+dJ
 Gc
 "}
 (11,1,1) = {"
@@ -2932,10 +2932,10 @@ iy
 iy
 HV
 Rs
-JY
-hP
-XJ
-mB
+GF
+eI
+Ey
+bv
 hB
 "}
 (12,1,1) = {"
@@ -2952,10 +2952,10 @@ Bw
 Ar
 qM
 Mx
-Bo
+Qy
 Ef
 Ef
-ba
+XJ
 zf
 iC
 Ue
@@ -2969,14 +2969,14 @@ hB
 hB
 yg
 XM
-Cl
-HQ
+fx
+as
 HK
-OA
-bv
+Vt
+rv
 Gs
 lo
-QQ
+vS
 yg
 hB
 hB
@@ -2992,11 +2992,11 @@ hB
 hB
 yg
 KU
-eI
-HQ
+Cl
+as
 aL
 aZ
-bv
+rv
 fs
 NU
 op
@@ -3015,11 +3015,11 @@ hB
 hB
 yg
 xq
-Cl
-HQ
+fx
+as
 HK
 Ss
-oL
+UM
 Xr
 TP
 rP
@@ -3042,10 +3042,10 @@ aP
 og
 zk
 BP
-pa
+Yu
 YX
 jg
-EC
+HQ
 yg
 hB
 hB
@@ -3065,7 +3065,7 @@ jV
 jV
 cC
 wO
-Dq
+uz
 cC
 cC
 cC
@@ -3091,7 +3091,7 @@ kR
 KE
 SX
 Av
-eA
+Wc
 cC
 hB
 hB
@@ -3108,13 +3108,13 @@ hB
 jV
 WC
 jZ
-YV
+nI
 cC
 tT
-tJ
+vJ
 cC
 hN
-oP
+kF
 cC
 hB
 hB
@@ -3133,8 +3133,8 @@ jV
 jV
 jV
 cC
-uz
-Rm
+ox
+Dm
 cC
 cC
 cC
@@ -3156,11 +3156,11 @@ yC
 gc
 NG
 eu
-Wg
+pa
 Af
 jL
-eg
-ox
+Wg
+jt
 ao
 vg
 iC
@@ -3174,17 +3174,17 @@ hB
 hB
 iC
 RJ
-UM
-UM
+Dq
+Dq
 sn
 NG
 nj
-Wk
+Fm
 PT
 cC
 ef
-VO
-TO
+kj
+qL
 vg
 iC
 hB
@@ -3200,14 +3200,14 @@ RJ
 yA
 WL
 Ca
-sc
+qb
 Fc
-XC
+IR
 Wt
 Iu
-au
-EP
-Cc
+UQ
+qp
+eM
 vg
 iC
 hB
@@ -3219,19 +3219,19 @@ hB
 hB
 hB
 Ue
-qp
+Ko
 RJ
-Yu
-hQ
+fg
+fi
 NG
 fK
-qL
+Op
 fK
 cC
-kr
+CU
 SF
 vg
-JZ
+Gf
 Ue
 hB
 hB
@@ -3273,7 +3273,7 @@ Jw
 kX
 yz
 rf
-ac
+XX
 HA
 hB
 hB
@@ -3295,8 +3295,8 @@ HA
 iT
 YF
 ui
-XX
-Op
+QI
+Xe
 HA
 iC
 hB
@@ -3316,9 +3316,9 @@ hB
 Ue
 pZ
 HA
-oN
-vJ
-eM
+kn
+JY
+uS
 HA
 pZ
 Ue


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/91ba1a85-df59-48a4-9936-131a00d58304)

Brings the Ivory's style more in line with what's been defined as ISF style while maintaining it's shape and style

overall

lost the absolution for a shadow
pistole c for ringneck
removed mega air tanks
redid decalling

## Changelog

:cl:
add: remaps the ivory. a little less gear, a bit more shape, a smidge more size.
/:cl:

