### PR TITLE
Anchorable Reagent Dispensers

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -9,6 +9,7 @@
 	max_integrity = 300
 	var/tank_volume = 1000 //In units, how much the dispenser can hold
 	var/reagent_id = /datum/reagent/water //The ID of the reagent that the dispenser uses
+	var/anchorable = TRUE //whether you can unwrench this thing
 
 /obj/structure/reagent_dispensers/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
@@ -21,6 +22,21 @@
 		return 0 //so we can refill them via their afterattack.
 	else
 		return ..()
+
+/obj/structure/reagent_dispensers/wrench_act(mob/living/user, obj/item/tool)
+	if(anchorable && user.a_intent != INTENT_HARM)
+		default_unfasten_wrench(user, tool)
+		return TRUE
+	else
+		return ..()
+
+/obj/structure/reagent_dispensers/examine(mob/user)
+	. = ..()
+	if(anchorable)
+		if(anchored)
+			. += span_notice("[src] is <b>bolted</b> to the floor.")
+		else
+			. += span_notice("[src] is un<b>bolted</b> from the floor.")
 
 /obj/structure/reagent_dispensers/Initialize()
 	create_reagents(tank_volume, DRAINABLE | AMOUNT_VISIBLE)
@@ -119,6 +135,7 @@
 	desc = "Contains condensed capsaicin for use in law \"enforcement.\""
 	icon_state = "pepper"
 	anchored = TRUE
+	anchorable = FALSE
 	density = FALSE
 	reagent_id = /datum/reagent/consumable/condensedcapsaicin
 
@@ -178,6 +195,7 @@
 	desc = "A huge metal vat with a tap on the front. Filled with cooking oil for use in frying food."
 	icon_state = "vat"
 	anchored = TRUE
+	anchorable = FALSE
 	reagent_id = /datum/reagent/consumable/cooking_oil
 
 /obj/structure/reagent_dispensers/servingdish
@@ -188,21 +206,11 @@
 	anchored = TRUE
 	reagent_id = /datum/reagent/consumable/nutraslop
 
-/obj/structure/reagent_dispensers/servingdish/wrench_act(mob/living/user, obj/item/tool)
-	. = ..()
-	default_unfasten_wrench(user, tool)
-	return TRUE
-
 /obj/structure/reagent_dispensers/plumbed
 	name = "stationairy water tank"
 	anchored = TRUE
 	icon_state = "water_stationairy"
 	desc = "A stationairy, plumbed, water tank."
-
-/obj/structure/reagent_dispensers/plumbed/wrench_act(mob/living/user, obj/item/I)
-	..()
-	default_unfasten_wrench(user, I)
-	return TRUE
 
 /obj/structure/reagent_dispensers/plumbed/ComponentInitialize()
 	AddComponent(/datum/component/plumbing/simple_supply)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -36,7 +36,7 @@
 		if(anchored)
 			. += span_notice("[src] is <b>bolted</b> to the floor.")
 		else
-			. += span_notice("[src] is un<b>bolted</b> from the floor.")
+			. += span_notice("[src] is <b>unbolted</b> from the floor.")
 
 /obj/structure/reagent_dispensers/Initialize()
 	create_reagents(tank_volume, DRAINABLE | AMOUNT_VISIBLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Generalizes anchoring behavior for reagent dispensers (e.g. welding tanks, water tanks, water coolers etc) so you can move them around or fasten them to a tile.

Certain large tanks or wall mounted ones still cannot be moved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

QoL. Helps with organization and gives players more freedom in how they want to arrange their ships/cargo. Not having your welding/water tanks flying around everywhere in zero g is also nice.

## Changelog

:cl:
add: Reagent dispensers can be unanchored and moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
