### PR TITLE
Fixes the black market camo set not spawning correctly

### DIFF
--- a/code/modules/cargo/blackmarket/packs/clothing.dm
+++ b/code/modules/cargo/blackmarket/packs/clothing.dm
@@ -148,7 +148,7 @@
 	stock_max = 8
 	availability_prob = 50
 
-/datum/blackmarket_item/clothing/frontiersmen_armor_set/spawn_item(loc)
+/datum/blackmarket_item/clothing/camo_set/spawn_item(loc)
 	var/obj/item/storage/backpack/duffelbag/sec/B = ..()
 	B.name = "Worn Duffelbag"
 	B.desc = "A beat up looking dufflebag."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bug fix good

## Changelog

:cl:
fix: Black market camoflauge set
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
