### PR TITLE
Increases duct tape stack sizes and makes them fit in belts and engineering pouches

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -268,6 +268,8 @@
 	name = "duct tape"
 	desc = "This roll of silver sorcery can fix just about anything."
 	icon_state = "tape_d"
+	amount = 15
+	max_amount = 15
 
 	lifespan = 400
 	nonorganic_heal = 20

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -83,7 +83,8 @@
 		/obj/item/clothing/mask/gas/welding,
 		/obj/item/clothing/head/welding, //WS end
 		/obj/item/gun/energy/plasmacutter,
-		/obj/item/bodycamera
+		/obj/item/bodycamera,
+		/obj/item/stack/tape/industrial
 		))
 
 /obj/item/storage/belt/utility/chief

--- a/code/game/objects/items/storage/pouches.dm
+++ b/code/game/objects/items/storage/pouches.dm
@@ -118,7 +118,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/toy/crayon/spraycan,
 		/obj/item/stack/marker_beacon,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/stack/tape/industrial
 		))
 
 /obj/item/storage/pouch/engi/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR increases the stack size of industrial tape from 10 to 15, and it adds industrial tape to the item whitelist for toolbelts and engineering pouches.

## Why It's Good For The Game

It may be interesting to have duct tape be more accessible, as it offers an avenue for repairs that doesn't rely on welding.

## Changelog

:cl:
balance: increases industrial tape stack sizes from 10 to 15, allows industrial tape to fit in toolbelts and engineering pouches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
