### PR TITLE
Fishi Roll Desc Tweaks + Crafting Shit

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -138,10 +138,10 @@
 
 /obj/item/reagent_containers/food/snacks/fishi
 	name = "Zohil temaki roll"
-	desc = "A form of temaki roll originating from Zohil, which consists of a whole, specially prepared fish that is wrapped in seaweed. While this recipe saw success there, space carp's natural toxicity makes this... difficult."
+	desc = "A form of temaki roll originating from Zohil, which consists of a whole, specially prepared fish that is wrapped in seaweed."
 	icon_state = "fi-shi"
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/toxin/carpotoxin = 2)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 18, /datum/reagent/consumable/nutriment/vitamin = 8, /datum/reagent/toxin/carpotoxin = 8)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 18, /datum/reagent/consumable/nutriment/vitamin = 8)
 	filling_color = "#eac57b"
 	tastes = list("raw fish" = 6, "dried seaweed" = 3)
 	foodtype = VEGETABLES | MEAT

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -86,10 +86,10 @@
 	subcategory = CAT_MEAT
 
 /datum/crafting_recipe/food/fishi
-	name = "Fi-shi roll"
+	name = "Zohil temaki roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/grown/seaweed/sheet = 8,
-		/obj/item/reagent_containers/food/snacks/fishmeat/carp = 4
+		/obj/item/reagent_containers/food/snacks/fishmeat = 4
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishi
 	subcategory = CAT_MEAT


### PR DESCRIPTION
## About The Pull Request

this shit is an insult to temaki rolls but mirrors the name to crafting tab + removes the vestigial aspawn toxin version of it and makes it not need carp

## Why It's Good For The Game

frankly i wouldve just removed it but its got a lore thing attached to it so whatever man

## Changelog

:cl:
fix: Fixed Zohil Temaki roll crafting typo + fixed recipe taking carp instead of any fish
/:cl: