### PR TITLE
Onehalf Tweaks

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
@@ -120,6 +120,11 @@
 	dir = 8
 	},
 /obj/item/clothing/neck/stethoscope,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white/plasma,
 /area/ruin/space/has_grav/refuelingpost/infirmary)
 "bh" = (
@@ -742,6 +747,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "0";
+	pixel_x = -16;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ruin/space/has_grav/refuelingpost/solarstorage)
 "im" = (
@@ -1125,6 +1135,11 @@
 "lK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "&";
+	pixel_x = -10;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ruin/space/has_grav/refuelingpost/solarstorage)
@@ -1742,6 +1757,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "+";
+	pixel_x = -12;
+	pixel_y = -11
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ruin/space/has_grav/refuelingpost/solarstorage)
@@ -2489,18 +2509,13 @@
 	},
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "credit";
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "credit";
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "credit";
 	pixel_x = -9;
 	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "3";
+	pixel_x = 9;
+	pixel_y = 4
 	},
 /obj/item/storage/backpack/satchel/flat/onehalftwo,
 /turf/open/floor/plasteel/patterned,
@@ -5810,7 +5825,7 @@ At
 XU
 At
 kD
-kD
+sO
 we
 Lg
 FG
@@ -5852,7 +5867,7 @@ At
 At
 At
 kD
-kD
+sO
 we
 NH
 jv

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -221,7 +221,7 @@
 #define ATMOS_TANK_AIRMIX "o2=2644;n2=10580;TEMP=293.15"
 #define ATMOS_TANK_FUEL "o2=33000;plasma=66000;TEMP=293.15"
 #define ATMOS_TANK_HYDROGEN_FUEL "o2=33000;h2=66000;TEMP=293.15"
-
+#define ATMOS_TANK_PLASMAHALF "plasma=6000;TEMP=293.15"
 
 //PLANETARY
 /// what pressure you have to be under to increase the effect of equipment meant for lavaland

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -412,7 +412,7 @@
 	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/carpet/blue/plasma
-	initial_gas_mix = ATMOS_TANK_PLASMA
+	initial_gas_mix = ATMOS_TANK_PLASMAHALF
 
 /turf/open/floor/carpet/narsie_act(force, ignore_mobs, probability = 20)
 	. = (force || prob(probability))

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -46,7 +46,7 @@
 /turf/open/floor/plasteel/white/telecomms
 	initial_gas_mix = TCOMMS_ATMOS
 /turf/open/floor/plasteel/white/plasma
-	initial_gas_mix = ATMOS_TANK_PLASMA
+	initial_gas_mix = ATMOS_TANK_PLASMAHALF
 
 /turf/open/floor/plasteel/mono
 	icon_state = "monotile_gray"
@@ -59,9 +59,9 @@
 	base_icon_state = "monotile_light"
 
 /turf/open/floor/plasteel/mono/white/plasma
-	initial_gas_mix = ATMOS_TANK_PLASMA
+	initial_gas_mix = ATMOS_TANK_PLASMAHALF
 /turf/open/floor/plasteel/mono/dark/plasma
-	initial_gas_mix = ATMOS_TANK_PLASMA
+	initial_gas_mix = ATMOS_TANK_PLASMAHALF
 /turf/open/floor/plasteel/mono/white/airless
 	initial_gas_mix = AIRLESS_ATMOS
 /turf/open/floor/plasteel/mono/dark/airless


### PR DESCRIPTION
## About The Pull Request

- Makes the filled rooms fill naturally using a normal gas pump instead of a volume
- Reduced level of plasma on already existing floors
- Added some more scribbled in crayon to the engineering room
- Removed two catwalks that annoyed me
- Added in some O- blood and an IV drip to medbay

## Why It's Good For The Game

Some stuff I forgot and too much plasma

## Changelog

:cl:
balance: Decreased amount of plasma in flooded rooms in Onehalf and added some misc tweaks like blood packs
/:cl: