### PR TITLE
Nimbus and Cirrus adjustments

### DIFF
--- a/_maps/shuttles/cybersun/cybersun_cirrus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_cirrus.dmm
@@ -4516,8 +4516,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/freezer{
-	name = "organ freezer";
-	anchored = 1
+	name = "organ freezer"
 	},
 /obj/item/organ/heart/cybernetic/tier2,
 /obj/item/organ/heart/cybernetic/tier3,

--- a/_maps/shuttles/cybersun/cybersun_nimbus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_nimbus.dmm
@@ -42,9 +42,10 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/tricord,
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/tricord{
-	pixel_x = -8
+/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/tricord,
+/obj/item/reagent_containers/glass/bottle/vial/small/preloaded/tricord{
+	pixel_x = -5;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/mono/white,
 /area/ship/cargo)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a real mk2 (instead of mk3) hypospray vials to Nimbus. Unwrenchess the organ freezer from the floor on Cirrus.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nimbus crew will no longer try to put large flasks in their small hypospray. Doctor on Cirrus will no longer have to call a mechanic every time to unwrench the freezer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Nimbus got an actual mk2 hypospray vials.
fix: organ freezer in Cirrus is no longer anchored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
