### PR TITLE
Makes the new jungle turfs have the correct atmos

### DIFF
--- a/code/datums/mapgen/greeble.dm
+++ b/code/datums/mapgen/greeble.dm
@@ -191,7 +191,7 @@
 
 /obj/effect/greeble_spawner/grass_patch_spawner/dark_jungle
 	name = "dark jungle grass patch spawner"
-	turf_to_spread = /turf/open/floor/plating/asteroid/dirt/grass/jungle_dark
+	turf_to_spread = /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark
 	big_brush = TRUE
 	only_spread_on_spawning_turf = TRUE
 	max_turfs_to_spread = 16
@@ -202,7 +202,7 @@
 
 /obj/effect/greeble_spawner/grass_patch_spawner/yellow_jungle
 	name = "yellow jungle grass patch spawner"
-	turf_to_spread = /turf/open/floor/plating/asteroid/dirt/grass/jungle_yellow
+	turf_to_spread = /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow
 	big_brush = FALSE
 	only_spread_on_spawning_turf = FALSE
 	max_turfs_to_spread = 5

--- a/code/game/turfs/open/floor/plating/jungle.dm
+++ b/code/game/turfs/open/floor/plating/jungle.dm
@@ -27,12 +27,13 @@
 /turf/open/floor/plating/asteroid/dirt/grass/jungle
 	icon = 'icons/turf/floors/junglegrass.dmi'
 	smooth_icon = 'icons/turf/floors/junglegrass.dmi'
+	initial_gas_mix = JUNGLEPLANET_DEFAULT_ATMOS
 
-/turf/open/floor/plating/asteroid/dirt/grass/jungle_dark
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark
 	icon = 'icons/turf/floors/darkjunglegrass.dmi'
 	smooth_icon = 'icons/turf/floors/darkjunglegrass.dmi'
 
-/turf/open/floor/plating/asteroid/dirt/grass/jungle_yellow
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow
 	icon = 'icons/turf/floors/yellowgrass.dmi'
 	smooth_icon = 'icons/turf/floors/yellowgrass.dmi'
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Some of the new jungle tiles didn't have the right starting atmos and was causing issues. Also makes them proper subtypes for neatness.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes are good.

## Changelog

:cl:
fix: Jungle turf atmos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
