### PR TITLE
Makes it easier to poke and annoy your colleagues than ever before. Also makes it so that hugging or shaking someone's hand requires you to grab them first.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -471,9 +471,12 @@
 						null, span_hear("You hear the rustling of clothes."), DEFAULT_MESSAGE_RANGE, list(M, src))
 			to_chat(M, span_notice("You wrap [src] into a tight bear hug!"))
 			to_chat(src, span_notice("[M] squeezes you super tightly in a firm bear hug!"))
-		else
+		else if((M.grab_state == GRAB_PASSIVE) && (M.pulling))
 			M.visible_message(span_notice("[M] hugs [src] to make [p_them()] feel better!"), \
 					span_notice("You hug [src] to make [p_them()] feel better!"))
+		else
+			M.visible_message(span_notice("[M] pokes [src]."), \
+					span_notice("You poke [src]."))
 		if(istype(M.dna.species, /datum/species/moth)) //WS edit - moth dust from hugging
 			mothdust += 15;
 		if(istype(dna.species, /datum/species/moth))
@@ -497,25 +500,26 @@
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "hug", /datum/mood_event/bad_touch_bear_hug)
 
 		// Let people know if they hugged someone really warm or really cold
-		if(M.bodytemperature > M.dna.species.bodytemp_heat_damage_limit)
-			to_chat(src, span_warning("It feels like [M] is over heating as they hug you."))
-		else if(M.bodytemperature < M.dna.species.bodytemp_cold_damage_limit)
-			to_chat(src, span_warning("It feels like [M] is freezing as they hug you."))
+		if (M.grab_state >= GRAB_PASSIVE)
+			if(M.bodytemperature > M.dna.species.bodytemp_heat_damage_limit)
+				to_chat(src, span_warning("It feels like [M] is over heating as they hug you."))
+			else if(M.bodytemperature < M.dna.species.bodytemp_cold_damage_limit)
+				to_chat(src, span_warning("It feels like [M] is freezing as they hug you."))
 
-		if(bodytemperature > dna.species.bodytemp_heat_damage_limit)
-			to_chat(M, span_warning("It feels like [src] is over heating as you hug them."))
-		else if(bodytemperature < dna.species.bodytemp_cold_damage_limit)
-			to_chat(M, span_warning("It feels like [src] is freezing as you hug them."))
+			if(bodytemperature > dna.species.bodytemp_heat_damage_limit)
+				to_chat(M, span_warning("It feels like [src] is over heating as you hug them."))
+			else if(bodytemperature < dna.species.bodytemp_cold_damage_limit)
+				to_chat(M, span_warning("It feels like [src] is freezing as you hug them."))
 
-		if(HAS_TRAIT(M, TRAIT_FRIENDLY))
-			if (hugger_mood.sanity >= SANITY_GREAT)
-				new /obj/effect/temp_visual/heart(loc)
-				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
-			else if (hugger_mood.sanity >= SANITY_DISTURBED)
-				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)
+			if(HAS_TRAIT(M, TRAIT_FRIENDLY))
+				if (hugger_mood.sanity >= SANITY_GREAT)
+					new /obj/effect/temp_visual/heart(loc)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
+				else if (hugger_mood.sanity >= SANITY_DISTURBED)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)
 
-		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
-			to_chat(M, span_warning("[src] looks visibly upset as you hug [p_them()]."))
+			if(HAS_TRAIT(src, TRAIT_BADTOUCH))
+				to_chat(M, span_warning("[src] looks visibly upset as you hug [p_them()]."))
 
 	else if((M.zone_selected == BODY_ZONE_L_ARM) || (M.zone_selected == BODY_ZONE_R_ARM))
 		if(!get_bodypart(check_zone(M.zone_selected)))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -434,7 +434,7 @@
 		if(istype(dna.species, /datum/species/moth))
 			M.mothdust += 10; // End WS edit
 
-	if(M.zone_selected == BODY_ZONE_PRECISE_MOUTH) // Nose boops!
+	else if(M.zone_selected == BODY_ZONE_PRECISE_MOUTH) // Nose boops!
 		nosound = TRUE
 		playsound(src, 'sound/effects/boop.ogg', 50, 0)
 		if (HAS_TRAIT(M, TRAIT_FRIENDLY))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -524,9 +524,12 @@
 	else if((M.zone_selected == BODY_ZONE_L_ARM) || (M.zone_selected == BODY_ZONE_R_ARM))
 		if(!get_bodypart(check_zone(M.zone_selected)))
 			to_chat(M, span_warning("[src] does not have a [M.zone_selected == BODY_ZONE_L_ARM ? "left" : "right"] arm!"))
-		else
+		else if((M.grab_state == GRAB_PASSIVE) && (M.pulling))
 			M.visible_message(span_notice("[M] shakes [src]'s hand."), \
 						span_notice("You shake [src]'s hand."))
+		else
+			M.visible_message(span_notice("[M] pats [src] on the shoulder."), \
+						span_notice("You pat [src] on the shoulder."))
 	else if((M.zone_selected == BODY_ZONE_L_LEG) || (M.zone_selected == BODY_ZONE_R_LEG))
 		if(!get_bodypart(check_zone(M.zone_selected)))
 			to_chat(M, span_warning("[src] does not have a [M.zone_selected == BODY_ZONE_L_LEG ? "left" : "right"] leg!"))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -500,7 +500,7 @@
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "hug", /datum/mood_event/bad_touch_bear_hug)
 
 		// Let people know if they hugged someone really warm or really cold
-		if (M.grab_state >= GRAB_PASSIVE)
+		if ((M.grab_state == GRAB_PASSIVE) && (M.pulling))
 			if(M.bodytemperature > M.dna.species.bodytemp_heat_damage_limit)
 				to_chat(src, span_warning("It feels like [M] is over heating as they hug you."))
 			else if(M.bodytemperature < M.dna.species.bodytemp_cold_damage_limit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes hugging so that it requires that one grabs the person they wish to hug first. If one clicks on another character without grabbing someone, they end up poking them instead. This PR also makes it so that you need to grab someone in order to shake their hand. Otherwise, you just pat the person on the shoulder instead. This PR also fixes a bug where shaking someone up from a lying down position would call both text for shaking them up, as well as text for a specific body region.

Before:
![image](https://github.com/user-attachments/assets/6243bd6d-a107-4a31-9ed0-d882068d9510)

After:
![image](https://github.com/user-attachments/assets/e84425eb-b8f4-4309-8cb3-599076718b85)


## Why It's Good For The Game

I've always found it a little silly that one could accidentally click on another character and hug them that way. This change should make it so that the more realistic scenario of tapping or poking someone happens instead. It also ensures that if someone wants to hug someone else, there is proper intent behind it. This also ties into bear hugs, which require an aggressive grab to function, so this would end up making hugs follow a logical sequence of intent.

It also makes sense to have to grab someone before shaking their hand, I think, for a similar reason, in that it signals intent better.

## Changelog

:cl:
balance: hugs now require grabbing the person to be hugged -- not doing so pokes that person instead. The same is true for shaking one's hand.
fix: fixes shaking someone up also poking them or patting them at the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
