### PR TITLE
Suit Storage Locks now respect access

### DIFF
--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -20,6 +20,7 @@
 	var/list/status = list()
 	status += "The UV bulb is [SSU.uv_super ? "glowing" : "dim"]."
 	status += "The service light is [SSU.safeties ? "off" : "on"]."
+	status += "The security lock is [SSU.locked ? "off" : "on"]."
 	return status
 
 /datum/wires/suit_storage_unit/on_pulse(wire)
@@ -34,6 +35,7 @@
 				SSU.shock(usr)
 		if(WIRE_LOCKDOWN)
 			SSU.locked = !SSU.locked
+			SSU.update_appearance()
 
 /datum/wires/suit_storage_unit/on_cut(wire, mend)
 	var/obj/machinery/suit_storage_unit/SSU = holder
@@ -51,3 +53,4 @@
 			else
 				SSU.lock_functional = FALSE
 				SSU.locked = FALSE
+			SSU.update_appearance()

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -33,7 +33,7 @@
 			if(usr)
 				SSU.shock(usr)
 		if(WIRE_LOCKDOWN)
-			!SSU.locked
+			SSU.locked = !SSU.locked
 
 /datum/wires/suit_storage_unit/on_cut(wire, mend)
 	var/obj/machinery/suit_storage_unit/SSU = holder
@@ -50,4 +50,4 @@
 				SSU.lock_functional = TRUE
 			else
 				SSU.lock_functional = FALSE
-				SSU.lock = FALSE
+				SSU.locked = FALSE

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -5,7 +5,7 @@
 /datum/wires/suit_storage_unit/New(atom/holder)
 	wires = list(
 		WIRE_HACK, WIRE_SAFETY,
-		WIRE_ZAP
+		WIRE_ZAP, WIRE_LOCKDOWN
 	)
 	add_duds(2)
 	..()
@@ -32,6 +32,8 @@
 		if(WIRE_ZAP)
 			if(usr)
 				SSU.shock(usr)
+		if(WIRE_LOCKDOWN)
+			!SSU.locked
 
 /datum/wires/suit_storage_unit/on_cut(wire, mend)
 	var/obj/machinery/suit_storage_unit/SSU = holder
@@ -43,3 +45,9 @@
 		if(WIRE_ZAP)
 			if(usr)
 				SSU.shock(usr)
+		if(WIRE_LOCKDOWN)
+			if(mend)
+				SSU.lock_functional = TRUE
+			else
+				SSU.lock_functional = FALSE
+				SSU.lock = FALSE

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -76,7 +76,7 @@
 	helmet_type = /obj/item/clothing/head/hardhat/atmos
 	mask_type = /obj/item/clothing/mask/gas/atmos
 	storage_type = /obj/item/watertank/atmos
-	req_access = (ACCESS_ATMOSPHERICS)
+	req_access = list(ACCESS_ATMOSPHERICS)
 
 LOCKED_SSU_HELPER(industrial/atmos_firesuit)
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -283,6 +283,8 @@ LOCKED_SSU_HELPER(minutemen/pilot)
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
+	wires = new /datum/wires/suit_storage_unit(src)
+	src.check_access(null)
 	if(req_access.len || req_one_access.len)
 		electronics = new(src)
 		if(req_access.len)
@@ -466,10 +468,10 @@ LOCKED_SSU_HELPER(minutemen/pilot)
 					to_chat(mob_occupant, span_userdanger("[src]'s confines grow warm, then hot, then scorching. You're being burned [!mob_occupant.stat ? "alive" : "away"]!"))
 				cook()
 		if ("lock", "unlock")
+			if(!electronics)
+				to_chat(user, span_warning("You can't cycle the lock on \the [src] without an airlock circuit installed!"))
 			if(!lock_functional)
 				to_chat(user, span_warning("The locking mechanism is shorted out!"))
-			if(!electronics)
-				to_chat(user, span_warning("You can't lock \the [src] without an airlock circuit installed!"))
 			else if (!state_open)
 				if(allowed(user))
 					locked = !locked
@@ -729,11 +731,11 @@ LOCKED_SSU_HELPER(minutemen/pilot)
 			if(!user.transferItemToLoc(I, src))
 				to_chat(user, span_warning("\The [I] is stuck to you!"))
 				return
+			electronics = I
 			if(electronics.one_access)
 				req_one_access = electronics.accesses
 			else
 				req_access = electronics.accesses
-			electronics = I
 	if(!state_open)
 		if(default_deconstruction_screwdriver(user, "[base_icon_state]", "[base_icon_state]", I))
 			update_appearance()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -1,5 +1,10 @@
 #define BASE_UV_CYCLES 7
 
+#define LOCKED_SSU_HELPER(unit_type)						\
+	/obj/machinery/suit_storage_unit/##unit_type/locked {	\
+		locked = TRUE;										\
+	}
+
 // SUIT STORAGE UNIT /////////////////
 /obj/machinery/suit_storage_unit
 	name = "suit storage unit"
@@ -34,6 +39,7 @@
 	state_open = FALSE
 	/// If the SSU's doors are locked closed. Can be toggled manually via the UI, but is also locked automatically when the UV decontamination sequence is running.
 	var/locked = FALSE
+	var/lock_functional = TRUE
 	panel_open = FALSE
 	/// If the safety wire is cut/pulsed, the SSU can run the decontamination sequence while occupied by a mob. The mob will be burned during every cycle of cook().
 	var/safeties = TRUE
@@ -55,6 +61,7 @@
 	var/message_cooldown
 	/// How long it takes to break out of the SSU.
 	var/breakout_time = 300
+	var/obj/item/electronics/airlock/electronics
 
 /obj/machinery/suit_storage_unit/industrial
 	name = "industrial suit storage unit"
@@ -64,10 +71,14 @@
 	circuit = /obj/item/circuitboard/machine/suit_storage_unit/industrial
 
 /obj/machinery/suit_storage_unit/industrial/atmos_firesuit
+	name = "firesuit storage unit"
 	suit_type = /obj/item/clothing/suit/fire/atmos
 	helmet_type = /obj/item/clothing/head/hardhat/atmos
 	mask_type = /obj/item/clothing/mask/gas/atmos
 	storage_type = /obj/item/watertank/atmos
+	req_access = (ACCESS_ATMOSPHERICS)
+
+LOCKED_SSU_HELPER(industrial/atmos_firesuit)
 
 /obj/machinery/suit_storage_unit/inherit/industrial //i know its dirty but, eh you fix it, i am mapping rn
 	name = "industrial suit storage unit"
@@ -76,61 +87,107 @@
 	base_icon_state = "industrial"
 	circuit = /obj/item/circuitboard/machine/suit_storage_unit/industrial
 
+LOCKED_SSU_HELPER(inherit)
+
+LOCKED_SSU_HELPER(inherit/industrial)
+
 /obj/machinery/suit_storage_unit/standard_unit
 	suit_type = /obj/item/clothing/suit/space/eva
 	helmet_type = /obj/item/clothing/head/helmet/space/eva
 	mask_type = /obj/item/clothing/mask/breath
 
 /obj/machinery/suit_storage_unit/captain
+	name = "captain's suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/swat/captain
 	mask_type = /obj/item/clothing/mask/gas/atmos/captain
 	storage_type = /obj/item/tank/jetpack/oxygen/captain
+	req_access = list(ACCESS_CAPTAIN)
+
+LOCKED_SSU_HELPER(captain)
 
 /obj/machinery/suit_storage_unit/engine
+	name = "engineer's suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine
 	mask_type = /obj/item/clothing/mask/breath
 	storage_type= /obj/item/clothing/shoes/magboots
+	req_access = list(ACCESS_CONSTRUCTION)
+
+LOCKED_SSU_HELPER(engine)
 
 /obj/machinery/suit_storage_unit/atmos
+	name = "atmospheric suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
 	mask_type = /obj/item/clothing/mask/gas/atmos
 	storage_type = /obj/item/watertank/atmos
+	req_access = list(ACCESS_ATMOSPHERICS)
+
+LOCKED_SSU_HELPER(atmos)
 
 /obj/machinery/suit_storage_unit/ce
+	name = "CE's suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/elite
 	mask_type = /obj/item/clothing/mask/breath
 	storage_type= /obj/item/clothing/shoes/magboots/advance
+	req_access = list(ACCESS_CE)
+
+LOCKED_SSU_HELPER(ce)
 
 /obj/machinery/suit_storage_unit/security
+	name = "security suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/security
 	mask_type = /obj/item/clothing/mask/gas/vigilitas
+	req_access = list(ACCESS_BRIG)
+
+LOCKED_SSU_HELPER(security)
 
 /obj/machinery/suit_storage_unit/hos
+	name = "HOS' suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/security/hos
 	mask_type = /obj/item/clothing/mask/gas/vigilitas
 	storage_type = /obj/item/tank/internals/oxygen
+	req_access = list(ACCESS_HOS)
+
+LOCKED_SSU_HELPER(hos)
 
 /obj/machinery/suit_storage_unit/mining
+	name = "mining suit storage unit"
 	suit_type = /obj/item/clothing/suit/hooded/explorer
 	mask_type = /obj/item/clothing/mask/gas/explorer
+	req_access = list(ACCESS_MINING)
+
+LOCKED_SSU_HELPER(mining)
 
 /obj/machinery/suit_storage_unit/mining/eva
 	suit_type = /obj/item/clothing/suit/space/hardsuit/mining
 	mask_type = /obj/item/clothing/mask/breath
 
+LOCKED_SSU_HELPER(mining/eva)
+
 /obj/machinery/suit_storage_unit/cmo
+	name = "CMO's suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/medical/cmo
 	mask_type = /obj/item/clothing/mask/breath/medical
 	storage_type = /obj/item/tank/internals/oxygen
+	req_access = list(ACCESS_CMO)
+
+LOCKED_SSU_HELPER(cmo)
 
 /obj/machinery/suit_storage_unit/rd
+	name = "RD's suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/rd
 	mask_type = /obj/item/clothing/mask/breath
+	req_access = list(ACCESS_RD)
+
+LOCKED_SSU_HELPER(rd)
 
 /obj/machinery/suit_storage_unit/syndicate
 	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi
 	mask_type = /obj/item/clothing/mask/gas/syndicate
 	storage_type = /obj/item/tank/jetpack/oxygen/harness
+
+/obj/machinery/suit_storage_unit/ert
+	name = "ERT suit storage unit"
+	req_access = list(ACCESS_CENT_SPECOPS)
 
 /obj/machinery/suit_storage_unit/ert/command
 	suit_type = /obj/item/clothing/suit/space/hardsuit/ert
@@ -168,18 +225,30 @@
 	storage_type = /obj/item/tank/internals/emergency_oxygen/engi
 
 /obj/machinery/suit_storage_unit/independent/security
+	name = "security suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/security/independent
 	mask_type = /obj/item/clothing/mask/gas
+	req_access = list(ACCESS_SECURITY)
+
+LOCKED_SSU_HELPER(independent/security)
 
 /obj/machinery/suit_storage_unit/independent/engineering
+	name = "engineering suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/engineer
 	helmet_type = /obj/item/clothing/head/helmet/space/light/engineer
 	mask_type = /obj/item/clothing/mask/breath
 	storage_type= /obj/item/clothing/shoes/magboots
+	req_access = list(ACCESS_ENGINE)
+
+LOCKED_SSU_HELPER(independent/engineering)
 
 /obj/machinery/suit_storage_unit/independent/mining/eva
+	name = "miner suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/mining/independent
 	mask_type = /obj/item/clothing/mask/breath
+	req_access = list(ACCESS_MINING)
+
+LOCKED_SSU_HELPER(independent/mining/eva)
 
 /obj/machinery/suit_storage_unit/independent/pilot
 	suit_type = /obj/item/clothing/suit/space/pilot
@@ -187,16 +256,24 @@
 	mask_type = /obj/item/clothing/mask/breath
 
 /obj/machinery/suit_storage_unit/minutemen
+	name = "minuteman suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/clip_patroller
 	mask_type = /obj/item/clothing/mask/gas/clip
+	req_access = list(ACCESS_BRIG)
+
+LOCKED_SSU_HELPER(minutemen)
 
 /obj/machinery/suit_storage_unit/minutemen/spotter
 	suit_type = /obj/item/clothing/suit/space/hardsuit/clip_spotter
+
+LOCKED_SSU_HELPER(minutemen/spotter)
 
 /obj/machinery/suit_storage_unit/minutemen/pilot
 	suit_type = /obj/item/clothing/suit/space/pilot
 	helmet_type = /obj/item/clothing/head/helmet/bulletproof/m10/clip_vc
 	mask_type = /obj/item/clothing/mask/breath
+
+LOCKED_SSU_HELPER(minutemen/pilot)
 
 //End shiptest suits
 
@@ -204,9 +281,16 @@
 	state_open = TRUE
 	density = FALSE
 
-/obj/machinery/suit_storage_unit/Initialize()
+/obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/suit_storage_unit(src)
+	if(req_access.len || req_one_access.len)
+		electronics = new(src)
+		if(req_access.len)
+			electronics.accesses = req_access
+		else
+			electronics.one_access = 1
+			electronics.accesses = req_one_access
+		locked = TRUE //SSUs with access requirements start locked
 	if(suit_type)
 		suit = new suit_type(src)
 	if(helmet_type)
@@ -221,9 +305,14 @@
 
 /obj/machinery/suit_storage_unit/examine(mob/user)
 	. = ..()
-	. += span_notice("Number of UV cycles reduced by <b>[lasers_bonus]<b>.")
+	. += span_notice("Number of UV cycles reduced by <b>[lasers_bonus]</b>.")
 	if(locked)
 		. += span_notice("The locking bolts on \the [src] are engaged, preventing it from being pried open.")
+	if(panel_open)
+		if(electronics)
+			. += span_notice("The airlock access electronics [locked ? "are securely locked in place" : "could be <b>pried</b> out."]")
+		else
+			. += span_notice("The airlock access electronics slot is open.")
 
 /obj/machinery/suit_storage_unit/RefreshParts()
 	lasers_bonus = 0
@@ -377,9 +466,16 @@
 					to_chat(mob_occupant, span_userdanger("[src]'s confines grow warm, then hot, then scorching. You're being burned [!mob_occupant.stat ? "alive" : "away"]!"))
 				cook()
 		if ("lock", "unlock")
-			if (!state_open)
-				locked = !locked
-				update_icon()
+			if(!lock_functional)
+				to_chat(user, span_warning("The locking mechanism is shorted out!"))
+			if(!electronics)
+				to_chat(user, span_warning("You can't lock \the [src] without an airlock circuit installed!"))
+			else if (!state_open)
+				if(allowed(user))
+					locked = !locked
+					update_icon()
+				else
+					to_chat(user, span_warning("Insufficent access."))
 		else
 			var/obj/item/item_to_dispense = vars[choice]
 			if (item_to_dispense)
@@ -615,6 +711,29 @@
 	if(panel_open && is_wire_tool(I))
 		wires.interact(user)
 		return
+	if(panel_open && electronics && I.tool_behaviour == TOOL_CROWBAR)
+		if(locked)
+			to_chat(user,span_warning("You can't remove the airlock electronics while the lock is engaged!"))
+			return
+		var/obj/item/electronics/airlock/ae = electronics
+		gen_access()
+		ae = electronics
+		electronics = null
+		ae.forceMove(drop_location())
+		return
+	if(panel_open && istype(I, /obj/item/electronics/airlock))
+		if(electronics)
+			to_chat(user,span_warning("The [src] already has an airlock electronic installed!"))
+			return
+		else
+			if(!user.transferItemToLoc(I, src))
+				to_chat(user, span_warning("\The [I] is stuck to you!"))
+				return
+			if(electronics.one_access)
+				req_one_access = electronics.accesses
+			else
+				req_access = electronics.accesses
+			electronics = I
 	if(!state_open)
 		if(default_deconstruction_screwdriver(user, "[base_icon_state]", "[base_icon_state]", I))
 			update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title. SSU locks can now respect access. You can adjust an SSU's access by installing an airlock circuit. Installed circuits can be removed with a crowbar. The circuit must be uninstalled before deconstruction.

Adds a wire to hack the lock.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The lock on SSUs were literally useless since they didn't respect access, and the only edge case they did something was when the power happened to be out. This should make them actually usable.

## Changelog

:cl:
add: Suit Storage Unit locks respect access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
