### PR TITLE
Add parent calls for atom_break and atom_destruction

### DIFF
--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -46,6 +46,7 @@
 /obj/structure/sign/barsign/atom_break(damage_flag)
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
 		broken = TRUE
+	. = ..()
 
 /obj/structure/sign/barsign/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/metal(drop_location(), 2)

--- a/code/game/objects/structures/cabinet.dm
+++ b/code/game/objects/structures/cabinet.dm
@@ -102,6 +102,7 @@
 		playsound(src, 'sound/effects/glassbr3.ogg', 100, TRUE)
 		new /obj/item/shard(loc)
 		new /obj/item/shard(loc)
+	. = ..()
 
 /obj/structure/cabinet/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -250,6 +250,7 @@
 /obj/structure/closet/atom_break(damage_flag)
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
 		bust_open()
+	. = ..()
 
 /obj/structure/closet/attackby(obj/item/W, mob/user, params)
 	if(user in src)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -77,6 +77,7 @@
 		playsound(src, "shatter", 70, TRUE)
 		update_appearance()
 		trigger_alarm()
+	. = ..()
 
 /obj/structure/displaycase/proc/trigger_alarm()
 	//Activate Anti-theft
@@ -567,6 +568,7 @@
 		playsound(src, "shatter", 70, TRUE)
 		update_appearance()
 		trigger_alarm() //In case it's given an alarm anyway.
+	. = ..()
 
 /obj/structure/displaycase/forsale/kitchen
 	desc = "A display case with an ID-card swiper. Use your ID to purchase the contents. Meant for the bartender and chef."

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -148,7 +148,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 28)
 			stored_extinguisher.forceMove(loc)
 			stored_extinguisher = null
 		update_appearance()
-
+	. = ..()
 
 /obj/structure/extinguisher_cabinet/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -247,7 +247,7 @@
 		var/obj/R = new rods_type(drop_location(), rods_broken) || locate(rods_type) in drop_location() // see above
 		transfer_fingerprints_to(R)
 		qdel(src)
-
+	. = ..()
 
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -61,6 +61,7 @@
 		if(desc == initial(desc))
 			desc = "Oh no, seven years of bad luck!"
 		broken = TRUE
+	. = ..()
 
 /obj/structure/mirror/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -299,6 +299,8 @@
 		var/mob/M = loc
 		to_chat(M, span_warning("Your [name] starts to fall apart!"))
 
+	. = ..()
+
 //This mostly exists so subtypes can call appriopriate update icon calls on the wearer.
 /obj/item/clothing/proc/update_clothes_damaged_state(damaging = TRUE)
 	if(damaging)

--- a/code/modules/mob/living/carbon/alien/utilities/structures.dm
+++ b/code/modules/mob/living/carbon/alien/utilities/structures.dm
@@ -393,6 +393,7 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(status != BURST)
 			Burst(kill=TRUE)
+	. = ..()
 
 /obj/structure/alien/egg/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 500)

--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -62,9 +62,6 @@
 		icon_state = "cablerelay-broken"
 		broken_status = RELAY_ADD_CABLE
 
-/obj/machinery/power/deck_relay/atom_destruction()
-	return ..() //this shouldn't break under usual means
-
 /obj/machinery/power/deck_relay/Destroy()
 	break_connections()
 	return ..()

--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -62,6 +62,7 @@
 		broken_status = RELAY_ADD_CABLE
 
 /obj/machinery/power/deck_relay/atom_destruction()
+	. = ..()
 	return //this shouldn't break under usual means
 
 /obj/machinery/power/deck_relay/Destroy()

--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -14,6 +14,7 @@
 	var/obj/machinery/power/deck_relay/above ///The relay that's above us (for bridging powernets)
 	anchored = TRUE
 	density = FALSE
+	resistance_flags = INDESTRUCTIBLE
 
 /obj/machinery/power/deck_relay/examine(mob/user)
 	. += ..()
@@ -62,8 +63,7 @@
 		broken_status = RELAY_ADD_CABLE
 
 /obj/machinery/power/deck_relay/atom_destruction()
-	. = ..()
-	return //this shouldn't break under usual means
+	return ..() //this shouldn't break under usual means
 
 /obj/machinery/power/deck_relay/Destroy()
 	break_connections()


### PR DESCRIPTION
## About The Pull Request
This PR adds some calls to the parent functions `atom_break` and `atom_destruction` in subclass overrides.

## Why It's Good For The Game
Just cleaning up some code to remove linting errors.

## Changelog

:cl:
fix: Added calls to parent methods where expected
/:cl: