### PR TITLE
Fixes grav anomaly core detonation

### DIFF
--- a/code/modules/assembly/anomalies.dm
+++ b/code/modules/assembly/anomalies.dm
@@ -82,11 +82,12 @@
 	//throngles u cutely
 	visible_message(span_warning("[src] implodes into itself, light itself bending for a split second!"))
 	for(var/mob/living/carbon/carbon in range(1,src))
-		if(carbon.run_armor_check(attack_flag = "melee") >= 20)
-			carbon.break_random_bone()
-		else if(carbon.run_armor_check(attack_flag = "melee") >= 40)
+		if(carbon.run_armor_check(attack_flag = "melee") >= 40)
 			carbon.break_all_bones() //crunch
+		else if(carbon.run_armor_check(attack_flag = "melee") >= 20)
+			carbon.break_random_bone()
 		carbon.apply_damage(20, BRUTE)
+	..()
 
 ///Hallucination Anomaly
 /obj/item/assembly/signaler/anomaly/hallucination


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Detonating anomaly cores has an opportunity cost of ~3000 credits so you will NEVER see these but the grav anomaly now properly deletes itself and attempts to do the mega ultra bone break before the smaller one which allows it to work

## Why It's Good For The Game

Working As Intended

## Changelog

:cl:
fix: detonating a grav anomaly core can now break bones as intended and also deletes the core as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
