### PR TITLE
Corrects Unsorted Cargo in cargo console

### DIFF
--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -156,7 +156,7 @@
 					/obj/item/coffee_cartridge)
 	crate_name = "Basic Coffee Supply Crate"
 
-/datum/supply_pack/service/coffee_cartridge
+/datum/supply_pack/civilian/coffee_cartridge
 	name = "Solar's Best Coffee Cartridge Resupply"
 	desc = "Contains five coffee cartridges for your coffee machine, imported from Sol."
 	cost = 750
@@ -167,7 +167,7 @@
 					/obj/item/coffee_cartridge)
 	crate_name = "Coffee Cartridge Supply Crate"
 
-/datum/supply_pack/service/coffee_cartridge_fancy
+/datum/supply_pack/civilian/coffee_cartridge_fancy
 	name = "Premium Coffee Cartridge Resupply"
 	desc = "Contains an assortment of five high-quality coffee cartridges."
 	cost = 1250
@@ -178,7 +178,7 @@
 					/obj/item/coffee_cartridge/fancy)
 	crate_name = "Premium Coffee Supply Crate"
 
-/datum/supply_pack/service/coffeekit
+/datum/supply_pack/civilian/coffeekit
 	name = "Coffee Shop Starter Crate"
 	desc = "All the basic equipment needed for enterprising coffee-selling spacefarers. Coffeemaker not included."
 	cost = 1250
@@ -193,7 +193,7 @@
 					/obj/item/reagent_containers/glass/bottle/syrup_bottle/caramel)
 	crate_name = "coffee equpment crate"
 
-/datum/supply_pack/service/coffeemaker
+/datum/supply_pack/civilian/coffeemaker
 	name = "Coffeemaker Crate"
 	desc = "Contains one pre-assembled Attention model coffeemaker."
 	cost = 1000
@@ -201,7 +201,7 @@
 	crate_name = "coffeemaker crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/service/coffeemaker_premium
+/datum/supply_pack/civilian/coffeemaker_premium
 	name = "Premium Coffeemaker Crate"
 	desc = "Contains one pre-assembled professional-grade Sirere model coffeemaker."
 	cost = 1500

--- a/code/modules/cargo/packs/machinery.dm
+++ b/code/modules/cargo/packs/machinery.dm
@@ -421,14 +421,14 @@
 	crate_name = "supermatter shard crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
-/datum/supply_pack/machine/smartfridge_board
+/datum/supply_pack/machinery/smartfridge_board
 	name = "Smart Fridge Board"
 	desc = "A spacious alternative to the run-of-the-mill fridges that most vessels come pre-equipped with."
 	cost = 500
 	contains = list(/obj/item/circuitboard/machine/smartfridge)
 	crate_name = "smart fridge crate"
 
-/datum/supply_pack/machine/grinder_board
+/datum/supply_pack/machinery/grinder_board
 	name = "All-In-One Grinder Board"
 	desc = "Now YOU can find out: Will! It! Blend?!"
 	cost = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Corrects PR #4451 by moving the coffee supplies out of the non-defined `/datum/supply_pack/service` path. Items are now properly under the `/datum/supply_pack/civilian`

Corrects #4911 by moving the machines added out of the non-defined `/datum/supply_pack/machine` path. Items are now properly under the `/datum/supply_pack/machinery` path

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<details>
  <summary>Before and After</summary>
<img width="600" height="700" alt="pZeQDk47Id" src="https://github.com/user-attachments/assets/58ea02b0-68e0-4b6c-b704-b8159a032daa" />

-----------------

<img width="600" height="700" alt="yqdIxiP7Ql" src="https://github.com/user-attachments/assets/4494513e-e421-4715-a54b-88d021639d58" />
</details>


## Why It's Good For The Game

Removes the stray items that were inside the "unsorted" tab. So they are now properly being placed in their respective categories.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Coffee Supplies have had their UPC codes changed to become Civilian Products.
fix: Smart Fridge and Grinder boards have had their UPC codes changed to Machinery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
