### PR TITLE
You can always place rods on hyperspace

### DIFF
--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -44,10 +44,6 @@
 /mob/living/throw_atom_into_space()
 	apply_damage_type(25, BRUTE)	// This may not seem like much, but if you toss someone out and they go through like four tiles, they're goners
 
-/turf/open/space/transit/CanBuildHere()
-	return SSshuttle.is_in_shuttle_bounds(src)
-
-
 /turf/open/space/transit/Initialize(mapload, inherited_virtual_z)
 	. = ..()
 	update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can always place rods on hyperspace (transit) tiles rather than just within in shipbounds.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being only to place rods on hyperspace within certain areas is a bit unintuitive and restrictive. It makes subshuttle boarding a slog for starters, since it basically restricts you to outpost elevator-like chokepoint combat, made even worse by the fact the "walls" in this case are kill tiles.

This should allow for much more freedom of movement and interesting decisions to be made.

## Changelog

:cl:
balance: You can always rod on hyperspace tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
