### PR TITLE
Corrects Coffee Machines

### DIFF
--- a/code/modules/food_and_drinks/coffee/items/coffee_pack.dm
+++ b/code/modules/food_and_drinks/coffee/items/coffee_pack.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/box/coffeepack/robusta
 	name = "robusta beans"
-	desc = "A bag containing fresh, undried coffee robusta beans."
+	desc = "A bag containing fresh, dried coffee robusta beans."
 	illustration = null
 	icon = 'icons/obj/item/coffee.dmi'
 	icon_state = "robusta_beans"
@@ -10,10 +10,14 @@
 	STR.max_items = 5
 	var/static/list/can_hold = typecacheof(list(/obj/item/food/grown/coffee))
 	STR.can_hold = can_hold
+	for(var/i in 1 to 5)
+		var/obj/item/food/grown/coffee/robusta/bean = new(src)
+		ADD_TRAIT(bean, TRAIT_DRIED, type)
+		bean.add_atom_colour("#ad7257", FIXED_COLOUR_PRIORITY)
 
 /obj/item/storage/box/coffeepack/arabica
 	name = "arabica beans"
-	desc = "A bag containing fresh, undried coffee arabica beans."
+	desc = "A bag containing fresh, dried coffee arabica beans."
 	illustration = null
 	icon = 'icons/obj/item/coffee.dmi'
 	icon_state = "arabica_beans"
@@ -23,3 +27,7 @@
 	STR.max_items = 5
 	var/static/list/can_hold = typecacheof(list(/obj/item/food/grown/coffee))
 	STR.can_hold = can_hold
+	for(var/i in 1 to 5)
+		var/obj/item/food/grown/coffee/bean = new(src)
+		ADD_TRAIT(bean, TRAIT_DRIED, type)
+		bean.add_atom_colour("#ad7257", FIXED_COLOUR_PRIORITY)

--- a/code/modules/food_and_drinks/coffee/items/condiment.dm
+++ b/code/modules/food_and_drinks/coffee/items/condiment.dm
@@ -1,9 +1,3 @@
-/obj/item/reagent_containers/condiment/pack/creamer
-	name = "creamer pack"
-	originalname = "creamer"
-	volume = 5
-	list_reagents = list(/datum/reagent/consumable/cream = 5)
-
 /obj/item/reagent_containers/condiment/pack/sugar
 	name = "sugar pack"
 	originalname = "sugar"
@@ -11,7 +5,7 @@
 	list_reagents = list(/datum/reagent/consumable/sugar = 5)
 
 ///Technically condiment packs but they are non transparent
-/obj/item/reagent_containers/condiment/creamer
+/obj/item/reagent_containers/condiment/pack/creamer
 	name = "coffee creamer pack"
 	desc = "Better not to think about what they are making this from."
 	icon = 'icons/obj/item/coffee.dmi'
@@ -20,7 +14,7 @@
 	list_reagents = list(/datum/reagent/consumable/creamer = 5)
 	fill_icon_thresholds = null
 
-/obj/item/reagent_containers/condiment/chocolate
+/obj/item/reagent_containers/condiment/pack/chocolate
 	name = "chocolate sprinkle pack"
 	desc = "The amount of sugar that's already there wasn't enough for you?"
 	icon = 'icons/obj/item/coffee.dmi'

--- a/code/modules/food_and_drinks/coffee/machine/coffeemaker.dm
+++ b/code/modules/food_and_drinks/coffee/machine/coffeemaker.dm
@@ -232,8 +232,8 @@
 		update_icon()
 		return TRUE
 
-	if(istype(attack_item, /obj/item/reagent_containers/condiment/creamer))
-		var/obj/item/reagent_containers/condiment/creamer/new_pack = attack_item
+	if(istype(attack_item, /obj/item/reagent_containers/condiment/pack/creamer))
+		var/obj/item/reagent_containers/condiment/pack/creamer/new_pack = attack_item
 		if(new_pack.reagents.total_volume < new_pack.reagents.maximum_volume)
 			balloon_alert(user, "the pack must be full!")
 			return TRUE
@@ -393,7 +393,7 @@
 	if(!creamer_packs)
 		balloon_alert(user, "no creamer left!")
 		return
-	var/obj/item/reagent_containers/condiment/creamer/new_pack = new(get_turf(src))
+	var/obj/item/reagent_containers/condiment/pack/creamer/new_pack = new(get_turf(src))
 	user.put_in_hands(new_pack)
 	creamer_packs--
 	update_icon()

--- a/code/modules/food_and_drinks/coffee/machine/impressa.dm
+++ b/code/modules/food_and_drinks/coffee/machine/impressa.dm
@@ -149,8 +149,8 @@
 		update_icon()
 		return TRUE
 
-	if(istype(attack_item, /obj/item/reagent_containers/condiment/creamer))
-		var/obj/item/reagent_containers/condiment/creamer/new_pack = attack_item
+	if(istype(attack_item, /obj/item/reagent_containers/condiment/pack/creamer))
+		var/obj/item/reagent_containers/condiment/pack/creamer/new_pack = attack_item
 		if(new_pack.reagents.total_volume < new_pack.reagents.maximum_volume)
 			balloon_alert(user, "the pack must be full!")
 			return TRUE
@@ -197,7 +197,7 @@
 			return TRUE
 		var/obj/item/storage/box/coffeepack/new_coffee_pack = attack_item
 		for(var/obj/item/food/grown/coffee/new_coffee in new_coffee_pack.contents)
-			if(!HAS_TRAIT(new_coffee, TRAIT_DRIED))
+			if(HAS_TRAIT(new_coffee, TRAIT_DRIED))
 				if(coffee_amount < BEAN_CAPACITY)
 					if(user.transferItemToLoc(new_coffee, src))
 						coffee += new_coffee

--- a/code/modules/food_and_drinks/coffee/structure/coffee_condi_display.dm
+++ b/code/modules/food_and_drinks/coffee/structure/coffee_condi_display.dm
@@ -12,9 +12,9 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 14
 	var/static/list/can_hold = typecacheof(list(/obj/item/reagent_containers/condiment/pack/sugar,
-												/obj/item/reagent_containers/condiment/creamer,
+												/obj/item/reagent_containers/condiment/pack/creamer,
 												/obj/item/reagent_containers/condiment/pack/astrotame,
-												/obj/item/reagent_containers/condiment/chocolate))
+												/obj/item/reagent_containers/condiment/pack/chocolate))
 	STR.can_hold = can_hold
 
 /obj/item/storage/fancy/coffee_condi_display/Initialize()
@@ -31,10 +31,10 @@
 		if(locate(/obj/item/reagent_containers/condiment/pack/astrotame) in contents)
 			inserted_overlay.icon_state = "condi_display_sweetener"
 			add_overlay(inserted_overlay)
-		if(locate(/obj/item/reagent_containers/condiment/creamer) in contents)
+		if(locate(/obj/item/reagent_containers/condiment/pack/creamer) in contents)
 			inserted_overlay.icon_state = "condi_display_creamer"
 			add_overlay(inserted_overlay)
-		if(locate(/obj/item/reagent_containers/condiment/chocolate) in contents)
+		if(locate(/obj/item/reagent_containers/condiment/pack/chocolate) in contents)
 			inserted_overlay.icon_state = "condi_display_chocolate"
 			add_overlay(inserted_overlay)
 
@@ -44,9 +44,9 @@
 	for(var/i = 1 to 3)
 		new /obj/item/reagent_containers/condiment/pack/astrotame(src)
 	for(var/i = 1 to 4)
-		new /obj/item/reagent_containers/condiment/creamer(src)
+		new /obj/item/reagent_containers/condiment/pack/creamer(src)
 	for(var/i = 1 to 3)
-		new /obj/item/reagent_containers/condiment/chocolate(src)
+		new /obj/item/reagent_containers/condiment/pack/chocolate(src)
 	update_icon()
 
 /obj/item/storage/fancy/coffee_condi_display/update_icon_state()

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -246,6 +246,8 @@
 		/datum/reagent/consumable/sugar = list("condi_sugar", "Sugar", "A packet of sugar. Used for sweetening, typically."),
 		/datum/reagent/consumable/astrotame = list("condi_astrotame", "Astrotame", "An artificial sweetener. Just be careful to not give yourself a headache with too much!"),
 		/datum/reagent/consumable/bbqsauce = list("condi_bbq", "BBQ sauce", "A sweet and savory packet of barbeque sauce. It's sticky!"),
+		/datum/reagent/consumable/creamer = list("condi_creamer", "Coffee Creamer", "A packet of coffee creamer. Better not to think about what they are making this from."),
+		/datum/reagent/consumable/chocolatepudding = list("condi_chocolate", "Chocolate Pudding", "A packet of chocolate pudding. The amount of sugar that's already there wasn't enough for you?"),
 		)
 
 /obj/item/reagent_containers/condiment/pack/create_reagents(max_vol, flags)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Coffee Machines no longer give invisible spirited coffee creamer packages.
- Also corrects the Chocolate Sprinkles pack as it had the same error.
- Coffee Bags ordered via Cargo once again contain coffee beans.
- Coffee Bags ordered via Cargo are dried before being shipped.
- The check that Premium Coffee Machines performed for Dried/Undried Beans was reversed when the beans were inside a bag. This has been corrected.

## Why It's Good For The Game

Ordering a premium coffee set and not getting any coffee beans is bad. Invisible sprites are bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Coffee Creamer Packages have sprites.
fix: Chocolate Sprinkles have sprites.
fix: Coffee is being placed inside the coffee bags, and its already dried.
fix: Premium Coffee Machine correctly understand dried and undried beans inside the coffee bag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
