### PR TITLE
Makes Hexacrete have a sane recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -602,7 +602,7 @@
 
 /datum/chemical_reaction/hexement
 	results = list(/datum/reagent/cement/hexement = 1)
-	required_reagents = list(/datum/reagent/cement = 6, /datum/reagent/phenol = 1)
+	required_reagents = list(/datum/reagent/cement = 6, /datum/reagent/stable_plasma = 1)
 	required_temp = 400
 	mix_message = "The mixture rapidly condenses and darkens in color..."
 


### PR DESCRIPTION

## About The Pull Request

Replaces Phenol in Hexacrete's recipe with Stable Plasma. 

## Why It's Good For The Game

This makes Hexacrete actually worth making, as Phenol is a pain to mix in bulk to make walls and flooring. Concrete already is used pretty rarely, and you never see Hexacrete because of the Phenol requirements.

## Changelog

:cl:
balance: Hexacrete now requires Stable Plasma to create.
/:cl:

