### PR TITLE
Fixes sparks passing through walls and windows

### DIFF
--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -78,7 +78,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	if(isnull(step))
 		return
 
-	ref.forceMove(step)
+	step_towards(ref, step)
 
 	if(steps)
 		addtimer(CALLBACK(src, PROC_REF(scoot), direction, ref, steps - 1), 5)


### PR DESCRIPTION
## About The Pull Request

Sparks no longer pass through solid objects to ignite gases on the other side of them.

## Why It's Good For The Game

We don't want fuel tanks burning up because a spark phased through a solid wall and ignited it.

## Changelog

:cl:
fix: Fixed sparks passing through walls and windows
/:cl:
