### PR TITLE
Mission cap on retrieve vanguard mission

### DIFF
--- a/code/datums/ruins/wasteplanet.dm
+++ b/code/datums/ruins/wasteplanet.dm
@@ -44,6 +44,7 @@
 	desc = "The IRMG has lost contact with one of it's contractees, and the associated Vanguard. All IRMG persons in the area are either already on-assignment, or unavailable. The IRMG is willing to contract out the retrieval of Vanguard Kavur's corpse to any entity in system."
 	faction = /datum/faction/inteq
 	value = 2500
+	mission_limit = 1
 	setpiece_item = /mob/living/carbon/human
 
 /datum/map_template/ruin/wasteplanet/yard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a mission cap for retrieve vanguard so inteq doesn't lose 5 vanguards named kavur

## Why It's Good For The Game

There were THREE of these last round. NOBODY is going to waste planets for 2k.

## Changelog

:cl:
balance: Retrieve vanguard mission can no longer have duplicates at the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
