### PR TITLE
Fixes missing blockade functionality

### DIFF
--- a/tgui/packages/tgui/interfaces/OutpostCommunications/Catalog.js
+++ b/tgui/packages/tgui/interfaces/OutpostCommunications/Catalog.js
@@ -18,7 +18,7 @@ import { formatMoney } from '../../format';
 export const CargoCatalog = (props, context) => {
   const { act, data } = useBackend(context);
 
-  const { self_paid, app_cost } = data;
+  const { self_paid, app_cost, blockade } = data;
 
   const supplies = Object.values(data.supplies);
 
@@ -64,17 +64,25 @@ export const CargoCatalog = (props, context) => {
               content="Clear"
               onClick={() => setCart([])}
             />
-            <Button
-              color="green"
-              content="Purchase"
-              onClick={() => {
-                act('purchase', {
-                  cart: cart,
-                  total: cartTotal,
-                });
-                setCart([]);
-              }}
-            />
+            {blockade ? (
+              <Button
+                icon="triangle-exclamation"
+                color="yellow"
+                content="Purchase Unavailable"
+              />
+            ) : (
+              <Button
+                color="green"
+                content="Purchase"
+                onClick={() => {
+                  act('purchase', {
+                    cart: cart,
+                    total: cartTotal,
+                  });
+                  setCart([]);
+                }}
+              />
+            )}
           </>
         </>
         {cart.length !== 0 ? (

--- a/tgui/packages/tgui/interfaces/OutpostCommunications/types.ts
+++ b/tgui/packages/tgui/interfaces/OutpostCommunications/types.ts
@@ -1,6 +1,7 @@
 export type Data = {
   points: number;
   outpostDocked: boolean;
+  blockade: boolean;
   onShip: boolean;
   numMissions: number;
   maxMissions: number;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reimplements functionality for outpost market blockades that was removed at some point(?). Controlled by the `supply_blocked` variable on the outpost's market.
<img width="571" height="203" alt="image" src="https://github.com/user-attachments/assets/d725b64b-6ac9-4638-a11b-540e294f2f04" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Re-adds missing functionality for admins to disable purchasing things from the outpost during events.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Market blockades now work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
