### PR TITLE
SUNS hatched subtypes

### DIFF
--- a/_maps/shuttles/cybersun/cybersun_cirrus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_cirrus.dmm
@@ -216,9 +216,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "cn" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
@@ -393,9 +391,7 @@
 	color = "#E6D2BA";
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "dM" = (
 /obj/structure/grille,
@@ -653,9 +649,7 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/cargo)
 "eQ" = (
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "fp" = (
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border{
@@ -773,9 +767,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "gu" = (
 /obj/structure/crate_shelf,
@@ -979,9 +971,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "hR" = (
 /obj/structure/chair/stool{
@@ -992,9 +982,7 @@
 	color = "#E6D2BA";
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "hZ" = (
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/corner{
@@ -1503,9 +1491,7 @@
 	color = "#E6D2BA";
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "ky" = (
 /obj/structure/filingcabinet/double,
@@ -1577,9 +1563,7 @@
 /obj/structure/sign/poster/contraband/space_cube{
 	pixel_x = 30
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "lb" = (
 /obj/structure/grille,
@@ -1674,9 +1658,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "no" = (
 /obj/structure/grille,
@@ -1753,9 +1735,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "nF" = (
 /obj/machinery/light/directional/south,
@@ -2016,9 +1996,7 @@
 /obj/effect/turf_decal/trimline/transparent/syndiered/line{
 	dir = 5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "qK" = (
 /obj/effect/turf_decal/corner/opaque/black{
@@ -2054,9 +2032,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "rp" = (
 /obj/effect/turf_decal/corner/opaque/black{
@@ -2180,9 +2156,7 @@
 	color = "#E6D2BA";
 	dir = 5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "sH" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -2358,9 +2332,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "vj" = (
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/line{
@@ -2562,9 +2534,7 @@
 /obj/structure/bedsheetbin{
 	pixel_y = 6
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "xu" = (
 /obj/effect/turf_decal/industrial/loading{
@@ -2611,9 +2581,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "yi" = (
 /turf/closed/wall/mineral/titanium,
@@ -3073,9 +3041,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Dh" = (
 /obj/structure/grille,
@@ -3174,9 +3140,7 @@
 	color = "#E6D2BA";
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "Fr" = (
 /obj/machinery/light/directional/north,
@@ -3307,9 +3271,7 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#E6D2BA"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "HW" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -3482,9 +3444,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Ju" = (
 /obj/structure/rack,
@@ -3773,9 +3733,7 @@
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/corner{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "MF" = (
 /obj/machinery/door/poddoor{
@@ -3940,9 +3898,7 @@
 	color = "#E6D2BA";
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "NG" = (
 /obj/structure/grille,
@@ -4221,9 +4177,7 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "Qz" = (
 /turf/closed/wall/mineral/titanium,
@@ -4325,9 +4279,7 @@
 /obj/effect/turf_decal/trimline/transparent/syndiered/line{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "RZ" = (
 /obj/structure/grille,
@@ -4556,9 +4508,7 @@
 	color = "#E6D2BA";
 	dir = 10
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "TV" = (
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/warning{
@@ -4873,9 +4823,7 @@
 	color = "#E6D2BA";
 	dir = 9
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "VM" = (
 /obj/machinery/door/airlock/medical{
@@ -4899,9 +4847,7 @@
 	color = "#E6D2BA";
 	dir = 6
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "Ww" = (
 /obj/machinery/stasis{
@@ -4980,9 +4926,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Xb" = (
 /obj/effect/turf_decal/corner/opaque/cybersunteal{
@@ -5029,9 +4973,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Xz" = (
 /obj/structure/grille,
@@ -5176,9 +5118,7 @@
 	pixel_x = -20;
 	pixel_y = 13
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "YC" = (
 /obj/machinery/light/directional/south,

--- a/_maps/shuttles/cybersun/cybersun_nimbus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_nimbus.dmm
@@ -73,9 +73,7 @@
 	pixel_x = 5;
 	pixel_y = -6
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "aQ" = (
 /obj/structure/closet/crate/bin,
@@ -139,9 +137,7 @@
 /area/ship/crew/ccommons)
 "cx" = (
 /obj/structure/chair/sofa/blue/corpo/corner/directional/south,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "cX" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
@@ -306,9 +302,7 @@
 /area/ship/cargo)
 "fv" = (
 /obj/structure/chair/sofa/blue/corpo/directional/south,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "fx" = (
 /obj/structure/cable/cyan{
@@ -376,9 +370,7 @@
 "gX" = (
 /obj/effect/turf_decal/spline/fancy/opaque/white,
 /obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "hp" = (
 /obj/machinery/power/shuttle/engine/electric,
@@ -514,9 +506,7 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/white,
 /obj/machinery/holopad/secure,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "jU" = (
 /obj/machinery/computer/cryopod/directional/north,
@@ -580,9 +570,7 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "lB" = (
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "lE" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line,
@@ -799,9 +787,7 @@
 /obj/item/radio/intercom/directional/north{
 	pixel_x = 5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "qj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -848,9 +834,7 @@
 	pixel_y = 16;
 	pixel_x = -32
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "rd" = (
 /obj/structure/cable/cyan{
@@ -916,9 +900,7 @@
 /area/ship/external/dark)
 "rL" = (
 /obj/structure/chair/sofa/blue/corpo/left/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "rP" = (
 /obj/structure/platform/ship_two,
@@ -1017,9 +999,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "tf" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/warning,
@@ -1032,9 +1012,7 @@
 /area/ship/external/dark)
 "tg" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "tj" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line,
@@ -1364,9 +1342,7 @@
 	name = "window shutters";
 	id = "zcouch2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "xU" = (
 /obj/structure/toilet{
@@ -1680,9 +1656,7 @@
 	name = "window shutters";
 	id = "zbridge"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Fq" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1806,9 +1780,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/white{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "Gu" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line,
@@ -1979,9 +1951,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "IW" = (
 /obj/machinery/holopad,
@@ -1996,9 +1966,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Jf" = (
 /obj/effect/turf_decal/box/white,
@@ -2080,9 +2048,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/black{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "KF" = (
 /obj/effect/spawner/bunk_bed{
@@ -2092,9 +2058,7 @@
 /obj/structure/sign/poster/contraband/cybersun{
 	pixel_x = -28
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "KN" = (
 /obj/structure/sign/number/seven{
@@ -2252,15 +2216,11 @@
 /area/ship/engineering/engine)
 "Ob" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "OX" = (
 /obj/effect/turf_decal/spline/fancy/opaque/white,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "OZ" = (
 /obj/structure/cable/cyan{
@@ -2298,9 +2258,7 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/dorm)
 "PI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2454,9 +2412,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Su" = (
 /obj/structure/table/chem,
@@ -2544,9 +2500,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Tj" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line,
@@ -2676,9 +2630,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/white{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "UV" = (
 /obj/machinery/power/shuttle/engine/electric/premium,
@@ -2692,9 +2644,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "UZ" = (
 /obj/structure/cable/cyan{
@@ -2831,9 +2781,7 @@
 "YM" = (
 /obj/effect/turf_decal/spline/fancy/opaque/white,
 /obj/machinery/light/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/crew/ccommons)
 "YR" = (
 /obj/structure/cable/cyan{
@@ -2882,9 +2830,7 @@
 /obj/item/folder/documents/syndicate/cybersun,
 /obj/item/reagent_containers/food/drinks/flask,
 /obj/item/reagent_containers/food/drinks/bottle/sake/foxgirl,
-/turf/open/floor/suns/hatch{
-	color = "#E6D2BA"
-	},
+/turf/open/floor/suns/hatch/bamboo,
 /area/ship/bridge)
 "Zy" = (
 /obj/effect/turf_decal/trimline/transparent/syndiered/line{

--- a/_maps/shuttles/independent/independent_corona.dmm
+++ b/_maps/shuttles/independent/independent_corona.dmm
@@ -230,9 +230,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "ff" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -572,9 +570,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "lH" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -690,9 +686,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "nM" = (
 /obj/effect/turf_decal/corner/opaque/lightgrey/mono,
@@ -739,9 +733,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "op" = (
 /obj/effect/turf_decal/corner_techfloor_grid{
@@ -982,9 +974,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "va" = (
 /obj/structure/table/chem,
@@ -1513,9 +1503,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "El" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -1634,9 +1622,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "Gh" = (
 /obj/effect/turf_decal/corner/opaque/lightgrey/mono,
@@ -1683,9 +1669,7 @@
 	pixel_y = 5;
 	pixel_x = 7
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "GJ" = (
 /obj/structure/chair/office{
@@ -1809,9 +1793,7 @@
 /area/ship/crew/canteen/kitchen)
 "Ir" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "Is" = (
 /obj/structure/closet/secure_closet/freezer{
@@ -2061,9 +2043,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "LA" = (
 /turf/closed/wall/mineral/titanium,
@@ -2161,9 +2141,7 @@
 /area/ship/crew/ccommons)
 "NU" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "NW" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -2202,9 +2180,7 @@
 	pixel_y = 20;
 	icon_state = "plant-28"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "Ow" = (
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
@@ -2475,9 +2451,7 @@
 	pixel_y = 4;
 	pixel_x = -5
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2513,9 +2487,7 @@
 	pixel_x = -12;
 	pixel_y = -20
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "Tl" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -2727,9 +2699,7 @@
 /area/ship/bridge)
 "VQ" = (
 /obj/structure/chair/comfy/grey/corpo/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "Wh" = (
 /obj/structure/railing{
@@ -2789,9 +2759,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/ccommons)
 "WY" = (
 /obj/structure/cable{
@@ -2803,9 +2771,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "Xc" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -2838,9 +2804,7 @@
 /obj/machinery/newscaster/directional/east{
 	pixel_y = -10
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/dorm)
 "XO" = (
 /turf/template_noop,

--- a/_maps/shuttles/syndicate/syndicate_mercury.dmm
+++ b/_maps/shuttles/syndicate/syndicate_mercury.dmm
@@ -188,9 +188,7 @@
 	color = "#D5A66E";
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D5A66E"
-	},
+/turf/open/floor/suns/hatch/birch,
 /area/ship/crew/dorm)
 "dm" = (
 /obj/effect/turf_decal/techfloor{
@@ -230,9 +228,7 @@
 /mob/living/simple_animal/pet/dog/corgi/capybara{
 	name = "Coco"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D5A66E"
-	},
+/turf/open/floor/suns/hatch/birch,
 /area/ship/crew/dorm)
 "dv" = (
 /obj/structure/bed/double,
@@ -320,9 +316,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "eZ" = (
 /obj/structure/cable{
@@ -416,9 +410,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "hd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -650,9 +642,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "kz" = (
 /obj/structure/cable/yellow{
@@ -1640,9 +1630,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "zH" = (
 /obj/item/clothing/suit/space/syndicate/suns,
@@ -1738,9 +1726,7 @@
 	name = "Window Lock";
 	id = "mercurydwindow"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D5A66E"
-	},
+/turf/open/floor/suns/hatch/birch,
 /area/ship/crew/dorm)
 "Bl" = (
 /obj/structure/table/wood/reinforced,
@@ -2129,9 +2115,7 @@
 	name = "helm";
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "Hv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2169,9 +2153,7 @@
 	dir = 1
 	},
 /obj/item/computer_hardware/card_slot,
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "Iy" = (
 /obj/machinery/light/floor,
@@ -2488,9 +2470,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "NT" = (
 /obj/machinery/space_heater,
@@ -3215,9 +3195,7 @@
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
 	dir = 9
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "WW" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -3336,9 +3314,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#332521"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#332521"
-	},
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "YS" = (
 /turf/closed/wall/mineral/titanium,

--- a/_maps/shuttles/syndicate/syndicate_panacea.dmm
+++ b/_maps/shuttles/syndicate/syndicate_panacea.dmm
@@ -25,9 +25,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "ar" = (
 /obj/machinery/power/terminal{
@@ -103,9 +101,7 @@
 /obj/structure/cable/blue{
 	icon_state = "2-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "aP" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
@@ -215,9 +211,7 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "bF" = (
 /obj/effect/turf_decal/suns/line/marble/fill{
@@ -578,9 +572,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "dU" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -916,9 +908,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "fK" = (
 /obj/item/storage/bag/chemistry{
@@ -1107,9 +1097,7 @@
 	dir = 8;
 	pixel_x = -30
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/captain)
 "gv" = (
 /obj/structure/table,
@@ -1286,9 +1274,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "hs" = (
 /obj/structure/table/wood/reinforced,
@@ -1404,9 +1390,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "ig" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -1743,9 +1727,7 @@
 /obj/structure/cable/blue{
 	icon_state = "2-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/captain)
 "jX" = (
 /turf/open/floor/carpet/red,
@@ -2221,9 +2203,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "mU" = (
 /obj/machinery/holopad/emergency,
@@ -2433,9 +2413,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "nG" = (
 /obj/effect/turf_decal/suns/line/fancy/fill{
@@ -2738,9 +2716,7 @@
 /obj/structure/cable/blue{
 	icon_state = "2-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "pn" = (
 /obj/effect/turf_decal/suns/line/marble,
@@ -2772,17 +2748,13 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "pB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "pE" = (
 /obj/machinery/computer/helm{
@@ -2849,9 +2821,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/captain)
 "pT" = (
 /obj/structure/urinal{
@@ -2919,9 +2889,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "qe" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -3143,9 +3111,7 @@
 	dir = 4
 	},
 /obj/structure/easel,
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "rk" = (
 /obj/effect/turf_decal/suns/line/marble/fill,
@@ -3248,9 +3214,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "sD" = (
 /obj/effect/turf_decal/suns/line/marble{
@@ -3526,9 +3490,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "ut" = (
 /obj/structure/window/reinforced/fulltile,
@@ -3840,9 +3802,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "wt" = (
 /obj/effect/turf_decal/siding/wood,
@@ -4140,9 +4100,7 @@
 	dir = 4;
 	name = "Patient Dorms"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm)
 "xZ" = (
 /obj/effect/turf_decal/suns/line/marble/fill/corner{
@@ -4358,9 +4316,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "zS" = (
 /obj/structure/window/reinforced/fulltile,
@@ -4450,9 +4406,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "At" = (
 /obj/structure/cable/blue{
@@ -4800,9 +4754,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Cs" = (
 /obj/structure/railing/corner,
@@ -4995,9 +4947,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Dp" = (
 /obj/structure/window/reinforced/fulltile,
@@ -5325,9 +5275,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/helm/viewscreen/directional/north,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "Fq" = (
 /obj/effect/turf_decal/suns/line/marble{
@@ -5457,9 +5405,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "FU" = (
 /obj/structure/chair/comfy/purple/directional/east,
@@ -5637,9 +5583,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "Ha" = (
 /obj/structure/chair/bench/beige{
@@ -5701,9 +5645,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "Hn" = (
 /obj/effect/turf_decal/suns/line/marble/corner{
@@ -6456,9 +6398,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Patient Rooms"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "LR" = (
 /turf/open/floor/suns/dark/plain,
@@ -6490,9 +6430,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "LY" = (
 /obj/structure/table,
@@ -6652,9 +6590,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "Mq" = (
 /obj/structure/chair/sofa/purple/corner/directional/south,
@@ -6937,9 +6873,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "OA" = (
 /obj/effect/turf_decal/borderfloorwhite,
@@ -6961,9 +6895,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-4"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "OK" = (
 /obj/effect/turf_decal/borderfloorwhite{
@@ -7197,9 +7129,7 @@
 	pixel_x = -7;
 	pixel_y = -19
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "QC" = (
 /obj/effect/turf_decal/suns/line/marble/corner,
@@ -7234,9 +7164,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "QO" = (
 /obj/structure/table/chem,
@@ -7312,9 +7240,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "Rh" = (
 /obj/effect/turf_decal/suns/line/marble/fill{
@@ -7499,9 +7425,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "RX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -7799,9 +7723,7 @@
 	dir = 4;
 	name = "Garden"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "TV" = (
 /obj/effect/turf_decal/suns/line/marble{
@@ -7880,9 +7802,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/turf/open/floor/suns/hatch{
-	color = "#543C30"
-	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/dorm/dormtwo)
 "UQ" = (
 /obj/effect/turf_decal/suns/line/marble{
@@ -8071,9 +7991,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "VG" = (
 /obj/structure/railing,
@@ -8448,9 +8366,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/suns/hatch{
-	color = "#D2BC9D"
-	},
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Yn" = (
 /obj/structure/railing/corner{

--- a/code/game/objects/items/stacks/tiles/tiles_suns.dm
+++ b/code/game/objects/items/stacks/tiles/tiles_suns.dm
@@ -4,14 +4,14 @@
 	icon_state = "tile_suns_light"
 	turf_type = /turf/open/floor/suns
 	tile_reskin_types = list(
-	/obj/item/stack/tile/suns/plain,
-	/obj/item/stack/tile/suns/pattern,
-	/obj/item/stack/tile/suns/hatch,
-	/obj/item/stack/tile/suns/diagonal,
-	/obj/item/stack/tile/suns/grid,
-	/obj/item/stack/tile/suns/dark,
-	/obj/item/stack/tile/suns/dark/plain,
-	/obj/item/stack/tile/suns/dark/pattern)
+		/obj/item/stack/tile/suns/plain,
+		/obj/item/stack/tile/suns/pattern,
+		/obj/item/stack/tile/suns/diagonal,
+		/obj/item/stack/tile/suns/grid,
+		/obj/item/stack/tile/suns/dark,
+		/obj/item/stack/tile/suns/dark/plain,
+		/obj/item/stack/tile/suns/dark/pattern,
+		)
 
 /obj/item/stack/tile/suns/plain
 	name = "white plain marble tile"
@@ -30,6 +30,57 @@
 	singular_name = "hatched wood floor tile"
 	icon_state = "tile_suns_lighthatched"
 	turf_type = /turf/open/floor/suns/hatch
+	tile_reskin_types = list(
+		/obj/item/stack/tile/suns/hatch/mahogany,
+		/obj/item/stack/tile/suns/hatch/maple,
+		/obj/item/stack/tile/suns/hatch/ebony,
+		/obj/item/stack/tile/suns/hatch/walnut,
+		/obj/item/stack/tile/suns/hatch/bamboo,
+		/obj/item/stack/tile/suns/hatch/birch,
+		/obj/item/stack/tile/suns/hatch/yew,
+		)
+
+/obj/item/stack/tile/suns/hatch/mahogany
+	name = "hatched mahogany tile"
+	color = WOOD_COLOR_RICH
+	turf_type = /turf/open/floor/suns/hatch/mahogany
+	merge_type = /obj/item/stack/tile/suns/hatch/mahogany
+
+/obj/item/stack/tile/suns/hatch/maple
+	name = "hatched maple tile"
+	color = WOOD_COLOR_PALE
+	turf_type = /turf/open/floor/suns/hatch/maple
+	merge_type = /obj/item/stack/tile/suns/hatch/maple
+
+/obj/item/stack/tile/suns/hatch/ebony
+	name = "hatched ebony tile"
+	color = WOOD_COLOR_BLACK
+	turf_type = /turf/open/floor/suns/hatch/ebony
+	merge_type = /obj/item/stack/tile/suns/hatch/ebony
+
+/obj/item/stack/tile/suns/hatch/walnut
+	name = "hatched walnut tile"
+	color = WOOD_COLOR_CHOCOLATE
+	turf_type = /turf/open/floor/suns/hatch/walnut
+	merge_type = /obj/item/stack/tile/suns/hatch/walnut
+
+/obj/item/stack/tile/suns/hatch/bamboo
+	name = "hatched bamboo tile"
+	color = WOOD_COLOR_PALE2
+	turf_type = /turf/open/floor/suns/hatch/bamboo
+	merge_type = /obj/item/stack/tile/suns/hatch/bamboo
+
+/obj/item/stack/tile/suns/hatch/birch
+	name = "hatched birch tile"
+	color = WOOD_COLOR_PALE3
+	turf_type = /turf/open/floor/suns/hatch/birch
+	merge_type = /obj/item/stack/tile/suns/hatch/birch
+
+/obj/item/stack/tile/suns/hatch/yew
+	name = "hatched yew tile"
+	color = WOOD_COLOR_YELLOW
+	turf_type = /turf/open/floor/suns/hatch/yew
+	merge_type = /obj/item/stack/tile/suns/hatch/yew
 
 /obj/item/stack/tile/suns/diagonal
 	name = "diagonal wooden tile"

--- a/code/game/turfs/open/floor/suns_floor.dm
+++ b/code/game/turfs/open/floor/suns_floor.dm
@@ -20,6 +20,27 @@
 	floor_tile = /obj/item/stack/tile/suns/hatch
 	flammability = 3
 
+/turf/open/floor/suns/hatch/mahogany
+	color = WOOD_COLOR_RICH
+
+/turf/open/floor/suns/hatch/maple
+	color = WOOD_COLOR_PALE
+
+/turf/open/floor/suns/hatch/ebony
+	color = WOOD_COLOR_BLACK
+
+/turf/open/floor/suns/hatch/walnut
+	color = WOOD_COLOR_CHOCOLATE
+
+/turf/open/floor/suns/hatch/bamboo
+	color = WOOD_COLOR_PALE2
+
+/turf/open/floor/suns/hatch/birch
+	color = WOOD_COLOR_PALE3
+
+/turf/open/floor/suns/hatch/yew
+	color = WOOD_COLOR_YELLOW
+
 /turf/open/floor/suns/diagonal
 	name = "diagonal wooden floor"
 	icon_state = "lightdiag"


### PR DESCRIPTION
## About The Pull Request

Adds subtypes of SUNS hatched tiles in standard wood colours and replaces them on the Mercury, Panacea, Nimbus, Cirrus, and Corona

![image](https://github.com/user-attachments/assets/4dbc30b5-521f-44c5-9d97-60ce5c35f960)

Did not do subtypes for diagonal tiles because so far I've not seen it use any other colour than its default

## Why It's Good For The Game

You've all seen that single white tile on the floorsafe in the Nimbus. No more. Helps with mapping too

May make these obtainable later

## Changelog

:cl:
add: Added colored subtypes of wood hatched tiles and replaced them with their respective variants on the Cirrus, Nimbus, Mercury, Panacea, and Corona
/:cl: