### PR TITLE
516 TGUI Hotfix

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -802,7 +802,16 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		[second_queue]
 	"}, "window=check_timer_sources;size=700x700")
 
-ADMIN_VERB(allow_browser_inspect, R_DEBUG, "Allow Browser Inspect", "Allow browser debugging via inspect", ADMIN_CATEGORY_DEBUG)
+/client/proc/allow_browser_inspect()
+	set category = "Debug.Debug"
+	set name = "Allow Browser Inspect"
+	set desc = "Allows browser debugging via inspect"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/client/user = usr
+
 	if(user.byond_version < 516)
 		to_chat(user, span_warning("You can only use this on 516!"))
 		return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -802,6 +802,14 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		[second_queue]
 	"}, "window=check_timer_sources;size=700x700")
 
+ADMIN_VERB(allow_browser_inspect, R_DEBUG, "Allow Browser Inspect", "Allow browser debugging via inspect", ADMIN_CATEGORY_DEBUG)
+	if(user.byond_version < 516)
+		to_chat(user, span_warning("You can only use this on 516!"))
+		return
+
+	to_chat(user, span_notice("You can now right click to use inspect on browsers."))
+	winset(user, null, list("browser-options" = "+devtools"))
+
 /proc/generate_timer_source_output(list/datum/timedevent/events)
 	var/list/per_source = list()
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_extra, list(
 	/client/proc/start_line_profiling,
 	/client/proc/stop_line_profiling,
 	/client/proc/check_timer_sources,
+	/client/proc/allow_browser_inspect,
 	/client/proc/air_status, //Air things
 	/client/proc/air_status_loc, //More air things
 	/client/proc/manipulate_organs,

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -42,36 +42,6 @@ type ByondType = {
   windowId: string;
 
   /**
-   * True if javascript is running in BYOND.
-   */
-  IS_BYOND: boolean;
-
-  /**
-   * Version of Trident engine of Internet Explorer. Null if N/A.
-   */
-  TRIDENT: number | null;
-
-  /**
-   * True if browser is IE8 or lower.
-   */
-  IS_LTE_IE8: boolean;
-
-  /**
-   * True if browser is IE9 or lower.
-   */
-  IS_LTE_IE9: boolean;
-
-  /**
-   * True if browser is IE10 or lower.
-   */
-  IS_LTE_IE10: boolean;
-
-  /**
-   * True if browser is IE11 or lower.
-   */
-  IS_LTE_IE11: boolean;
-
-  /**
    * If `true`, unhandled errors and common mistakes result in a blue screen
    * of death, which stops this window from handling incoming messages and
    * closes the active instance of tgui datum if there was one.

--- a/tgui/packages/tgui-panel/audio/player.js
+++ b/tgui/packages/tgui-panel/audio/player.js
@@ -31,7 +31,7 @@ export class AudioPlayer {
       this.node.playbackRate = this.options.pitch || 1;
       this.node.currentTime = this.options.start || 0;
       this.node.volume = this.volume;
-      this.node.play();
+      this.node.play()?.catch((error) => logger.log('playback error', error));
       for (let subscriber of this.onPlaySubscribers) {
         subscriber();
       }

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -167,7 +167,7 @@ class ChatRenderer {
     // Find scrollable parent
     this.scrollNode = findNearestScrollableParent(this.rootNode);
     this.scrollNode.addEventListener('scroll', this.handleScroll);
-    setImmediate(() => {
+    setTimeout(() => {
       this.scrollToBottom();
     });
     // Flush the queue
@@ -409,7 +409,6 @@ class ChatRenderer {
             </Element>,
             childNode
           );
-          /* eslint-enable react/no-danger */
         }
 
         // Highlight text
@@ -444,13 +443,9 @@ class ChatRenderer {
       message.node = node;
       // Query all possible selectors to find out the message type
       if (!message.type) {
-        // IE8: Does not support querySelector on elements that
-        // are not yet in the document.
-        // prettier-ignore
-        const typeDef = !Byond.IS_LTE_IE8 && MESSAGE_TYPES
-          .find(typeDef => (
-            typeDef.selector && node.querySelector(typeDef.selector)
-          ));
+        const typeDef = MESSAGE_TYPES.find(
+          (typeDef) => typeDef.selector && node.querySelector(typeDef.selector),
+        );
         message.type = typeDef?.type || MESSAGE_TYPE_UNKNOWN;
       }
       updateMessageBadge(message);
@@ -473,7 +468,7 @@ class ChatRenderer {
         this.rootNode.appendChild(fragment);
       }
       if (this.scrollTracking) {
-        setImmediate(() => this.scrollToBottom());
+        setTimeout(() => this.scrollToBottom());
       }
     }
     // Notify listeners that we have processed the batch
@@ -550,10 +545,6 @@ class ChatRenderer {
   }
 
   saveToDisk() {
-    // Allow only on IE11
-    if (Byond.IS_LTE_IE10) {
-      return;
-    }
     // Compile currently loaded stylesheets as CSS text
     let cssText = '';
     const styleSheets = document.styleSheets;

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -444,7 +444,7 @@ class ChatRenderer {
       // Query all possible selectors to find out the message type
       if (!message.type) {
         const typeDef = MESSAGE_TYPES.find(
-          (typeDef) => typeDef.selector && node.querySelector(typeDef.selector),
+          (typeDef) => typeDef.selector && node.querySelector(typeDef.selector)
         );
         message.type = typeDef?.type || MESSAGE_TYPE_UNKNOWN;
       }

--- a/tgui/packages/tgui-panel/panelFocus.js
+++ b/tgui/packages/tgui-panel/panelFocus.js
@@ -15,7 +15,7 @@ import { focusMap } from 'tgui/focus';
 // text you can select with the mouse.
 const MIN_SELECTION_DISTANCE = 10;
 
-const deferredFocusMap = () => setImmediate(() => focusMap());
+const deferredFocusMap = () => setTimeout(() => focusMap());
 
 export const setupPanelFocusHacks = () => {
   let focusStolen = false;

--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -162,7 +162,7 @@ export const backendMiddleware = (store) => {
       Byond.winset(Byond.windowId, {
         'is-visible': false,
       });
-      setImmediate(() => focusMap());
+      setTimeout(() => focusMap());
     }
 
     if (type === 'backend/update') {
@@ -192,7 +192,7 @@ export const backendMiddleware = (store) => {
       setupDrag();
       // We schedule this for the next tick here because resizing and unhiding
       // during the same tick will flash with a white background.
-      setImmediate(() => {
+      setTimeout(() => {
         perf.mark('resume/start');
         // Doublecheck if we are not re-suspended.
         const { suspended } = selectBackend(store.getState());

--- a/tgui/packages/tgui/components/Box.tsx
+++ b/tgui/packages/tgui/components/Box.tsx
@@ -65,15 +65,12 @@ export type BoxProps = {
 export const unit = (value: unknown): string | undefined => {
   if (typeof value === 'string') {
     // Transparently convert pixels into rem units
-    if (value.endsWith('px') && !Byond.IS_LTE_IE8) {
+    if (value.endsWith('px')) {
       return parseFloat(value) / 12 + 'rem';
     }
     return value;
   }
   if (typeof value === 'number') {
-    if (Byond.IS_LTE_IE8) {
-      return value * 12 + 'px';
-    }
     return value + 'rem';
   }
 };
@@ -210,11 +207,6 @@ export const computeBoxProps = (props: BoxProps) => {
   // Compute props
   for (let propName of Object.keys(props)) {
     if (propName === 'style') {
-      continue;
-    }
-    // IE8: onclick workaround
-    if (Byond.IS_LTE_IE8 && propName === 'onClick') {
-      computedProps.onclick = props[propName];
       continue;
     }
     const propValue = props[propName];

--- a/tgui/packages/tgui/components/Flex.tsx
+++ b/tgui/packages/tgui/components/Flex.tsx
@@ -19,8 +19,6 @@ export const computeFlexClassName = (props: FlexProps) => {
   return classes([
     'Flex',
     props.inline && 'Flex--inline',
-    Byond.IS_LTE_IE10 && 'Flex--iefix',
-    Byond.IS_LTE_IE10 && props.direction === 'column' && 'Flex--iefix--column',
     computeBoxClassName(props),
   ]);
 };
@@ -60,11 +58,7 @@ export type FlexItemProps = BoxProps & {
 };
 
 export const computeFlexItemClassName = (props: FlexItemProps) => {
-  return classes([
-    'Flex__item',
-    Byond.IS_LTE_IE10 && 'Flex__item--iefix',
-    computeBoxClassName(props),
-  ]);
+  return classes(['Flex__item', computeBoxClassName(props)]);
 };
 
 export const computeFlexItemProps = (props: FlexItemProps) => {

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -74,7 +74,6 @@ export class Section extends Component<SectionProps> {
       <div
         className={classes([
           'Section',
-          Byond.IS_LTE_IE8 && 'Section--iefix',
           fill && 'Section--fill',
           fitted && 'Section--fitted',
           scrollable && 'Section--scrollable',

--- a/tgui/packages/tgui/stories/ByondUi.stories.js
+++ b/tgui/packages/tgui/stories/ByondUi.stories.js
@@ -35,7 +35,7 @@ const Story = (props, context) => {
           <Button
             icon="chevron-right"
             onClick={() =>
-              setImmediate(() => {
+              setTimeout(() => {
                 try {
                   const result = new Function('return (' + code + ')')();
                   if (result && result.then) {

--- a/tgui/packages/tgui/styles/components/Flex.scss
+++ b/tgui/packages/tgui/styles/components/Flex.scss
@@ -12,20 +12,3 @@
   display: inline-flex;
 }
 
-.Flex--iefix {
-  display: block;
-}
-
-.Flex--iefix.Flex--inline {
-  display: inline-block;
-}
-
-.Flex__item--iefix {
-  display: inline-block;
-}
-
-.Flex--iefix--column {
-  & > .Flex__item--iefix {
-    display: block;
-  }
-}

--- a/tgui/packages/tgui/styles/components/Flex.scss
+++ b/tgui/packages/tgui/styles/components/Flex.scss
@@ -11,4 +11,3 @@
 .Flex--inline {
   display: inline-flex;
 }
-

--- a/tgui/packages/tgui/styles/components/Section.scss
+++ b/tgui/packages/tgui/styles/components/Section.scss
@@ -77,19 +77,6 @@ $separator-color: colors.$primary !default;
   bottom: 0;
 }
 
-.Section--fill.Section--iefix {
-  display: table !important;
-  width: 100% !important;
-  height: 100% !important;
-  border-collapse: collapse;
-  border-spacing: 0;
-
-  & > .Section__rest {
-    display: table-row !important;
-    height: 100% !important;
-  }
-}
-
 .Section--scrollable {
   overflow-x: hidden;
   overflow-y: hidden;

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -52,8 +52,15 @@
       : null;
   })();
 
+  // Blink engine version
+  Byond.BLINK = (function () {
+    var groups = navigator.userAgent.match(/Chrome\/(\d+)\./);
+    var majorVersion = groups && groups[1];
+    return majorVersion ? parseInt(majorVersion, 10) : null;
+  })();
+
   // Basic checks to detect whether this page runs in BYOND
-  var isByond = (Byond.TRIDENT !== null || window.cef_to_byond)
+  var isByond = (Byond.TRIDENT !== null || Byond.BLINK !== null || window.cef_to_byond)
     && location.hostname === '127.0.0.1'
     && location.search !== '?external';
     //As of BYOND 515 the path doesn't seem to include tmp dir anymore if you're trying to open tgui in external browser and looking why it doesn't work
@@ -61,10 +68,6 @@
 
   // Version constants
   Byond.IS_BYOND = isByond;
-  Byond.IS_LTE_IE8 = Byond.TRIDENT !== null && Byond.TRIDENT <= 4;
-  Byond.IS_LTE_IE9 = Byond.TRIDENT !== null && Byond.TRIDENT <= 5;
-  Byond.IS_LTE_IE10 = Byond.TRIDENT !== null && Byond.TRIDENT <= 6;
-  Byond.IS_LTE_IE11 = Byond.TRIDENT !== null && Byond.TRIDENT <= 7;
 
   // Strict mode flag
   Byond.strictMode = Boolean(Number(parseMetaTag('tgui:strictMode')));
@@ -73,17 +76,12 @@
   Byond.__callbacks__ = [];
 
   // Reviver for BYOND JSON
-  // IE8: No reviver for you!
-  // See: https://stackoverflow.com/questions/1288962
-  var byondJsonReviver;
-  if (!Byond.IS_LTE_IE8) {
-    byondJsonReviver = function (key, value) {
-      if (typeof value === 'object' && value !== null && value.__number__) {
-        return parseFloat(value.__number__);
-      }
-      return value;
-    };
-  }
+  var byondJsonReviver = function (key, value) {
+    if (typeof value === 'object' && value !== null && value.__number__) {
+      return parseFloat(value.__number__);
+    }
+    return value;
+  };
 
   // Makes a BYOND call.
   // See: https://secure.byond.com/docs/ref/skinparams.html
@@ -244,23 +242,10 @@
   var loadedAssetByUrl = {};
 
   var isStyleSheetLoaded = function (node, url) {
-    // Method #1 (works on IE10+)
     var styleSheet = node.sheet;
     if (styleSheet) {
       return styleSheet.rules.length > 0;
     }
-    // Method #2
-    var styleSheets = document.styleSheets;
-    var len = styleSheets.length;
-    for (var i = 0; i < len; i++) {
-      var styleSheet = styleSheets[i];
-      if(styleSheet.href === undefined)
-        continue;
-      if (styleSheet.href.indexOf(url) !== -1) {
-        return styleSheet.rules.length > 0;
-      }
-    }
-    // All methods failed
     return false;
   };
 
@@ -307,11 +292,8 @@
     if (type === 'js') {
       var node = document.createElement('script');
       node.type = 'text/javascript';
-      node.crossOrigin = 'anonymous';
-      // IE8: Prefer non-https protocols
-      node.src = Byond.IS_LTE_IE9
-        ? url.replace('https://', 'http://')
-        : url;
+      node.crossOrigin = 'anonymous';      
+      node.src = url;
       if (sync) {
         node.defer = true;
       }
@@ -331,11 +313,8 @@
     if (type === 'css') {
       var node = document.createElement('link');
       node.type = 'text/css';
-      node.rel = 'stylesheet';
-      // IE8: Prefer non-https protocols
-      node.href = Byond.IS_LTE_IE9
-        ? url.replace('https://', 'http://')
-        : url;
+      node.rel = 'stylesheet';      
+      node.href = url;
       // Temporarily set media to something inapplicable
       // to ensure it'll fetch without blocking render
       if (!sync) {
@@ -395,7 +374,7 @@ window.onerror = function (msg, url, line, col, error) {
       else {
         window.onerror.__stack__ = stack;
       }
-      var textProp = Byond.IS_LTE_IE8 ? 'innerText' : 'textContent';
+      var textProp = 'textContent';
       errorStack[textProp] = window.onerror.__stack__;
     }
     // Set window geometry

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -321,6 +321,18 @@
       if (!sync) {
         node.media = 'only x';
       }
+      var removeNodeAndRetry = function () {
+        node.parentNode.removeChild(node);
+        node = null;
+        retry();
+      }
+      // 516: Chromium won't call onload() if there is a 404 error
+      // Legacy IE doesn't use onerror, so we retain that
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#stylesheet_load_events
+      node.onerror = function () {
+        node.onerror = null;
+        removeNodeAndRetry();
+      }
       node.onload = function () {
         node.onload = null;
         if (isStyleSheetLoaded(node, url)) {
@@ -328,10 +340,7 @@
           node.media = 'all';
           return;
         }
-        // Try again
-        node.parentNode.removeChild(node);
-        node = null;
-        retry();
+        removeNodeAndRetry();
       };
       injectNode(node);
       return;

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -292,7 +292,7 @@
     if (type === 'js') {
       var node = document.createElement('script');
       node.type = 'text/javascript';
-      node.crossOrigin = 'anonymous';      
+      node.crossOrigin = 'anonymous';
       node.src = url;
       if (sync) {
         node.defer = true;
@@ -313,7 +313,8 @@
     if (type === 'css') {
       var node = document.createElement('link');
       node.type = 'text/css';
-      node.rel = 'stylesheet';      
+      node.rel = 'stylesheet';
+      node.crossOrigin = 'anonymous';
       node.href = url;
       // Temporarily set media to something inapplicable
       // to ensure it'll fetch without blocking render
@@ -637,6 +638,6 @@ Thank you for your cooperation.
 // Signal tgui that we're ready to receive updates
 Byond.sendMessage('ready');
 </script>
-  
+
 </body>
 </html>


### PR DESCRIPTION
Ports most of tgstation/tgstation#82527

> Apparently you cant just stuff the byond helper functions into an external js file, but if you do, byond won't even let you know its a problem until the servers crash and you have to run `bin/clean` just to unbork your entire repo
>
> This reimplements the changes from tgstation/tgstation PR 82473 without:
> - moving the byond helper functions externally
> - causing a tooltip render issue in panel
> 
> 516 prep (again this time)

## Changelog

:cl: jlsnow301
fix: Gets TGUI <i>FUNCTIONAL</i>, but not necessarily smooth on 516. There's still going to be a lot of issues, but at least it'll be playable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
