### PR TITLE
Thruster speed on helm consoles is now accurate

### DIFF
--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -267,7 +267,7 @@
 		thrust_used += real_engine.burn_engine(percentage, seconds_per_tick)
 
 	thrust_used = thrust_used / (shuttle_port.turf_count * 100)
-	est_thrust = thrust_used / percentage * 100 //cheeky way of rechecking the thrust, check it every time it's used
+	est_thrust = thrust_used * 100 / (percentage * seconds_per_tick) //cheeky way of rechecking the thrust, check it every time it's used
 
 	return thrust_used
 
@@ -280,7 +280,7 @@
 		real_engine.update_engine()
 		if(real_engine.enabled)
 			calculated_thrust += real_engine.thrust
-	est_thrust = calculated_thrust / (shuttle_port.turf_count * 100)
+	est_thrust = calculated_thrust / (shuttle_port.turf_count * 100) * 1 SECONDS / SSphysics.wait
 
 /**
  * Calculates the average fuel fullness of all engines.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

based on #4670 except without the part that changes thruster output
In the event the physics subsystem has its speed modified this should allow that to be handled in real time by the helm console on update

## Why It's Good For The Game

Tells you how fast you can ACTUALLY expect a ship to speed up in seconds rather than not doing that

## Changelog

:cl: Sapphicoverload, theos
tweak: Thruster speed on helm consoles is now accurate to how fast the ship accelerates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
