### PR TITLE
lessens revolver unwielded spread slightly

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -13,7 +13,7 @@
 	icon_state = "montagne"
 	item_state = "hp_generic"
 	manufacturer = MANUFACTURER_HUNTERSPRIDE
-	spread_unwielded = 15
+	spread_unwielded = 8
 	recoil = 0
 
 	default_ammo_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44/montagne

--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -113,7 +113,7 @@ EMPTY_GUN_HELPER(revolver/firebrand)
 	unique_reskin_changes_inhand = TRUE
 
 	recoil = 0
-	spread_unwielded = 10
+	spread_unwielded = 8
 
 /obj/item/gun/ballistic/revolver/shadow/ComponentInitialize()
 	. = ..()

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -183,6 +183,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 	fire_delay = 0.35 SECONDS
 
 	spread = 3
+	spread_unwielded = 8
 	recoil = 1
 	recoil_unwielded = 2
 


### PR DESCRIPTION
## About The Pull Request

Makes the unwielded spread on the military viper, shadow and montagne to be slightly less than the shortened civvie viper

## Why It's Good For The Game

Mil vipers supposed to be more accurate. Also lessened the .44 revolver to be less spread than the gun shooting the bigger cartridge

## Changelog

:cl:
balance: Slightly less spread on the military viper, HP shadow, and HP montagne
/:cl: