### PR TITLE
Make it so suit pockets are openable again

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -137,6 +137,7 @@
 	strip_delay = EQUIP_DELAY_COAT * 1.5
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
+	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		return FALSE
 	if(unique_reskin && !current_skin)


### PR DESCRIPTION
## About The Pull Request

Some suits can be opened and closed, and also have pockets.
Both accessing the pockets and opening/closing is assigned to 
AltClick. 
Right now alt clicking makes it so you just toggle the suit making it's inventory inaccessible.
With this pr AltClicking a suit both open it's inventory and toggles it.

## Why It's Good For The Game

Having access to pockets is good and having the suits be toggled when you do so gives a visual indicator that the person wearing is looking trough it's suit.

## Changelog

:cl:
fix: The inventory of coats and labcoat is accessible again.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
