### PR TITLE
Oxygen lockers no longer obliterate themselves sometimes and have plasma tanks for plasma breathing individuals

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -29,7 +29,7 @@
 	if (prob(40))
 		new /obj/item/storage/toolbox/emergency(src)
 
-	switch (pick_weight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 4, "delete" = 1)))
+	switch (pick_weight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10)))
 		if ("small")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/tank/internals/emergency_oxygen(src)
@@ -48,13 +48,6 @@
 		if ("both")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/clothing/mask/breath(src)
-
-		if ("nothing")
-			EMPTY_BLOCK_GUARD
-
-		// teehee
-		if ("delete")
-			qdel(src)
 
 /*
  * Fire Closet

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -33,21 +33,32 @@
 		if ("small")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/tank/internals/emergency_oxygen(src)
+			new /obj/item/tank/internals/plasmaman/belt(src)
+			new /obj/item/tank/internals/plasmaman/belt(src)
 			new /obj/item/clothing/mask/breath(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/extinguisher_refill(src)
+			new /obj/item/extinguisher_refill(src)
 
 		if ("aid")
 			new /obj/item/tank/internals/emergency_oxygen(src)
+			new /obj/item/tank/internals/plasmaman/belt(src)
 			new /obj/item/storage/firstaid/o2(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/extinguisher_refill(src)
 
 		if ("tank")
 			new /obj/item/tank/internals/oxygen(src)
+			new /obj/item/tank/internals/plasmaman(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/extinguisher_refill(src)
 
 		if ("both")
 			new /obj/item/tank/internals/emergency_oxygen(src)
+			new /obj/item/tank/internals/plasmaman/belt(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/storage/firstaid/o2(src)
+			new /obj/item/extinguisher_refill(src)
 
 /*
  * Fire Closet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

my le oxygen locker with le emergency equipment le doesn't fucking exist???

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: oxygen lockers no longer have a chance to contain NOTHING or vanish leaving behind nothing but a red toolbox
add: oxygen lockers now have phorid accessories! Enjoy having more than one tank!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
