### PR TITLE
Replaces the "oxygen" cans filled with plasma with oxygen cans on cave base.

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_cave_base.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_cave_base.dmm
@@ -2142,13 +2142,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/toxins{
-	icon_state = "blue";
-	name = "oxygen canister";
-	desc = "Oxygen. Necessary for human life."
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating/rust,
 /area/ruin/whitesands/cave_base/engi)
 "yd" = (
@@ -4252,14 +4248,10 @@
 /area/ruin/whitesands/cave_base/engi)
 "Ta" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
-/obj/machinery/portable_atmospherics/canister/toxins{
-	icon_state = "blue";
-	name = "oxygen canister";
-	desc = "Oxygen. Necessary for human life."
-	},
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/concrete/slab_1,
 /area/ruin/whitesands/cave_base/engi)
 "Tg" = (
@@ -4818,13 +4810,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/toxins{
-	icon_state = "blue";
-	name = "oxygen canister";
-	desc = "Oxygen. Necessary for human life."
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/ruin/whitesands/cave_base/engi)
 "Zb" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
says in the title.


## Why It's Good For The Game
Gotcha mapping is not good. There is not hint of plasma in the ruin anyways.

## Changelog

:cl:

fix: removes the fake oxygen cans on cave base and replaces them with actual oxygen.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
