### PR TITLE
Fixes normal vending machines not displaying stock

### DIFF
--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -42,8 +42,8 @@ const VendingRow = (props, context) => {
           }
         >
           {custom ? product.amount : (!productStock && '0') ||
-            (product.max_amount >= 0 && productStock) ||
-            (product.max_amount < 0 && '∞')} in stock
+          (product.max_amount >= 0 && productStock) ||
+          (product.max_amount < 0 && '∞')} in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -41,9 +41,10 @@ const VendingRow = (props, context) => {
             'good'
           }
         >
-          {custom ? product.amount : (!productStock && '0') ||
-            (product.max_amount >= 0 && productStock) ||
-            (product.max_amount < 0 && '∞')} in stock
+          {custom ? product.amount :
+          (!productStock && '0') ||
+          (product.max_amount >= 0 && productStock) ||
+          (product.max_amount < 0 && '∞')} in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -41,10 +41,10 @@ const VendingRow = (props, context) => {
             'good'
           }
         >
-          {custom ? product.amount :
-          (!productStock && '0') ||
-          (product.max_amount >= 0 && productStock) ||
-          (product.max_amount < 0 && '∞')} in stock
+          {custom ? product.amount : (!productStock && '0') ||
+            (product.max_amount >= 0 && productStock) ||
+            (product.max_amount < 0 && '∞')}
+          in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -42,8 +42,8 @@ const VendingRow = (props, context) => {
           }
         >
           {custom ? product.amount : (!productStock && '0') ||
-          (product.max_amount >= 0 && productStock) ||
-          (product.max_amount < 0 && '∞')} in stock
+            (product.max_amount >= 0 && productStock) ||
+            (product.max_amount < 0 && '∞')} in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -41,9 +41,10 @@ const VendingRow = (props, context) => {
             'good'
           }
         >
-          {custom ? product.amount : (!productStock && '0') ||
+          {(custom && product.amount) ||
+            (!productStock && '0') ||
             (product.max_amount >= 0 && productStock) ||
-            (product.max_amount < 0 && '∞')}
+            (product.max_amount < 0 && '∞')}{' '}
           in stock
         </Box>
       </Table.Cell>

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -41,7 +41,9 @@ const VendingRow = (props, context) => {
             'good'
           }
         >
-          {custom ? product.amount : productStock.amount} in stock
+          {custom ? product.amount : (!productStock && '0') ||
+            (product.max_amount >= 0 && productStock) ||
+            (product.max_amount < 0 && '∞')} in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I made a mistake in #4855 and accidentally made normal vendors not display how much stock they had left.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I should fix my mistakes.

## Changelog

:cl:
fix: Vendors not displaying stock amounts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
