### PR TITLE
Allows bodycameras to be worn around the neck

### DIFF
--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -11,7 +11,7 @@
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start
 	var/area/myarea = null
 	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK
 	var/view_range = 5
 	var/busy = FALSE
 	var/can_transmit_across_z_levels = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A common complaint about bodycameras has been that they're a little too restrictive in terms of where they can be placed on a person and still function. A rework of bodycameras is planned, but in the meantime, this should help alleviate the issue -- though only slightly.

## Why It's Good For The Game

Bodycameras are too restrictive, and this can provide a tiny bit of QOL.

## Changelog

:cl:
balance: allows bodycameras to be worn around the neck
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
