### PR TITLE
Fixes CI for now by making windows build not mandatory

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -221,7 +221,7 @@ jobs:
   completion_gate: # Serves as a non-moving target for branch rulesets
     if: always() && !cancelled()
     name: Completion Gate
-    needs: [test_windows, compile_all_maps, run_linters, run_all_tests]
+    needs: [compile_all_maps, run_linters, run_all_tests]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
Fixes CI for now by making windows build not mandatory

this can either be removed in the future or made to use a cache for byond installer (how does this even work)