### PR TITLE
Fix some reagent explosions not exploding hard enough

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -3,7 +3,16 @@
 	var/modifier = 0
 
 /datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, created_volume)
-	explode(holder, created_volume)
+	// We do all this because created_volume is actually the number of time the reaction occurs not the created volume
+	var/volume_per_reaction = 0
+	if (results.len)
+		for(var/reagent in results)
+			volume_per_reaction += results[reagent]
+	else
+		for(var/reagent in required_reagents)
+			volume_per_reaction += required_reagents[reagent]
+
+	explode(holder, created_volume*volume_per_reaction)
 
 /datum/chemical_reaction/reagent_explosion/proc/explode(datum/reagents/holder, created_volume)
 	if(QDELETED(holder.my_atom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is a quick in chemcode more specificly in `/datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, created_volume)`. The quirk being that `created_volume` is actually the number of times the reaction occur. 
This means that the strength of an explosion will be divided by the volume of required 

This PR fixes this by making using by using either the volume of created explosive or the volume of the required reagent for the explosion.

Example : lets say you want to detonate RDX with telsium to get a strengthdiv of 3 instead of the 6 that you get by just heating the RDX. This reaction require 2u of reagent which right now mean the power of the explosion is divided by 2, which leaves you with a stregthdiv of 6.


Here are the reactions that were changed by this PR :
| new_strengthdiv | old_strengthdiv | theorical_strengthdiv | type                                                                       |
| --------------- | --------------- | ----------- | -------------------------------------------------------------------------- |
| 3               | 6               | 2           | /datum/chemical_reaction/reagent_explosion/nitroglycerin                   |
| 12              | 24              | 6           | /datum/chemical_reaction/reagent_explosion/rdx                             |
| 3               | 6               | 3           | /datum/chemical_reaction/reagent_explosion/rdx_explosion2                  |
| 3               | 6               | 3           | /datum/chemical_reaction/reagent_explosion/rdx_explosion3                  |
| 5               | 10              | 5           | /datum/chemical_reaction/reagent_explosion/penthrite_explosion_epinephrine |
| 5               | 10              | 5           | /datum/chemical_reaction/reagent_explosion/penthrite_explosion_atropine    |
| 10              | 20              | 10          | /datum/chemical_reaction/reagent_explosion/potassium_explosion             |
| 10              | 20              | 10          | /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom    |
| 6               | 24              | 6           | /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2          |
| 100             | 200             | 100         | /datum/chemical_reaction/reagent_explosion/teslium_lightning               |

theorical_strengthdiv: the strengthdiv as written in code.
old_strengthdiv: effective stregthdiv of the reaction before the PR
new_strengthdiv: effective strengthdiv of the reaction after the PR

## Why It's Good For The Game

On mix explosions not being underpowered is good.

## Changelog

:cl:
balance: Fix on mix reagent explosions being underpowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
