### PR TITLE
Removes combat exosuits from cargo + mech rocket removal

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
@@ -2482,7 +2482,6 @@
 "Ec" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine,
 /obj/structure/closet/crate/secure/weapon,
 /turf/open/floor/plasteel/patterned/brushed,

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -391,13 +391,13 @@ weapons
 	faction = /datum/faction/nt
 	faction_discount = 20
 
-/datum/supply_pack/mech/weapon/missile_rack
+/*/datum/supply_pack/mech/weapon/missile_rack
 	name = "BRM-6 kit"
 	desc = "Contains a low-explosive missile launcher, excellent for breaching through obstacles."
 	cost = 3000
 	contains = list(
 		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching
-	)
+	)*/
 
 /*
 ammo
@@ -434,10 +434,10 @@ ammo
 	faction = /datum/faction/nt
 	faction_discount = 20
 
-/datum/supply_pack/mech/ammo/missile_rack_ammo
+/*/datum/supply_pack/mech/ammo/missile_rack_ammo
 	name = "BRM-6 missile box"
 	desc = "Contains a box of six breaching missiles designed to explode upon striking hard surfaces."
 	cost = 600 //these are remarkably inefficient against anything except exosuits
 	contains = list(
 		/obj/item/mecha_ammo/missiles_br
-	)
+	)*/

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -56,69 +56,6 @@ Build Your Own Suit
 	faction = /datum/faction/syndicate/cybersun
 	faction_discount = 40
 
-/*/datum/supply_pack/mech/gygax_parts
-	name = "501p construction kit"
-	desc = "An agile combat exosuit sold across the galaxy by Cybersun. Or at least the parts to it."
-	cost = 12000
-	contains = list(
-		/obj/item/mecha_parts/chassis/gygax,
-		/obj/item/mecha_parts/part/gygax_head,
-		/obj/item/mecha_parts/part/gygax_torso,
-		/obj/item/mecha_parts/part/gygax_left_arm,
-		/obj/item/mecha_parts/part/gygax_right_arm,
-		/obj/item/mecha_parts/part/gygax_left_leg,
-		/obj/item/mecha_parts/part/gygax_right_leg,
-		/obj/item/mecha_parts/part/gygax_armor,
-		/obj/item/circuitboard/mecha/gygax/peripherals,
-		/obj/item/circuitboard/mecha/gygax/main,
-		/obj/item/circuitboard/mecha/gygax/targeting
-	)
-	crate_name = "501p Construction Kit"
-	faction = /datum/faction/syndicate/cybersun
-	faction_discount = 40
-
-/datum/supply_pack/mech/mpgygax_parts
-	name = "NT-501p-MP construction kit"
-	desc = "A set of parts for the NT-501p-MP exosuit model, dervived from the original Cybersun designs and modified for mass production. The armor plating was reduced to cut costs for mass production, but the lighter weight allows the NT-501p-MP's modified servos to perform swift moderate distance charges without heavily taxing the power supply. "
-	cost = 8000
-	contains = list(
-		/obj/item/mecha_parts/chassis/mp_gygax,
-		/obj/item/mecha_parts/part/gygax_head,
-		/obj/item/mecha_parts/part/gygax_torso,
-		/obj/item/mecha_parts/part/gygax_left_arm,
-		/obj/item/mecha_parts/part/gygax_right_arm,
-		/obj/item/mecha_parts/part/gygax_left_leg,
-		/obj/item/mecha_parts/part/gygax_right_leg,
-		/obj/item/mecha_parts/part/mpgygax_armor,
-		/obj/item/circuitboard/mecha/gygax/peripherals,
-		/obj/item/circuitboard/mecha/gygax/main,
-		/obj/item/circuitboard/mecha/gygax/targeting
-	)
-	crate_name = "NT-501p-MP Construction Kit"
-	faction = /datum/faction/nt
-	faction_locked = TRUE
-
-/datum/supply_pack/mech/durand_parts
-	name = "Durand construction kit"
-	desc = "The kit to a bulky suit most frequently used by the CLIP Minutemen, older models tend to find themselves disassembled and sold off."
-	cost = 15000
-	contains = list(
-		/obj/item/mecha_parts/chassis/durand,
-		/obj/item/mecha_parts/part/durand_head,
-		/obj/item/mecha_parts/part/durand_torso,
-		/obj/item/mecha_parts/part/durand_left_arm,
-		/obj/item/mecha_parts/part/durand_right_arm,
-		/obj/item/mecha_parts/part/durand_left_leg,
-		/obj/item/mecha_parts/part/durand_right_leg,
-		/obj/item/mecha_parts/part/durand_armor,
-		/obj/item/circuitboard/mecha/durand/peripherals,
-		/obj/item/circuitboard/mecha/durand/main,
-		/obj/item/circuitboard/mecha/durand/targeting
-	)
-	crate_name = "Durand Construction Kit"
-	faction = /datum/faction/clip
-	faction_discount = 20*/
-
 /*
 Mech Equipment
 */
@@ -391,14 +328,6 @@ weapons
 	faction = /datum/faction/nt
 	faction_discount = 20
 
-/*/datum/supply_pack/mech/weapon/missile_rack
-	name = "BRM-6 kit"
-	desc = "Contains a low-explosive missile launcher, excellent for breaching through obstacles."
-	cost = 3000
-	contains = list(
-		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching
-	)*/
-
 /*
 ammo
 */
@@ -434,10 +363,3 @@ ammo
 	faction = /datum/faction/nt
 	faction_discount = 20
 
-/*/datum/supply_pack/mech/ammo/missile_rack_ammo
-	name = "BRM-6 missile box"
-	desc = "Contains a box of six breaching missiles designed to explode upon striking hard surfaces."
-	cost = 600 //these are remarkably inefficient against anything except exosuits
-	contains = list(
-		/obj/item/mecha_ammo/missiles_br
-	)*/

--- a/code/modules/cargo/packs/mechs.dm
+++ b/code/modules/cargo/packs/mechs.dm
@@ -56,7 +56,7 @@ Build Your Own Suit
 	faction = /datum/faction/syndicate/cybersun
 	faction_discount = 40
 
-/datum/supply_pack/mech/gygax_parts
+/*/datum/supply_pack/mech/gygax_parts
 	name = "501p construction kit"
 	desc = "An agile combat exosuit sold across the galaxy by Cybersun. Or at least the parts to it."
 	cost = 12000
@@ -117,7 +117,7 @@ Build Your Own Suit
 	)
 	crate_name = "Durand Construction Kit"
 	faction = /datum/faction/clip
-	faction_discount = 20
+	faction_discount = 20*/
 
 /*
 Mech Equipment


### PR DESCRIPTION
## About The Pull Request

Removes the gygax, NT gygax, and the durand from cargo. Equipment and upgrade kits remain (just in case)

Also removes the BRM-6 from cargo and the SRM-8 from cavecrew

## Why It's Good For The Game

-They trivialize PVE content (including all ruins and drills of all difficulties), almost nothing is able to challenge a crew with a fully-operational combat exosuit
-You'd have to constantly W-key into the hardest ruin never repairing to probably even have a chance to be killed
-You can just ignore like half the drill mobs because they can't deal damage to you
-Repair is slow but free and you can just do it and continue on your way

-They heavily skew PVP into a stomp for the side that has them, so much hangs on the Suit Alone for victory
-Their counters include: ions (do almost nothing), high-calibre automatic fire (easily dealt with by just trading fire with the person shooting at you and killing them), rockets (oneshot and lame), taipan (need to hit all 3 shots on a moving target with high recoil without getting killed)
-Most combat I've personally seen and participated in has devolved into one side constantly withdrawing due to being unable to do anything to an exosuit and then the slaughter when they can run no more. Not very interesting

But why don't we make changes to fit them into the loop better?

-Decrease armour to make them more balanced? Brings back a lot of the issues they had before where they weren't worth their price because they were so flimsy and most guns could permanently put them out of commission, and put a huge sinker in your budget
-Increase the price? Only would delay the problem to later in the round, which Shiptest rounds often last long anyways
-Decrease stored ammo and increase maintenance prices even more? Was already done and from observation didn't help much, and adjusting these further would either make them not worth using or holding comically small amounts of ammunition for their high upkeep
-More system faults that happen upon taking more damage? Theres already a fair few of them and almost all of them suck, and I'm not convinced more would do much
-More expensive repair? Only solves one problem of having to invest to keep your suit maintained, but doesn't prevent you from stomping out the enemy / a ruin anyways
-Increase ruin / enemy difficulty to compensate for mechs? Mappers shouldn't have to increase the difficulty of their ruins to compensate for a no-slowdown, high-armour exosuit, and would just make things miserable to go through for a normal crew

## Changelog

:cl:
del: Removed combat exosuits from cargo. Other methods of getting player-accessible exosuits unchanged.
del: Removed the BRM-6 breaching rockets from cargo and removes SRM-8 missile rack from Jungle Cavecrew
/:cl: