### PR TITLE
Blackmarket Uplink no longer eats your headset

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -162,7 +162,7 @@
 	result = /obj/item/blackmarket_uplink
 	time = 30
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_MULTITOOL)
-	blacklist = list(/obj/item/radio/headset)
+	blacklist = list(/obj/item/radio/headset, /obj/item/radio/intercom)
 	reqs = list(
 		/obj/item/stock_parts/scanning_module = 1,
 		/obj/item/stack/cable_coil = 15,

--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -162,6 +162,7 @@
 	result = /obj/item/blackmarket_uplink
 	time = 30
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_MULTITOOL)
+	blacklist = list(/obj/item/radio/headset)
 	reqs = list(
 		/obj/item/stock_parts/scanning_module = 1,
 		/obj/item/stack/cable_coil = 15,


### PR DESCRIPTION
## About The Pull Request

adds radio/headset to a blacklist for blackmarket uplink crafting

## Why It's Good For The Game

it aint supposed to take headset

## Changelog

:cl:
fix: Stops blackmarket uplink crafting from eating your headset
/:cl: