### PR TITLE
Scrapstation Touch Ups

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -2161,7 +2161,7 @@
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	id = "office_s"
+	id = "office_a"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/ramzi_station/armory)

--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -1730,7 +1730,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters{
-	id = "office_s"
+	id = "office_a"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/ramzi_station/armory)
@@ -4517,7 +4517,7 @@
 /obj/item/solar_assembly{
 	layer = 2.8
 	},
-/obj/machinery/porta_turret/ship/ramzi/light,
+/obj/machinery/porta_turret/ruin/ramzi/light,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/ramzi_station/solars)
 "zA" = (
@@ -8784,7 +8784,7 @@
 	},
 /obj/machinery/door/window/southleft,
 /obj/machinery/door/poddoor/shutters{
-	id = "office_s"
+	id = "office_a"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/ramzi_station/armory)

--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -1861,7 +1861,6 @@
 /obj/effect/turf_decal/corner/opaque/lime/half,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/pgf_wreck/bridge)
 "lh" = (
@@ -2829,7 +2828,6 @@
 /obj/structure/cable,
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/power/terminal,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -20;
@@ -3176,9 +3174,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/space/pgf_wreck/cargo)
 "st" = (
@@ -4564,9 +4559,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/blood/squirt{
 	dir = 4
 	},
@@ -5722,7 +5714,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/space/pgf_wreck)
 "FK" = (

--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -4513,15 +4513,11 @@
 "zz" = (
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow,
-/obj/machinery/porta_turret/ship/ramzi/heavy{
-	turret_respects_id = 0;
-	turret_flags = 62;
-	lethal = 1
-	},
 /obj/effect/decal/cleanable/glass,
 /obj/item/solar_assembly{
 	layer = 2.8
 	},
+/obj/machinery/porta_turret/ship/ramzi/light,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/ramzi_station/solars)
 "zA" = (
@@ -5478,11 +5474,7 @@
 /obj/item/solar_assembly{
 	layer = 2.8
 	},
-/obj/machinery/porta_turret/ship/ramzi/heavy{
-	turret_respects_id = 0;
-	turret_flags = 62;
-	lethal = 1
-	},
+/obj/machinery/porta_turret/ruin/ramzi/heavy,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/ramzi_station/solars)
 "Ez" = (
@@ -6556,7 +6548,6 @@
 /area/ruin/space/pgf_wreck)
 "KB" = (
 /obj/structure/closet/cabinet,
-/obj/item/storage/guncase/pistol/viper,
 /obj/item/storage/box/ammo/a357,
 /obj/item/clothing/under/syndicate/gorlex,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
@@ -6567,6 +6558,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
 	dir = 6
 	},
+/obj/item/storage/guncase/pistol/a357,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/ramzi_station/foreman)
 "KD" = (
@@ -8144,7 +8136,7 @@
 /area/ruin/space)
 "SE" = (
 /obj/structure/lattice,
-/mob/living/simple_animal/hostile/human/ramzi/ranged/space/sniper,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/space/smg,
 /turf/open/space/basic,
 /area/ruin/space)
 "SG" = (
@@ -8725,6 +8717,16 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/space/pgf_wreck)
+"Vu" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/glass,
+/obj/item/solar_assembly{
+	layer = 2.8
+	},
+/obj/machinery/porta_turret/ruin/ramzi/heavy,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/ramzi_station/solars)
 "Vv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -13377,7 +13379,7 @@ jR
 jR
 jR
 aD
-zz
+Vu
 Fm
 Fm
 Fm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes extra APC terminals on the wreck

Foreman's 357 is now a Coalition version rather than indie

Fixes armory shutter IDs

Removes a boomslang guy near the wreck and replaces one of the heavy turrets on the solar array with a strike turret.

## Why It's Good For The Game

Fixes are good. The abundance of long range sniper enemies was also a bit oppressive in a zero-g environment, so I culled a few of them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Scrapping station wreck no longer has extra terminals, foreman's office has correct revolver, armory shutters IDs
balance: Removes a deadeye and replaces a revolt turret with a strike on Scrapping Station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
