### PR TITLE
Ballistic Shield Balancing

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -9,8 +9,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	force = 10
 	item_flags = SLOWS_WHILE_IN_HAND
-	slowdown = 0.5
-	drag_slowdown = 0.5
+	slowdown = 1
+	drag_slowdown = 1
 	block_chance = 50
 	throwforce = 5
 	throw_speed = 2
@@ -79,8 +79,8 @@
 	custom_materials = list(/datum/material/iron=8500)
 
 	force = 15
-	max_integrity = 900
-	block_chance = 70
+	max_integrity = 600
+	block_chance = 60
 	integrity_failure = 0.1
 	material_flags = MATERIAL_NO_EFFECTS
 
@@ -90,19 +90,21 @@
 			user.visible_message(span_warning("[user] bashes [src] with [W]!"))
 			playsound(src, shield_bash_sound, 50, TRUE)
 			COOLDOWN_START(src, baton_bash, BATON_BASH_COOLDOWN)
-	else if(istype(W, /obj/item/stack/sheet/metal))
+	else if(istype(W, /obj/item/stack/sheet/plasteel))
 		if (obj_integrity >= max_integrity)
 			to_chat(user, span_warning("[src] is already in perfect condition."))
-		else
-			var/obj/item/stack/sheet/metal/T = W
-			T.use(1)
+		while(obj_integrity < max_integrity)
+			if(!do_after(user, 30	, target= src))
+				return
+			var/obj/item/stack/sheet/plasteel/T = W
+			T.use(10)
 			obj_integrity = max_integrity
 			to_chat(user, span_notice("You repair [src] with [T]."))
 			name = src::name
 			broken = FALSE
-			block_chance = 70
-			slowdown = 0.5
-			drag_slowdown = 0.5
+			block_chance = 60
+			slowdown = 1
+			drag_slowdown = 1
 
 /obj/item/shield/riot/spike
 	name = "spike shield"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -89,7 +89,7 @@
 		if (obj_integrity >= max_integrity)
 			to_chat(user, span_warning("[src] is already in perfect condition."))
 		while(obj_integrity < max_integrity)
-			if(!do_after(user, 30	, target= src))
+			if(!do_after(user, 30, target= src))
 				return
 			var/obj/item/stack/sheet/plasteel/T = W
 			T.use(10)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -31,11 +31,6 @@
 	var/recoil_bonus = -2
 	var/broken = FALSE
 
-/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	. = ..()
-	if(.)
-		on_block(owner, hitby, attack_text, damage, attack_type)
-
 /obj/item/shield/proc/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
 	take_damage(damage)
 

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -9,8 +9,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	force = 10
 	item_flags = SLOWS_WHILE_IN_HAND
-	slowdown = 1
-	drag_slowdown = 1
+	slowdown = 1.25
+	drag_slowdown = 1.25
 	block_chance = 50
 	throwforce = 5
 	throw_speed = 2
@@ -98,8 +98,8 @@
 			name = src::name
 			broken = FALSE
 			block_chance = 60
-			slowdown = 1
-			drag_slowdown = 1
+			slowdown = 1.25
+			drag_slowdown = 1.25
 
 /obj/item/shield/riot/spike
 	name = "spike shield"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -69,7 +69,7 @@
 
 /obj/item/shield/riot
 	name = "ballistic shield"
-	desc = "A shield adept at blocking blunt objects and bullets from connecting with the torso of the shield wielder. Use metal to repair."
+	desc = "A shield adept at blocking blunt objects and bullets from connecting with the torso of the shield wielder. Use 10 plasteel to repair."
 	icon_state = "ballistic"
 	custom_materials = list(/datum/material/iron=8500)
 
@@ -103,7 +103,7 @@
 
 /obj/item/shield/riot/spike
 	name = "spike shield"
-	desc = "A ballistic shield adept at blocking blunt objects and bullets, adorned with a vicious spike. Use metal to repair"
+	desc = "A ballistic shield adept at blocking blunt objects and bullets, adorned with a vicious spike. Use 10 plasteel to repair"
 	icon_state = "spike"
 	force = 24
 	attack_verb = list("stabbed", "gashed")
@@ -155,7 +155,7 @@
 
 /obj/item/shield/riot/flash
 	name = "strobe shield"
-	desc = "A shield with a built in, high intensity light capable of blinding and disorienting suspects. Takes regular handheld flashes as bulbs. Use metal to repair."
+	desc = "A shield with a built in, high intensity light capable of blinding and disorienting suspects. Takes regular handheld flashes as bulbs. Use 10 plasteel to repair."
 	icon_state = "flashshield"
 	item_state = "flashshield"
 	var/obj/item/assembly/flash/handheld/embedded_flash

--- a/html/changelogs/AutoChangeLog-pr-5063.yml
+++ b/html/changelogs/AutoChangeLog-pr-5063.yml
@@ -1,0 +1,5 @@
+author: Erikafox
+changes:
+  - {bugfix: you can now properly tell when someone has an excessive amount of 
+      wet stacks}
+delete-after: true


### PR DESCRIPTION
## About The Pull Request

- Reduces block chance to 60
- Reduces integrity from 900 to 600
- Dramatically increases slowdown from 0.5 to 1.25
- Repair now requires 10 plasteel sheets and a lengthy do_after

## Why It's Good For The Game

During the short time its been merged Ive seen people use the shields to go Protagonist Mode on Far Greater numbers taking hilarious amounts of fire with little drawback. They were even repairing their shields while being fired upon

This should keep ballistic shields as a slow, defensive tool to act best as mobile cover instead of a station-esque desword 

## Changelog

:cl:
balance: Shields block slightly less, have less integrity, slow you down much more, and now require time and 10 plasteel to repaiar
/:cl: