### PR TITLE
removes sand and mud slowdown

### DIFF
--- a/code/game/turfs/open/floor/plating/beach.dm
+++ b/code/game/turfs/open/floor/plating/beach.dm
@@ -20,7 +20,7 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_ASH)
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_ASH)
-	slowdown = 0.42
+	slowdown = 0
 
 
 	has_footsteps = TRUE

--- a/code/game/turfs/open/floor/plating/desert.dm
+++ b/code/game/turfs/open/floor/plating/desert.dm
@@ -12,7 +12,7 @@
 	clawfootstep = FOOTSTEP_SAND
 	planetary_atmos = TRUE
 	initial_gas_mix = DESERT_DEFAULT_ATMOS
-	slowdown = 1.05
+	slowdown = 0
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_ASH)
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_ASH)

--- a/code/game/turfs/open/floor/plating/jungle.dm
+++ b/code/game/turfs/open/floor/plating/jungle.dm
@@ -2,7 +2,7 @@
 /turf/open/floor/plating/asteroid/dirt/jungle
 	name = "mud"
 	desc = "Upon closer examination, it's still dirt, just more wet than usual."
-	slowdown = 0.5
+	slowdown = 0
 	baseturfs = /turf/open/floor/plating/asteroid/dirt/jungle
 	initial_gas_mix = JUNGLEPLANET_DEFAULT_ATMOS
 	footstep = FOOTSTEP_MUD
@@ -19,7 +19,7 @@
 	icon = 'icons/turf/planetary/jungle.dmi'
 	icon_state = "wasteland"
 	base_icon_state = "wasteland"
-	slowdown = 0.7
+	slowdown = 0
 	baseturfs = /turf/open/floor/plating/asteroid/dirt/wasteland
 	floor_variance = 15
 	initial_gas_mix = JUNGLEPLANET_DEFAULT_ATMOS
@@ -42,7 +42,7 @@
 /turf/open/floor/plating/dirt/jungle
 	name = "mud"
 	desc = "Upon closer examination, it's still dirt, just more wet than usual."
-	slowdown = 0.5
+	slowdown = 0
 	baseturfs = /turf/open/floor/plating/dirt/jungle
 	initial_gas_mix = JUNGLEPLANET_DEFAULT_ATMOS
 	light_color = COLOR_JUNGLEPLANET_LIGHT
@@ -72,7 +72,7 @@
 	desc = "Looks a bit dry."
 	icon = 'icons/turf/planetary/jungle.dmi'
 	icon_state = "wasteland"
-	slowdown = 1
+	slowdown = 0
 	baseturfs = /turf/open/floor/plating/dirt/jungle/wasteland
 	var/floor_variance = 15
 

--- a/code/game/turfs/open/floor/plating/lavaland.dm
+++ b/code/game/turfs/open/floor/plating/lavaland.dm
@@ -52,7 +52,7 @@
 	planetary_atmos = TRUE
 	light_color = COLOR_LAVAPLANET_LIGHT
 
-	slowdown = 1.05
+	slowdown = 0
 
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -85,8 +85,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_ASH)
 	canSmoothWith = list(SMOOTH_GROUP_FLOOR_ASH, SMOOTH_GROUP_CLOSED_TURFS)
 	layer = HIGH_TURF_LAYER
-	slowdown = 1
-
+	slowdown = 0
 /turf/open/floor/plating/ashplanet/rocky
 	gender = PLURAL
 	name = "rocky ground"
@@ -106,7 +105,7 @@
 	name = "wet rocky ground"
 	smoothing_flags = NONE
 	icon_state = "wateryrock"
-	slowdown = 2
+	slowdown = 0
 	footstep = FOOTSTEP_FLOOR
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW

--- a/code/game/turfs/open/floor/plating/moon.dm
+++ b/code/game/turfs/open/floor/plating/moon.dm
@@ -14,7 +14,7 @@
 	layer = SAND_TURF_LAYER
 	planetary_atmos = TRUE
 	initial_gas_mix = AIRLESS_ATMOS
-	slowdown = 0.8 //hardsuits will slow enough
+	slowdown = 0
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_ASH)
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_ASH)

--- a/code/game/turfs/open/floor/plating/shrouded.dm
+++ b/code/game/turfs/open/floor/plating/shrouded.dm
@@ -8,7 +8,7 @@
 
 	floor_variance = 83
 	max_icon_states = 5
-	slowdown = 1.05
+	slowdown = 0
 	planetary_atmos = TRUE
 	initial_gas_mix = SHROUDED_DEFAULT_ATMOS
 	footstep = FOOTSTEP_SAND

--- a/code/game/turfs/open/floor/plating/whitesands.dm
+++ b/code/game/turfs/open/floor/plating/whitesands.dm
@@ -15,7 +15,7 @@
 	digResult = /obj/item/stack/ore/glass/whitesands
 	floor_variance = 83
 	max_icon_states = 5
-	slowdown = 1.05
+	slowdown = 0
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_FLOOR_ASH)
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_ASH)


### PR DESCRIPTION
## About The Pull Request

Cuts sand and mud slowdown, setting it to 0.

## Why It's Good For The Game

Most planets that have slowdown tiles usually have significant amounts of ranged enemies (notably hermits, both the rifleman and SKM) on top of the primarily sand generation. It's pretty miserable considering the simplemobs are immune to it.

Snow and water keep it since the risk of getting obliterated by 300 homeless men with assault rifles is significantly lower

## Changelog

:cl:
balance: Sand and mud tiles no longer slow you down
/:cl: