### PR TITLE
Renames Inteq Recruits to Auxiliaries

### DIFF
--- a/_maps/configs/inteq_colossus.json
+++ b/_maps/configs/inteq_colossus.json
@@ -41,7 +41,7 @@
 			"outfit": "/datum/outfit/job/inteq/security",
 			"slots": 3
 		},
-		"Recruit": {
+		"Auxiliary": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
 			"slots": 2
 		}

--- a/_maps/configs/inteq_talos.json
+++ b/_maps/configs/inteq_talos.json
@@ -47,7 +47,7 @@
 			"outfit": "/datum/outfit/job/inteq/paramedic",
 			"slots": 1
 		},
-		"Recruit": {
+		"Auxiliary": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
 			"slots": 2
 		}

--- a/_maps/configs/inteq_valor.json
+++ b/_maps/configs/inteq_valor.json
@@ -47,7 +47,7 @@
 			"outfit": "/datum/outfit/job/inteq/engineer",
 			"slots": 1
 		},
-		"Recruit": {
+		"Auxiliary": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
 			"slots": 2
 		}

--- a/_maps/configs/inteq_vaquero.json
+++ b/_maps/configs/inteq_vaquero.json
@@ -39,7 +39,7 @@
 			"outfit": "/datum/outfit/job/inteq/security",
 			"slots": 1
 		},
-		"Recruit": {
+		"Auxiliary": {
 			"outfit": "/datum/outfit/job/inteq/assistant",
 			"slots": 1
 		}

--- a/code/modules/clothing/factions/inteq.dm
+++ b/code/modules/clothing/factions/inteq.dm
@@ -220,7 +220,7 @@
 
 /obj/item/clothing/head/warden/inteq
 	name = "master at arms' campaign hat"
-	desc = "A special brown campaign hat with the IRMG insignia emblazoned on it. For yelling at clueless recruits in style."
+	desc = "A special brown campaign hat with the IRMG insignia emblazoned on it. For yelling at clueless auxiliaries in style."
 	icon = 'icons/obj/clothing/faction/inteq/hats.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/inteq/hats.dmi'
 	icon_state = "maahat"

--- a/code/modules/clothing/outfits/factions/inteq.dm
+++ b/code/modules/clothing/outfits/factions/inteq.dm
@@ -19,8 +19,8 @@
 ///assistants
 
 /datum/outfit/job/inteq/assistant
-	name = "IRMG - Recruit"
-	id_assignment = "Recruit"
+	name = "IRMG - Auxiliary"
+	id_assignment = "Auxiliary"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
 

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -217,8 +217,8 @@
 	name = "Avery Inteq"
 
 /obj/effect/mob_spawn/human/corpse/inteq/recruit
-	name = "IRMG Recruit"
-	id_job = "Recruit"
+	name = "IRMG Auxiliary"
+	id_job = "Auxiliary"
 	outfit = /datum/outfit/job/inteq/assistant
 
 /obj/effect/mob_spawn/human/corpse/inteq/medic


### PR DESCRIPTION
## About The Pull Request

Renames the Inteq Recruits to Auxiliaries. No gear changes or otherwise.

## Why It's Good For The Game

Recruits tend to be in a strange position on Inteq ships, being distinctly entry-level roles but... compared to other roles like Reservists (CMM), Navyman (PGF) and Deckhand (Indie), they are far more shoehorned into the specific role. This allows them to still fill that role while having a more open set of responsibilities.

Auxiliaries themselves, as a real world unit, are rooted in history as support staff for police or military forces. This ranges from culinary staff to nurses to others. This also includes non-combat roles like radio and civil defense. 

https://en.wikipedia.org/wiki/Auxiliaries

Hopefully this also allows people looking to get introduced to the faction also have the option of simply playing a basic support role.

## Changelog

:cl:
balance: Recruits are now Auxiliaries.
/:cl: