### PR TITLE
More Ore Vein Tweaks

### DIFF
--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -134,11 +134,6 @@
 		/obj/effect/radiation/waste/intense = 10,
 		/obj/structure/geyser/random = 1,
 		/obj/effect/spawner/random/anomaly/waste = 1,
-		/obj/structure/vein/waste = 4,
-		/obj/structure/vein/waste/classtwo = 6,
-		/obj/structure/vein/waste/classtwo/rare = 2,
-		/obj/structure/vein/waste/classthree = 2,
-		/obj/structure/vein/waste/classthree/rare = 1,
 	)
 
 	mob_spawn_list = list(
@@ -332,9 +327,6 @@
 		/obj/effect/radiation/waste/intense = 10,
 		/obj/structure/geyser/random = 1,
 		/obj/effect/spawner/random/anomaly/waste/cave = 1,
-		/obj/structure/vein/waste = 8,
-		/obj/structure/vein/waste/classtwo = 4,
-		/obj/structure/vein/waste/classthree = 1,
 	)
 	mob_spawn_list = list(
 		/mob/living/basic/hivebot = 50,

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -290,7 +290,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/obj/item/stack/ore/iron = 50,
 		/obj/item/stack/ore/gold = 30,
 		/obj/item/stack/ore/silver = 20,
-		/obj/item/stack/ore/plasma = 10,
+		/obj/item/stack/ore/uranium = 10,
 		/obj/item/stack/ore/diamond = 10,
 		/obj/item/stack/ore/titanium = 1,
 		)
@@ -312,7 +312,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/obj/item/stack/ore/iron = 40,
 		/obj/item/stack/ore/gold = 20,
 		/obj/item/stack/ore/silver = 10,
-		/obj/item/stack/ore/plasma = 10,
+		/obj/item/stack/ore/uranium = 10,
 		/obj/item/stack/ore/diamond = 10,
 		/obj/item/stack/ore/titanium = 4,
 		)
@@ -339,7 +339,7 @@ GLOBAL_LIST_EMPTY(ore_veins)
 	)
 	ore_list = list(
 		/obj/item/stack/ore/iron = 10,
-		/obj/item/stack/ore/plasma = 10,
+		/obj/item/stack/ore/uranium = 10,
 		/obj/item/stack/ore/gold = 10,
 		/obj/item/stack/ore/silver = 10,
 		/obj/item/stack/ore/diamond = 10,

--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -287,8 +287,10 @@ GLOBAL_LIST_EMPTY(ore_veins)
 
 	//same surface ore drop rate too...
 	ore_list = list(
+		/obj/item/stack/ore/iron = 50,
 		/obj/item/stack/ore/gold = 30,
 		/obj/item/stack/ore/silver = 20,
+		/obj/item/stack/ore/plasma = 10,
 		/obj/item/stack/ore/diamond = 10,
 		/obj/item/stack/ore/titanium = 1,
 		)
@@ -305,11 +307,12 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/jungle/seedling = 1,
 		/mob/living/simple_animal/hostile/jungle/mega_arachnid = 1,
 		/mob/living/simple_animal/hostile/jungle/mook = 1,
-		/mob/living/simple_animal/hostile/jungle/leaper = 1,
 	)
 	ore_list = list(
+		/obj/item/stack/ore/iron = 40,
 		/obj/item/stack/ore/gold = 20,
 		/obj/item/stack/ore/silver = 10,
+		/obj/item/stack/ore/plasma = 10,
 		/obj/item/stack/ore/diamond = 10,
 		/obj/item/stack/ore/titanium = 4,
 		)
@@ -333,9 +336,10 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/jungle/seedling = 5,
 		/mob/living/simple_animal/hostile/jungle/mega_arachnid = 20,
 		/mob/living/simple_animal/hostile/jungle/mook = 30,
-		/mob/living/simple_animal/hostile/jungle/leaper = 10,
 	)
 	ore_list = list(
+		/obj/item/stack/ore/iron = 10,
+		/obj/item/stack/ore/plasma = 10,
 		/obj/item/stack/ore/gold = 10,
 		/obj/item/stack/ore/silver = 10,
 		/obj/item/stack/ore/diamond = 10,
@@ -504,96 +508,6 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/obj/item/stack/ore/diamond = 5,
 		/obj/item/stack/ore/bluespace_crystal = 4,
 		)
-//wasteplanet
-/obj/structure/vein/waste
-	// class 1 has easy mobs, the ones you find on the surface
-	mob_types = list(
-		//hivebots, not too difficult
-		/mob/living/basic/hivebot/strong = 20,
-		/mob/living/basic/hivebot/ranged = 40,
-		/mob/living/basic/hivebot/rapid = 30,
-		//bots, are hostile
-		/mob/living/simple_animal/bot/firebot/rockplanet = 15,
-		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
-		)
-
-	//same surface ore drop rate too...
-	ore_list = list(
-		/obj/item/stack/ore/iron = 40,
-		/obj/item/stack/ore/plasma = 35,
-		/obj/item/stack/ore/uranium = 30,
-
-		/obj/item/stack/ore/silver = 5,
-		/obj/item/stack/ore/gold = 4,
-		)
-
-/obj/structure/vein/waste/classtwo
-	mining_charges = 8
-	vein_class = 2
-	mob_types = list( //nor organics, more biased towards hivebots though
-		/mob/living/basic/hivebot/strong = 20,
-		/mob/living/basic/hivebot/ranged = 50,
-		/mob/living/basic/hivebot/rapid = 50,
-		/mob/living/simple_animal/bot/firebot/rockplanet = 15,
-		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 1,
-		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
-		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 20
-	)
-	ore_list = list(
-		/obj/item/stack/ore/iron = 30,
-		/obj/item/stack/ore/plasma = 25,
-		/obj/item/stack/ore/uranium = 20,
-
-		/obj/item/stack/ore/silver = 10,
-		/obj/item/stack/ore/gold = 8,
-		/obj/item/stack/ore/diamond = 1,
-		)
-	//seeing as hivebots die in 1-2 hits from pistols we spawn more
-	max_mobs = 7
-	spawn_time = 10 SECONDS
-
-/obj/structure/vein/waste/classtwo/rare
-	mining_charges = 12
-	vein_class = 2
-	ore_list = list(
-		/obj/item/stack/ore/uranium = 10,
-		)
-
-/obj/structure/vein/waste/classthree
-	mining_charges = 10
-	vein_class = 3
-
-	mob_types = list( //Whoops! All hivebots!
-		/mob/living/basic/hivebot/strong = 20,
-		/mob/living/basic/hivebot/ranged = 40,
-		/mob/living/basic/hivebot/rapid = 20,
-		/mob/living/basic/hivebot = 20,
-		/mob/living/basic/hivebot/core = 1
-	)
-	ore_list = list(
-		/obj/item/stack/ore/iron = 15,
-		/obj/item/stack/ore/plasma = 15,
-		/obj/item/stack/ore/uranium = 10,
-
-		/obj/item/stack/ore/silver = 10,
-		/obj/item/stack/ore/gold = 10,
-		/obj/item/stack/ore/diamond = 5,
-		)
-	//ditto
-	max_mobs = 7
-	spawn_time = 8 SECONDS
-
-/obj/structure/vein/waste/classthree/rare
-	mining_charges = 14
-	vein_class = 3
-	ore_list = list(
-		/obj/item/stack/ore/uranium = 10,
-		)
-
-/obj/structure/vein/waste/classfour
-	mining_charges = 30
-	vein_class = 4
 
 //moons, have a dupe of asteroid but less of an emphasis on  goliaths
 

--- a/code/modules/missions/outpost/drill_mission.dm
+++ b/code/modules/missions/outpost/drill_mission.dm
@@ -17,7 +17,6 @@
 		/datum/planet_type/jungle = /obj/structure/vein/jungle,
 		/datum/planet_type/sand = /obj/structure/vein/sand,
 		/datum/planet_type/rock = /obj/structure/vein/rockplanet,
-		/datum/planet_type/waste = /obj/structure/vein/waste,
 		/datum/planet_type/moon = /obj/structure/vein/moon,
 		/datum/planet_type/asteroid = /obj/structure/vein/asteroid,
 	)


### PR DESCRIPTION
## About The Pull Request

Cuts waste veins, removes leapers from high class jungle veins, and adds iron and plasma to normal jungle veins.

## Why It's Good For The Game

Waste veins sucked ass, leapers are broken and don't work, and jungle veins could use a little more ore variety in the normal veins.

## Changelog

:cl:
del: Removed Leapers from jungle veins
del: Removed waste veins
balance: Added greater ore variety to normal jungle veins
/:cl: