### PR TITLE
Military & Sec Belt subtypes can now hold One Medium-Sized Pistol

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -609,7 +609,7 @@
 				to_chat(M, span_warning("[host] has too much junk in it, make some space!"))
 			return FALSE //Storage item is full
 	if(storage_flags & STORAGE_LIMIT_MAX_W_CLASS)
-		if(I.w_class > max_w_class)
+		if(I.w_class > max_w_class && !is_type_in_typecache(I, exception_hold))
 			if(!stop_messages)
 				to_chat(M, span_warning("[I] is much too long for [host]!"))
 			return FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -597,7 +597,7 @@
 			if(amount >= can_hold_max_of_items[I.type])
 				if(!stop_messages)
 					to_chat(M, span_warning("[host] cannot hold another [I]!"))
-					return FALSE
+				return FALSE
 	if(is_type_in_typecache(I, cant_hold) || HAS_TRAIT(I, TRAIT_NO_STORAGE_INSERT) || (can_hold_trait && !HAS_TRAIT(I, can_hold_trait))) //Items which this container can't hold.
 		if(!stop_messages)
 			to_chat(M, span_warning("[host] cannot hold [I]!"))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -323,7 +323,15 @@
 		/obj/item/stock_parts/cell/gun,
 		/obj/item/ammo_box/magazine/ammo_stack, //handfuls of bullets
 		/obj/item/bodycamera,
+		/obj/item/gun/ballistic/automatic/pistol,
+		/obj/item/gun/ballistic/revolver,
+		/obj/item/gun/energy/laser,
+		/obj/item/gun/energy/disabler,
+		/obj/item/gun/energy/kalix/pistol,
 		))
+	STR.can_hold_max_of_items = typecacheof(list(
+		/obj/item/gun = 1,
+	))
 
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -473,7 +481,6 @@
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/gun/energy/laser,
 		/obj/item/gun/energy/disabler,
-		/obj/item/gun/energy/e_gun,
 		/obj/item/gun/energy/kalix/pistol,
 		))
 	STR.exception_hold = exception_cache

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -468,7 +468,19 @@
 /obj/item/storage/belt/military/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	var/static/list/exception_cache = typecacheof(list(
+		/obj/item/gun/ballistic/automatic/pistol,
+		/obj/item/gun/ballistic/revolver,
+		/obj/item/gun/energy/laser,
+		/obj/item/gun/energy/disabler,
+		/obj/item/gun/energy/e_gun,
+		/obj/item/gun/energy/kalix/pistol,
+		))
+	STR.exception_hold = exception_cache
 	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.can_hold_max_of_items = typecacheof(list(
+		/obj/item/gun = 1,
+	))
 
 /obj/item/storage/belt/military/cobra/PopulateContents()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

thanks to erika and zym for helping me out here

All belt/military and belt/security can now fit one medium-sized pistol (along with a few energy weapons of similar size)

fixes a few storage things to make it possible

## Why It's Good For The Game

The sprites visually have what I think is a holster and I think a belt holster is probably good

## Changelog

:cl:
balance: Military and Security belts can now fit one Medium-Sized Pistol (And Other Small Energy Weapons)
fix: Fixed storage's exception_hold so some items can actually be exempted from a size restriction
/:cl: