### PR TITLE
Makes Lipstick Colours More Faded + Transparent

### DIFF
--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -11,7 +11,7 @@
 
 /obj/item/lipstick/purple
 	name = "purple lipstick"
-	colour = "#9c6db5CC"
+	colour = "#5f387099"
 
 /obj/item/lipstick/jade
 	//It's still called Jade, but theres no HTML color for jade, so we use lime.

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -5,22 +5,22 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "lipstick"
 	w_class = WEIGHT_CLASS_TINY
-	var/colour = "#520401"
+	var/colour = "#a36262CC"
 	var/open = FALSE
 	var/lipstick_trait
 
 /obj/item/lipstick/purple
 	name = "purple lipstick"
-	colour = "#420b63"
+	colour = "#9c6db5CC"
 
 /obj/item/lipstick/jade
 	//It's still called Jade, but theres no HTML color for jade, so we use lime.
 	name = "jade lipstick"
-	colour = "#00a86b"
+	colour = "#44755dE6"
 
 /obj/item/lipstick/black
 	name = "black lipstick"
-	colour = "#242424"
+	colour = "#3F3B519C"
 
 /obj/item/lipstick/random
 	name = "lipstick"

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -5,22 +5,22 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "lipstick"
 	w_class = WEIGHT_CLASS_TINY
-	var/colour = "red"
+	var/colour = "#520401"
 	var/open = FALSE
 	var/lipstick_trait
 
 /obj/item/lipstick/purple
 	name = "purple lipstick"
-	colour = "purple"
+	colour = "#420b63"
 
 /obj/item/lipstick/jade
 	//It's still called Jade, but theres no HTML color for jade, so we use lime.
 	name = "jade lipstick"
-	colour = "lime"
+	colour = "#00a86b"
 
 /obj/item/lipstick/black
 	name = "black lipstick"
-	colour = "black"
+	colour = "#242424"
 
 /obj/item/lipstick/random
 	name = "lipstick"


### PR DESCRIPTION
## About The Pull Request

Makes lipstick less vibrant so it can make somewhat of an attempt to look good (with one pixel lol)

red - black - jade - purple in order
<img width="193" height="34" alt="image" src="https://github.com/user-attachments/assets/196494c5-1ad1-4058-b040-0d865d9475e1" />
<img width="52" height="40" alt="image" src="https://github.com/user-attachments/assets/660de899-3864-4aa4-8a10-4983030ad8a8" />
<img width="37" height="34" alt="image" src="https://github.com/user-attachments/assets/e9e268dc-1e2a-43c4-905f-e355096614a8" />

Still trying to get the colours Juuuuust right so if you got suggestions I'll look at em

## Why It's Good For The Game

The vibrant ones just Did Not look good especially on the sides

## Changelog

:cl:
add: Made lipstick colours softer
/:cl: