### PR TITLE
Removes R&D from the last two ruins it exists in

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
@@ -2118,7 +2118,7 @@
 	pixel_y = -33;
 	specialfunctions = 4
 	},
-/obj/machinery/computer/rdconsole{
+/obj/structure/salvageable/computer{
 	dir = 1
 	},
 /obj/machinery/button/door{

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_abandoned_mechbay.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_abandoned_mechbay.dmm
@@ -1463,7 +1463,7 @@
 /turf/open/floor/plating/wasteplanet,
 /area/overmap_encounter/planetoid/cave/explored)
 "qN" = (
-/obj/machinery/computer/rdconsole{
+/obj/structure/salvageable/computer{
 	dir = 1
 	},
 /obj/effect/turf_decal/box/white,


### PR DESCRIPTION
## About The Pull Request

Removes R&D consoles from the Jungle Medtech and Wasteplanet Mechbay.

## Why It's Good For The Game

This kills the last remaining R&D consoles in ruins that were missed by previous passes, nearly completing public-facing R&D removal.

## Changelog

:cl:
balance: All remaining R&D consoles have been removed from planets.
/:cl:
