### PR TITLE
Allows working subshuttles to be spawned in ruins and the outpost.

### DIFF
--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -12881,7 +12881,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 QL
 QL
 QL
@@ -12957,7 +12957,7 @@ QL
 CP
 QL
 QL
-QL
+CP
 wl
 wl
 wl
@@ -12969,7 +12969,7 @@ QL
 Lh
 QL
 QL
-QL
+CP
 QL
 QL
 QL
@@ -13046,7 +13046,7 @@ wl
 wl
 QL
 QL
-up
+CP
 QL
 zq
 QL
@@ -13140,7 +13140,7 @@ QL
 Lh
 QL
 QL
-QL
+CP
 QL
 TF
 Sc
@@ -13218,7 +13218,7 @@ QL
 Lh
 QL
 QL
-QL
+CP
 QL
 QL
 QL
@@ -13297,7 +13297,7 @@ wl
 wl
 QL
 QL
-QL
+CP
 QL
 QL
 QL
@@ -13375,7 +13375,7 @@ CP
 QL
 QL
 QL
-QL
+CP
 QL
 wl
 wl
@@ -13390,7 +13390,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 QL
 Lh
 QL
@@ -13464,7 +13464,7 @@ QL
 wl
 wl
 QL
-QL
+up
 QL
 QL
 Lh
@@ -13544,7 +13544,7 @@ Lh
 QL
 QL
 QL
-QL
+CP
 wl
 wl
 wl
@@ -13634,10 +13634,10 @@ wl
 wl
 QL
 QL
+CP
 QL
 QL
-QL
-QL
+CP
 QL
 QL
 QL
@@ -13725,7 +13725,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 QL
 QL
 QL
@@ -13880,7 +13880,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 QL
 wl
 wl
@@ -13972,12 +13972,12 @@ wl
 QL
 QL
 QL
+CP
 QL
 QL
 QL
 QL
-QL
-QL
+CP
 QL
 Rj
 Rj
@@ -14059,7 +14059,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 QL
 QL
 Rj
@@ -14132,7 +14132,7 @@ QL
 CP
 QL
 QL
-QL
+CP
 QL
 QL
 wl
@@ -14218,7 +14218,7 @@ QL
 QL
 QL
 QL
-QL
+CP
 wl
 wl
 wl

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -3023,6 +3023,7 @@
 "qY" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "qZ" = (
@@ -4004,6 +4005,9 @@
 /area/outpost/exterior)
 "wK" = (
 /obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
@@ -5495,6 +5499,9 @@
 /area/outpost/crew/bar)
 "El" = (
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
@@ -7279,6 +7286,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "Nr" = (
@@ -8026,6 +8036,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "Sx" = (
@@ -8095,6 +8108,9 @@
 	},
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
@@ -8743,6 +8759,7 @@
 /area/outpost/external)
 "WN" = (
 /obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "WT" = (

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -577,6 +577,16 @@
 	icon_state = "platingdmg2"
 	},
 /area/outpost/maintenance/starboard)
+"da" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "dg" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/tech,
@@ -620,6 +630,16 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/medical)
+"du" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 6
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "dy" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -809,6 +829,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/bathroom)
+"ez" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "eA" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -982,6 +1013,16 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/bar)
+"fv" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "fx" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 10
@@ -1006,6 +1047,21 @@
 "fA" = (
 /turf/closed/indestructible/titanium/nodiagnonal,
 /area/outpost/cargo/smeltery)
+"fD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/outpost{
+	name = "Brig"
+	},
+/turf/open/floor/plasteel/tech,
+/area/outpost/security/checkpoint)
 "fF" = (
 /obj/effect/turf_decal/borderfloor/full,
 /obj/effect/turf_decal/industrial/warning{
@@ -1421,6 +1477,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/vacant_rooms/shop)
+"hR" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "hW" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only,
@@ -1735,6 +1801,9 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/outpost/security/armory)
+"jM" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/outpost/operations)
 "jN" = (
 /obj/effect/turf_decal/borderfloor/full,
 /obj/effect/turf_decal/industrial/warning{
@@ -1970,6 +2039,12 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
+"kT" = (
+/obj/effect/landmark/outpost/subshuttle_dock{
+	subship_template = /datum/map_template/shuttle/subshuttles/ancon
+	},
+/turf/open/floor/hangar/temperate,
+/area/outpost/operations)
 "kW" = (
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/turf_decal/siding/white/corner{
@@ -2363,6 +2438,10 @@
 "mK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/outpost/maintenance/port)
+"mR" = (
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/hangar/temperate,
+/area/outpost/operations)
 "mU" = (
 /obj/machinery/computer/mission{
 	dir = 4
@@ -2441,12 +2520,8 @@
 /turf/open/floor/plating,
 /area/outpost/maintenance/port)
 "nf" = (
-/obj/structure/closet/secure_closet/contraband,
-/obj/effect/turf_decal/trimline/opaque/vired/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/security/checkpoint)
+/turf/open/floor/hangar/temperate,
+/area/outpost/operations)
 "ng" = (
 /obj/effect/turf_decal/borderfloor/full,
 /obj/machinery/airalarm/directional/east,
@@ -2678,6 +2753,17 @@
 	},
 /turf/open/floor/plating/asteroid/snow/temperatre/lit,
 /area/outpost/exterior)
+"oY" = (
+/obj/structure/closet/secure_closet/contraband,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/structure/sign/departments/evac{
+	pixel_y = -31;
+	name = "\improper Shuttle Dock sign"
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/security/checkpoint)
 "pd" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -2781,6 +2867,16 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
+"pR" = (
+/obj/machinery/door/airlock/outpost{
+	name = "Dock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "pX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -2924,6 +3020,11 @@
 "qW" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/outpost/vacant_rooms/shop)
+"qY" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "qZ" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -2991,6 +3092,16 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/tech,
 /area/outpost/vacant_rooms/shop)
+"rt" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "ry" = (
 /obj/effect/turf_decal/corner/opaque/blue/border{
 	dir = 8
@@ -3266,6 +3377,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/outpost/security/checkpoint)
+"tn" = (
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "to" = (
 /obj/effect/turf_decal/corner/opaque/nsorange/border{
 	dir = 4
@@ -3725,6 +3844,16 @@
 /obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
+"vE" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "vF" = (
 /obj/structure/railing/corner/wood{
 	dir = 8
@@ -3873,6 +4002,12 @@
 "wE" = (
 /turf/closed/indestructible/rock/schist,
 /area/outpost/exterior)
+"wK" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "wQ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/gun/ballistic/automatic/pistol/disposable{
@@ -4149,6 +4284,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
+"ye" = (
+/obj/effect/turf_decal/siding/white/corner,
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "yh" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/outpost/crew/cryo)
@@ -4857,6 +4996,17 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/checkpoint)
+"BP" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "BQ" = (
 /obj/effect/turf_decal/borderfloor/full,
 /turf/open/floor/plasteel/patterned,
@@ -4887,6 +5037,16 @@
 /obj/structure/chair/sofa/blue/corpo/left/directional/south,
 /turf/open/floor/carpet/blue,
 /area/outpost/crew/dorm)
+"BY" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "Ca" = (
 /obj/structure/chair/bench/blue{
 	dir = 4
@@ -5333,6 +5493,12 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/bar)
+"El" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "En" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 8
@@ -6893,6 +7059,17 @@
 	light_range = 2
 	},
 /area/outpost/exterior)
+"My" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "MB" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only,
@@ -7098,6 +7275,12 @@
 	light_range = 2
 	},
 /area/outpost/exterior)
+"Np" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "Nr" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck/kotahi{
@@ -7839,6 +8022,12 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/crew/cryo)
+"Sw" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "Sx" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -7901,20 +8090,14 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo/smeltery)
 "SQ" = (
-/obj/machinery/door/airlock/outpost{
-	name = "Brig"
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/siding/white/corner{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/tech,
-/area/outpost/security/checkpoint)
+/area/outpost/operations)
 "SS" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -8178,6 +8361,15 @@
 	light_range = 2
 	},
 /area/outpost/exterior)
+"Us" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2;
+	planetary_atmos = 1
+	},
+/area/outpost/operations)
 "Ut" = (
 /obj/structure/curtain/cloth/grey,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8549,6 +8741,10 @@
 	},
 /turf/open/floor/wood/walnut,
 /area/outpost/external)
+"WN" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations)
 "WT" = (
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
@@ -9328,6 +9524,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (2,1,1) = {"
 Rj
@@ -9385,6 +9589,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -9496,6 +9708,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (4,1,1) = {"
 Rj
@@ -9580,6 +9800,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (5,1,1) = {"
 Rj
@@ -9637,6 +9865,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -9748,6 +9984,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (7,1,1) = {"
 Rj
@@ -9832,6 +10076,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (8,1,1) = {"
 Rj
@@ -9889,6 +10141,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10000,6 +10260,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (10,1,1) = {"
 Rj
@@ -10084,6 +10352,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (11,1,1) = {"
 Rj
@@ -10141,6 +10417,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10252,6 +10536,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (13,1,1) = {"
 Rj
@@ -10310,6 +10602,14 @@ CD
 CD
 CD
 KY
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10420,6 +10720,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (15,1,1) = {"
 Rj
@@ -10484,6 +10792,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10588,6 +10904,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (17,1,1) = {"
 Rj
@@ -10657,6 +10981,14 @@ QL
 QL
 QL
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10756,6 +11088,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (19,1,1) = {"
 Rj
@@ -10825,6 +11165,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -10924,6 +11272,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (21,1,1) = {"
 Rj
@@ -10993,6 +11349,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -11092,6 +11456,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (23,1,1) = {"
 Rj
@@ -11161,6 +11533,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -11253,6 +11633,14 @@ Rj
 Rj
 Rj
 Rj
+KY
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -11332,10 +11720,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+rt
+BY
+BY
+BY
+BY
+BP
+BY
+BY
+BY
+BY
+BY
+hR
 Rj
 Rj
 Rj
@@ -11416,10 +11812,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+mR
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+mR
+tn
 Rj
 Rj
 Rj
@@ -11499,12 +11903,20 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
+KY
+ez
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+kT
+nf
+Us
+KY
 Rj
 Rj
 Rj
@@ -11584,10 +11996,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -11668,10 +12088,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -11752,10 +12180,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -11836,10 +12272,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -11920,10 +12364,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+mR
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+mR
+tn
 Rj
 Rj
 Rj
@@ -12004,10 +12456,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -12088,10 +12548,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -12172,10 +12640,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -12256,10 +12732,18 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
+vE
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+tn
 Rj
 Rj
 Rj
@@ -12336,15 +12820,23 @@ Rj
 Rj
 Rj
 Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
+jM
+jM
+jM
+jM
+ez
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+Us
+KY
 Rj
 Rj
 Rj
@@ -12420,14 +12912,22 @@ za
 za
 za
 za
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
+jM
+Sw
+wK
+pR
+vE
+mR
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+nf
+mR
+tn
 Rj
 Rj
 Rj
@@ -12504,14 +13004,22 @@ aV
 za
 aV
 za
-za
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
-Rj
+jM
+El
+ye
+pR
+fv
+da
+da
+da
+da
+My
+da
+da
+da
+da
+da
+du
 Rj
 Rj
 Rj
@@ -12588,8 +13096,16 @@ qu
 za
 qu
 ZR
-za
+jM
+El
+qY
+jM
 Rj
+Rj
+Rj
+Rj
+Rj
+KY
 Rj
 Rj
 Rj
@@ -12672,7 +13188,15 @@ BK
 za
 BK
 qU
-za
+jM
+El
+WN
+jM
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -12749,20 +13273,28 @@ kF
 sM
 tK
 vg
-SQ
+fD
 AK
 JT
 OE
 FS
 Se
 Cb
-za
+pR
+SQ
+Np
+jM
+Rj
+ju
+ju
+ju
+ju
 Rj
 Rj
-ju
-ju
-ju
-ju
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -12839,14 +13371,22 @@ bA
 WG
 MG
 sJ
-nf
-za
-Rj
+oY
+jM
+jM
+jM
+jM
 Rj
 ju
 gZ
 gZ
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -12927,10 +13467,18 @@ za
 za
 Rj
 Rj
+Rj
+Rj
 ju
 fP
 tv
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13010,11 +13558,19 @@ za
 za
 Rj
 Rj
+Rj
+Rj
 ju
 ju
 sk
 sk
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13093,12 +13649,20 @@ za
 Rj
 Rj
 Rj
+Rj
+Rj
 ju
 ju
 Ia
 vb
 XI
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13177,12 +13741,20 @@ eo
 Ly
 Rj
 Rj
+Rj
+Rj
 ju
 vc
 jq
 nh
 HN
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13261,12 +13833,20 @@ dR
 Ly
 Rj
 Rj
+Rj
+Rj
 ju
 mg
 XZ
 Hp
 nY
 ju
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13345,12 +13925,20 @@ eo
 Rj
 Rj
 Rj
+Rj
+Rj
 ju
 Hy
 Km
 vA
 Fu
 Iv
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13429,6 +14017,8 @@ eo
 mK
 mK
 mK
+vs
+vs
 ju
 ju
 fQ
@@ -13441,9 +14031,15 @@ zk
 zk
 zk
 zk
-zk
-zk
 yv
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (51,1,1) = {"
 Rj
@@ -13519,6 +14115,14 @@ Sm
 nm
 wD
 nm
+vs
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13612,6 +14216,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (53,1,1) = {"
 Rj
@@ -13688,6 +14300,14 @@ ZW
 fb
 ZW
 vs
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13780,6 +14400,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (55,1,1) = {"
 Rj
@@ -13856,6 +14484,14 @@ fz
 Dr
 fz
 VR
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -13948,6 +14584,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (57,1,1) = {"
 Rj
@@ -14024,6 +14668,14 @@ fz
 lE
 tF
 VR
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -14116,6 +14768,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (59,1,1) = {"
 Rj
@@ -14192,6 +14852,14 @@ Aj
 YX
 Aj
 vs
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -14284,6 +14952,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (61,1,1) = {"
 Rj
@@ -14360,6 +15036,14 @@ WL
 WL
 WL
 iZ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -14452,6 +15136,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (63,1,1) = {"
 Rj
@@ -14528,6 +15220,14 @@ hx
 vR
 Bm
 iZ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -14620,6 +15320,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (65,1,1) = {"
 Rj
@@ -14697,6 +15405,14 @@ mo
 OC
 Un
 iZ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -14788,6 +15504,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (67,1,1) = {"
 Rj
@@ -14872,6 +15596,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (68,1,1) = {"
 Rj
@@ -14946,6 +15678,14 @@ mq
 rS
 LP
 iZ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -15040,6 +15780,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (70,1,1) = {"
 Rj
@@ -15124,6 +15872,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (71,1,1) = {"
 Rj
@@ -15197,6 +15953,14 @@ Rj
 bc
 oL
 iZ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -15292,6 +16056,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (73,1,1) = {"
 Rj
@@ -15376,6 +16148,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (74,1,1) = {"
 Rj
@@ -15440,6 +16220,14 @@ Rj
 Rj
 Rj
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -15544,6 +16332,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (76,1,1) = {"
 Rj
@@ -15613,6 +16409,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -15712,6 +16516,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (78,1,1) = {"
 Rj
@@ -15781,6 +16593,14 @@ QL
 CP
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -15880,6 +16700,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (80,1,1) = {"
 Rj
@@ -15953,6 +16781,14 @@ lJ
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -16048,6 +16884,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (82,1,1) = {"
 Rj
@@ -16123,6 +16967,14 @@ lJ
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -16216,6 +17068,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (84,1,1) = {"
 Rj
@@ -16300,6 +17160,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (85,1,1) = {"
 Rj
@@ -16369,6 +17237,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -16468,6 +17344,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (87,1,1) = {"
 Rj
@@ -16537,6 +17421,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -16636,6 +17528,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (89,1,1) = {"
 Rj
@@ -16704,6 +17604,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -16804,6 +17712,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (91,1,1) = {"
 Rj
@@ -16888,6 +17804,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (92,1,1) = {"
 Rj
@@ -16953,6 +17877,14 @@ QL
 QL
 QL
 QL
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -17056,6 +17988,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (94,1,1) = {"
 Rj
@@ -17113,6 +18053,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -17224,6 +18172,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (96,1,1) = {"
 Rj
@@ -17308,6 +18264,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (97,1,1) = {"
 Rj
@@ -17365,6 +18329,14 @@ Rj
 lJ
 lJ
 lJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj
@@ -17476,6 +18448,14 @@ Rj
 Rj
 Rj
 Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 "}
 (99,1,1) = {"
 Rj
@@ -17534,6 +18514,14 @@ JH
 VY
 JH
 JH
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
 Rj
 Rj
 Rj

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -3414,9 +3414,7 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/cargo/smeltery)
 "up" = (
-/obj/effect/landmark/outpost/subshuttle_dock{
-	subship_template = /datum/map_template/shuttle/subshuttles/skink
-	},
+/mob/living/basic/bear/polar,
 /turf/open/floor/plating/asteroid/snow/temperatre/lit,
 /area/outpost/external)
 "ut" = (
@@ -3642,12 +3640,6 @@
 /obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/carpet/red,
 /area/outpost/security/checkpoint)
-"vn" = (
-/obj/effect/landmark/subship{
-	subship_template = /datum/map_template/shuttle/subshuttles/skink
-	},
-/turf/open/floor/plating/asteroid/snow/temperatre/lit,
-/area/outpost/external)
 "vo" = (
 /obj/effect/turf_decal/corner/opaque/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -11786,7 +11778,7 @@ QL
 QL
 QL
 QL
-vn
+QL
 QL
 QL
 QL

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -3414,9 +3414,8 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/cargo/smeltery)
 "up" = (
-/mob/living/basic/bear/polar{
-	faction = list("neutral");
-	name = "polar bear"
+/obj/effect/landmark/outpost/subshuttle_dock{
+	subship_template = /datum/map_template/shuttle/subshuttles/skink
 	},
 /turf/open/floor/plating/asteroid/snow/temperatre/lit,
 /area/outpost/external)
@@ -3643,6 +3642,12 @@
 /obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/carpet/red,
 /area/outpost/security/checkpoint)
+"vn" = (
+/obj/effect/landmark/subship{
+	subship_template = /datum/map_template/shuttle/subshuttles/skink
+	},
+/turf/open/floor/plating/asteroid/snow/temperatre/lit,
+/area/outpost/external)
 "vo" = (
 /obj/effect/turf_decal/corner/opaque/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -11781,7 +11786,7 @@ QL
 QL
 QL
 QL
-QL
+vn
 QL
 QL
 QL
@@ -12884,7 +12889,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 QL
 QL
 QL
@@ -12960,7 +12965,7 @@ QL
 CP
 QL
 QL
-CP
+QL
 wl
 wl
 wl
@@ -12972,7 +12977,7 @@ QL
 Lh
 QL
 QL
-CP
+QL
 QL
 QL
 QL
@@ -13049,7 +13054,7 @@ wl
 wl
 QL
 QL
-CP
+up
 QL
 zq
 QL
@@ -13143,7 +13148,7 @@ QL
 Lh
 QL
 QL
-CP
+QL
 QL
 TF
 Sc
@@ -13221,7 +13226,7 @@ QL
 Lh
 QL
 QL
-CP
+QL
 QL
 QL
 QL
@@ -13300,7 +13305,7 @@ wl
 wl
 QL
 QL
-CP
+QL
 QL
 QL
 QL
@@ -13378,7 +13383,7 @@ CP
 QL
 QL
 QL
-CP
+QL
 QL
 wl
 wl
@@ -13393,7 +13398,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 QL
 Lh
 QL
@@ -13467,7 +13472,7 @@ QL
 wl
 wl
 QL
-up
+QL
 QL
 QL
 Lh
@@ -13547,7 +13552,7 @@ Lh
 QL
 QL
 QL
-CP
+QL
 wl
 wl
 wl
@@ -13637,10 +13642,10 @@ wl
 wl
 QL
 QL
-CP
 QL
 QL
-CP
+QL
+QL
 QL
 QL
 QL
@@ -13728,7 +13733,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 QL
 QL
 QL
@@ -13883,7 +13888,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 QL
 wl
 wl
@@ -13975,12 +13980,12 @@ wl
 QL
 QL
 QL
-CP
 QL
 QL
 QL
 QL
-CP
+QL
+QL
 QL
 Rj
 Rj
@@ -14062,7 +14067,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 QL
 QL
 Rj
@@ -14135,7 +14140,7 @@ QL
 CP
 QL
 QL
-CP
+QL
 QL
 QL
 wl
@@ -14221,7 +14226,7 @@ QL
 QL
 QL
 QL
-CP
+QL
 wl
 wl
 wl

--- a/_maps/outpost/nanotrasen_ice.dmm
+++ b/_maps/outpost/nanotrasen_ice.dmm
@@ -4290,6 +4290,7 @@
 /area/outpost/security/armory)
 "ye" = (
 /obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/trimline/opaque/vired/corner,
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "yh" = (
@@ -8111,6 +8112,9 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/vired/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)

--- a/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
+++ b/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
@@ -421,7 +421,7 @@
 /obj/machinery/button/door{
 	pixel_x = 8;
 	pixel_y = 23;
-	id = "ancon_wondow";
+	id = "ancon_window";
 	name = "window shutters"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
+++ b/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
@@ -38,6 +38,9 @@
 	dir = 4;
 	id = "ancon_door"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "dw" = (
@@ -58,6 +61,9 @@
 /obj/machinery/door/poddoor/preopen{
 	dir = 4;
 	id = "ancon_door"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -80,6 +86,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -139,9 +148,6 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light/directional/east,
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -154,6 +160,9 @@
 /obj/item/clipboard{
 	pixel_y = 3;
 	pixel_x = -8
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -212,6 +221,9 @@
 	pixel_x = 4;
 	id = "ancon_hf"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "xH" = (
@@ -239,6 +251,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-10"
+	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "yp" = (
@@ -414,9 +429,6 @@
 "Th" = (
 /obj/effect/turf_decal/corner/opaque/green/half,
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/structure/cable{
 	icon_state = "0-9"
 	},
@@ -468,6 +480,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "ZG" = (
@@ -475,11 +490,11 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/port_gen/pacman,
 /obj/item/wrench,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 

--- a/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
+++ b/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
@@ -1,9 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aD" = (
-/obj/effect/turf_decal/corner/opaque/green/diagonal,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 1
+	},
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/corner/opaque/green/diagonal{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -21,27 +24,42 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "br" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "ancon_hf";
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "ancon_door"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "dw" = (
-/obj/machinery/door/airlock/external/glass{
-	dir = 4
-	},
 /obj/docking_port/mobile{
 	dir = 8;
 	name = "ancon dock";
 	preferred_direction = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "ancon_hf"
+	},
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "ancon_door"
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "hj" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
@@ -51,6 +69,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/structure/closet/crate/secure/plasma,
+/obj/item/stack/sheet/mineral/plasma/fifty,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "jj" = (
@@ -63,16 +84,15 @@
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "kE" = (
-/obj/effect/turf_decal/corner/opaque/green/half{
-	dir = 1
+/obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
 	},
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/power/terminal{
+/obj/effect/turf_decal/trimline/opaque/green/corner{
 	dir = 8
 	},
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -89,37 +109,24 @@
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "nV" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
-/obj/effect/landmark/ert_shuttle_spawn,
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
-"pk" = (
-/obj/effect/turf_decal/trimline/opaque/green/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-5"
-	},
-/obj/structure/cable{
-	icon_state = "1-5"
-	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "te" = (
-/obj/effect/turf_decal/corner/opaque/green/diagonal,
 /obj/effect/turf_decal/siding/thinplating/light,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/corner/opaque/green/diagonal{
+	dir = 4
+	},
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/obj/effect/landmark/ert_shuttle_brief_spawn,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "tk" = (
@@ -132,87 +139,33 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = -19;
-	dir = 1
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = -1;
+	pixel_x = 7
+	},
+/obj/item/pen{
+	pixel_x = 7
+	},
+/obj/item/clipboard{
+	pixel_y = 3;
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "up" = (
-/obj/machinery/photocopier,
 /obj/effect/turf_decal/corner/opaque/green/half,
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
-"vV" = (
-/obj/structure/closet/emcloset/wall/directional/north,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"xH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -12;
-	pixel_y = 9
-	},
-/obj/item/taperecorder{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/item/tape{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/item/tape{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"xZ" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/eastleft,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ancon_engine";
-	name = "Engine Shutters";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/bridge)
-"yi" = (
-/obj/effect/turf_decal/corner/opaque/green/border{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/bridge)
-"yp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"zI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/table,
 /obj/item/camera{
 	pixel_x = -4;
 	pixel_y = 7
+	},
+/obj/item/taperecorder{
+	pixel_x = -12;
+	pixel_y = 9
 	},
 /obj/item/camera{
 	pixel_x = 2;
@@ -226,23 +179,117 @@
 	pixel_x = -5;
 	pixel_y = -9
 	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"zJ" = (
-/obj/machinery/power/shuttle/engine/electric/premium,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Ct" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/item/taperecorder{
+	pixel_y = 8;
+	pixel_x = -2
 	},
+/obj/item/tape{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/tape{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure{
+	name = "inquiry supplies"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"vV" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	pixel_x = -5;
+	pixel_y = 23;
+	id = "ancon_door";
+	name = "door shutters"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_y = 22;
+	pixel_x = 4;
+	id = "ancon_hf"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"xH" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"xZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ancon_window";
+	dir = 4
 	},
-/obj/effect/landmark/ert_shuttle_spawn,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"yi" = (
+/obj/effect/turf_decal/corner/opaque/green/border{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -19;
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plasteel,
+/area/ship/bridge)
+"yp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ancon_window"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"zI" = (
+/obj/machinery/power/shuttle/engine/electric/premium,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"zJ" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/eastright,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ancon_engine";
+	name = "Engine Shutters";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "ancon_engine"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Ct" = (
+/obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/green/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "DF" = (
@@ -263,109 +310,79 @@
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "FS" = (
-/obj/effect/turf_decal/corner/opaque/green/diagonal,
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/east,
+/obj/structure/table,
+/obj/machinery/fax/nanotrasen{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/corner/opaque/green/diagonal{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "IJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"KF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"LE" = (
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
-"LV" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
-"MW" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
 	},
-/obj/effect/landmark/ert_shuttle_spawn,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
-"Nk" = (
-/obj/effect/turf_decal/trimline/opaque/green/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
-"Om" = (
-/obj/machinery/door/airlock/external/glass{
+"LE" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/eastleft,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ancon_engine";
+	name = "Engine Shutters";
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "ancon_engine"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
+/area/ship/bridge)
+"LV" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"Nk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/green/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Rg" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
-/obj/effect/landmark/ert_shuttle_spawn,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Rz" = (
 /obj/effect/turf_decal/corner/opaque/green/half{
 	dir = 1
 	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/landmark/ert_shuttle_spawn,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "SI" = (
@@ -376,28 +393,53 @@
 /obj/structure/chair/comfy/blue{
 	dir = 4
 	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	layer = 3.3
+	},
+/obj/machinery/button/door{
+	pixel_x = -3;
+	pixel_y = 23;
+	id = "ancon_engine";
+	name = "engine shutters"
+	},
+/obj/machinery/button/door{
+	pixel_x = 8;
+	pixel_y = 23;
+	id = "ancon_wondow";
+	name = "window shutters"
+	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
 "Th" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/eastright,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ancon_engine";
-	name = "Engine Shutters";
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/green/half,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "0-9"
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "TQ" = (
-/obj/effect/turf_decal/corner/opaque/green/diagonal{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/thinplating/light,
+/obj/effect/turf_decal/corner/opaque/green/diagonal{
+	dir = 4
+	},
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/effect/mapping_helpers/crate_shelve,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Vu" = (
@@ -420,77 +462,83 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 1
 	},
-/obj/effect/landmark/ert_shuttle_brief_spawn,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "Zr" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/bridge)
 "ZG" = (
-/obj/structure/table,
-/obj/machinery/fax/nanotrasen{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/corner/opaque/green/half,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/wrench,
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
 
 (1,1,1) = {"
 tk
-tk
+zI
 LV
 dw
 br
 LV
-tk
+zI
 tk
 "}
 (2,1,1) = {"
-tk
-zJ
+LV
+LE
 LV
 vV
 Zr
 LV
 zJ
-tk
+LV
 "}
 (3,1,1) = {"
 LV
-xZ
-LV
-Om
-Om
-LV
-Th
+lu
+kE
+jj
+jj
+Ct
+DF
 LV
 "}
 (4,1,1) = {"
 yp
-lu
-pk
-jj
-jj
+Rz
+Fz
+IJ
+IJ
 Nk
-DF
+Th
 yp
 "}
 (5,1,1) = {"
 yp
 Rz
-Fz
-Ct
-MW
+XH
+xH
+xH
 TQ
 ZG
 yp
 "}
 (6,1,1) = {"
 yp
-kE
+Rz
 XH
-KF
-IJ
+xH
+xH
 hj
 up
 yp
@@ -499,7 +547,7 @@ yp
 LV
 LV
 aD
-zI
+xH
 xH
 te
 LV
@@ -539,9 +587,9 @@ tk
 tk
 tk
 LV
-yp
-yp
-LE
+xZ
+xZ
+LV
 tk
 tk
 "}

--- a/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
+++ b/_maps/shuttles/subshuttles/nanotrasen_ancon.dmm
@@ -405,9 +405,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/ert_shuttle_spawn,
-/obj/structure/chair/comfy/blue{
-	dir = 4
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
 	layer = 3.3

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -702,6 +702,13 @@ SUBSYSTEM_DEF(overmap)
 		quaternary_dock.adjust_dock_for_landing = TRUE
 		docking_ports += quaternary_dock
 
+	else // we've spawned a ruin and are now checking for any docks that it has
+		for(var/obj/docking_port/stationary/port as obj in SSshuttle.stationary)
+			if(port.virtual_z() == vlevel.id)
+				if(port in docking_ports)
+					continue
+				docking_ports += port
+
 	var/list/datum/weakref/spawned_mission_pois = list()
 	for(var/obj/effect/landmark/mission_poi/mission_poi in SSmissions.unallocated_pois)
 		if(!vlevel.is_in_bounds(mission_poi))

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -437,11 +437,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "subship_dock"
 	dir = NORTH
 	var/datum/map_template/shuttle/subship_template
+	var/load_on_init = FALSE
+	var/outpost_docker = FALSE
 	var/offset_x = 0
 	var/offset_y = 0
 
-/obj/effect/landmark/subship/New(loc)
+/obj/effect/landmark/subship/New(loc, datum/map_template/shuttle/ship_template, datum/overmap/dock_holder)
 	..(loc)
+	if(!subship_template && ship_template)
+		subship_template = ship_template
 	var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[initial(subship_template.file_name)]
 	var/dock_x
 	var/dock_y
@@ -458,9 +462,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 		if(WEST)
 			dock_x = template.height - template.port_y_offset
 			dock_y = template.port_x_offset - 1
-	var/obj/docking_port/stationary/dock = new(locate(x + offset_x + dock_x, y + offset_y + dock_y, z))
+	var/obj/docking_port/stationary/dock = new(locate(x + offset_x + dock_x, y + offset_y + dock_y, z), dock_holder)
 	dock.roundstart_template = subship_template
-	dock.load_template_on_initialize = FALSE
+	dock.outpost_special_dock_perms = outpost_docker
+	dock.load_template_on_initialize = load_on_init
 	dock.dir = angle2dir_cardinal(dir2angle(template.port_dir)+dir2angle(dir))
 	switch(template.port_dir) // Setting the dock's bounding box vars
 		if(NORTH)
@@ -489,3 +494,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	// Subship landmarks are in the bounding box of the subship, meaning that the landmark can be landed on which destroys it.
 	// I'm not sure landmarks destroyed on landing is intended behavior or not, so we're not destroying the dock on deletion just in case it is.
 	. = ..()
+
+/obj/effect/landmark/subship/map_spawn
+	load_on_init = TRUE
+
+/obj/effect/landmark/subship/map_spawn/outpost
+	outpost_docker = TRUE
+	load_on_init = FALSE
+
+
+

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -498,6 +498,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/subship/map_spawn
 	load_on_init = TRUE
 
+/obj/effect/landmark/subship/map_spawn/ruin
+	load_on_init = FALSE
+
 /obj/effect/landmark/subship/map_spawn/outpost
 	outpost_docker = TRUE
 	load_on_init = FALSE

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -444,7 +444,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 
 /obj/effect/landmark/subship/New(loc, datum/map_template/shuttle/ship_template, datum/overmap/dock_holder)
 	..(loc)
-	if(!subship_template && ship_template)
+	if(ship_template)
 		subship_template = ship_template
 	var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[initial(subship_template.file_name)]
 	var/dock_x

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -498,6 +498,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/subship/outpost
 	outpost_docker = TRUE
 	load_on_init = FALSE
+	subship_template = /datum/map_template/shuttle/subshuttles/tanto
 
 
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -495,13 +495,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	// I'm not sure landmarks destroyed on landing is intended behavior or not, so we're not destroying the dock on deletion just in case it is.
 	. = ..()
 
-/obj/effect/landmark/subship/map_spawn
-	load_on_init = TRUE
-
-/obj/effect/landmark/subship/map_spawn/ruin
-	load_on_init = FALSE
-
-/obj/effect/landmark/subship/map_spawn/outpost
+/obj/effect/landmark/subship/outpost
 	outpost_docker = TRUE
 	load_on_init = FALSE
 

--- a/code/modules/overmap/_overmap_datum.dm
+++ b/code/modules/overmap/_overmap_datum.dm
@@ -37,6 +37,9 @@
 	/// Whether or not the overmap object is currently docking.
 	var/docking
 
+	/// Whether this can attempt to dock to the special ports on the outpost
+	var/outpost_special_dock_perms = FALSE
+
 	/// Current overmap we are apart of.
 	var/datum/overmap_star_system/current_overmap
 	/// List of all datums docked in this datum.

--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -286,7 +286,7 @@
 	if(istype(our_likely_vlevel) && selfloop)
 		our_likely_vlevel.selfloop()
 
-	for(var/obj/docking_port/stationary/port as obj in reserve_docks)
+	for(var/obj/docking_port/stationary/port in reserve_docks)
 		if(port.roundstart_template)
 			port.name = "[name] auxillary docking location"
 			port.load_roundstart()

--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -286,6 +286,11 @@
 	if(istype(our_likely_vlevel) && selfloop)
 		our_likely_vlevel.selfloop()
 
+	for(var/obj/docking_port/stationary/port as obj in reserve_docks)
+		if(port.roundstart_template)
+			port.name = "[name] auxillary docking location"
+			port.load_roundstart()
+
 	SEND_SIGNAL(src, COMSIG_OVERMAP_LOADED)
 	loading = FALSE
 	return TRUE

--- a/code/modules/overmap/objects/outpost/mapping.dm
+++ b/code/modules/overmap/objects/outpost/mapping.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(outpost_landmarks)
 
 /obj/effect/landmark/outpost/subshuttle_dock
 	name = "subshuttle outpost dock landmark"
-	var/datum/map_template/shuttle/subship_template
+	var/datum/map_template/shuttle/subship_template = /datum/map_template/shuttle/subshuttles/skink //place holder
 
 /obj/effect/landmark/outpost/subshuttle_dock/proc/set_up_dock(datum/overmap/outpost/parent_outpost)
 	new /obj/effect/landmark/subship/outpost(loc, subship_template, parent_outpost)

--- a/code/modules/overmap/objects/outpost/mapping.dm
+++ b/code/modules/overmap/objects/outpost/mapping.dm
@@ -75,4 +75,4 @@ GLOBAL_LIST_EMPTY(outpost_landmarks)
 	var/datum/map_template/shuttle/subship_template
 
 /obj/effect/landmark/outpost/subshuttle_dock/proc/set_up_dock(datum/overmap/outpost/parent_outpost)
-	new /obj/effect/landmark/subship/map_spawn/outpost(loc, subship_template, parent_outpost)
+	new /obj/effect/landmark/subship/outpost(loc, subship_template, parent_outpost)

--- a/code/modules/overmap/objects/outpost/mapping.dm
+++ b/code/modules/overmap/objects/outpost/mapping.dm
@@ -15,7 +15,6 @@ GLOBAL_LIST_EMPTY(outpost_landmarks)
 	GLOB.outpost_landmarks -= src
 	. = ..()
 
-
 /obj/effect/landmark/outpost/hangar_dock
 	name = "hangar dock landmark"
 
@@ -70,3 +69,10 @@ GLOBAL_LIST_EMPTY(outpost_landmarks)
 /obj/machinery/light/floor/hangar/LateInitialize()
 	. = ..()
 	brightness = 20
+
+/obj/effect/landmark/outpost/subshuttle_dock
+	name = "subshuttle outpost dock landmark"
+	var/datum/map_template/shuttle/subship_template
+
+/obj/effect/landmark/outpost/subshuttle_dock/proc/set_up_dock(datum/overmap/outpost/parent_outpost)
+	new /obj/effect/landmark/subship/map_spawn/outpost(loc, subship_template, parent_outpost)

--- a/code/modules/overmap/objects/outpost/mapping.dm
+++ b/code/modules/overmap/objects/outpost/mapping.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(outpost_landmarks)
 
 /obj/effect/landmark/outpost/subshuttle_dock
 	name = "subshuttle outpost dock landmark"
-	var/datum/map_template/shuttle/subship_template = /datum/map_template/shuttle/subshuttles/skink //place holder
+	var/datum/map_template/shuttle/subship_template = /datum/map_template/shuttle/subshuttles/tanto //place holder
 
 /obj/effect/landmark/outpost/subshuttle_dock/proc/set_up_dock(datum/overmap/outpost/parent_outpost)
 	new /obj/effect/landmark/subship/outpost(loc, subship_template, parent_outpost)

--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -10,7 +10,9 @@
 	// Set to an instance of the singleton for its type in New.
 	var/datum/map_template/outpost/main_template = null
 
-	var/list/obj/docking_port/stationary/reserve_docks
+	var/list/obj/docking_port/stationary/reserve_docks = list()
+
+	var/list/obj/docking_port/stationary/main_floor_docks = list()
 
 	var/datum/map_template/outpost/elevator_template = null
 	/// List of hangar templates. This list should contain hangar templates sufficient for any ship to dock within one,
@@ -211,6 +213,13 @@
 		else
 			shaft_lists[mach_mark.shaft] += mach_mark
 
+	for(var/obj/effect/landmark/outpost/subshuttle_dock/sub_dock in GLOB.outpost_landmarks)
+		sub_dock.set_up_dock(src)
+
+	for(var/obj/docking_port/stationary/docks in main_floor_docks)
+		docks.name = "[name] subshuttle dock"
+		docks.load_roundstart()
+
 	for(var/shaft_name in shaft_lists)
 		var/list/obj/shaft_li = shaft_lists[shaft_name]
 		var/obj/effect/landmark/outpost/elevator/anchor_landmark = shaft_li[1]
@@ -256,6 +265,10 @@
 	for(var/obj/docking_port/stationary/reserve_dock as anything in reserve_docks)
 		if(!reserve_dock.docked && !reserve_dock.current_docking_ticket)
 			LAZYADD(docks, reserve_dock)
+	if(requesting_interactor.outpost_special_dock_perms == TRUE)
+		for(var/obj/docking_port/stationary/main_floor_dock as anything in main_floor_docks)
+			if(!main_floor_dock.docked && !main_floor_dock.current_docking_ticket)
+				LAZYADD(docks, main_floor_dock)
 	return docks
 
 /datum/overmap/outpost/post_docked(datum/overmap/ship/controlled/dock_requester)

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -119,7 +119,7 @@
  * * creation_template - The template used to create the ship.
  * * target_port - The port to dock the new ship to.
  */
-/datum/overmap/ship/controlled/Initialize(position, system_spawned_in, datum/map_template/shuttle/creation_template, create_shuttle = TRUE)
+/datum/overmap/ship/controlled/Initialize(position, system_spawned_in, datum/map_template/shuttle/creation_template, create_shuttle = TRUE, outpost_special_docking_perms)
 	. = ..()
 	if(creation_template)
 		source_template = creation_template
@@ -138,6 +138,8 @@
 
 			refresh_engines()
 		ship_account = new(name, source_template.starting_funds)
+		if(outpost_special_docking_perms)
+			outpost_special_dock_perms = TRUE
 
 	else
 		stack_trace("Attempted to create a controlled ship without a template!")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -219,6 +219,7 @@
 	var/json_key
 	//Setting this to false will prevent the roundstart_template from being loaded on Initiallize(). You should set this to false if this loads a subship on a ship map template
 	var/load_template_on_initialize = TRUE
+	var/outpost_special_dock_perms = FALSE //gives the ship we're spawning special dock perms on the outpost
 	/// The docking ticket of the ship docking to this port.
 	var/datum/docking_ticket/current_docking_ticket
 	/// Moves docking port around in it's "box" so that any ship can land in this "box" think of this as, whatever the height and width are set to on initialize, anything smaller than the "box" can land in it with this on
@@ -234,7 +235,7 @@
 	///ditto
 	var/datum/map_template/outpost/hangar/initial_hangar_template
 
-/obj/docking_port/stationary/Initialize(mapload)
+/obj/docking_port/stationary/Initialize(mapload, datum/overmap/dock_holder)
 	. = ..()
 	SSshuttle.stationary += src
 	initial_location = list("x" = x, "y" = y, "z" = z)
@@ -246,6 +247,9 @@
 			T.flags_1 |= NO_RUINS_1
 		if(SSshuttle.initialized && load_template_on_initialize) // If the docking port is loaded via map but SSshuttle has already init (therefore this would never be called)
 			INVOKE_ASYNC(src, PROC_REF(load_roundstart))
+	if(istype(dock_holder, /datum/overmap/outpost))
+		var/datum/overmap/outpost/parent_outpost = dock_holder
+		LAZYADD(parent_outpost.main_floor_docks,src)
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#f00")
@@ -263,7 +267,7 @@
 		if(!roundstart_template)
 			CRASH("Invalid path ([template]) passed to docking port.")
 
-		var/datum/overmap/ship/controlled/new_ship = new(SSovermap.get_overmap_object_by_location(src), , template, FALSE) //Don't instantiate, we handle that ourselves
+		var/datum/overmap/ship/controlled/new_ship = new(SSovermap.get_overmap_object_by_location(src), , template, FALSE, outpost_special_dock_perms) //Don't instantiate, we handle that ourselves
 		new_ship.connect_new_shuttle_port(SSshuttle.action_load(template, new_ship, src))
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now map and spawn working subshuttles in ruins and outposts. Ruins can be mapped with normal subshuttle dock landmarks, but for outposts you will need to use /obj/effect/landmark/outpost/subshuttle_dock for them to work properly.

Adds a dock to NT Ice and touches up the Ancon subshuttle.

<img width="1018" height="990" alt="image" src="https://github.com/user-attachments/assets/1cb576d1-4749-4af2-b758-17e10a1a32c1" />
<img width="352" height="256" alt="image" src="https://github.com/user-attachments/assets/0ca2b575-5925-4947-be6f-d35e05709266" />


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I think it's nice to have the option to have working subshuttles in ruins and outposts, and they should make good set pieces when needed.

## Changelog

:cl:
add: Subshuttle spawners can now be mapped onto ruins and outpost maps to spawn functional ships.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
