### PR TITLE
Printable glowsticks.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -46,6 +46,14 @@
 	build_path = /obj/item/flashlight
 	category = list("initial","Tools")
 
+/datum/design/glowstick
+	name = "Glowstick"
+	id = "glowstick"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 50, /datum/material/glass = 20)
+	build_path = /obj/item/flashlight/glowstick
+	category = list("initial","Tools")
+
 /datum/design/extinguisher
 	name = "Fire Extinguisher"
 	id = "extinguisher"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Do you like flares? Did you forget to stock up on them? Worry not, you can print glowsticks now - they have the same light range as flashlights, which you can already print, so it's more of a flavor item anyways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
add: Glowsticks can now be printed in an autolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
