### PR TITLE
Fixes wolf alphas not being gibbed on butcher

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -103,15 +103,6 @@
 		retreat_message_said = TRUE
 	retreat_distance = 30
 
-/mob/living/simple_animal/hostile/asteroid/wolf/gib()
-	move_force = MOVE_FORCE_DEFAULT
-	move_resist = MOVE_RESIST_DEFAULT
-	pull_force = PULL_FORCE_DEFAULT
-	if(prob(15))
-		var/obj/trophy = new mob_trophy(loc)
-		visible_message(span_warning("You notice a [trophy.name] might be salvagable."))
-	..()
-
 //alpha wolf- smaller chance to spawn, practically a miniboss. Has the ability to do a short, untelegraphed lunge with a stun. Be careful!
 /mob/living/simple_animal/hostile/asteroid/wolf/alpha
 	name = "alpha wolf"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -108,8 +108,8 @@
 	move_resist = MOVE_RESIST_DEFAULT
 	pull_force = PULL_FORCE_DEFAULT
 	if(prob(15))
-		new mob_trophy(loc)
-		visible_message(span_warning("You notice a damaged ear that might be salvagable."))
+		var/obj/trophy = new mob_trophy(loc)
+		visible_message(span_warning("You notice a [trophy.name] might be salvagable."))
 	..()
 
 //alpha wolf- smaller chance to spawn, practically a miniboss. Has the ability to do a short, untelegraphed lunge with a stun. Be careful!

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -108,7 +108,7 @@
 	move_resist = MOVE_RESIST_DEFAULT
 	pull_force = PULL_FORCE_DEFAULT
 	if(prob(15))
-		new /obj/item/mob_trophy/wolf_ear(loc)
+		new mob_trophy(loc)
 		visible_message(span_warning("You notice a damaged ear that might be salvagable."))
 	..()
 
@@ -137,11 +137,6 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2, /obj/item/stack/sheet/sinew/wolf = 4, /obj/item/stack/sheet/sinew/wolf = 4, /obj/item/stack/sheet/bone = 5)
 	loot = list()
 	mob_trophy = /obj/item/mob_trophy/fang
-
-/mob/living/simple_animal/hostile/asteroid/wolf/alpha/gib()
-	move_force = MOVE_FORCE_DEFAULT
-	move_resist = MOVE_RESIST_DEFAULT
-	pull_force = PULL_FORCE_DEFAULT
 
 /mob/living/simple_animal/hostile/asteroid/wolf/random/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gib override that didn't call parent or do anything yippee


## Changelog

:cl:
fix: alpha wolves now explode into giblets properly when cut up with a knife
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
