### PR TITLE
fixes active turfs and missions on jungle_cavecrew

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
@@ -38,7 +38,6 @@
 /area/ruin/jungle/cavecrew/security)
 "af" = (
 /obj/effect/turf_decal/industrial/warning{
-	dir = 2;
 	color = "#808080"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -96,9 +95,7 @@
 	pixel_x = -4;
 	pixel_y = 9
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "aL" = (
 /obj/machinery/door/airlock/grunge{
@@ -129,12 +126,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "aY" = (
 /obj/structure/falsewall/plastitanium,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/dormitories)
 "aZ" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -145,9 +144,7 @@
 /area/ruin/jungle/cavecrew/cargo)
 "bb" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "bh" = (
 /obj/machinery/computer/camera_advanced{
@@ -216,7 +213,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/dormitories)
 "cK" = (
 /obj/item/stack/rods/ten{
@@ -274,9 +271,7 @@
 "cZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/security)
 "dd" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -322,7 +317,9 @@
 /area/ruin/jungle/cavecrew/security)
 "dI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "dJ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -340,9 +337,7 @@
 	pixel_x = -2;
 	pixel_y = 3
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "dQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -351,7 +346,9 @@
 /turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "dT" = (
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/jungle/cavecrew/cargo)
 "ed" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -385,11 +382,11 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 4;
 	layer = 3.1
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/water/jungle,
 /area/ruin/jungle/cavecrew/cargo)
 "eD" = (
@@ -489,7 +486,9 @@
 /area/ruin/jungle/cavecrew/hallway)
 "fA" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "fG" = (
 /obj/structure/flora/ausbushes/stalkybush{
@@ -518,7 +517,7 @@
 "fN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "fO" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -591,7 +590,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	dir = 2;
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/stairs{
@@ -643,7 +641,9 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "ij" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -657,7 +657,6 @@
 	dir = 4;
 	name = "tactical swivel chair"
 	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/officer/neutured,
 /turf/open/floor/plasteel/dark,
 /area/ruin/jungle/cavecrew/bridge)
 "iE" = (
@@ -666,8 +665,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/mission_poi/main/kill{
-	mission_index = 1
+	already_spawned = 1
 	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/neutured,
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/cavecrew/bridge)
 "iN" = (
@@ -733,7 +733,7 @@
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/jungleplanet/lit{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/powered)
@@ -746,9 +746,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "ju" = (
 /obj/structure/chair/comfy/shuttle{
@@ -813,9 +811,7 @@
 "kb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "ke" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -868,9 +864,7 @@
 /obj/structure/cable{
 	icon_state = "1-9"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "kH" = (
 /obj/structure/cable{
@@ -984,10 +978,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plating{
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/jungleplanet/lit{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
@@ -1017,7 +1009,7 @@
 	pixel_y = 5;
 	pixel_x = -4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "lV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1081,7 +1073,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/jungle/cavecrew/security)
 "mu" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "mw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1110,7 +1102,7 @@
 /obj/structure/cable{
 	icon_state = "2-6"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "mD" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
@@ -1146,9 +1138,7 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "nh" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -1305,9 +1295,7 @@
 /turf/open/floor/plasteel/patterned,
 /area/ruin/jungle/cavecrew/cargo)
 "oW" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 2
-	},
+/turf/open/floor/plasteel/stairs,
 /area/ruin/jungle/cavecrew/cargo)
 "pb" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -1331,9 +1319,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "px" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1435,16 +1421,19 @@
 /area/ruin/powered)
 "rQ" = (
 /obj/structure/railing{
-	dir = 2;
 	layer = 4.1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "rT" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "sj" = (
 /obj/effect/turf_decal/techfloor{
@@ -1502,9 +1491,7 @@
 /obj/structure/sign/poster/official/moth/meth{
 	pixel_y = 32
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/dormitories)
 "sJ" = (
 /obj/structure/table/reinforced{
@@ -1526,13 +1513,17 @@
 "tj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "to" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "tu" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1570,16 +1561,16 @@
 /obj/structure/cable{
 	icon_state = "1-9"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "tO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "2-6"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "tQ" = (
 /obj/structure/flora/grass/jungle{
@@ -1613,7 +1604,7 @@
 /area/ruin/jungle/cavecrew/dormitories)
 "ue" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ship/storage)
 "uf" = (
 /obj/effect/turf_decal/techfloor/hole{
@@ -1632,9 +1623,7 @@
 /area/ruin/jungle/cavecrew/security)
 "un" = (
 /obj/structure/falsewall/plastitanium,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/dormitories)
 "uo" = (
 /obj/structure/chair/stool/bar{
@@ -1642,9 +1631,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "uq" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -1691,8 +1678,8 @@
 /obj/structure/railing{
 	layer = 3.1
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
 "vk" = (
@@ -1894,7 +1881,7 @@
 /obj/item/trash/tray,
 /obj/item/trash/waffles,
 /obj/item/trash/energybar,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/hallway)
 "xr" = (
 /obj/effect/turf_decal/industrial/traffic{
@@ -1967,9 +1954,7 @@
 /obj/machinery/power/terminal,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage)
 "xT" = (
@@ -2009,7 +1994,7 @@
 "yk" = (
 /obj/effect/turf_decal/borderfloor,
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/dormitories)
 "yv" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -2048,9 +2033,7 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "yJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2075,7 +2058,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "zj" = (
 /obj/structure/cable{
@@ -2518,7 +2501,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/jungle/cavecrew/bridge)
 "Ep" = (
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "Es" = (
 /obj/structure/flora/grass/jungle/b,
@@ -2529,8 +2514,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg3"
 	},
 /area/ruin/powered)
 "EI" = (
@@ -2544,8 +2529,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg3"
 	},
 /area/ruin/powered)
 "EP" = (
@@ -2590,12 +2575,8 @@
 /obj/item/stack/rods/ten{
 	pixel_x = 7
 	},
-/obj/machinery/light/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "FY" = (
 /obj/structure/flora/ausbushes/stalkybush{
@@ -2791,12 +2772,12 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 4;
 	layer = 3.1
 	},
 /mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/water/jungle,
 /area/ruin/jungle/cavecrew/cargo)
 "II" = (
@@ -2821,7 +2802,9 @@
 /area/ruin/jungle/cavecrew/dormitories)
 "IJ" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/powered)
 "IM" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -2897,11 +2880,11 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 4;
 	layer = 3.1
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/water/jungle,
 /area/ruin/jungle/cavecrew/cargo)
 "JB" = (
@@ -3016,7 +2999,7 @@
 	id = "gut_engines";
 	name = "Thruster Blast Door"
 	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ship/storage)
 "KH" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -3042,9 +3025,7 @@
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "KM" = (
 /obj/structure/cable{
@@ -3137,7 +3118,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "LD" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -3159,7 +3142,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "Mm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3174,13 +3159,10 @@
 /area/ruin/jungle/cavecrew/hallway)
 "Mn" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "Ms" = (
 /obj/structure/railing{
-	dir = 2;
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/stairs{
@@ -3196,7 +3178,7 @@
 "MC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "MR" = (
 /mob/living/simple_animal/hostile/carp,
@@ -3251,9 +3233,7 @@
 	pixel_y = 21;
 	pixel_x = -10
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/dormitories)
 "Nn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3262,7 +3242,9 @@
 "No" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "Np" = (
 /obj/effect/turf_decal/techfloor{
@@ -3285,7 +3267,7 @@
 	dir = 1;
 	pixel_y = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/jungle/cavecrew/cargo)
 "NH" = (
 /obj/machinery/door/window/brigdoor/southright{
@@ -3320,7 +3302,7 @@
 	name = "Thruster Blast Door"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ship/storage)
 "NR" = (
 /turf/open/floor/plating/dirt/jungle/dark,
@@ -3359,7 +3341,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/dormitories)
 "OK" = (
 /obj/effect/turf_decal/weather/dirt/corner{
@@ -3391,7 +3373,7 @@
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "Pg" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -3413,8 +3395,8 @@
 "Pv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg3"
 	},
 /area/ruin/powered)
 "Pz" = (
@@ -3448,7 +3430,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "Qh" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3492,7 +3476,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "Qx" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -3631,14 +3615,12 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "Sj" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/ruin/jungle/cavecrew/bridge)
 "So" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -3664,7 +3646,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/powered)
 "ST" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3789,7 +3773,9 @@
 	dir = 8;
 	pixel_x = 8
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "plating_rust"
+	},
 /area/ruin/powered)
 "Us" = (
 /obj/effect/turf_decal/steeldecal/steel_decals10{
@@ -4040,8 +4026,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
 "WD" = (
@@ -4107,9 +4093,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "XV" = (
 /turf/open/floor/plasteel/stairs{
@@ -4140,9 +4124,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating,
 /area/ruin/jungle/cavecrew/hallway)
 "Yw" = (
 /turf/open/floor/plasteel/stairs{
@@ -5520,7 +5502,7 @@ Fw
 Nr
 fS
 mC
-EG
+XU
 PU
 to
 PU
@@ -5640,10 +5622,10 @@ pt
 aQ
 aQ
 lG
-SN
+XU
 yZ
 to
-EG
+SN
 ng
 KK
 EG

--- a/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
@@ -664,10 +664,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/mission_poi/main/kill{
-	already_spawned = 1
-	},
 /mob/living/simple_animal/hostile/human/frontier/ranged/officer/neutured,
+/obj/effect/landmark/mission_poi/main/kill{
+	already_spawned = 1;
+	type_to_spawn = /mob/living/simple_animal/hostile/human/frontier/ranged/officer
+	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/cavecrew/bridge)
 "iN" = (
@@ -2160,7 +2161,8 @@
 	pixel_y = -3
 	},
 /obj/effect/landmark/mission_poi/main{
-	mission_index = 2
+	mission_index = 2;
+	type_to_spawn = /obj/item/documents/frontier
 	},
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/cavecrew/bridge)
@@ -2515,7 +2517,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/jungleplanet/lit{
-	icon_state = "platingdmg3"
+	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
 "EI" = (
@@ -3646,9 +3648,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/jungleplanet/lit{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/jungleplanet/lit,
 /area/ruin/powered)
 "ST" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4093,7 +4093,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/jungleplanet/lit,
+/turf/open/floor/plating/jungleplanet/lit{
+	icon_state = "platingdmg3"
+	},
 /area/ruin/powered)
 "XV" = (
 /turf/open/floor/plasteel/stairs{
@@ -5502,12 +5504,12 @@ Fw
 Nr
 fS
 mC
-XU
+SN
 PU
 to
 PU
 PU
-XU
+SN
 Mg
 LB
 CC
@@ -5622,13 +5624,13 @@ pt
 aQ
 aQ
 lG
-XU
+SN
 yZ
 to
-SN
+EG
 ng
 KK
-EG
+XU
 OZ
 EO
 yZ


### PR DESCRIPTION
## Changelog

:cl:
fix: jungle cavecrew will generate less spacewind
fix: jungle cave crew will only spawn one officer, irregardless of mission
fix: jungle cave crew can have documents spawn now.
/:cl: