### PR TITLE
Removes access restrictions on Outpost Maint airlocks

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -2675,9 +2675,7 @@
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
 "lq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list("101")
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -2690,7 +2688,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/outpost/maintenance/fore)
@@ -6344,8 +6341,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_access = list("101")
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/maintenance/central)
@@ -7161,9 +7157,7 @@
 "Ed" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	req_access = list("101")
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -7172,7 +7166,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -7562,7 +7555,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_access = list("101");
 	id_tag = "meeting"
 	},
 /obj/structure/cable/yellow{
@@ -7893,7 +7885,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -7901,8 +7892,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_access = list("101")
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/lounge)
@@ -8631,7 +8621,6 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/welded,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -8840,8 +8829,7 @@
 /area/outpost/crew/bar)
 "KZ" = (
 /obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_access = list("101")
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -8861,7 +8849,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo)
 "Lb" = (

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -2506,7 +2506,7 @@
 "qA" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1;
-	req_one_access_txt = "101"
+	req_one_access_txt = null
 	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only,
@@ -3356,7 +3356,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_one_access_txt = "101"
+	req_one_access_txt = null
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/maintenance/fore)
@@ -4194,7 +4194,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_one_access_txt = "101"
+	req_one_access_txt = null
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/maintenance/fore)
@@ -4882,7 +4882,7 @@
 "FA" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1;
-	req_one_access_txt = "101"
+	req_one_access_txt = null
 	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only,
@@ -6059,7 +6059,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_one_access_txt = "101"
+	req_one_access_txt = null
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the access restrictions on most of the outpost maint airlocks on indie space and NT ice. Doors that lead to restricted areas are still locked.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Discussed during maptainer meet a while ago and I've been meaning to get around to doing this. The outpost maints in general aren't actually restricted areas, and the locks on them created the implication that they in fact were. Having them open should provide more interesting avenues for getting around the outpost as well.

## Changelog

:cl:
del: Outpost maint access restrictions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
