### PR TITLE
Fix turret human shoot toggle not toggling shoot human

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -72,13 +72,11 @@
 	/// Turret flags about who is turret allowed to shoot
 	var/turret_flags = TURRET_FLAG_DEFAULT
 
-	/// If the turret is currently retaliating. Turrets will ignore all other settings to shoot at the attacker until they're dead or out of range
+	/// If the turret is currently retaliating. Turrets will ignore all other settings to shoot at the attacker until they're dead or out of range //this. does not work. right now.
 	var/retaliating = FALSE
 
-	/// Same faction mobs will never be shot at, no matter the other settings
+	/// Factions accounted for by IFF settings
 	var/list/faction = list("neutral", FACTION_TURRET)
-
-	var/list/target_faction = list("hostile")
 
 	/// does our turret give a flying fuck about what accesses someone has?
 	var/turret_respects_id = TRUE
@@ -505,10 +503,10 @@
 		targets -= target
 		return FALSE
 
-	if((check_flags & TURRET_FLAG_SHOOT_NONFACTION) && faction_check(src.faction, target_mob.faction))
+	if((check_flags & TURRET_FLAG_SHOOT_NONFACTION) && faction_check(src.faction, target_mob.faction)) //contrary to what these say they do they actually exclude targets rather than include them
 		return FALSE
 
-	if((check_flags & TURRET_FLAG_SHOOT_SPECIFIC_FACTION) && !faction_check(src.faction, target_mob.faction))
+	if((check_flags & TURRET_FLAG_SHOOT_SPECIFIC_FACTION) && !faction_check(src.faction, target_mob.faction)) //in case you ever wanted to only have a turret shoot 1 faction. or turn it on its masters (ship turrets have undying loyalty their crew)
 		return FALSE
 
 	if(iscyborg(target_mob))
@@ -533,6 +531,9 @@
 		return target(target_mob)
 
 	//We know the target must be a human now
+	if(!(check_flags & TURRET_FLAG_SHOOT_HUMANS))
+		return FALSE
+
 	var/mob/living/carbon/human/target_carbon = target_mob
 
 	if(turret_respects_id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This setting did LITERALLY NOTHING!!! now turning it off makes it not shoot people

## Why It's Good For The Game

I like my turrets not shooting random innocent scrappers

## Changelog

:cl:
fix: turrets set to not target humans will now not target humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
