### PR TITLE
Less active ruin missions

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -394,7 +394,7 @@
 	min_val = 127
 
 /datum/config_entry/number/max_dynamic_missions
-	config_entry_value = 1
+	config_entry_value = 0.66
 	min_val = 0
 
 /datum/config_entry/number/commendation_percent_poll

--- a/code/controllers/subsystem/missions.dm
+++ b/code/controllers/subsystem/missions.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(missions)
 	flags = SS_NO_INIT
 	priority = FIRE_PRIORITY_MISSIONS
 	wait = 10 SECONDS
-	var/default_mission_count = 5
+	var/default_mission_count = 3
 	var/list/obj/effect/landmark/mission_poi/unallocated_pois = list()
 	var/list/datum/mission/ruin/inactive_ruin_missions = list()
 	var/list/datum/mission/ruin/active_ruin_missions = list()
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(missions)
 		if(prob(50))
 			continue
 
-		if(!(active_ruin_missions.len < default_mission_count + (SSovermap.controlled_ships.len * CONFIG_GET(number/max_dynamic_missions))))
+		if(!(active_ruin_missions.len < default_mission_count + round((SSovermap.controlled_ships.len * CONFIG_GET(number/max_dynamic_missions)))))
 			break
 
 		if(mission_to_start.mission_limit)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -514,7 +514,7 @@ OVERMAP_GENERATOR_TYPE solar_system
 OVERMAP_ENCOUNTER_SIZE 127
 
 ## Max dynamic mission count active per ship
-MAX_DYNAMIC_MISSIONS 1
+MAX_DYNAMIC_MISSIONS 0.66
 
 ## The time required before a ship is allowed to bluespace jump. -1 disables it entirely
 ## In deciseconds, valid values are -1 to INFINITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the missions per ship and the default number so there are less of them
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: there are now less active ruin missions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
