### PR TITLE
Fix for loop syntax

### DIFF
--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -78,7 +78,7 @@
 	var/textLen = min(length(text), 7)
 	var/startX = 16 - (2*textLen)
 	var/i
-	for(i=1; i <= textLen, i++)
+	for(i=1; i <= textLen; i++)
 		var/letter = uppertext(text[i])
 		var/icon/letter_icon = icon("icon" = 'icons/Font_Minimal.dmi', "icon_state" = letter)
 		letter_icon.Shift(EAST, startX) //16 - (2*n)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -350,7 +350,7 @@ field_generator power level display
 	if(connected_gens.len < 2)
 		return
 	var/CGcounter
-	for(CGcounter = 1; CGcounter < connected_gens.len, CGcounter++)
+	for(CGcounter = 1; CGcounter < connected_gens.len; CGcounter++)
 
 		var/list/CGList = ((connected_gens[CGcounter].connected_gens & connected_gens[CGcounter+1].connected_gens)^src)
 		if(!CGList.len)


### PR DESCRIPTION
## About The Pull Request
This PR modifies the syntax of two for loops to use `;` exclusively instead of mixing `;` and `,`.

## Why It's Good For The Game
Just cleaning up some code to remove linting errors.

## Changelog

:cl:
fix: Cleaning up some QA lints
/:cl: