### PR TITLE
Removes one bit of dust causing a warning

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -4556,10 +4556,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/library)
-"sP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/reinforced,
-/area/outpost/maintenance/central)
 "sR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -19611,7 +19607,7 @@ bk
 bk
 cq
 cq
-sP
+cq
 Mu
 DV
 Gg


### PR DESCRIPTION
## About The Pull Request

Sweeps up the dust inside of a wall
![image](https://github.com/user-attachments/assets/7265a6a9-07ee-49fd-b365-28a80983894d)


## Why It's Good For The Game

Less ominous dust warnings may help coders sleep at night

## Changelog

Not really any in-game changes