### PR TITLE
Scope Audit

### DIFF
--- a/code/game/objects/items/attachments/short_scope.dm
+++ b/code/game/objects/items/attachments/short_scope.dm
@@ -8,7 +8,7 @@
 	pixel_shift_y = 2
 	size_mod = 0
 	var/zoom_mod = 4
-	var/zoom_out_mod = 2
+	var/zoom_out_mod = 0
 	var/min_recoil_mod = 0.1
 	var/aim_slowdown_mod = 0.2
 

--- a/code/game/objects/items/attachments/short_scope.dm
+++ b/code/game/objects/items/attachments/short_scope.dm
@@ -7,7 +7,7 @@
 	pixel_shift_x = 1
 	pixel_shift_y = 2
 	size_mod = 0
-	var/zoom_mod = 6
+	var/zoom_mod = 4
 	var/zoom_out_mod = 2
 	var/min_recoil_mod = 0.1
 	var/aim_slowdown_mod = 0.2

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -60,7 +60,6 @@
 
 	//truly a doohickey for every occasion
 	unique_attachments = list (
-		/obj/item/attachment/scope,
 		/obj/item/attachment/energy_bayonet,
 	)
 

--- a/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/code/modules/projectiles/guns/ballistic/assault.dm
@@ -61,7 +61,6 @@
 	//truly a doohickey for every occasion
 	unique_attachments = list (
 		/obj/item/attachment/scope,
-		/obj/item/attachment/long_scope,
 		/obj/item/attachment/energy_bayonet,
 	)
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -107,9 +107,6 @@
 	ammo_x_offset = 3
 	manufacturer = MANUFACTURER_SHARPLITE
 
-	unique_attachments = list(
-		/obj/item/attachment/scope,
-	)
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1,

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -109,7 +109,6 @@
 
 	unique_attachments = list(
 		/obj/item/attachment/scope,
-		/obj/item/attachment/long_scope,
 	)
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -1,4 +1,4 @@
-#define CLIP_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet, /obj/item/attachment/scope, /obj/item/attachment/long_scope, /obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
+#define CLIP_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet,/obj/item/attachment/long_scope, /obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
 #define CLIP_ATTACHMENT_POINTS list(ATTACHMENT_SLOT_MUZZLE = 1,ATTACHMENT_SLOT_RAIL = 1,ATTACHMENT_SLOT_SCOPE=1)
 
 
@@ -670,6 +670,7 @@ NO_MAG_GUN_HELPER(automatic/marksman/f4/inteq)
 	deploy_spread_bonus = -10 //2 degree spread when deployed, making it VERY accurate for an lmg
 
 	valid_attachments = CLIP_ATTACHMENTS
+	unique_attachments = list(/obj/item/attachment/scope)
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_SCOPE = 1

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -1,4 +1,4 @@
-#define CLIP_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet,/obj/item/attachment/long_scope, /obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
+#define CLIP_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet, /obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
 #define CLIP_ATTACHMENT_POINTS list(ATTACHMENT_SLOT_MUZZLE = 1,ATTACHMENT_SLOT_RAIL = 1,ATTACHMENT_SLOT_SCOPE=1)
 
 

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
@@ -72,7 +72,6 @@
 
 	unique_attachments = list(
 		/obj/item/attachment/scope,
-		/obj/item/attachment/long_scope,
 	)
 
 	slot_available = list(

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/lasers.dm
@@ -70,10 +70,6 @@
 	charge_sections = 2
 	slot_flags = 0
 
-	unique_attachments = list(
-		/obj/item/attachment/scope,
-	)
-
 	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1,

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -803,7 +803,7 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra)
 
 /obj/item/gun/ballistic/automatic/assault/hydra/dmr
 	name = "SBR-80 \"Hydra\""
-	desc = "Scarborough Arms' premier modular assault rifle platform. This example is configured as a marksman rifle, with an extended barrel and medium-zoom scope. Its lightweight cartridge is compensated for with a 2-round burst action. Chambered in 5.56mm CLIP."
+	desc = "Scarborough Arms' premier modular assault rifle platform. This example is configured as a marksman rifle, with an extended barrel and medium-zoom scope. Its lightweight cartridge is compensated for with a 2-round burst action, though it is unable to fit large extended magazines. Chambered in 5.56mm CLIP."
 
 	icon_state = "hydra_dmr"
 	item_state = "hydra_dmr"
@@ -819,6 +819,10 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra)
 	zoom_amt = 6
 	zoom_out_amt = 2
 	default_ammo_type = /obj/item/ammo_box/magazine/m556_42_hydra/small
+	blacklisted_ammo_types = list(
+		/obj/item/ammo_box/magazine/m556_42_hydra/extended,
+		/obj/item/ammo_box/magazine/m556_42_hydra/casket,
+	)
 
 NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -1,4 +1,4 @@
-#define SCARBOROUGH_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet, /obj/item/attachment/energy_bayonet, /obj/item/attachment/scope, /obj/item/attachment/gun, /obj/item/attachment/sling, /obj/item/attachment/ammo_counter)
+#define SCARBOROUGH_ATTACHMENTS list(/obj/item/attachment/silencer, /obj/item/attachment/laser_sight, /obj/item/attachment/rail_light, /obj/item/attachment/bayonet, /obj/item/attachment/energy_bayonet, /obj/item/attachment/gun, /obj/item/attachment/sling, /obj/item/attachment/ammo_counter)
 #define SCARBOROUGH_ATTACH_SLOTS list(ATTACHMENT_SLOT_MUZZLE = 1, ATTACHMENT_SLOT_SCOPE = 1, ATTACHMENT_SLOT_RAIL = 1)
 
 //########### PISTOLS ###########//
@@ -118,6 +118,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/ringneck/indie)
 	show_magazine_on_sprite = TRUE
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	unique_attachments = list(/obj/item/attachment/scope)
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
@@ -242,6 +243,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 	show_magazine_on_sprite = TRUE
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	unique_attachments = list(/obj/item/attachment/scope)
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
@@ -920,6 +922,7 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/dmr)
 	wield_delay = 0.65 SECONDS
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	unique_attachments = list(/obj/item/attachment/scope)
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(

--- a/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/serene_sporting/ballistics.dm
@@ -1,4 +1,4 @@
-#define SERENE_ATTACHMENTS list(/obj/item/attachment/rail_light, /obj/item/attachment/bayonet,/obj/item/attachment/scope,/obj/item/attachment/long_scope, /obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
+#define SERENE_ATTACHMENTS list(/obj/item/attachment/rail_light, /obj/item/attachment/bayonet,/obj/item/attachment/scope,/obj/item/attachment/sling, /obj/item/attachment/gun, /obj/item/attachment/ammo_counter)
 #define SERENE_ATTACH_SLOTS list(ATTACHMENT_SLOT_MUZZLE = 1, ATTACHMENT_SLOT_RAIL = 1, ATTACHMENT_SLOT_SCOPE = 1)
 
 /* Micro Target */

--- a/code/modules/projectiles/guns/manufacturer/solar_armories/ballistic.dm
+++ b/code/modules/projectiles/guns/manufacturer/solar_armories/ballistic.dm
@@ -1,4 +1,4 @@
-#define SOLAR_ATTACHMENTS list(/obj/item/attachment/laser_sight,/obj/item/attachment/rail_light,/obj/item/attachment/bayonet,/obj/item/attachment/energy_bayonet,/obj/item/attachment/scope,/obj/item/attachment/long_scope, /obj/item/attachment/gun, /obj/item/attachment/sling)
+#define SOLAR_ATTACHMENTS list(/obj/item/attachment/laser_sight,/obj/item/attachment/rail_light,/obj/item/attachment/bayonet,/obj/item/attachment/energy_bayonet,/obj/item/attachment/scope,/obj/item/attachment/gun, /obj/item/attachment/sling)
 #define SOLAR_ATTACH_SLOTS list(ATTACHMENT_SLOT_MUZZLE = 1, ATTACHMENT_SLOT_SCOPE = 1, ATTACHMENT_SLOT_RAIL = 1)
 
 ///SOLAR ARMORIES


### PR DESCRIPTION
## About The Pull Request

Locks scopes and long scopes from most weapons
- Assault rifles can no longer mount either scope because of high firerate and high accuracy
- Accelerator Laser Cannons and E50s can no longer mount either scope because of hitscan / nine zillion burn projectile
- Reduced zoom amount from medium scopes to give you only about 4 tiles of extra visibility
- Long scopes are locked to the Illestren, lever actions like the Absolution, and the Beacon (we have sniper rifle at home)
- Prevents the Hydra DMR from using Extended and Casket mags. This is kind of out of scope (hah) but I may as well hit something that's been bothering me with one of the DMRs in the DMR balance pr
- Snipers (and longer ranged ones like the Taipan) maintain their zoom
- DMRs maintain their zoom
- Lets a few weird guns keep scopes like shotguns and pistols keep scopes since they're inaccurate so you can use em for scouting or some shit idk

## Why It's Good For The Game

They're pretty unfair with how the game is with how much visibility you have on your screen by default. This mostly hits attachments since our weapons that actually have inbuilt scopes are balanced around low rate of fire and low magazine sizes

Hydra DMR is kind of unrelated but this locks it to not be too braindead

## Changelog

:cl:
balance: Prevents most automatic guns from mounting scopes (along with a few more like the E50 and Accelerator laser cannon)
balance: Locks the long scope to the Illestren, lever-actions, and Beacon
balance: Decreased medium scope zoom to give you only about 4 tiles of extra visibility
balance: Hydra DMR can no longer mount extended or casket mags
/:cl: