### PR TITLE
Removes some races' abilities to have languages by default.

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -358,10 +358,8 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	blocked_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard
-	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-								/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-							/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard/ash
 	selected_language = /datum/language/kalixcian_common
@@ -402,20 +400,16 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 							/datum/language/machine = list(LANGUAGE_ATOM))
 
 /datum/language_holder/moth
-	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-								/datum/language/moffic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-							/datum/language/moffic = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/skeleton
 	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/ethereal
-	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-								/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-							/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/fly
 	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
@@ -426,10 +420,8 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/kepori
-	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-								/datum/language/teceti_unified = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
-							/datum/language/teceti_unified = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/vox
 	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Continuation of https://github.com/shiptest-ss13/Shiptest/pull/4776. Removes Sarathi, Elzuosa, Mothpeople, and Kepori from having their languages by default.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The PGF's outfits have Kalcomm by default already, and you can use quirks to add the language you want for other characters. Vox Pidgin and Rachnidian have been left untouched, since the only way to physically speak said language requires you to be a part of said group, plus there isn't any existing way to add said languages to yourself. Until a large rework(coming 2028) is done, the quirk system in use is better than inherent racial benefits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del: Sarathi, Elzuosa, Mothpeople, and Kepori no longer have free extra languages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
