### PR TITLE
removes skeleton spawners in river rockvalley stash

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_river_valley_stash.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_river_valley_stash.dmm
@@ -415,7 +415,7 @@
 /area/ruin/rockplanet/river_valley_stash/shuttle)
 "qa" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/mob_spawn/human/skeleton/alive,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid/rockplanet/wet,
 /area/overmap_encounter/planetoid/cave/explored)
 "qn" = (
@@ -479,7 +479,7 @@
 /area/ruin/rockplanet/river_valley_stash/hut)
 "rB" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/mob_spawn/human/skeleton/alive,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating/grass/rockplanet,
 /area/overmap_encounter/planetoid/cave/explored)
 "rO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
yeah

## Why It's Good For The Game

mob spawners bad
## Changelog

:cl:
fix: removes skeleton spawners on rockvalley stash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
