### PR TITLE
Fixes "an negative" typo

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -278,7 +278,7 @@
 /datum/emote/living/carbon/human/robot_tongue/no
 	key = "no"
 	key_third_person = "no"
-	message = "emits an negative blip."
+	message = "emits a negative blip."
 
 /datum/emote/living/carbon/human/robot_tongue/no/run_emote(mob/user, params)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -27,7 +27,7 @@
 
 /datum/emote/silicon/no
 	key = "no"
-	message = "emits an negative blip."
+	message = "emits a negative blip."
 	sound = 'sound/machines/synth_no.ogg'
 
 /datum/emote/silicon/ping


### PR DESCRIPTION
## About The Pull Request

Fixes "emits an negative blip.", replacing it with "emits a negative blip."

## Changelog

:cl:
spellcheck: fixed a few typos
/:cl:

