### PR TITLE
Makes the beacon have two shots

### DIFF
--- a/code/modules/cargo/packs/weapon_attachments.dm
+++ b/code/modules/cargo/packs/weapon_attachments.dm
@@ -38,15 +38,6 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
-/datum/supply_pack/attachment/alof
-	name = "Alof Tube Crate"
-	desc = "Contains an antiquated spring operated magazine attachment for the HP Beacon. Has a capacity of three rounds."
-	cost = 1000
-	contains = list(/obj/item/attachment/alof)
-	crate_name = "alof crate"
-	faction = /datum/faction/srm
-	faction_discount = 10
-
 /datum/supply_pack/attachment/silencer
 	name = "Suppressor Crate"
 	desc = "Contains a single suppressor to be mounted on a firearm."

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -58,7 +58,7 @@
 	name = "beacon internal magazine"
 	ammo_type = /obj/item/ammo_casing/a4570
 	caliber = ".45-70"
-	max_ammo = 1
+	max_ammo = 2
 	multiload = FALSE
 
 /obj/item/ammo_box/magazine/internal/shot/underbarrel

--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -969,8 +969,8 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow)
 //Break-Action Rifle
 /obj/item/gun/ballistic/shotgun/doublebarrel/beacon
 	name = "HP Beacon"
-	desc = "A single-shot break-action rifle made by Hunter's Pride and sold to civilian hunters. Boasts excellent accuracy and stopping power. Uses .45-70 ammo."
-	sawn_desc= "A single-shot break-action pistol chambered in .45-70. A bit difficult to aim."
+	desc = "A break-action rifle made by Hunter's Pride and sold to civilian hunters. Boasts excellent accuracy and stopping power. Uses .45-70 ammo."
+	sawn_desc= "A break-action pistol chambered in .45-70. A bit difficult to aim."
 	base_icon_state = "beacon"
 	icon_state = "beacon"
 	item_state = "beacon"
@@ -1040,8 +1040,8 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow)
 EMPTY_GUN_HELPER(shotgun/doublebarrel/beacon)
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/beacon/factory
-	desc = "A single-shot break-action rifle made by Hunter's Pride and sold to civilian hunters. This example has been kept in excellent shape and may as well be fresh out of the workshop. Uses .45-70 ammo."
-	sawn_desc= "A single-shot break-action pistol chambered in .45-70. A bit difficult to aim."
+	desc = "A break-action rifle made by Hunter's Pride and sold to civilian hunters. This example has been kept in excellent shape and may as well be fresh out of the workshop. Uses .45-70 ammo."
+	sawn_desc= "A break-action pistol chambered in .45-70. A bit difficult to aim."
 	base_icon_state = "beacon_factory"
 	icon_state = "beacon_factory"
 	item_state = "beacon_factory"
@@ -1055,7 +1055,7 @@ EMPTY_GUN_HELPER(shotgun/doublebarrel/beacon)
 //pre sawn off beacon
 /obj/item/gun/ballistic/shotgun/doublebarrel/beacon/presawn
 	name = "HP Beacon"
-	sawn_desc= "A single-shot break-action pistol chambered in .45-70. A bit difficult to aim."
+	sawn_desc= "A break-action pistol chambered in .45-70. A bit difficult to aim."
 	sawn_off = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT

--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -995,7 +995,7 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow)
 	recoil = 0
 	recoil_unwielded = 5
 
-	gun_firemodes = list(FIREMODE_SEMIAUTO)
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
 	default_firemode = FIREMODE_SEMIAUTO
 
 	unique_attachments = list(

--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -995,7 +995,7 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow)
 	recoil = 0
 	recoil_unwielded = 5
 
-	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
+	gun_firemodes = list(FIREMODE_SEMIAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 
 	unique_attachments = list(


### PR DESCRIPTION
## About The Pull Request

makes the beacon able to shoot two rounds. removes the alof tube from cargo

## Why It's Good For The Game

beacon is kind of a sad weapon and i remember there being talk of redesigning this thing to be two shots. no sprite update in this pr (perspective makes it believable, for now at least)

alofs would make this too jank so its out of cargo. likely be better for the improv shotgun if that shitty thing ever gets a touchup

wanted to throw some other stuff in like .45-70 tweaks for better goliath crunching or adding the burst firemode but it was either out of scope or too broken (burst made it so there was no reason to ever use the single shot)

## Changelog

:cl:
del: Removed alofs tube from cargo
balance: Beacon now can fire two rounds. Sprite unchanged
/:cl: