### PR TITLE
Macro Cleanup for Lint Compliance

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -39,10 +39,10 @@
 
 /// Deactivates the functionality defines by the element on the given datum
 /datum/element/proc/Detach(datum/source, ...)
+	SHOULD_CALL_PARENT(TRUE)
 	SIGNAL_HANDLER
 
 	SEND_SIGNAL(source, COMSIG_ELEMENT_DETACH, src)
-	SHOULD_CALL_PARENT(TRUE)
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 /datum/element/Destroy(force)

--- a/code/game/objects/structures/cabinet.dm
+++ b/code/game/objects/structures/cabinet.dm
@@ -63,7 +63,6 @@
 	else if(open || broken)
 		if(istype(I, allowed_type) && !stored)
 			var/obj/item/storee = I
-			SIGNAL_HANDLER
 			if(storee && HAS_TRAIT(storee, TRAIT_WIELDED))
 				to_chat(user, span_warning("Unwield the [storee.name] first."))
 				return


### PR DESCRIPTION
## About The Pull Request
This PR adjusts two macros that create set statement at the top of procs.

In `code/datums/elements/_element.dm` we move `SHOULD_CALL_PARENT(TRUE)` to the top of the proc where set statements go.

In `code/game/objects/structures/cabinet.dm` we remove `SIGNAL_HANDLER` buried deep down in the proc because:
- `SIGNAL_HANDLER` only takes effect if placed with the other proc-level metadata at the top of the definition. In this case, it was buried mid-proc, so it had no functional impact.
- It should be defined on the base class [code/_onclick/item_attack.dm](https://github.com/shiptest-ss13/Shiptest/blob/master/code/_onclick/item_attack.dm#L54), not an override in a subclass

Moreover, as `SIGNAL_HANDLER` is an alias for `SHOULD_NOT_SLEEP`, we can't really define it in the base class because there is a lot of sleepy stuff (`input()` and such) in overrides.

There is a `SIGNAL_HANDLER_DOES_SLEEP` in [code/__DEFINES/dcs/helpers.dm](https://github.com/shiptest-ss13/Shiptest/blob/master/code/__DEFINES/dcs/helpers.dm#L15), but it is a no-op, and the comments recommend "Do not use this for new work."

So it goes.

## Why It's Good For The Game
Just cleaning up some code to remove linting errors.

## Changelog
:cl:
fix: Cleaning up some QA lints
/:cl:
