### PR TITLE
fix high priority mission selection

### DIFF
--- a/code/modules/events/high_priority_mission.dm
+++ b/code/modules/events/high_priority_mission.dm
@@ -28,7 +28,7 @@
 		pickable_missions.Add(inactive_mission)
 	if(pickable_missions.len)
 		priority_mission = pick(pickable_missions)
-		if(priority_mission != active)
+		if(priority_mission.active != TRUE)
 			priority_mission.start_mission()
 		message_admins("[priority_mission][ADMIN_VV(priority_mission)] has been selected for [src]")
 

--- a/code/modules/events/high_priority_mission.dm
+++ b/code/modules/events/high_priority_mission.dm
@@ -20,12 +20,16 @@
 /datum/round_event/high_priority_mission/setup()
 	target_outpost = pick(SSovermap.outposts)
 	var/list/pickable_missions = list()
-	for(var/datum/mission/ruin/active_mission)
+	for(var/datum/mission/ruin/active_mission in SSmissions.active_ruin_missions)
 		if(active_mission.dibs_string)
 			continue
 		pickable_missions.Add(active_mission)
+	for(var/datum/mission/ruin/inactive_mission in SSmissions.inactive_ruin_missions)
+		pickable_missions.Add(inactive_mission)
 	if(pickable_missions.len)
 		priority_mission = pick(pickable_missions)
+		if(priority_mission != active)
+			priority_mission.start_mission()
 		message_admins("[priority_mission][ADMIN_VV(priority_mission)] has been selected for [src]")
 
 /datum/round_event/high_priority_mission/start()


### PR DESCRIPTION
## About The Pull Request
fixes the high priority mission event and makes it so it can grab an inactive mission and start it

## Changelog

:cl:
fix: high priority mission no longer cycles through world.
/:cl: