### PR TITLE
Woodsman Nerf

### DIFF
--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -88,12 +88,6 @@
 	contains = list(/obj/item/ammo_box/magazine/m23/empty)
 	cost = 200
 
-/datum/supply_pack/magazine/woodsman_mag_extended
-	name = "Woodsman Magazine Crate"
-	desc = "Contains an 8x50mmR magazine for the Woodsman Rifle, with a capacity of ten rounds."
-	contains = list(/obj/item/ammo_box/magazine/m23/extended/empty)
-	cost = 500
-
 /datum/supply_pack/magazine/m20_auto_elite
 	name = "Auto Elite Magazine Crate"
 	desc = "Contains a .44 Roumain magazine for the Auto Elite pistol, with a capacity of nine rounds."

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -268,7 +268,7 @@ EMPTY_GUN_HELPER(automatic/m12_sporter/mod)
 	spread_unwielded = 20
 	recoil = 1.25
 	recoil_unwielded = 6
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.75 SECONDS
 	wield_delay = 1.15 SECONDS //a little longer and less wieldy than other DMRs
 	zoom_out_amt = 2
 
@@ -305,16 +305,6 @@ NO_MAG_GUN_HELPER(automatic/marksman/woodsman)
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/m23/empty
-	start_empty = TRUE
-
-/obj/item/ammo_box/magazine/m23/extended
-	name = "Model 23 Extended Magazine (8x50mmR)"
-	desc = "A 10-round magazine for the Model 23 \"Woodsman\". These rounds do high damage, with excellent armor penetration."
-	icon_state = "woodsman_extended-1"
-	base_icon_state = "woodsman_extended"
-	max_ammo = 10
-
-/obj/item/ammo_box/magazine/m23/extended/empty
 	start_empty = TRUE
 
 /* super soaker */


### PR DESCRIPTION
## About The Pull Request

Removes the Extended Mag and decreases the fire_delay back to 0.75 seconds

## Why It's Good For The Game

This thing was already good and was a slept-on Monster for clearing ruins. Ten round mags, a scope, good AP and fire_delay only 0.1 slower than burst-fire machine pistols.

It's good enough with it's original fire delay and easily-swappable mags and scope. Didn't need more.

## Changelog

:cl:
del: Removed Woodsman extended mag
balance: Woodsman fire delay nerfed to old levels
/:cl: