### PR TITLE
drills automatically shut down

### DIFF
--- a/code/modules/missions/dynamic/signaled.dm
+++ b/code/modules/missions/dynamic/signaled.dm
@@ -77,6 +77,9 @@
 
 	if(num_current == num_wanted)
 		SEND_SIGNAL(src, COMSIG_DRILL_SAMPLES_DONE)
+		say("Required samples gathered, shutting down!")
+		if(active)
+			stop_mining()
 
 /obj/machinery/drill/mission/ruin
 	name = "industrial grade mining drill"


### PR DESCRIPTION

## Why It's Good For The Game


## Changelog

:cl:
add: scanner drills automatically shut down upon reaching the required sample count
/:cl:

