### PR TITLE
add slowdown to crates + make duffelbags more available

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -17,7 +17,8 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
-	drag_slowdown = 0
+	//half as much as a closet
+	drag_slowdown = 0.75
 	pass_flags_self = LETPASSCLICKS
 	var/obj/item/paper/manifest/manifest
 	var/shelve = FALSE

--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -1,5 +1,7 @@
 /datum/supply_pack/civilian
 	category = "Civilian & Decoration"
+	crate_name = "civilian supply crate"
+	crate_type = /obj/structure/closet/crate/wooden
 
 /*
 		Janitorial
@@ -330,7 +332,27 @@
 					/obj/item/clothing/shoes/sneakers/black,
 					/obj/item/clothing/shoes/sneakers/black)
 	crate_name = "spare jumpsuits crate"
-	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/civilian/satchel
+	name = "Spare Satchel Crate"
+	desc = "Contains a spare backpack, for the intrepid traveller who managed to lose the last one."
+	cost = 50
+	contains = list(/obj/item/storage/backpack/satchel)
+	crate_name = "spare satchel crate"
+
+/datum/supply_pack/civilian/backpack
+	name = "Spare Backpack Crate"
+	desc = "Contains a spare backpack, for the starfarers who just can't keep track of where they took it off."
+	cost = 50
+	contains = list(/obj/item/storage/backpack)
+	crate_name = "spare backpack crate"
+
+/datum/supply_pack/civilian/duffels
+	name = "Spare Duffelbag Crate"
+	desc = "Contains a spare duffelbag. Ideal for carrying items across long distances."
+	cost = 50
+	contains = list(/obj/item/storage/backpack/duffelbag)
+	crate_name = "spare duffelbag crate"
 
 /datum/supply_pack/civilian/broadcast_camera
 	name = "Broadcast Camera Crate"


### PR DESCRIPTION
## About The Pull Request
as title

## Why It's Good For The Game

Duffelbags are supposed to be the quick to move storage solution, and I think this would encourage them being used in that position.

Also you should be able to buy satchels and such.
## Changelog

:cl:
add: you can now purchase duffelbags at da outpost
balance: pulling a crate now slows you down
/:cl: