### PR TITLE
Fixes IPCs getting stuck in an infinite healing loop when doing surgery

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -53,15 +53,19 @@
 
 
 //These procs fetch a cumulative total damage from all bodyparts
-/mob/living/carbon/getBruteLoss()
+/mob/living/carbon/getBruteLoss(ignore_integrity = TRUE)
 	var/amount = 0
 	for(var/obj/item/bodypart/BP as anything in bodyparts)
+		if (!ignore_integrity && BP.get_curable_damage() <= 0)
+			continue
 		amount += BP.brute_dam
 	return amount
 
-/mob/living/carbon/getFireLoss()
+/mob/living/carbon/getFireLoss(ignore_integrity = TRUE)
 	var/amount = 0
 	for(var/obj/item/bodypart/BP as anything in bodyparts)
+		if (!ignore_integrity && BP.get_curable_damage() <= 0)
+			continue
 		amount += BP.burn_dam
 	return amount
 

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -55,7 +55,7 @@
 /datum/surgery_step/heal/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(!..())
 		return
-	while((brutehealing && target.getBruteLoss()) || (burnhealing && target.getFireLoss()))
+	while((brutehealing && target.getBruteLoss(FALSE)) || (burnhealing && target.getFireLoss(FALSE)))
 		if(!..())
 			break
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

getBruteLoss and getFireLoss now have added functionality for considering integrity, which is by default off except in the case of healing surgery.

## Why It's Good For The Game

Fixes a bug need I say more.

closes #4665
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: The healing surgeries now correctly consider limb integrity when rechecking if a surgery step can continue, stopping correctly once they can no longer heal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
