### PR TITLE
Death (Maybe)

### DIFF
--- a/code/game/objects/effects/spawners/random/boards.dm
+++ b/code/game/objects/effects/spawners/random/boards.dm
@@ -188,8 +188,6 @@
 	loot = list(
 			/obj/item/circuitboard/aicore = 5,
 			/obj/item/circuitboard/machine/chem_dispenser = 5,
-			/obj/item/circuitboard/machine/circuit_imprinter = 5,
-			/obj/item/circuitboard/machine/protolathe = 5,
 			/obj/item/circuitboard/machine/rad_collector = 5,
 			/obj/item/circuitboard/machine/launchpad = 5,
 			/obj/item/circuitboard/machine/shuttle/engine/electric = 5,


### PR DESCRIPTION
## About The Pull Request

Removes one of the last sources of RnD from the code

## Why It's Good For The Game

As said above, removes one of the last sources of RnD (Outside of the Talos, as construction is one of its niches), and also removes two items you cannot even use without ransacking a Talos for its console as to my knowledge they were originally all removed by Cloudbreak in all sources (Salvage and ruin loot)

## Changelog

:cl:
del: Removes Omni Protolathes and Circuit Imprinters from the rare board drop pool
/:cl: