### PR TITLE
ESG rebalancing

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -102,8 +102,8 @@
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/ultima
-	projectile_type = /obj/projectile/beam/weak
-	pellets = 6
+	projectile_type = /obj/projectile/beam/weak/shotgun
+	pellets = 3
 	variance = 25
 	e_cost = 1000
 	select_name = "kill"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -246,6 +246,7 @@
 	inhand_y_dimension = 64
 	icon_state = "iotshotgun"
 	item_state = "shotgun_combat"
+	fire_delay = 0.6 SECONDS
 	shaded_charge = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/scatter/ultima, /obj/item/ammo_casing/energy/laser/ultima)
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -104,6 +104,7 @@
 
 /obj/projectile/beam/weak/shotgun
 	damage = 20
+	armour_penetration = -10
 	var/tile_dropoff = 1
 	var/ap_dropoff = 5
 	var/ap_dropoff_cutoff = -35

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -102,6 +102,23 @@
 /obj/projectile/beam/weak
 	damage = 15
 
+/obj/projectile/beam/weak/shotgun
+	damage = 20
+	var/tile_dropoff = 1
+	var/ap_dropoff = 5
+	var/ap_dropoff_cutoff = -35
+
+/obj/projectile/beam/weak/shotgun/Range() //10% loss per tile = max range of 10, generally
+	..()
+	if(damage > 0)
+		damage -= tile_dropoff
+	if(armour_penetration > ap_dropoff_cutoff)
+		armour_penetration -= ap_dropoff
+	if(accuracy_mod < 3)
+		accuracy_mod += 0.3
+	if(damage < 0 && stamina < 0)
+		qdel(src)
+
 /obj/projectile/beam/weak/sharplite
 	damage = 15
 	speed = 0.25


### PR DESCRIPTION
## About The Pull Request

- Decreases number of lasers to 3
- Increases damage of individual laser to 20 (60 on hit instead of 80 on hit from before)
- Fire rate set to 0.6 seconds
- Adjusts AP to be slightly less
- Gives the lasers damage and AP falloff

## Why It's Good For The Game

This was a shotgun that had few of the shotgun drawbacks in that you could just run fullspeed at people and spam fire it one-handed and obliterate people through most armours because Laser

Should remain useful just not shotgun but Stronger. It mostly falls off against armour for the most part

## Changelog

:cl:
balance: Adjusted damage, AP, firerate, and laser amount on the E-SG laser shotgun to be less
/:cl: