### PR TITLE
fix gelled bone wounds not processing

### DIFF
--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -467,6 +467,7 @@
 
 	limb.receive_damage(25, stamina = 100, wound_bonus = CANT_WOUND)
 	gelled = TRUE
+	processes = TRUE
 
 /// if someone is using surgical tape on our wound
 /datum/wound/blunt/proc/tape(obj/item/stack/sticky_tape/surgical/I, mob/user)


### PR DESCRIPTION
## About The Pull Request

gel causes bones to heal slowly but it wasn't starting the process to actually do that

## Changelog

:cl:

fix: bone gel on its own now causes bone breaks to heal
/:cl: