### PR TITLE
Fixes Turfs on ICW Base and fixes one wire

### DIFF
--- a/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
@@ -2283,6 +2283,9 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/engine/waste/lit,
 /area/overmap_encounter/planetoid/wasteplanet/explored)
 "iO" = (
@@ -6124,7 +6127,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/wasteplanet/wasteplanet_icwbase/warehouse)
 "yf" = (
-/turf/open/water/acid,
+/turf/open/water/acid/waste,
 /area/overmap_encounter/planetoid/wasteplanet/explored)
 "yk" = (
 /obj/effect/decal/cleanable/robot_debris/gib,

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
@@ -2061,6 +2061,13 @@
 	},
 /turf/open/floor/engine/waste/lit,
 /area/overmap_encounter/planetoid/wasteplanet/explored)
+"hG" = (
+/obj/structure/cable,
+/obj/machinery/porta_turret/ruin/frontiersmen{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/wasteplanet/lit,
+/area/ruin/wasteplanet/wasteplanet_icwbase/TURRETS)
 "hH" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/bordercee{
 	dir = 4
@@ -2669,9 +2676,7 @@
 /area/overmap_encounter/planetoid/wasteplanet/explored)
 "kG" = (
 /obj/structure/cable,
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen");
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 5
 	},
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
@@ -3293,10 +3298,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen")
-	},
+/obj/machinery/porta_turret/ruin/frontiersmen,
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
 /area/ruin/wasteplanet/wasteplanet_icwbase/TURRETS)
 "nn" = (
@@ -4790,9 +4792,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen");
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
@@ -6366,10 +6366,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen")
-	},
+/obj/machinery/porta_turret/ruin/frontiersmen,
 /turf/open/floor/concrete/pavement/wasteplanet,
 /area/ruin/wasteplanet/wasteplanet_icwbase/TURRETS)
 "zp" = (
@@ -6681,10 +6678,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen")
-	},
+/obj/machinery/porta_turret/ruin/frontiersmen,
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
 /area/ruin/wasteplanet/wasteplanet_icwbase/TURRETS)
 "Ao" = (
@@ -8496,9 +8490,7 @@
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen/heavy{
-	faction = list("Frontiersmen")
-	},
+/obj/machinery/porta_turret/ruin/frontiersmen/heavy,
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
 /area/ruin/wasteplanet/wasteplanet_icwbase/TURRETS)
 "Ib" = (
@@ -9656,9 +9648,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen");
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
@@ -11611,9 +11601,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen");
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 1
 	},
 /turf/open/floor/plating/wasteplanet{
@@ -12060,9 +12048,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/porta_turret/ship/frontiersmen{
-	reqpower = 0;
-	faction = list("Frontiersmen");
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/wasteplanet/lit,
@@ -16146,7 +16132,7 @@ yf
 Nx
 Kp
 nX
-kG
+hG
 Wt
 Cd
 fg

--- a/code/game/turfs/open/acid.dm
+++ b/code/game/turfs/open/acid.dm
@@ -147,3 +147,7 @@
 /turf/open/water/acid/whitesands
 	planetary_atmos = TRUE
 	initial_gas_mix = SANDPLANET_DEFAULT_ATMOS
+
+/turf/open/water/acid/waste
+	planetary_atmos = TRUE
+	initial_gas_mix = WASTEPLANET_DEFAULT_ATMOS


### PR DESCRIPTION
## About The Pull Request

The acid tiles had default atmos before which fucked a bunch of stuff up. There was also one missing tile that rendered the entire north part of the map unpowered.

Also makes the ship turrets into ruin turrets

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
fix: Fixed improper turfs on the ICW Base Waste Ruin that caused wind and fixed one wire
fix: ICW Base turrets are no longer ship turrets
/:cl: