### PR TITLE
Garden/Geyser Scanning

### DIFF
--- a/code/controllers/subsystem/missions.dm
+++ b/code/controllers/subsystem/missions.dm
@@ -60,12 +60,15 @@ SUBSYSTEM_DEF(missions)
 
 /datum/controller/subsystem/missions/proc/get_researcher_name()
 	var/group = pick(list(
-		"Cybersun Industries",
-		"CMM-GOLD",
-		"Nanotrasen Anomalous Studies Division",
+		"Cybersun Biodynamics",
+		"CLIP-GOLD Frontier Investigations Office",
+		"Nanotrasen Frontier Studies Division",
 		"The Naturalienwissenschaftlicher Studentenverbindungs-Verband",
-		"The Central Solarian Anomaly Research Agency",
-		"DeForest Medical R&D",
+		"The Central Solarian Frontier Research Agency",
+		"NGR Bureau of Expansion",
+		"A Gezenan newscaster",
+		"Tecetian researchers",
+		"The representative of a Rachnid guild",
 		"A strange sarathi on the outpost"
 	))
 	return group

--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -1,136 +1,51 @@
 /obj/item/survey_handheld
 	name = "Survey Handheld"
-	desc = "A small tool designed for quick and inefficient data collection about your local star sector."
+	desc = "A small tool designed for collecting and correlating information on planetary conditions."
 	icon = 'icons/obj/item/survey_handheld.dmi'
 	icon_state = "survey"
-	var/static/list/z_active = list()
-	var/static/list/z_history = list()
-	var/active = FALSE
-	var/survey_value = 300
-	var/survey_delay = 4 SECONDS
+	//all of these vars are assigned by the mission that creates us.
+	///how many scans does this handheld want?
+	var/scans_required
+	///how many scans does this handheld have
+	var/scan_tally = 0
+	///what the target of our scanning is.
+	var/atom/scan_target
+
+/obj/item/survey_handheld/examine(mob/user)
+	. = ..()
+	if(scans_required)
+		. += span_notice("The scanner reports [scan_tally] of [scans_required] scans have been completed.")
+
+/obj/item/survey_handheld/attack_obj(obj/O, mob/living/user)
+	. = ..()
+	if(istype(O, scan_target) && scan_tally < scans_required)
+		if(O?:scanned == TRUE)
+			to_chat(user, span_notice("[O] has already been scanned"))
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
+			return FALSE
+		user.visible_message(span_notice("[user] begins scanning the [O]."), span_notice("You begin scanning [O]."), span_notice("Analytic rustles quickly start and stop"))
+		if(do_after(user, 3 SECONDS, O, show_progress = TRUE))
+			if(increment_scan())
+				to_chat(user, span_notice("You add [O] to the scanner's databank"))
+				playsound(src, 'sound/machines/whirr_beep.ogg', 20)
+				O?:scanned = TRUE
+	if(istype(O, /obj/structure/geyser))
+		var/obj/structure/geyser/scan_target = O
+		to_chat(user, "[scan_target] is producing [scan_target.reagent_id.name]!")
+	return
+
+/obj/item/survey_handheld/proc/increment_scan()
+	scan_tally += 1
+	if(scan_tally == scans_required)
+		say("Sufficient samples gathered. Scanner ready for turn in!")
+	return TRUE
 
 /obj/item/survey_handheld/advanced
 	name = "Advanced Survey Handheld"
-	desc = "An improved version of its predecessor this tool collects large amounts of data."
+	desc = "An advanced survey scanner specialized in collecting large amounts of information on unique environments."
 	icon_state = "survey-adv"
-	survey_value = 450
-	survey_delay = 3 SECONDS
 
 /obj/item/survey_handheld/elite
 	name = "Experimental Survey Handheld"
-	desc = "An improvement on even the Advanced version; this handheld was designed to be extremely fast in collecting data."
+	desc = "An experimental survey scanner utilizing deep radar techniques to quickly ascertain information on its locale."
 	icon_state = "survey-elite"
-	survey_value = 650
-	survey_delay = 2 SECONDS
-
-/obj/item/survey_handheld/attack_self(mob/user)
-	if(active)
-		return
-
-	var/turf/src_turf = get_turf(src)
-
-	var/my_z = "[virtual_z()]"
-	if(z_active[my_z])
-		flick(icon_state + "-corrupted", src)
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
-		src_turf.visible_message(span_warning("Warning: interference detected in current sector"))
-		return
-
-	if(!z_history[my_z])
-		z_history[my_z] = 1
-
-	active = TRUE
-	z_active[my_z] = TRUE
-	while(user.get_active_held_item() == src)
-		to_chat(user, span_notice("You begin to scan your surroundings with [src]."))
-
-		var/penalty = 1 - (z_history[my_z] - 1) * 0.05 // You lose five percent of value and are five percent slower
-		if(!penalty || penalty < 0.20) // If you are below 20% value, do nothing and abort
-			flick(icon_state + "-corrupted", src)
-			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
-			src_turf.visible_message(span_warning("Warning: unable to locate valuable information in current sector."))
-			break
-
-		if(!do_after(user, survey_delay / penalty, src))
-			flick(icon_state + "-corrupted", src)
-			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
-			src_turf.visible_message(span_warning("Warning: results corrupted. Please try again."))
-			break
-
-		flick(icon_state + "print", src)
-		playsound(src, 'sound/machines/whirr_beep.ogg', 20)
-		src_turf.visible_message(span_notice("Data recorded and enscribed to research packet."))
-		z_history[my_z]++
-
-		var/obj/item/result = new /obj/item/research_notes(null, survey_value * penalty, pick(list("astronomy", "physics", "planets", "space")))
-
-		var/obj/item/research_notes/notes = locate() in get_turf(user)
-		if(notes)
-			notes.merge(result)
-		else if(!user.put_in_hands(result) && istype(user.get_inactive_held_item(), /obj/item/research_notes))
-			var/obj/item/research_notes/research = user.get_inactive_held_item()
-			research.merge(result)
-			continue
-
-	active = FALSE
-	z_active[my_z] = FALSE
-
-/datum/design/survey_handheld
-	name = "Survey Handheld"
-	id = "survey-handheld"
-	build_type = AUTOLATHE
-	build_path = /obj/item/survey_handheld
-	materials = list(
-		/datum/material/iron = 2000,
-		/datum/material/glass = 1000,
-	)
-	category = list("initial", "Tools")
-
-/datum/design/survey_handheld_advanced
-	name = "Advanced Survey Handheld"
-	id = "survey-handheld-advanced"
-	build_type = PROTOLATHE
-	build_path = /obj/item/survey_handheld/advanced
-	materials = list(
-		/datum/material/iron = 3000,
-		/datum/material/glass = 2000,
-		/datum/material/gold = 2000,
-	)
-	category = list("Tool Designs")
-
-/datum/design/survey_handheld_elite
-	name = "Elite Survey Handheld"
-	id = "survey-handheld-elite"
-	build_type = PROTOLATHE
-	build_path = /obj/item/survey_handheld/elite
-	materials = list(
-		/datum/material/iron = 5000,
-		/datum/material/silver = 5000,
-		/datum/material/gold = 3000,
-		/datum/material/uranium = 3000,
-		/datum/material/diamond = 2000,
-	)
-	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
-
-/datum/design/survey_handheld_exp
-	name = "Experimental Survey Handheld"
-	id = "survey-handheld-exp"
-	build_type = PROTOLATHE
-	build_path = /obj/item/survey_handheld/elite
-	materials = list(
-		/datum/material/iron = 5000,
-		/datum/material/silver = 5000,
-		/datum/material/gold = 3000,
-		/datum/material/uranium = 3000,
-		/datum/material/diamond = 3000,
-		/datum/material/bluespace = 3000,
-	)
-	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
-/obj/structure/anomaly
-	name = "Defaultic Bind"
-	desc = "The truly unexpected anomaly. Let a coder know if you see this!"
-	max_integrity = 300

--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -19,7 +19,7 @@
 /obj/item/survey_handheld/attack_obj(obj/O, mob/living/user)
 	. = ..()
 	if(istype(O, scan_target) && scan_tally < scans_required)
-		if(O?:scanned == TRUE)
+		if(O?:mission_scanned == TRUE)
 			to_chat(user, span_notice("[O] has already been scanned"))
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 20)
 			return FALSE

--- a/code/game/objects/items/survery_handheld.dm
+++ b/code/game/objects/items/survery_handheld.dm
@@ -28,7 +28,7 @@
 			if(increment_scan())
 				to_chat(user, span_notice("You add [O] to the scanner's databank"))
 				playsound(src, 'sound/machines/whirr_beep.ogg', 20)
-				O?:scanned = TRUE
+				O?:mission_scanned = TRUE
 	if(istype(O, /obj/structure/geyser))
 		var/obj/structure/geyser/scan_target = O
 		to_chat(user, "[scan_target] is producing [scan_target.reagent_id.name]!")

--- a/code/game/objects/structures/geyser.dm
+++ b/code/game/objects/structures/geyser.dm
@@ -9,10 +9,12 @@
 
 	var/erupting_state = null //set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
 	var/activated = FALSE //whether we are active and generating chems
-	var/reagent_id = /datum/reagent/fuel/oil
+	var/datum/reagent/reagent_id = /datum/reagent/fuel/oil
 	var/potency = 2 //how much reagents we add every process (2 seconds)
 	var/max_volume = 500
 	var/start_volume = 50
+	///used for missions
+	var/scanned = FALSE
 
 /obj/structure/geyser/proc/start_chemming()
 	activated = TRUE
@@ -41,7 +43,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/uranium/radium = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()
@@ -57,7 +59,7 @@
 
 	slot_flags = ITEM_SLOT_MASK
 
-	custom_materials = list(/datum/material/iron = 150) // WS Edit - Item Materials
+	custom_materials = list(/datum/material/iron = 150)
 
 	var/plunge_mod = 1 //time*plunge_mod = total time we take to plunge an object
 

--- a/code/game/objects/structures/geyser.dm
+++ b/code/game/objects/structures/geyser.dm
@@ -14,7 +14,7 @@
 	var/max_volume = 500
 	var/start_volume = 50
 	///used for missions
-	var/scanned = FALSE
+	var/mission_scanned = FALSE
 
 /obj/structure/geyser/proc/start_chemming()
 	activated = TRUE

--- a/code/game/objects/structures/geyser.dm
+++ b/code/game/objects/structures/geyser.dm
@@ -43,7 +43,14 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/uranium/radium = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(
+		/datum/reagent/clf3 = 10,
+		/datum/reagent/uranium/radium = 10,
+		/datum/reagent/ammonia = 6,
+		/datum/reagent/saltpetre = 6,
+		/datum/reagent/medicine/omnizine/protozine = 3,
+		/datum/reagent/wittel = 1
+	)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -486,6 +486,8 @@
 	light_power = 0.5
 	light_range = 1
 	needs_sharp_harvest = FALSE
+	///Used for garden scan missions
+	var/scanned = FALSE
 
 /obj/structure/flora/ash/garden/arid
 	name = "sandy garden"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -487,7 +487,7 @@
 	light_range = 1
 	needs_sharp_harvest = FALSE
 	///Used for garden scan missions
-	var/scanned = FALSE
+	var/mission_scanned = FALSE
 
 /obj/structure/flora/ash/garden/arid
 	name = "sandy garden"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -490,10 +490,10 @@
 	var/mission_scanned = FALSE
 
 /obj/structure/flora/ash/garden/arid
-	name = "sandy garden"
+	name = "rock garden"
 	desc = "Beneath a bluff of soft silicate, a sheltered grove slumbers."
 	icon_state = "gardenarid"
-	harvested_name = "sandy garden"
+	harvested_name = "rock garden"
 	harvested_desc = "Beneath a bluff of soft silicate, a sheltered grove slumbered. Some desert wanderer seems to have picked it clean."
 	harvest = /obj/effect/spawner/random/food_or_drink/garden/arid
 	harvest_amount_high = 1

--- a/code/modules/missions/outpost/garden_scan.dm
+++ b/code/modules/missions/outpost/garden_scan.dm
@@ -99,7 +99,7 @@
 	scanner_type = /obj/item/survey_handheld/advanced
 	num_wanted = 6
 	danger_bonus = 75
-	garden_string = "sandy gardens"
+	garden_string = "rocky gardens"
 	planet_hint = "Rock"
 
 //Survey: we like chemicals

--- a/code/modules/missions/outpost/garden_scan.dm
+++ b/code/modules/missions/outpost/garden_scan.dm
@@ -105,7 +105,7 @@
 //Survey: we like chemicals
 
 /datum/mission/outpost/survey/geyser
-	name = ""
+	name = "scan chemical geyser"
 	desc = ""
 	value = 2500
 	objective_type = /obj/structure/geyser
@@ -116,8 +116,6 @@
 	num_wanted = 1
 
 /datum/mission/outpost/survey/geyser/New(...)
-	if(!name)
-		name = "scan chemical geyser"
 	if(!desc)
 		desc = "[SSmissions.get_researcher_name()] has requested that we locate and scan planetary geysers for potential investment into pharmacuticals within the system. Utilze the provided scanner to scan and record data on [num_wanted] geyser."
 	. = ..()

--- a/code/modules/missions/outpost/garden_scan.dm
+++ b/code/modules/missions/outpost/garden_scan.dm
@@ -99,7 +99,7 @@
 	scanner_type = /obj/item/survey_handheld/advanced
 	num_wanted = 6
 	danger_bonus = 75
-	garden_string = "rocky gardens"
+	garden_string = "rock gardens"
 	planet_hint = "Rock"
 
 //Survey: we like chemicals

--- a/code/modules/missions/outpost/garden_scan.dm
+++ b/code/modules/missions/outpost/garden_scan.dm
@@ -1,0 +1,122 @@
+/datum/mission/outpost/survey
+	//incoming pr: scan 12 rocks
+	desc = "Survey some features"
+
+	weight = 0
+
+	/// The type of scanner to be spawned when the mission is accepted.
+	var/obj/item/survey_handheld/scanner_type
+	/// Instance of the scanner, spawned after the mission is accepted.
+	var/obj/item/survey_handheld/scanner
+
+	var/atom/movable/objective_type
+	var/num_wanted = 1
+	var/allow_subtypes = FALSE
+	var/count_stacks = TRUE
+
+/datum/mission/outpost/survey/accept(datum/overmap/ship/controlled/acceptor, turf/accept_loc)
+	. = ..()
+	scanner = spawn_bound(scanner_type, accept_loc, VARSET_CALLBACK(src, scanner, null))
+	scanner.name += " ([capitalize(objective_type.name)])"
+	scanner.scans_required = num_wanted
+	scanner.scan_target = objective_type
+
+/datum/mission/outpost/survey/Destroy()
+	scanner = null
+	return ..()
+
+/datum/mission/outpost/survey/can_complete()
+	. = ..()
+	if(!.)
+		return
+	var/obj/docking_port/mobile/cont_port = SSshuttle.get_containing_shuttle(scanner)
+	return . && (current_num() >= num_wanted) && (cont_port?.current_ship == servant)
+
+/datum/mission/outpost/survey/get_progress_string()
+	return "[current_num()]/[num_wanted]"
+
+/datum/mission/outpost/survey/turn_in()
+	recall_bound(scanner)
+	return ..()
+
+/datum/mission/outpost/survey/give_up()
+	recall_bound(scanner)
+	return ..()
+
+/datum/mission/outpost/survey/proc/current_num()
+	if(!scanner)
+		return 0
+	return scanner.scan_tally
+
+
+//Survey: The heavens
+
+/datum/mission/outpost/survey/garden
+	name = ""
+	desc = ""
+	value = 1500
+	weight = 10
+	duration = 60 MINUTES
+	scanner_type = /obj/item/survey_handheld
+	objective_type = /obj/structure/flora/ash/garden
+	num_wanted = 12
+	var/danger_bonus = 50
+	var/garden_string = "lush gardens"
+	var/planet_hint ="Beach and Jungle"
+
+/datum/mission/outpost/survey/garden/New(...)
+	if(!name)
+		name = "Survey [garden_string]"
+	if(!desc)
+		desc = "[SSmissions.get_researcher_name()] has requested that we conduct a survey on the worlds in [GLOB.station_name] and determine their suitablity for future colonization. \
+		The first step of this process is analysis of local flora. Utilize the provided scanner to scan [num_wanted] botanical 'gardens' on nearby worlds. [capitalize(garden_string)] are usually found on [planet_hint]-class worlds."
+	num_wanted = rand(num_wanted-4,num_wanted+2)
+	value = rand(value*0.75, value*1.25) + (num_wanted*50)
+	. = ..()
+
+/datum/mission/outpost/survey/garden/waste
+	value = 3000
+	scanner_type = /obj/item/survey_handheld/advanced
+	objective_type = /obj/structure/flora/ash/garden/waste
+	weight = 4
+	num_wanted = 6
+	danger_bonus = 100
+	garden_string = "sickly gardens"
+	planet_hint = "Waste"
+
+/datum/mission/outpost/survey/garden/ice
+	value = 2000
+	objective_type = /obj/structure/flora/ash/garden/frigid
+	scanner_type = /obj/item/survey_handheld/advanced
+	num_wanted = 6
+	danger_bonus = 75
+	garden_string = "chilly gardens"
+	planet_hint = "Ice"
+
+/datum/mission/outpost/survey/garden/arid
+	value = 2000
+	objective_type = /obj/structure/flora/ash/garden/arid
+	scanner_type = /obj/item/survey_handheld/advanced
+	num_wanted = 6
+	danger_bonus = 75
+	garden_string = "sandy gardens"
+	planet_hint = "Rock"
+
+//Survey: we like chemicals
+
+/datum/mission/outpost/survey/geyser
+	name = ""
+	desc = ""
+	value = 2500
+	scanner_type = /obj/item/survey_handheld/elite
+	duration = 60 MINUTES
+	weight = 4
+
+	num_wanted = 1
+
+/datum/mission/outpost/survey/geyser/New(...)
+	if(!name)
+		name = "scan chemical geyser"
+	if(!desc)
+		desc = "[SSmissions.get_researcher_name()] has requested that we locate and scan planetary geysers for potential investment into pharmacuticals within the system. Utilze the provided scanner to scan and record data on [num_wanted] geyser."
+	. = ..()

--- a/code/modules/missions/outpost/garden_scan.dm
+++ b/code/modules/missions/outpost/garden_scan.dm
@@ -108,6 +108,7 @@
 	name = ""
 	desc = ""
 	value = 2500
+	objective_type = /obj/structure/geyser
 	scanner_type = /obj/item/survey_handheld/elite
 	duration = 60 MINUTES
 	weight = 4

--- a/code/modules/missions/outpost/research_mission.dm
+++ b/code/modules/missions/outpost/research_mission.dm
@@ -66,7 +66,7 @@
 
 /datum/mission/outpost/research/meteor
 	name = "Asteroid field research mission"
-	desc = " require data on the behavior of asteroid fields in the system for an ongoing study. \
+	desc = "requires data on the behavior of asteroid fields in the system for an ongoing study. \
 			Please anchor the attached sensor array to your ship and fly it through the fields. \
 			It must be powered to collect the data."
 	value = 1500
@@ -76,7 +76,7 @@
 
 /datum/mission/outpost/research/carp
 	name = "Carp migration research mission"
-	desc = " require data on the migration patterns of space carp for an ongoing study. \
+	desc = "requires data on the migration patterns of space carp for an ongoing study. \
 			Please anchor the attached sensor array to your ship and fly it through the fields. \
 			It must be powered to collect the data."
 	value = 88
@@ -87,7 +87,7 @@
 
 /datum/mission/outpost/research/dust
 	name = "dust research mission"
-	desc = " require data on the density of space dust for updated navcharts. \
+	desc = "requires data on the density of space dust for updated navcharts. \
 			Please anchor the attached sensor array to your ship and fly it through the fields. \
 			It must be powered to collect the data."
 	value = 800
@@ -97,7 +97,7 @@
 
 /datum/mission/outpost/research/radstorm
 	name = "Radiation storm field research mission"
-	desc = "We require data on the behavior of radiation storms in the system for an ongoing study. \
+	desc = "requires data on the behavior of radiation storms in the system for an ongoing study. \
 			Please anchor the attached sensor array to your ship and fly it through the fields. \
 			It must be powered to collect the data."
 	value = 1500
@@ -107,7 +107,7 @@
 
 /datum/mission/outpost/research/ion
 	name = "Ion storm research mission"
-	desc = "We require data on the behavior of electromagnetic storms in the system for an ongoing study. \
+	desc = "requires data on the behavior of electromagnetic storms in the system for an ongoing study. \
 			Please anchor the attached sensor array to your ship and fly it through the storms. \
 			It must be powered to collect the data."
 	value = 2500
@@ -117,7 +117,7 @@
 
 /datum/mission/outpost/research/flare
 	name = "Solar flare field research mission"
-	desc = "We require data on the behavior of solar flares in the system for an ongoing study. \
+	desc = "requires data on the behavior of solar flares in the system for an ongoing study. \
 			Please anchor the attached sensor array to your ship and fly it through the fields. \
 			It must be powered to collect the data."
 	value = 2000

--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -257,7 +257,7 @@
 		if(10, 11)
 			. += "[pick(GLOB.planet_prefixes)] [pick(GLOB.planet_names)]"
 		if(12)
-			. += "[pick(GLOB.adjectives)] [pick(GLOB.planet_names)]"
+			. += "[capitalize(pick(GLOB.adjectives))] [pick(GLOB.planet_names)]"
 
 /**
  * Load a level for a ship that's visiting the level.

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -168,7 +168,6 @@
 	description = "Big Data, in space!"
 	prereq_ids = list("base")
 	design_ids = list(
-		"survey-handheld-advanced",
 		"design_disk_adv"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
@@ -414,7 +413,6 @@
 		"mining",
 		"rdcamera",
 		"seccamera",
-		"survey-handheld-elite",
 		"design_disk_super",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
@@ -445,7 +443,7 @@
 	display_name = "Computerized Recordkeeping"
 	description = "Organized record databases and how they're used."
 	prereq_ids = list("comptech")
-	design_ids = list("secdata", "med_data", "prisonmanage", "vendor", "automated_announcement", "survey-handheld-exp", "design_disk_elite")
+	design_ids = list("secdata", "med_data", "prisonmanage", "vendor", "automated_announcement", "design_disk_elite")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 2000
 

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -2601,6 +2601,7 @@
 #include "code\modules\missions\outpost\_outpost.dm"
 #include "code\modules\missions\outpost\acquire_mission.dm"
 #include "code\modules\missions\outpost\drill_mission.dm"
+#include "code\modules\missions\outpost\garden_scan.dm"
 #include "code\modules\missions\outpost\research_mission.dm"
 #include "code\modules\mob\death.dm"
 #include "code\modules\mob\emote.dm"


### PR DESCRIPTION
## About The Pull Request

Refactors survey scanners into an object for scanning gardens and geysers and making money off of it.
Adds missions to do that.

## Why It's Good For The Game

It's a way to make money that isn't fighting. Or fishing. Or f

## Changelog

:cl:
add: Garden scanning missions: Take a survey scanner from the outpost and go scan the everliving shit out of some gardens.
Add Geyser scanning missions. See above
balance: hollow water no longer spawns in geysers
/:cl:
