### PR TITLE
Chisel Corner Fix

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -34,6 +34,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		T.update_atom_colour()
 	if(T.dir != dir)
 		T.setDir(dir)
+	if(T.smoothing_flags != smoothing_flags)
+		T.smoothing_flags = smoothing_flags
 	return T
 
 /turf/open/copyTurf(turf/T, copy_air = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of: https://github.com/PentestSS13/Pentest/pull/284

Chisel corners got reset back to the original appearance when a shuttle moved. This PR fixes that, though it has nothing to do with the chisel itself. I have tested it over multiple trips and it appears to work fine. 

I have not tested it with ship rotation/docking, but it will likely work just fine. copyTurf()  is problematic as I note in [a different PR](https://github.com/PentestSS13/Pentest/pull/288).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Took way too long to pin down. Makes ships pretty.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Chisel corners will now be preserved when the ship moves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
