### PR TITLE
Rename Buttons

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -106,6 +106,14 @@
 				playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 				qdel(src)
 
+		if(istype(W, /obj/item/pen))
+			var/new_name = stripped_input(user, "Enter a new name for the button.", "Rename Button", name, MAX_NAME_LEN)
+			if(!new_name || !panel_open || !in_range(src, user) && loc != user) //Mostly copy pasted from airlocks.
+				return
+			else
+				name = new_name
+				return //Do not need to update the appearance.
+
 		update_appearance()
 		return
 

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -108,7 +108,7 @@
 
 		if(istype(W, /obj/item/pen))
 			var/new_name = stripped_input(user, "Enter a new name for the button.", "Rename Button", name, MAX_NAME_LEN)
-			if(!new_name || !panel_open || !in_range(src, user) && loc != user) //Mostly copy pasted from airlocks.
+			if(!new_name || !panel_open || !in_range(src, user)) //Mostly copy pasted from airlocks.
 				return
 			else
 				name = new_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of: https://github.com/PentestSS13/Pentest/pull/282

Allows one to rename buttons with a pen, provided the maintenance panel is open.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

QoL. You can sort of already do this with a hand labeler, but this looks so much nicer and will prevent my untimely death as I forget which button is the holofield and which is the blast doors.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: You can now rename buttons with a pen after opening the maintenance panel with a screwdriver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
