### PR TITLE
tactical armor vests no longer block syringes

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -53,7 +53,6 @@
 	desc = "A heavy set of the finest mass-produced stamped plasteel armor plates money can buy."
 	icon_state = "marine_light"
 	item_state = "armor"
-	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN
 	armor = list("melee" = 20, "bullet" = 45, "laser" = 45, "energy" = 25, "bomb" = 30, "bio" = 65, "fire" = 40, "acid" = 50)
 	cold_protection = CHEST|GROIN


### PR DESCRIPTION
## Changelog

:cl:
balance: tactical armor vests no longer block syringes
/:cl
