### PR TITLE
Buffs 44 Damage and reduces recoil on the M20 Auto Elite

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -93,8 +93,8 @@ NO_MAG_GUN_HELPER(automatic/pistol/m17)
 	eject_sound = 'sound/weapons/gun/pistol/deagle_unload.ogg'
 	eject_empty_sound = 'sound/weapons/gun/pistol/deagle_unload.ogg'
 
-	recoil_unwielded = 4
-	recoil = 1
+	recoil_unwielded = 3
+	recoil = 0.5
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -172,13 +172,13 @@
 
 /obj/projectile/bullet/a44roum
 	name = ".44 roumain bullet"
-	damage =  25
+	damage =  30
 	speed = BULLET_SPEED_REVOLVER
 	bullet_identifier = "small bullet"
 
 /obj/projectile/bullet/a44roum/rubber
 	name = ".44 roumain rubber bullet"
-	damage =  7
+	damage =  10
 	stamina = 40
 	armour_penetration = -10
 	speed_mod = BULLET_SPEED_RUBBER_MOD
@@ -186,7 +186,7 @@
 
 /obj/projectile/bullet/a44roum/hp
 	name = ".44 roumain hollow point bullet"
-	damage =  40
+	damage =  45
 	armour_penetration = -10
 	ricochet_chance = 0
 	speed_mod = BULLET_SPEED_HP_MOD


### PR DESCRIPTION
## About The Pull Request

25 to 30 and 1 to 0.5

## Why It's Good For The Game

.44's advantage it would've gotten with AP was pretty much entirely lost by low volume of fire and damage compared to similar cartridges. This has resulted in .44 guns being fairly uninteresting outside of one revolver and rarely used (notably most problematic with the M20 Auto Elite)

Reduces the recoil on the Auto Elite as well, as between that and .44 no Vanguard I've seen has ever used it (and I only point them out because I have never once seen the civilian version Ever that was not wielded myself the very first round it was tested because it was given to me for free)

Testing Data:
(Original)
- Average Seven to Crit on Ramzi with Basic Vest (accounting for unarmoured limbs)
- Average Seven to Crit on Rusted Red
- Average Eleven to Crit on Rusted Elite
- Ten to Crit on Bulletproof (accounting for unarmoured limbs)

(New)
- Average Six to Crit on Ramzi with Basic Vest (accounting for unarmoured limbs)
- Average Six to Crit on Rusted Red
- Average Nine to Crit on Rusted Elite
- Average Eight to Crit on Bulletproof (accounting for unarmoured limbs)

## Changelog

:cl:
balance: Increased .44's damage and reduced recoil on the M20 Auto Elite
/:cl: