### PR TITLE
Removes Default Solarian Knowledge From Humans

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -361,10 +361,8 @@ Key procs
 							/datum/language/buzzwords = list(LANGUAGE_ATOM))
 
 /datum/language_holder/human
-	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-								/datum/language/solarian_international = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-							/datum/language/solarian_international = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/empty
 	understood_languages = list()


### PR DESCRIPTION
## About The Pull Request

Human != Solarian
Solarian outfits already grant solarian understanding

## Why It's Good For The Game
I get annoyed when my dumb bitch girl knows more than one language she's supposed to be a dumb bitch my immersion is being broken
## Changelog

:cl:
balance: humans no longer know solarian by default
/:cl:
