### PR TITLE
Dismantle Light Switches + Mount Fix

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -18,7 +18,7 @@
 		dir_amount = 8\
 	)
 
-/obj/machinery/light_switch/Initialize()
+/obj/machinery/light_switch/Initialize(mapload, ndir, building = FALSE)
 	. = ..()
 	if(istext(area))
 		area = text2path(area)
@@ -26,9 +26,20 @@
 		area = GLOB.areas_by_type[area]
 	if(!area)
 		area = get_area(src)
-
 	if(!name)
 		name = "light switch ([area.name])"
+
+	if(building)
+		setDir(ndir)
+		switch(dir) //Not great, but necessary as with buttons. Otherwise requires altering a ton of files.
+			if(NORTH)
+				pixel_y = -18 //Yes, NORTH is actually the south-facing mount.
+			if(SOUTH)
+				pixel_y = 20
+			if(EAST)
+				pixel_x = -20
+			if(WEST)
+				pixel_x = 20
 
 	update_appearance()
 
@@ -64,6 +75,24 @@
 
 	area.power_change()
 
+/obj/machinery/light_switch/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER || I.tool_behaviour == TOOL_CROWBAR)
+		var/action_description = I.tool_behaviour == TOOL_SCREWDRIVER ? "unscrew" : "pry"
+		to_chat(user, span_notice("You start [action_description]ing \the [src]..."))
+
+		if(I.use_tool(src, user, 15, volume=60))
+			user.visible_message(
+				span_notice("[user] [action_description == "pry" ? "pries" : "unscrews"] [src] from its socket."),
+				span_notice("You [action_description] [src] from its socket.")
+			)
+			var/obj/item/wallframe/light_switch/frame = new /obj/item/wallframe/light_switch()
+			frame.forceMove(user.drop_location())
+			I.play_tool_sound(src)
+			qdel(src)
+		return
+	else
+		return ..()
+
 /obj/machinery/light_switch/power_change()
 	SHOULD_CALL_PARENT(0)
 	if(area == get_area(src))
@@ -81,6 +110,5 @@
 	desc = "A ready-to-go light switch. Just slap it on a wall!"
 	icon_state = "button"
 	result_path = /obj/machinery/light_switch
-	pixel_shift = 24
 	inverse = FALSE
 	custom_materials = list(/datum/material/iron = 75)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -86,7 +86,7 @@
 				span_notice("You [action_description] [src] from its socket.")
 			)
 			var/obj/item/wallframe/light_switch/frame = new /obj/item/wallframe/light_switch()
-			frame.forceMove(user.drop_location())
+			try_put_in_hand(frame, user)
 			I.play_tool_sound(src)
 			qdel(src)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/PentestSS13/Pentest/pull/278

Light switches could not be dismantled from what I've tried, and could only be destroyed. This corrects that. Screwdriver and crowbar can both be used to create a frame after a short delay. Additionally, I have fixed the pixel offset and direction when mounting light switches on the wall.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It hurts my soul to smack light switches until they die.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Light switches can now be properly dismantled into frames with crowbar or screwdriver.
fix: Light switches are mounted with the right directional set and with the correct offset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
