### PR TITLE
Improvised Shotgun Sprite Fix

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -150,7 +150,8 @@ NO_MAG_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
 	mob_overlay_icon = null
-
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
 	base_icon_state = "ishotgun"
 	icon_state = "ishotgun"
 	item_state = "ishotgun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the improvised shotgun sprite floating outside of the player's reach by properly setting its inhand dimensions to x64. I did this for the TRABUCO but I just forgot to fix the improv shotgun as well with it.

This is also a PSA for more people to use the improvised shotgun because it makes for a surprisingly effective weapon when you're dead broke and need fauna dead. If you've got double barrel muscle memory then using this thing is just that with one less shot,

![image](https://github.com/user-attachments/assets/abc82b1f-b23e-4f58-8743-42d42256a5fe)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Broken floating gun sprites are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: improvised Shotgun sprites are now fixed and are actually in your hand again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
