### PR TITLE
Revert "Fixes various thruster-related bugs"

### DIFF
--- a/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -29,7 +29,7 @@
 	if(heat_creation)
 		heat_engine()
 	var/to_use = fuel_use * (percentage / 100) * seconds_per_tick
-	return resolved_heater.consume_fuel(to_use, fuel_type) * thrust / fuel_use //This proc returns how much was actually burned, so let's use that and multiply it by the thrust to get all the thrust we CAN give.
+	return resolved_heater.consume_fuel(to_use, fuel_type) / to_use * percentage / 100 * thrust //This proc returns how much was actually burned, so let's use that and multiply it by the thrust to get all the thrust we CAN give.
 
 /obj/machinery/power/shuttle/engine/fueled/return_fuel()
 	. = ..()
@@ -259,7 +259,7 @@
 
 /obj/machinery/power/shuttle/engine/electric/burn_engine(percentage = 100, seconds_per_tick)
 	. = ..()
-	var/true_percentage = min(newavail() / (power_per_burn * seconds_per_tick), percentage / 100) * seconds_per_tick
+	var/true_percentage = min(newavail() / power_per_burn, percentage / 100)
 	add_delayedload(power_per_burn * true_percentage)
 	return thrust * true_percentage
 
@@ -299,11 +299,11 @@
 	for(var/reagent in fuel_reagents)
 		reagent_amount_holder += fuel_reagents[reagent]
 
-/obj/machinery/power/shuttle/engine/liquid/burn_engine(percentage = 100, seconds_per_tick)
+/obj/machinery/power/shuttle/engine/liquid/burn_engine(percentage = 100)
 	. = ..()
-	var/true_percentage = seconds_per_tick * percentage / 100
+	var/true_percentage = 1
 	for(var/reagent in fuel_reagents)
-		true_percentage *= reagents.remove_reagent(reagent, fuel_reagents[reagent] * true_percentage) / (fuel_reagents[reagent] * true_percentage)
+		true_percentage *= reagents.remove_reagent(reagent, fuel_reagents[reagent]) / fuel_reagents[reagent]
 	return thrust * true_percentage
 
 /obj/machinery/power/shuttle/engine/liquid/return_fuel()

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -271,7 +271,7 @@
 		thrust_used += real_engine.burn_engine(percentage, seconds_per_tick)
 
 	thrust_used = thrust_used / (shuttle_port.turf_count * 100)
-	est_thrust = thrust_used * 100 / (percentage * seconds_per_tick) //cheeky way of rechecking the thrust, check it every time it's used
+	est_thrust = thrust_used / percentage * 100 //cheeky way of rechecking the thrust, check it every time it's used
 
 	return thrust_used
 


### PR DESCRIPTION
## About The Pull Request

Reverts shiptest-ss13/Shiptest#4670

## Why It's Good For The Game

All the fixes slowed pretty much every ship to a crawl, even subshuttles. I tried adjusting thrust on all engines to compensate for the pr but it was extremely weird to set everything so high and even weirder with combustions, where they get to pill-speeds at even just 24 because of how they react to different gas mixes and parts.

## Changelog

:cl:
del: Reverts fixes to plasma and ion thrusters that ended up slowing down ships to a crawl
/:cl: