### PR TITLE
comments out admins in admins.txt

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -4,7 +4,7 @@
 #Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
-MarkSuckerberg = Development Head
-rkz = Development Head
+#MarkSuckerberg = Development Head
+#rkz = Development Head
 
 #just use the database, this is deprecated

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -5,6 +5,5 @@
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
 #MarkSuckerberg = Development Head
-#rkz = Development Head
 
 #just use the database, this is deprecated


### PR DESCRIPTION
This just comments out the admins in admins.txt. Really this only affects servers not using a database.

Also, did anyone notice rkz got added in this file 9 months ago as part of their newfood PR? It looks accidental, but I've removed it anyways. Leaving in mark's entry just to serve as an example for people who need to configure local test instances.

## Changelog

:cl:
server: comments out the default admins in admins.txt. Removed rkz from it.
/:cl:

