### PR TITLE
maplint instead of warn for dust in walls

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_bombed_starport.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_bombed_starport.dmm
@@ -294,7 +294,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/jungle/airbase/dorms)
 "bw" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall,
 /area/overmap_encounter/planetoid/jungle/explored)
 "bz" = (
@@ -693,7 +692,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/jungle/airbase/engineering)
 "dp" = (
-/obj/effect/decal/cleanable/chem_pile,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/jungle/airbase)
 "dq" = (

--- a/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_cavecrew.dmm
@@ -766,8 +766,6 @@
 	},
 /area/ruin/jungle/cavecrew/dormitories)
 "jm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/jungle/cavecrew/engineering)
 "jn" = (

--- a/_maps/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
@@ -509,10 +509,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/office)
-"jq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall,
-/area/ship/science/storage)
 "jw" = (
 /obj/effect/gibspawner/generic,
 /turf/open/floor/plasteel/dark,
@@ -3899,7 +3895,7 @@ CV
 tY
 tY
 tY
-jq
+tY
 Sh
 nr
 SU

--- a/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -2428,7 +2428,6 @@
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
 "oF" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/concrete,
 /area/ruin/jungle/paradise/construction)
 "oG" = (

--- a/_maps/RandomRuins/RockRuins/rockplanet_budgetcuts.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_budgetcuts.dmm
@@ -139,7 +139,6 @@
 /turf/open/floor/plasteel,
 /area/ruin/rockplanet/nanotrasen)
 "bV" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/ruin/rockplanet/nanotrasen)
 "bY" = (
@@ -2041,7 +2040,6 @@
 /turf/open/floor/plating/asteroid/rockplanet/lit,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "HL" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/rockplanet,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "Ia" = (

--- a/_maps/RandomRuins/SandRuins/whitesands_brazillianlab.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_brazillianlab.dmm
@@ -1576,7 +1576,6 @@
 	},
 /area/ruin/unpowered)
 "Zd" = (
-/obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/wood/nonmetal,
 /area/ruin/unpowered)
 "Zf" = (

--- a/_maps/RandomRuins/SandRuins/whitesands_cave_base.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_cave_base.dmm
@@ -3738,7 +3738,6 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ruin/whitesands/cave_base/engi)
 "Nf" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/whitesands,
 /area/overmap_encounter/planetoid/cave/explored)
 "Nj" = (

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_camp_saloon.dmm
@@ -1178,7 +1178,6 @@
 	},
 /area/ruin/whitesands/saloon)
 "IE" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/wood,
 /area/ruin/whitesands/saloon)
 "IP" = (

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbyslopcrash.dmm
@@ -813,7 +813,6 @@
 /turf/open/floor/plating/asteroid/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
 "so" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/whitesands/pubbycrash/engine_room)
 "ss" = (

--- a/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
@@ -75,7 +75,6 @@
 /obj/machinery/button/shieldwallgen{
 	dir = 8;
 	pixel_x = 18;
-	pixel_y = 0;
 	id = "fuelingholo"
 	},
 /turf/open/floor/plating/airless,
@@ -282,8 +281,7 @@
 	dir = 1
 	},
 /obj/item/paper_bin{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ruin/space/has_grav/refuelingpost/bridge)
@@ -2827,7 +2825,6 @@
 /obj/structure/table/glass,
 /obj/item/documents/nanotrasen,
 /obj/item/shard{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/landmark/mission_poi/main{
@@ -3029,9 +3026,7 @@
 /turf/open/space/basic,
 /area/ruin/space/refuelingsolars)
 "JF" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -3370,7 +3365,6 @@
 /area/ruin/space/has_grav/refuelingpost/upper)
 "ML" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/industrial/caution,
@@ -3639,10 +3633,6 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/corner,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/refuelingpost/cargo)
-"QH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/space/has_grav/refuelingpost/armory)
 "QP" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank,
@@ -3675,7 +3665,6 @@
 	icon_state = "med"
 	},
 /obj/item/reagent_containers/hypospray/medipen/tramal{
-	pixel_x = 0;
 	pixel_y = -5
 	},
 /obj/item/reagent_containers/hypospray/medipen/tramal{
@@ -3683,7 +3672,6 @@
 	pixel_y = -4
 	},
 /obj/item/reagent_containers/hypospray/medipen/morphine{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/hypospray/medipen/morphine{
@@ -3780,7 +3768,6 @@
 /area/ruin/space/hivebotshuttle)
 "RY" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/industrial/caution,
@@ -3895,13 +3882,9 @@
 	dir = 1
 	},
 /obj/item/clipboard{
-	pixel_x = -13;
-	pixel_y = 0
+	pixel_x = -13
 	},
-/obj/item/stamp/nanotrasen/captain{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/stamp/nanotrasen/captain,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ruin/space/has_grav/refuelingpost/bridge)
 "Tk" = (
@@ -3940,8 +3923,7 @@
 	dir = 4
 	},
 /obj/item/newspaper{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/paper/crumpled/fluff,
 /obj/item/paper/crumpled/fluff{
@@ -3972,7 +3954,6 @@
 	name = "internals crate"
 	},
 /obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/tank/internals/emergency_oxygen/engi{
@@ -4615,7 +4596,6 @@
 	},
 /obj/machinery/button/door{
 	pixel_x = 6;
-	pixel_y = 0;
 	name = "mechbay shutters";
 	id = "ripleyfueling"
 	},
@@ -5629,7 +5609,7 @@ kN
 YT
 YT
 jR
-QH
+YT
 zt
 CI
 oW

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
@@ -2232,7 +2232,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/wasteplanet/wasteplanet_icwbase/tcom1)
 "io" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/wasteplanet/wasteplanet_icwbase/hab)
 "ip" = (
@@ -4533,7 +4532,6 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/wasteplanet/wasteplanet_icwbase/cic)
 "rN" = (
@@ -7038,7 +7036,6 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/wasteplanet/wasteplanet_icwbase/cybersun)
 "BO" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/wasteplanet/wasteplanet_icwbase/cybersun)
 "BQ" = (
@@ -11998,7 +11995,6 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/wasteplanet/wasteplanet_icwbase/warehouse)
 "Wn" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/wasteplanet/wasteplanet_icwbase/cybersun)
 "Wp" = (

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_icwbase.dmm
@@ -734,7 +734,6 @@
 /turf/open/floor/circuit/red/anim,
 /area/ruin/wasteplanet/wasteplanet_icwbase/vault)
 "cP" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/wasteplanet/wasteplanet_icwbase/tcom1)
 "cR" = (
@@ -8429,7 +8428,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/wasteplanet/wasteplanet_icwbase/hab)
 "HP" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/wasteplanet/wasteplanet_icwbase/cic)
 "HS" = (

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
@@ -664,9 +664,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/wasteplanet/tradepost/center)
-"hO" = (
-/turf/closed/wall,
-/area/ruin/wasteplanet/tradepost/barracks)
 "hU" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 4
@@ -2074,7 +2071,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/wasteplanet/tradepost/barracks)
 "wL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall,
 /area/ruin/wasteplanet/tradepost/barracks)
@@ -2153,9 +2149,6 @@
 /obj/item/stack/ore/salvage/scraptitanium/five,
 /turf/open/floor/plating/asteroid/wasteplanet,
 /area/overmap_encounter/planetoid/cave/explored)
-"xF" = (
-/turf/closed/wall,
-/area/ruin/wasteplanet/tradepost/barracks)
 "xM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -4444,10 +4437,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/wasteplanet/tradepost/center)
-"TS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/rust,
-/area/ruin/wasteplanet/tradepost/barracks)
 "TT" = (
 /obj/effect/decal/cleanable/oil/streak{
 	icon_state = "streak4"
@@ -5708,18 +5697,18 @@ Ud
 Ud
 en
 Ud
-hO
-hO
-hO
+vR
+vR
+vR
 Rt
 nO
 mK
 Rt
 Rt
-hO
+vR
 Rt
-hO
-hO
+vR
+vR
 bm
 jy
 jy
@@ -5761,7 +5750,7 @@ Ud
 Ud
 Ud
 Rt
-hO
+vR
 sb
 wB
 Rt
@@ -5770,10 +5759,10 @@ ya
 Rt
 RR
 Vy
-hO
+vR
 Rr
 CE
-hO
+vR
 QB
 QB
 QB
@@ -5823,10 +5812,10 @@ zT
 wG
 Ga
 zS
-hO
+vR
 Yj
 Gc
-hO
+vR
 QB
 br
 FZ
@@ -5870,16 +5859,16 @@ Rt
 bZ
 nt
 xm
-hO
-hO
-hO
+vR
+vR
+vR
 Rt
 su
 XQ
-hO
+vR
 vS
 nr
-hO
+vR
 QB
 QB
 Le
@@ -5919,20 +5908,20 @@ Ud
 en
 en
 en
-hO
+vR
 eH
 ZN
 wW
 Xo
 Ji
-hO
+vR
 JB
 EF
 RI
 DB
 Yw
 DL
-hO
+vR
 QB
 QB
 Le
@@ -5972,13 +5961,13 @@ Ud
 Ud
 en
 QB
-hO
+vR
 Iq
 ZN
 wW
 Rt
 Rt
-hO
+vR
 lB
 xx
 AI
@@ -6025,7 +6014,7 @@ en
 en
 Nl
 QB
-hO
+vR
 eH
 ZN
 dN
@@ -6138,12 +6127,12 @@ aI
 Ho
 um
 Rt
-hO
+vR
 FI
-hO
-TS
-xF
-hO
+vR
+Rt
+vR
+vR
 Ps
 QB
 uC
@@ -6186,9 +6175,9 @@ QB
 ly
 Ps
 Rt
-hO
-hO
-hO
+vR
+vR
+vR
 Rt
 Rt
 nU
@@ -6243,7 +6232,7 @@ QB
 QB
 QB
 QB
-hO
+vR
 qJ
 OQ
 Wk

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
@@ -1992,10 +1992,6 @@
 /turf/open/floor/concrete/pavement/wasteplanet,
 /area/overmap_encounter/planetoid/cave/explored)
 "vR" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "drip3"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/ruin/wasteplanet/tradepost/barracks)
 "vS" = (
@@ -2158,11 +2154,6 @@
 /turf/open/floor/plating/asteroid/wasteplanet,
 /area/overmap_encounter/planetoid/cave/explored)
 "xF" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "drip3"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/ruin/wasteplanet/tradepost/barracks)
 "xM" = (

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_tradepost.dmm
@@ -2385,7 +2385,6 @@
 /turf/open/floor/concrete/pavement/wasteplanet,
 /area/overmap_encounter/planetoid/cave/explored)
 "Ac" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/yesdiag,
 /area/ruin/wasteplanet/tradepost/barracks)
 "Ae" = (
@@ -2795,7 +2794,6 @@
 /turf/open/floor/carpet/blue,
 /area/ruin/wasteplanet/tradepost/center)
 "Ex" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/ruin/wasteplanet/tradepost/barracks)
 "ED" = (
@@ -3103,7 +3101,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/wasteplanet/tradepost/barracks)
 "Hv" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/yesdiag,
 /area/ruin/wasteplanet/tradepost/center)
 "Hy" = (
@@ -4584,7 +4581,6 @@
 /turf/open/floor/concrete/pavement/wasteplanet/lit,
 /area/overmap_encounter/planetoid/wasteplanet/explored)
 "Wk" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall,
 /area/ruin/wasteplanet/tradepost/barracks)
 "Wl" = (

--- a/_maps/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/shuttles/inteq/inteq_talos.dmm
@@ -4869,7 +4869,6 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Bn" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hangar)
 "Br" = (

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	if(NeverShouldHaveComeHere(loc))
 		if(mapload)
-			WARNING("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in \the [get_area(src)]. \
+			log_mapping("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in \the [get_area(src)]. \
 				Please remove it or allow it to pass NeverShouldHaveComeHere if it's intended.")
 		return INITIALIZE_HINT_QDEL
 	var/static/list/loc_connections = list(

--- a/tools/maplint/lints/decals_in_walls.yml
+++ b/tools/maplint/lints/decals_in_walls.yml
@@ -1,3 +1,9 @@
 /turf/closed:
   banned_neighbors:
-  - /obj/effect/decal/cleanable
+  - /obj/effect/decal/cleanable/dirt
+  - /obj/effect/decal/cleanable/food
+  - /obj/effect/decal/cleanable/glass
+  - /obj/effect/decal/cleanable/chem_pile
+  - =/obj/effect/decal/cleanable/blood
+  - =/obj/effect/decal/cleanable/blood/old
+  - =/obj/effect/decal/cleanable/blood/tracks

--- a/tools/maplint/lints/decals_in_walls.yml
+++ b/tools/maplint/lints/decals_in_walls.yml
@@ -1,0 +1,3 @@
+/turf/closed:
+  banned_neighbors:
+  - /obj/effect/decal/cleanable


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
swaps the warning for nevershouldhavecome here check to a log instead of a warn
adds a maplint of banning some cleanable decals inside of closed turf
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the warnings were extremely flakey and diffifuclt to use
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
