### PR TITLE
Fixes Frontiersmen simplemob drops

### DIFF
--- a/code/modules/mob/living/simple_animal/corpse_spawners/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/corpse_spawners/frontiersman.dm
@@ -104,3 +104,5 @@
 	back = null
 	belt = /obj/item/storage/belt/security/military/frontiersmen
 	l_hand = null
+	backpack_contents = null
+	box = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Simplemob flametroopers still had their bag contents set which they meant they still spawned with gear in their bags. They and the surgeons also dropped pirate radios, which isnt great too.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes an unintended drop.

## Changelog

:cl:
fix: Flametrooper corpse outfit no longer spawns with unintended bag contents.
fix: Simple mob surgeons and flametroopers dont drop pirate radios
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
