### PR TITLE
Girders act like barricades

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	var/state = GIRDER_NORMAL
 	var/girderpasschance = 50 // percentage chance that a projectile passes through the girder.
+	var/unanchoredpasschance = 80 // provides worse cover while unanchored since it's loose and moving about
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
 	var/next_beep = 0 //Prevents spamming of the construction sound
 	max_integrity = 200
@@ -301,15 +302,16 @@
 
 /obj/structure/girder/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
+	var/pass_chance = anchored ? girderpasschance : unanchoredpasschance
 	if(istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if(proj.firer && Adjacent(proj.firer))
 			return TRUE
-		if(prob(girderpasschance))
+		if(prob(pass_chance))
 			return TRUE
 		return FALSE
 	if((mover.pass_flags & PASSGRILLE))
-		return prob(girderpasschance)
+		return prob(pass_chance)
 
 /obj/structure/girder/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)
 	. = !density

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -5,7 +5,7 @@
 	anchored = TRUE
 	density = TRUE
 	var/state = GIRDER_NORMAL
-	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
+	var/girderpasschance = 50 // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
 	var/next_beep = 0 //Prevents spamming of the construction sound
 	max_integrity = 200
@@ -301,7 +301,14 @@
 
 /obj/structure/girder/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if((mover.pass_flags & PASSGRILLE) || istype(mover, /obj/projectile))
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return TRUE
+		if(prob(girderpasschance))
+			return TRUE
+		return FALSE
+	if((mover.pass_flags & PASSGRILLE))
 		return prob(girderpasschance)
 
 /obj/structure/girder/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Girders act similarly to barricades like sandbags, allowing bullets to pass through if you're firing adjacent to it. They have a 50% chance (down from 80) to block bullets otherwise.

They have only a 20% chance to block bullets while unanchored however, since they're loose and are therefore worse cover.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I think this adds more depth to how you interact with the enviroment and destructible walls. A girder is now an opportunity to get a good angle once a wall goes down, rather than effectively a second obstacle you need to destroy to engage opponents. 

## Changelog

:cl:
add: Girders act like barricades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
