### PR TITLE
assorted changeling improvements

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -53,6 +53,7 @@
 	destination.dna.real_name = real_name
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
 	destination.flavor_text = destination.dna.features["flavor_text"] //Update the flavor_text to use new dna text
+	destination.dna.current_body_size = current_body_size
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
 		destination.dna.default_mutation_genes = default_mutation_genes
@@ -65,6 +66,7 @@
 	new_dna.blood_type = blood_type
 	new_dna.features = features.Copy()
 	new_dna.species = new species.type
+	new_dna.species.species_traits = species.species_traits
 	new_dna.real_name = real_name
 	new_dna.update_body_size() //Must come after features.Copy()
 	new_dna.mutations = mutations.Copy()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,7 +1,3 @@
-GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega"))
-GLOBAL_LIST_INIT(slots, list("head", "wear_mask", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store"))
-GLOBAL_LIST_INIT(slot2slot, list("head" = ITEM_SLOT_HEAD, "wear_mask" = ITEM_SLOT_MASK, "neck" = ITEM_SLOT_NECK, "back" = ITEM_SLOT_BACK, "wear_suit" = ITEM_SLOT_OCLOTHING, "w_uniform" = ITEM_SLOT_ICLOTHING, "shoes" = ITEM_SLOT_FEET, "belt" = ITEM_SLOT_BELT, "gloves" = ITEM_SLOT_GLOVES, "glasses" = ITEM_SLOT_EYES, "ears" = ITEM_SLOT_EARS, "wear_id" = ITEM_SLOT_ID, "s_store" = ITEM_SLOT_SUITSTORE))
-GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "wear_mask" = /obj/item/clothing/mask/changeling, "back" = /obj/item/changeling, "wear_suit" = /obj/item/clothing/suit/changeling, "w_uniform" = /obj/item/clothing/under/changeling, "shoes" = /obj/item/clothing/shoes/changeling, "belt" = /obj/item/changeling, "gloves" = /obj/item/clothing/gloves/changeling, "glasses" = /obj/item/clothing/glasses/changeling, "ears" = /obj/item/changeling, "wear_id" = /obj/item/changeling, "s_store" = /obj/item/changeling))
 GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our this objective to all lings
 
 
@@ -99,53 +95,6 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 			codenamed \"Thing\", and it was highly adaptive and extremely dangerous. We have reason to believe that the Thing has allied with the Syndicate, and you should note that likelihood \
 			of the Thing being sent to a station in this sector is highly likely. It may be in the guise of any crew member. Trust nobody - suspect everybody. Do not announce this to the crew, \
 			as paranoia may spread and inhibit workplace efficiency."
-
-/proc/changeling_transform(mob/living/carbon/human/user, datum/changelingprofile/chosen_prof)
-	var/datum/dna/chosen_dna = chosen_prof.dna
-	user.real_name = chosen_prof.name
-	user.underwear = chosen_prof.underwear
-	user.undershirt = chosen_prof.undershirt
-	user.socks = chosen_prof.socks
-
-	chosen_dna.transfer_identity(user, 1)
-	user.updateappearance(mutcolor_update=1)
-
-	///Bodypart data hack. Will rewrite when I rewrite changelings soon-ish
-	for(var/obj/item/bodypart/BP as anything in user.bodyparts)
-		if(IS_ORGANIC_LIMB(BP))
-			BP.update_limb(is_creating = TRUE)
-
-	user.domutcheck()
-
-	//vars hackery. not pretty, but better than the alternative.
-	for(var/slot in GLOB.slots)
-		if(istype(user.vars[slot], GLOB.slot2type[slot]) && !(chosen_prof.exists_list[slot])) //remove unnecessary flesh items
-			qdel(user.vars[slot])
-			continue
-
-		if((user.vars[slot] && !istype(user.vars[slot], GLOB.slot2type[slot])) || !(chosen_prof.exists_list[slot]))
-			continue
-
-		var/obj/item/C
-		var/equip = 0
-		if(!user.vars[slot])
-			var/thetype = GLOB.slot2type[slot]
-			equip = 1
-			C = new thetype(user)
-
-		else if(istype(user.vars[slot], GLOB.slot2type[slot]))
-			C = user.vars[slot]
-
-		C.appearance = chosen_prof.appearance_list[slot]
-		C.name = chosen_prof.name_list[slot]
-		C.flags_cover = chosen_prof.flags_cover_list[slot]
-		C.item_state = chosen_prof.item_state_list[slot]
-		C.mob_overlay_icon = chosen_prof.mob_overlay_icon_list[slot]
-		C.mob_overlay_state = chosen_prof.mob_overlay_state_list[slot] //WS EDIT - Mob Overlay State
-		if(equip)
-			user.equip_to_slot_or_del(C, GLOB.slot2slot[slot])
-
-	user.regenerate_icons()
 
 
 /datum/game_mode/changeling/generate_credit_text()

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -83,6 +83,18 @@
 							var/datum/mind/M = mind
 							user.mind.memory += "<li>Conspirator: [M.name]</li>"
 						user.mind.memory += "</ul>"
+
+		// guestbook
+		if(user.mind.guestbook && suckedbrain.guestbook)
+			var/datum/guestbook/ling_guestbook = user.mind.guestbook
+			var/datum/guestbook/victim_guestbook = suckedbrain.guestbook
+			// iterate through the real names that the victim knows
+			for(var/potential_guest in victim_guestbook.known_names)
+				// skip people that the ling already knows
+				if((LAZYACCESS(ling_guestbook.known_names, potential_guest)))
+					continue
+				ling_guestbook.known_names += potential_guest // there should be a proc for adding a guest without needing a mob, probably
+
 		user.mind.memory += "<b>That's all [target] had.</b><BR>"
 		user.memory() //I can read your mind, kekeke. Output all their notes.
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -11,15 +11,7 @@
 		to_chat(user, span_notice("We must exit the pipes before we can transform back!"))
 		return FALSE
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	var/list/names = list()
-	for(var/datum/changelingprofile/prof in changeling.stored_profiles)
-		names += "[prof.name]"
-
-	var/chosen_name = input("Select the target DNA: ", "Target DNA", null) as null|anything in sortList(names)
-	if(!chosen_name)
-		return
-
-	var/datum/changelingprofile/chosen_prof = changeling.get_dna(chosen_name)
+	var/datum/changelingprofile/chosen_prof = changeling.select_dna()
 	if(!chosen_prof)
 		return
 	if(!user || user.notransform)
@@ -28,7 +20,10 @@
 	..()
 	changeling.purchasedpowers -= src
 
-	var/newmob = user.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSTUNS | TR_KEEPREAGENTS | TR_KEEPSE)
+	var/datum/dna/chosen_dna = chosen_prof.dna
+	var/datum/species/chosen_species = chosen_dna.species
+	user.humanize(chosen_species)
 
-	changeling_transform(newmob, chosen_prof)
+	changeling.transform(user, chosen_prof)
+	user.regenerate_icons()
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -78,7 +78,7 @@
 	if(changeling.chosen_sting)
 		unset_sting(user)
 		return
-	selected_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
+	selected_dna = changeling.select_dna()
 	if(!selected_dna)
 		return
 	if(NOTRANSSTING in selected_dna.dna.species.species_traits)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -7,13 +7,72 @@
 	req_dna = 1
 	req_human = 1
 
+/datum/antagonist/changeling/proc/transform(mob/living/carbon/human/user, datum/changelingprofile/chosen_prof)
+	var/datum/dna/chosen_dna = chosen_prof.dna
+	user.real_name = chosen_prof.name
+	user.generic_adjective = chosen_prof.generic_adjective
+	user.underwear = chosen_prof.underwear
+	user.underwear_color = chosen_prof.underwear_color
+	user.undershirt = chosen_prof.undershirt
+	user.undershirt_color = chosen_prof.undershirt_color
+	user.age = chosen_prof.age
+	user.socks = chosen_prof.socks
+	user.socks_color = chosen_prof.socks_color
+
+	chosen_dna.transfer_identity(user, 1)
+	user.updateappearance(mutcolor_update=1)
+
+	///Bodypart data hack. Will rewrite when I rewrite changelings soon-ish
+	for(var/obj/item/bodypart/BP as anything in user.bodyparts)
+		if(IS_ORGANIC_LIMB(BP))
+			BP.update_limb(is_creating = TRUE)
+
+	user.domutcheck()
+
+	//vars hackery. not pretty, but better than the alternative.
+	for(var/slot in GLOB.slots)
+		if(istype(user.vars[slot], GLOB.slot2type[slot]) && !(chosen_prof.exists_list[slot])) //remove unnecessary flesh items
+			qdel(user.vars[slot])
+			continue
+
+		if((user.vars[slot] && !istype(user.vars[slot], GLOB.slot2type[slot])) || !(chosen_prof.exists_list[slot]))
+			continue
+
+		if(istype(user.vars[slot], GLOB.slot2type[slot]) && slot == "wear_id") //always remove old flesh IDs, so they get properly updated
+			qdel(user.vars[slot])
+
+		var/obj/item/C
+		var/equip = 0
+		if(!user.vars[slot])
+			var/thetype = GLOB.slot2type[slot]
+			equip = 1
+			C = new thetype(user)
+
+		else if(istype(user.vars[slot], GLOB.slot2type[slot]))
+			C = user.vars[slot]
+
+		C.appearance = chosen_prof.appearance_list[slot]
+		C.name = chosen_prof.name_list[slot]
+		C.flags_cover = chosen_prof.flags_cover_list[slot]
+		C.item_state = chosen_prof.item_state_list[slot]
+		C.mob_overlay_icon = chosen_prof.mob_overlay_icon_list[slot]
+		C.mob_overlay_state = chosen_prof.mob_overlay_state_list[slot] //WS EDIT - Mob Overlay State
+
+		if(istype(C, /obj/item/changeling/id) && chosen_prof.id_icon)
+			var/obj/item/changeling/id/flesh_id = C
+			flesh_id.hud_icon = chosen_prof.id_icon
+
+		if(equip)
+			user.equip_to_slot_or_del(C, GLOB.slot2slot[slot])
+			if(!QDELETED(C))
+				ADD_TRAIT(C, TRAIT_NODROP, CHANGELING_TRAIT)
+
+	user.regenerate_icons()
+	current_profile = chosen_prof
+
 /obj/item/clothing/glasses/changeling
 	name = "flesh"
 	item_flags = DROPDEL
-
-/obj/item/clothing/glasses/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/glasses/changeling/attack_hand(mob/user)
@@ -26,10 +85,6 @@
 /obj/item/clothing/under/changeling
 	name = "flesh"
 	item_flags = DROPDEL
-
-/obj/item/clothing/under/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/under/changeling/attack_hand(mob/user)
@@ -44,10 +99,6 @@
 	allowed = list(/obj/item/changeling)
 	item_flags = DROPDEL
 
-/obj/item/clothing/suit/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/suit/changeling/attack_hand(mob/user)
 	if(loc == user && user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
@@ -59,10 +110,6 @@
 /obj/item/clothing/head/changeling
 	name = "flesh"
 	item_flags = DROPDEL
-
-/obj/item/clothing/head/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/head/changeling/attack_hand(mob/user)
@@ -76,10 +123,6 @@
 	name = "flesh"
 	item_flags = DROPDEL
 
-/obj/item/clothing/shoes/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/shoes/changeling/attack_hand(mob/user)
 	if(loc == user && user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
@@ -92,10 +135,6 @@
 	name = "flesh"
 	item_flags = DROPDEL
 
-/obj/item/clothing/gloves/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/gloves/changeling/attack_hand(mob/user)
 	if(loc == user && user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
@@ -107,10 +146,6 @@
 /obj/item/clothing/mask/changeling
 	name = "flesh"
 	item_flags = DROPDEL
-
-/obj/item/clothing/mask/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/mask/changeling/attack_hand(mob/user)
@@ -126,10 +161,6 @@
 	allowed = list(/obj/item/changeling)
 	item_flags = DROPDEL
 
-/obj/item/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/changeling/attack_hand(mob/user)
 	if(loc == user && user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
@@ -138,26 +169,59 @@
 		return
 	. = ..()
 
+/obj/item/changeling/id
+	slot_flags = ITEM_SLOT_ID
+	/// Cached flat icon of the ID
+	var/icon/cached_flat_icon
+	/// HUD job icon of the ID
+	var/hud_icon
+
+/obj/item/changeling/id/equipped(mob/user, slot, initial)
+	. = ..()
+	if(hud_icon)
+		var/image/holder = user.hud_list[ID_HUD]
+		var/icon/I = icon(user.icon, user.icon_state, user.dir)
+		holder.pixel_y = I.Height() - world.icon_size
+		holder.icon_state = hud_icon
+
+/**
+ * Returns cached flat icon of the ID, creates one if there is not one already cached
+ */
+/obj/item/changeling/id/proc/get_cached_flat_icon()
+	if(!cached_flat_icon)
+		cached_flat_icon = getFlatIcon(src)
+	return cached_flat_icon
+
+/obj/item/changeling/id/get_examine_string(mob/user, thats = FALSE)
+	return "[icon2html(get_cached_flat_icon(), user)] [thats? "That's ":""][get_examine_name(user)]" //displays all overlays in chat
+
 //Change our DNA to that of somebody we've absorbed.
 /datum/action/changeling/transform/sting_action(mob/living/carbon/human/user)
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	var/datum/changelingprofile/chosen_prof = changeling.select_dna("Select the target DNA: ", "Target DNA")
+	var/datum/changelingprofile/chosen_prof = changeling.select_dna()
 
 	if(!chosen_prof)
 		return
 	..()
-	changeling_transform(user, chosen_prof)
+	changeling.transform(user, chosen_prof)
 	return TRUE
 
-/datum/antagonist/changeling/proc/select_dna(prompt, title)
+/**
+ * Gives a changeling a list of all possible dnas in their profiles to choose from and returns profile containing their chosen dna
+ */
+/datum/antagonist/changeling/proc/select_dna()
 	var/mob/living/carbon/user = owner.current
 	if(!istype(user))
 		return
-	var/list/names = list("Drop Flesh Disguise")
-	for(var/datum/changelingprofile/prof in stored_profiles)
-		names += "[prof.name]"
 
-	var/chosen_name = input(prompt, title, null) as null|anything in sortList(names)
+	var/list/disguises = list("Drop Flesh Disguise" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_drop"))
+	for(var/datum/changelingprofile/current_profile in stored_profiles)
+		var/datum/icon_snapshot/snap = current_profile.profile_snapshot
+		var/image/disguise_image = image(icon = snap.icon, icon_state = snap.icon_state)
+		disguise_image.overlays = snap.overlays
+		disguises[current_profile.name] = disguise_image
+
+	var/chosen_name = show_radial_menu(user, user, disguises, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 40, require_near = TRUE, tooltips = TRUE)
 	if(!chosen_name)
 		return
 
@@ -165,6 +229,21 @@
 		for(var/slot in GLOB.slots)
 			if(istype(user.vars[slot], GLOB.slot2type[slot]))
 				qdel(user.vars[slot])
-
+		return
 	var/datum/changelingprofile/prof = get_dna(chosen_name)
 	return prof
+
+
+/**
+ * Checks if we are allowed to interact with a radial menu
+ *
+ * Arguments:
+ * * user The carbon mob interacting with the menu
+ */
+/datum/antagonist/changeling/proc/check_menu(mob/living/carbon/user)
+	if(!istype(user))
+		return FALSE
+	var/datum/antagonist/changeling/changeling_datum = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	if(!changeling_datum)
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -62,6 +62,7 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_body()
 	remove_overlay(BODY_LAYER)
 	dna.species.handle_body(src)
+	dna.update_body_size()
 
 /mob/living/carbon/human/update_fire()
 	..((fire_stacks > HUMAN_FIRE_STACK_ICON_NUM) ? "Standing" : "Generic_mob_burning")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
its 1:28 am as i write this and i want to draft pr this so i at least have something to show for the 4 hours i grappled with this thing for

* ports some parts of https://github.com/tgstation/tgstation/pull/68117, https://github.com/tgstation/tgstation/pull/56344, https://github.com/tgstation/tgstation/pull/55680
* makes it so changeling absorbing now gives you the victim's guestbook

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes the antagonist that can steal identities steal identities better

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Absorbing someone as a changeling now grants you their guestbook.
add: The Human form ability now uses a radial menu.
add: Changelings now use a radial menu to select DNAs.
fix: Changeling shapeshifting should now properly show age, species traits, and height.
fix: Changelings will now show correct ID job icon on security huds upon transformation, if ID was actually equipped as a part of the flesh disguise. Upon reabsorbing the flesh disguise ID, the icon will also immediately disappear, so keep that in mind.
fix: Changeling flesh disguise IDs will now properly show overlays upon examine.
fix: Changeling flesh disguise will now properly include suit storage slot item, if there is any.
fix: Human form should now update your species accordingly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
