### PR TITLE
Adjusts the Placement of Teleporter Pieces

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -18,20 +18,31 @@
 	link_power_station()
 
 /obj/machinery/computer/teleporter/Destroy()
-	if (power_station)
+	if(power_station)
+		if(power_station.teleporter_hub) //Else the teleporter will stay on despite being non-functional.
+			power_station.engaged = FALSE
+			power_station.teleporter_hub.update_appearance()
+			calibrating = FALSE
+			power_station.update_appearance() //To make sure the appearance is reset here too.
 		power_station.teleporter_console = null
 		power_station = null
 	return ..()
 
 /obj/machinery/computer/teleporter/proc/link_power_station()
-	if(power_station)
-		return
-	for(var/direction in GLOB.cardinals)
-		power_station = locate(/obj/machinery/teleport/station, get_step(src, direction))
-		if(power_station)
-			power_station.link_console_and_hub()
-			break
-	return power_station
+	if(!power_station)
+		var/obj/machinery/teleport/hub/adjacent_hub
+		var/obj/machinery/teleport/station/unlinked_station
+		for(var/direction in GLOB.cardinals)
+			unlinked_station = locate(/obj/machinery/teleport/station, get_step(src, direction)) //Check for the power station first.
+			if(unlinked_station && unlinked_station.link_console_and_hub(unlinked_console = src))
+				power_station = unlinked_station
+				break
+
+			adjacent_hub = locate(/obj/machinery/teleport/hub, get_step(src, direction)) //Failing that, check for a hub with a linked power station.
+			if(adjacent_hub && adjacent_hub.power_station && !adjacent_hub.power_station.teleporter_console)
+				power_station = adjacent_hub.power_station
+				power_station.teleporter_console = src //Set it directly, easy.
+				break
 
 /obj/machinery/computer/teleporter/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of: https://github.com/PentestSS13/Pentest/pull/281

Teleporters worked on the following principle: Console (controls it) --> Power Station (turns it on and off) --> Hub (the gate portion), placed in that order, cardinally.

I thought this was too limiting, and the code for this is ancient, so I refactored it somewhat to allow more loose formations. Specifically the Hub can now be in the middle of the Power Station and Console. Power Station --> Hub <-- Console. The Hub and Power Station still have to be next to each other. You can still use the original configuration too, or various L-type designs. This should also prevent weird recursions in links.

I have also cleaned up the relevant code, added some exceptions for when things are destroyed to fix some weird visual effects and such.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More of a QoL. I think having more design space is a good thing. And the Hub being in the middle just looks right.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
refactor: Teleporter pieces can now be arranged to have the hub in the middle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
