### PR TITLE
Removes shuttles from Autowiki Shiptable generations

### DIFF
--- a/code/modules/autowiki/pages/shiptable.dm
+++ b/code/modules/autowiki/pages/shiptable.dm
@@ -14,6 +14,8 @@
 		var/datum/map_template/shuttle/ship = SSmapping.shuttle_templates[shipname]
 		if(!ship.faction)
 			continue
+		if(ship.category == "subshuttles") // Skip generating/showing subshuttles
+			continue
 
 		LAZYADDASSOCLIST(factions[ship.faction.parent_faction], ship.faction.type, ship)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Updates `code\modules\autowiki\pages\shiptable.dm` so shuttles aren't shown on the [autowiki shiptable](https://shiptest.net/wiki/Template:Autowiki/Content/ShipTable).
## Why It's Good For The Game
Getting the autowiki shiptable to a more usable state, no player-facing changes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
