### PR TITLE
Cuts a majority of the dynamic missions tied to high reward ruins

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -29,6 +29,7 @@
 	description = "Records show this settlement as belonging to the SRM, but no one has heard from them as of late. I wonder what happened?"
 	suffix = "icemoon_ice_lodge.dmm"
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
+//	ruin_mission_types = list(/datum/mission/ruin/fallen_montagne)
 
 /datum/mission/ruin/fallen_montagne
 	name = "dark signal investigation"
@@ -45,6 +46,11 @@
 	description = "CLIP has recently lost contact with one of it's Anomaly Research Labs. Reports suggest the frontiersmen may have been behind it."
 	suffix = "icemoon_tesla_lab.dmm"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/blackbox,
+		/datum/mission/ruin/daughter
+			)
+*/
 
 /datum/mission/ruin/daughter
 	name = "find our daughter!"

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -49,7 +49,7 @@
 /*	ruin_mission_types = list(
 		/datum/mission/ruin/blackbox,
 		/datum/mission/ruin/daughter
-			)
+	)
 */
 
 /datum/mission/ruin/daughter

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -29,7 +29,6 @@
 	description = "Records show this settlement as belonging to the SRM, but no one has heard from them as of late. I wonder what happened?"
 	suffix = "icemoon_ice_lodge.dmm"
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
-	ruin_mission_types = list(/datum/mission/ruin/fallen_montagne)
 
 /datum/mission/ruin/fallen_montagne
 	name = "dark signal investigation"
@@ -46,10 +45,6 @@
 	description = "CLIP has recently lost contact with one of it's Anomaly Research Labs. Reports suggest the frontiersmen may have been behind it."
 	suffix = "icemoon_tesla_lab.dmm"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
-	ruin_mission_types = list(
-		/datum/mission/ruin/blackbox,
-		/datum/mission/ruin/daughter
-	)
 
 /datum/mission/ruin/daughter
 	name = "find our daughter!"

--- a/code/datums/ruins/jungle.dm
+++ b/code/datums/ruins/jungle.dm
@@ -70,6 +70,11 @@
 	description = "An abandoned airbase dating back to the ICW, partially scuttled, and moved right back into by the Ramzi Clique."
 	suffix = "jungle_bombed_starport.dmm"
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_HAZARDOUS, RUIN_TAG_LIVEABLE)
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/signaled/kill/ramzi/airbase,
+		/datum/mission/ruin/icw_documents
+	)
+*/
 
 /datum/mission/ruin/signaled/kill/ramzi/airbase
 	mission_limit = 1

--- a/code/datums/ruins/jungle.dm
+++ b/code/datums/ruins/jungle.dm
@@ -70,10 +70,6 @@
 	description = "An abandoned airbase dating back to the ICW, partially scuttled, and moved right back into by the Ramzi Clique."
 	suffix = "jungle_bombed_starport.dmm"
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_HAZARDOUS, RUIN_TAG_LIVEABLE)
-	ruin_mission_types = list(
-		/datum/mission/ruin/signaled/kill/ramzi/airbase,
-		/datum/mission/ruin/icw_documents
-	)
 
 /datum/mission/ruin/signaled/kill/ramzi/airbase
 	mission_limit = 1

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -29,11 +29,6 @@
 	id = "wreck_factory"
 	description = "A Nanotrasen processing facility, assaulted by a pirate raid that has killed most of the staff. The offices however, remain unbreached for now."
 	suffix = "lavaland_surface_wrecked_factory.dmm"
-	ruin_mission_types = list(
-		/datum/mission/ruin/nanotrasen_docs,
-		/datum/mission/ruin/captain_medal,
-		/datum/mission/ruin/brainchip
-	)
 
 /datum/mission/ruin/nanotrasen_docs
 	name = "Nanotrasen Asset Recovery Program."

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -29,6 +29,12 @@
 	id = "wreck_factory"
 	description = "A Nanotrasen processing facility, assaulted by a pirate raid that has killed most of the staff. The offices however, remain unbreached for now."
 	suffix = "lavaland_surface_wrecked_factory.dmm"
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/nanotrasen_docs,
+		/datum/mission/ruin/captain_medal,
+		/datum/mission/ruin/brainchip
+	)
+*/
 
 /datum/mission/ruin/nanotrasen_docs
 	name = "Nanotrasen Asset Recovery Program."

--- a/code/datums/ruins/rockplanet.dm
+++ b/code/datums/ruins/rockplanet.dm
@@ -33,10 +33,6 @@
 	description = "A former pre-ICW era Nanotrasen outpost converted into a moonshine distillery by Frontiersman bootleggers."
 	id = "rockplanet_distillery"
 	suffix = "rockplanet_distillery.dmm"
-	ruin_mission_types = list(
-		/datum/mission/ruin/signaled/kill/frontiersmen,
-		/datum/mission/ruin/multiple/moonshine_crates/distillery
-	)
 
 /datum/mission/ruin/multiple/moonshine_crates/distillery
 	name = "Assess and Retrieve Booze Supply"
@@ -81,11 +77,6 @@
 	description = "A crashed Ramzi Clique vessel that has since become an isolated pirate outpost."
 	id = "rockplanet_rustbase"
 	suffix = "rockplanet_rustbase.dmm"
-
-	ruin_mission_types = list(
-		/datum/mission/ruin/signaled/kill/bright,
-		/datum/mission/ruin/signaled/kill/amuro,
-	)
 
 /datum/mission/ruin/signaled/kill/bright
 	name = "Kill Captain Dwight"

--- a/code/datums/ruins/rockplanet.dm
+++ b/code/datums/ruins/rockplanet.dm
@@ -49,7 +49,6 @@
 	ruin_tags = list(RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
 	ruin_mission_types = list(
 		/datum/mission/ruin/signaled/drill/mining_base,
-		/datum/mission/ruin/ns_manager,
 	)
 
 /datum/mission/ruin/signaled/drill/mining_base

--- a/code/datums/ruins/rockplanet.dm
+++ b/code/datums/ruins/rockplanet.dm
@@ -33,6 +33,11 @@
 	description = "A former pre-ICW era Nanotrasen outpost converted into a moonshine distillery by Frontiersman bootleggers."
 	id = "rockplanet_distillery"
 	suffix = "rockplanet_distillery.dmm"
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/signaled/kill/frontiersmen,
+		/datum/mission/ruin/multiple/moonshine_crates/distillery
+	)
+*/
 
 /datum/mission/ruin/multiple/moonshine_crates/distillery
 	name = "Assess and Retrieve Booze Supply"
@@ -49,7 +54,7 @@
 	ruin_tags = list(RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
 	ruin_mission_types = list(
 		/datum/mission/ruin/signaled/drill/mining_base,
-		/datum/mission/ruin/ns_manager,
+//		/datum/mission/ruin/ns_manager,
 	)
 
 /datum/mission/ruin/signaled/drill/mining_base
@@ -77,6 +82,11 @@
 	description = "A crashed Ramzi Clique vessel that has since become an isolated pirate outpost."
 	id = "rockplanet_rustbase"
 	suffix = "rockplanet_rustbase.dmm"
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/signaled/kill/bright,
+		/datum/mission/ruin/signaled/kill/amuro,
+	)
+*/
 
 /datum/mission/ruin/signaled/kill/bright
 	name = "Kill Captain Dwight"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -36,7 +36,6 @@
 	name = "Singularity Lab"
 	description = "An overgrown facility, home to an inactive singularity and many plants"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
-	ruin_mission_types = list(/datum/mission/ruin/oh_fuck)
 
 /datum/mission/ruin/oh_fuck
 	name = "Singularity Generator Signature"
@@ -59,10 +58,6 @@
 	name = "Ramzi Scrapping Station"
 	description = "A Syndicate FOB dating back to the ICW, now home to the Ramzi Clique and their latest haul."
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
-	ruin_mission_types = list(
-		/datum/mission/ruin/pgf_captain,
-		/datum/mission/ruin/signaled/kill/foreman
-	)
 
 /datum/mission/ruin/signaled/kill/foreman
 	name = "Kill Foreman Bonsha"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -36,6 +36,7 @@
 	name = "Singularity Lab"
 	description = "An overgrown facility, home to an inactive singularity and many plants"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
+//	ruin_mission_types = list(/datum/mission/ruin/oh_fuck)
 
 /datum/mission/ruin/oh_fuck
 	name = "Singularity Generator Signature"
@@ -58,6 +59,11 @@
 	name = "Ramzi Scrapping Station"
 	description = "A Syndicate FOB dating back to the ICW, now home to the Ramzi Clique and their latest haul."
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER)
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/pgf_captain,
+		/datum/mission/ruin/signaled/kill/foreman
+	)
+*/
 
 /datum/mission/ruin/signaled/kill/foreman
 	name = "Kill Foreman Bonsha"

--- a/code/datums/ruins/wasteplanet.dm
+++ b/code/datums/ruins/wasteplanet.dm
@@ -61,10 +61,6 @@
 	suffix = "wasteplanet_icwbase.dmm"
 
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
-	ruin_mission_types = list(
-		/datum/mission/ruin/multiple/notes,
-		/datum/mission/ruin/signaled/kill/kitt
-	)
 
 /* Aurora wrote these */
 

--- a/code/datums/ruins/wasteplanet.dm
+++ b/code/datums/ruins/wasteplanet.dm
@@ -61,6 +61,11 @@
 	suffix = "wasteplanet_icwbase.dmm"
 
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_SHELTER, RUIN_TAG_HAZARDOUS)
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/multiple/notes,
+		/datum/mission/ruin/signaled/kill/kitt
+	)
+*/
 
 /* Aurora wrote these */
 

--- a/code/datums/ruins/whitesands.dm
+++ b/code/datums/ruins/whitesands.dm
@@ -17,6 +17,10 @@
 	description = "The former home of a poor sod on observation duty. Now a cunning trap."
 	suffix = "whitesands_cave_base.dmm"
 	ruin_tags = list(RUIN_TAG_MINOR_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
+/*	ruin_mission_types = list(
+		/datum/mission/ruin/radiological,
+	)
+*/
 
 /datum/mission/ruin/radiological
 	name = "Radiological Signature"

--- a/code/datums/ruins/whitesands.dm
+++ b/code/datums/ruins/whitesands.dm
@@ -17,9 +17,6 @@
 	description = "The former home of a poor sod on observation duty. Now a cunning trap."
 	suffix = "whitesands_cave_base.dmm"
 	ruin_tags = list(RUIN_TAG_MINOR_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
-	ruin_mission_types = list(
-		/datum/mission/ruin/radiological,
-	)
 
 /datum/mission/ruin/radiological
 	name = "Radiological Signature"


### PR DESCRIPTION
## About The Pull Request

Cuts most dynamic missions. Some of the hardest ones are about N+S rock world difficulty and below (and this one in particular only because of the drill)

## Why It's Good For The Game

Maptainer and general development stance seems to be that dynamic missions has pretty broadly taken the focus away from exploration and sets it on these hard, guaranteed ruins themselves. Most crews likely rarely come across River Valley Stash when Rust Base is right there. Or perhaps some have never cleared Ice Training Facility when Tesla Lab and Ice Lodge contracts are right next door.

Kept most of the low difficulty dynamic missions because I think we can still make some good use of it and nothing is really lost from beelining these.

List may be subject to change. The missions themselves remain in the game for if I end up making them high priority mission event only.

## Changelog

:cl:
del: Removed many high reward dynamic missions from the list
/:cl: