### PR TITLE
Doubles Wear Thresholds on most Weapons

### DIFF
--- a/code/game/objects/items/gun_maint_kit.dm
+++ b/code/game/objects/items/gun_maint_kit.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_BULKY //no carrying these around, sorry :(
 	custom_materials = list(/datum/material/iron = 500)
 	/// Amount of wear removed from a gun on use
-	var/wear_reduction = 60
+	var/wear_reduction = 120
 	/// Number of times this gun fixer can be used
 	var/uses = 5
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -34,7 +34,7 @@
 	/// Gun will start to jam at this level of wear
 	var/wear_minor_threshold = 60
 	/// Gun will start to jam more at this level of wear. The grace period between jams is also removed for extra fun
-	var/wear_major_threshold = 180
+	var/wear_major_threshold = 120
 	/// Highest wear value so the gun doesn't end up completely irreperable
 	var/wear_maximum = 300
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -34,7 +34,7 @@
 	/// Gun will start to jam at this level of wear
 	var/wear_minor_threshold = 60
 	/// Gun will start to jam more at this level of wear. The grace period between jams is also removed for extra fun
-	var/wear_major_threshold = 120
+	var/wear_major_threshold = 180
 	/// Highest wear value so the gun doesn't end up completely irreperable
 	var/wear_maximum = 300
 

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -24,9 +24,9 @@
 	gunslinger_spread_bonus = 16
 
 	light_range = 2
-	wear_minor_threshold = 100
-	wear_major_threshold = 300
-	wear_maximum = 600
+	wear_minor_threshold = 200
+	wear_major_threshold = 600
+	wear_maximum = 1200
 
 /obj/item/gun/ballistic/automatic/assault/skm
 	name = "\improper SKM-24"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -69,9 +69,9 @@
 
 	gunslinger_recoil_bonus = 1
 	wear_rate = 1
-	wear_minor_threshold = 30
-	wear_major_threshold = 90
-	wear_maximum = 150
+	wear_minor_threshold = 60
+	wear_major_threshold = 180
+	wear_maximum = 300
 
 //Dual Feed Shotgun
 

--- a/code/modules/projectiles/guns/ballistic/smg.dm
+++ b/code/modules/projectiles/guns/ballistic/smg.dm
@@ -27,9 +27,9 @@
 
 	gunslinger_recoil_bonus = 2
 	gunslinger_spread_bonus = 16
-	wear_minor_threshold = 120
-	wear_major_threshold = 360
-	wear_maximum = 600
+	wear_minor_threshold = 240
+	wear_major_threshold = 720
+	wear_maximum = 1200
 
 /obj/item/gun/ballistic/automatic/smg/wt550
 	name = "\improper WT-550 Automatic Rifle"

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -95,6 +95,10 @@
 	spread = 8
 	spread_unwielded = 20
 
+	wear_minor_threshold = 240
+	wear_major_threshold = 720
+	wear_maximum = 1200
+
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -260,9 +260,9 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
 	fire_delay = 0.4 SECONDS
-	wear_minor_threshold = 120
-	wear_major_threshold = 360
-	wear_maximum = 600
+	wear_minor_threshold = 240
+	wear_major_threshold = 720
+	wear_maximum = 1200
 	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
 	default_firemode = FIREMODE_SEMIAUTO
 

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -220,6 +220,9 @@ EMPTY_GUN_HELPER(automatic/m12_sporter)
 	icon_state = "larker"
 	item_state = "larker"
 
+	wear_minor_threshold = 240
+	wear_major_threshold = 720
+	wear_maximum = 1200
 	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
 	gun_firenames = list(FIREMODE_SEMIAUTO = "single", FIREMODE_BURST = "triptych")
 	default_firemode = FIREMODE_BURST


### PR DESCRIPTION
## About The Pull Request

Doubles the thresholds on SMGs, Assault Rifles, Pistols, and Shotguns. HMGs and anything in between (DMRs, snipers) keep the same wear thresholds.

Also increases the amount of wear the cleaning kit gets rid of. Probably not an issue for anything that uses DMR wear since I can't imagine a crazy amount of fouling building up to require extensive cleaning anyways

## Why It's Good For The Game

Shifts wear thresholds to require cleaning after a bigger ruin / drill is done rather than having to do so in the middle of it. Some minor testing with the Bulldog had me require to clean after being a bit over the minor malfunction threshold after clearing Frontie beach depot twice. A Hydra was just barely under the major malfunction threshold after N+S facility Class 4 drill with t1 parts

DMRs / HMGs keep their same wear thresholds since they either already it high (HMGs) or fire slowly and methodically enough that the current thresholds are fine (DMRs)

## Changelog

:cl:
balance: Doubled the weapon wear thresholds on Shotguns, SMGs, Pistols, and Assault Rifles. 
balance: Weapon Cleaning Kit now cleans twice as effectively
/:cl: