### PR TITLE
Fixes fax spam only sending a single piece of mail

### DIFF
--- a/code/modules/events/fax_spam.dm
+++ b/code/modules/events/fax_spam.dm
@@ -24,11 +24,11 @@
 			pick_faxes += fax_machine
 
 /datum/round_event/fax_spam/tick()
-	if(activeFor % spam_frequency == 0)
-		var/obj/item/paper/spam/spam_message = new spam_type
+	if((activeFor % spam_frequency) == 0)
 		for(var/obj/machinery/fax/fax_machine in pick_faxes)
 			if(!prob(spam_prob))
 				continue
+			var/obj/item/paper/spam/spam_message = new spam_type
 			fax_machine.receive(spam_message, spam_message.sender)
 
 /obj/item/paper/spam


### PR DESCRIPTION
## About The Pull Request

Calling receive() on a fax physically moves the actual paper. The issue is the event only initializes a single paper, so it'd end up juggling it around inbetween faxes. 

So we need to initialize a new one for each fax we target with our spam.

![image](https://github.com/user-attachments/assets/e911af9c-321a-47c9-8ed0-142d24ce0b8a)

## Why It's Good For The Game

Bug fix good

closes #4770

## Changelog

:cl:
fix: The spam fax event now actually spams faxes
/:cl:
