### PR TITLE
disables player spawning of panacea

### DIFF
--- a/_maps/configs/syndicate_panacea.json
+++ b/_maps/configs/syndicate_panacea.json
@@ -62,5 +62,5 @@
 			"slots": 5
 		}
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
im shocked this is still here
## Changelog

:cl:
del: Panacea no longer spawnable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
