### PR TITLE
Increases the junkie pill to ten unit per pill

### DIFF
--- a/code/datums/traits/negative/addictions.dm
+++ b/code/datums/traits/negative/addictions.dm
@@ -30,7 +30,7 @@
 		for(var/i in 1 to 7)
 			var/obj/item/reagent_containers/pill/P = new(drug_instance)
 			P.icon_state = pill_state
-			P.reagents.add_reagent(reagent_type, 1)
+			P.reagents.add_reagent(reagent_type, 10)
 
 	var/obj/item/accessory_instance
 	if (accessory_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
increases the amount of reagent per pill in the junkie's starting pill bottle to ten units (up from one)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
one god damn unit between seven pills is not enough to satisfy addictions for any meaningful time. 70 units of meth/happiness/morphine/crank should be enough time for the junkie('s crew) to get the chems/ruin loot/stab someone in the outpost/buy it from someone because right now one unit per basically guarantees the junkie will be suffering from unavoidable withdrawl of a random chem, some of which have incredibly lethal withdrawls. 

## Changelog

:cl: Goat
balance: The reagent amount per pill in the roundstart junkie pill bottle has been increased (1 unit -> 10 units)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
