### PR TITLE
Medical Aid kit and Advanced First Aid kit comes with painkillers

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -116,7 +116,7 @@
 		/obj/item/hemostat = 1,
 		/obj/item/cautery = 1,
 		/obj/item/healthanalyzer = 1,
-		/obj/item/storage/pill_bottle/tramal
+		/obj/item/storage/pill_bottle/tramal = 1
 		)
 	generate_items_inside(items_inside,src)
 
@@ -238,6 +238,11 @@
 	item_state = "firstaid-rad"
 	custom_premium_price = 1100
 
+/obj/item/storage/firstaid/advanced/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 10
+
 /obj/item/storage/firstaid/advanced/PopulateContents()
 	if(empty)
 		return
@@ -246,7 +251,9 @@
 		/obj/item/reagent_containers/pill/patch/synthflesh = 3,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 2,
 		/obj/item/stack/medical/gauze = 1,
-		/obj/item/storage/pill_bottle/penacid = 1)
+		/obj/item/storage/pill_bottle/penacid = 1,
+		/obj/item/reagent_containers/glass/bottle/dimorlin = 1,
+		/obj/item/reagent_containers/syringe = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/tactical

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -115,7 +115,9 @@
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
 		/obj/item/cautery = 1,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/healthanalyzer = 1,
+		/obj/item/storage/pill_bottle/tramal
+		)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/ancient
@@ -514,3 +516,11 @@
 /obj/item/storage/pill_bottle/placebatol/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/placebatol(src)
+
+/obj/item/storage/pill_bottle/tramal
+	name = "bottle of tramal pills"
+	desc = "Contains tramal pills, a mild painkiller."
+
+/obj/item/storage/pill_bottle/tramal/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/tramal(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a pill bottle of tramal to the medical aid kit and a bottle of dimorlin and a syringe to the advanced first aid kit.

Increases the max items on the advanced aid kit to 10 so it can fit everything.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Since we've moved to painkiller gameplay for surgery, it makes sense to have painkillers in the relevant medical kits. Especially in the case of the medical aid kit, having a starting source of painkillers for surgery should help normalize and encourage their use in gameplay.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Medical Aid kit and Advanced First Aid kit now have painkillers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
