### PR TITLE
Less Waste Density

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -90,11 +90,7 @@
 		GAS_CO=2,
 	)
 	restricted_gases = list(
-		GAS_CHLORINE=1,
-		GAS_AMMONIA=1,
-		GAS_SO2=3,
-		GAS_CO=2,
-		GAS_O3=1,
+		GAS_SO2=0.1,
 	)
 	restricted_chance = 10
 

--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -1,6 +1,6 @@
 /datum/map_generator/planet_generator/waste
 
-	mountain_height = 0.35
+	mountain_height = 0.6
 	perlin_zoom = 40
 
 	initial_closed_chance = 45
@@ -78,11 +78,11 @@
 			BIOME_HIGHEST_HUMIDITY = /datum/biome/cave/waste/tar_bed
 		),
 		BIOME_HOT_CAVE = list( //metal wreck for salvaging
-			BIOME_LOWEST_HUMIDITY = /datum/biome/cave/waste/metal/hivebot,
-			BIOME_LOW_HUMIDITY = /datum/biome/cave/waste/metal/hivebot,
-			BIOME_MEDIUM_HUMIDITY = /datum/biome/cave/waste/metal/hivebot,
+			BIOME_LOWEST_HUMIDITY = /datum/biome/cave/waste,
+			BIOME_LOW_HUMIDITY = /datum/biome/cave/waste,
+			BIOME_MEDIUM_HUMIDITY = /datum/biome/cave/waste/metal,
 			BIOME_HIGH_HUMIDITY = /datum/biome/cave/waste/metal/,
-			BIOME_HIGHEST_HUMIDITY = /datum/biome/cave/waste/metal/
+			BIOME_HIGHEST_HUMIDITY = /datum/biome/cave/waste/metal
 		)
 	)
 
@@ -286,11 +286,11 @@
 	)
 
 	closed_turf_types =  list(
-		/turf/closed/mineral/random/wasteplanet = 40,
+		/turf/closed/mineral/random/wasteplanet = 60,
 		/turf/closed/wall/r_wall/wasteplanet = 1,
-		/turf/closed/wall/r_wall/rust/wasteplanet = 3,
-		/turf/closed/wall/wasteplanet = 2,
-		/turf/closed/wall/rust/wasteplanet = 6
+		/turf/closed/wall/r_wall/rust/wasteplanet = 2,
+		/turf/closed/wall/wasteplanet = 1,
+		/turf/closed/wall/rust/wasteplanet = 2
 	)
 
 	flora_spawn_list = list(
@@ -337,7 +337,7 @@
 
 	flora_spawn_chance = 30
 	feature_spawn_chance = 4
-	mob_spawn_chance = 5
+	mob_spawn_chance = 2
 
 /datum/biome/cave/waste/tar_bed //tar colorings here
 	open_turf_types = list(
@@ -387,6 +387,7 @@
 		/turf/open/floor/plating/wasteplanet = 4
 	)
 	closed_turf_types = list(
+		/turf/closed/mineral/random/wasteplanet = 60,
 		/turf/closed/wall/r_wall/wasteplanet = 1,
 		/turf/closed/wall/r_wall/rust/wasteplanet = 1,
 		/turf/closed/wall/wasteplanet = 5,
@@ -421,38 +422,8 @@
 		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 3,
 		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
 		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 20
+		/obj/structure/spawner/hivebot = 10
 	)
-
-/datum/biome/cave/waste/metal/hivebot
-	flora_spawn_list = list(
-		/obj/effect/spawner/random/trash/decal = 90,
-		/obj/effect/spawner/random/waste/radiation = 16,
-		/obj/effect/spawner/random/waste/radiation/more_rads = 2,
-		/obj/effect/spawner/random/waste/girder = 60,
-		/obj/structure/reagent_dispensers/watertank = 20,
-		/obj/item/stack/cable_coil/cut = 50,
-		/obj/structure/closet/crate/secure/loot = 3,
-		/obj/effect/spawner/random/maintenance = 2,
-		/obj/effect/spawner/random/maintenance/two = 5,
-		/obj/effect/spawner/random/maintenance/three = 10,
-		/obj/effect/spawner/random/maintenance/four = 20,
-		/obj/effect/spawner/random/waste/salvageable = 40,
-		/obj/structure/foamedmetal = 100,
-	)
-	mob_spawn_list = list( //Whoops! All hivebots!
-		/mob/living/basic/hivebot/strong = 20,
-		/mob/living/basic/hivebot/ranged = 40,
-		/mob/living/basic/hivebot/rapid = 20,
-		/mob/living/basic/hivebot = 40,
-		/mob/living/basic/hivebot/core = 10
-	)
-	mob_spawn_chance = 15
-	feature_spawn_list = list(
-		/obj/structure/spawner/hivebot = 10,
-		)
-
-	feature_spawn_chance = 2 //hivebot biomes should have their dongles
 
 /datum/biome/cave/waste/conc //da concrete jungle baybee
 	open_turf_types = list(
@@ -461,6 +432,7 @@
 		/turf/open/floor/concrete/pavement/wasteplanet = 4
 	)
 	closed_turf_types = list(
+		/turf/closed/mineral/random/wasteplanet = 60,
 		/turf/closed/wall/concrete/wasteplanet = 15,
 		/turf/closed/wall/concrete/reinforced/wasteplanet = 3
 	)
@@ -489,9 +461,9 @@
 		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 3,
 		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
 		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 25
+		/obj/structure/spawner/hivebot = 10
 	)
 
 	flora_spawn_chance = 30
 	feature_spawn_chance = 8
-	mob_spawn_chance = 5
+	mob_spawn_chance = 2

--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -1,6 +1,6 @@
 /datum/map_generator/planet_generator/waste
 
-	mountain_height = 0.6
+	mountain_height = 0.5
 	perlin_zoom = 40
 
 	initial_closed_chance = 45
@@ -387,7 +387,7 @@
 		/turf/open/floor/plating/wasteplanet = 4
 	)
 	closed_turf_types = list(
-		/turf/closed/mineral/random/wasteplanet = 60,
+		/turf/closed/mineral/random/wasteplanet = 45,
 		/turf/closed/wall/r_wall/wasteplanet = 1,
 		/turf/closed/wall/r_wall/rust/wasteplanet = 1,
 		/turf/closed/wall/wasteplanet = 5,
@@ -432,7 +432,7 @@
 		/turf/open/floor/concrete/pavement/wasteplanet = 4
 	)
 	closed_turf_types = list(
-		/turf/closed/mineral/random/wasteplanet = 60,
+		/turf/closed/mineral/random/wasteplanet = 50,
 		/turf/closed/wall/concrete/wasteplanet = 15,
 		/turf/closed/wall/concrete/reinforced/wasteplanet = 3
 	)

--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -265,7 +265,7 @@
 		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 3,
 		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
 		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 10
+		/obj/structure/spawner/hivebot = 15
 	)
 	mob_spawn_chance = 2
 
@@ -422,7 +422,7 @@
 		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 3,
 		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
 		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 10
+		/obj/structure/spawner/hivebot = 15
 	)
 
 /datum/biome/cave/waste/conc //da concrete jungle baybee
@@ -461,7 +461,7 @@
 		/mob/living/simple_animal/bot/secbot/ed209/rockplanet = 3,
 		/mob/living/simple_animal/hostile/abandoned_minebot = 15,
 		/mob/living/simple_animal/bot/floorbot/rockplanet = 15,
-		/obj/structure/spawner/hivebot = 10
+		/obj/structure/spawner/hivebot = 15
 	)
 
 	flora_spawn_chance = 30

--- a/code/datums/mapgen/planetary/WasteGenerator.dm
+++ b/code/datums/mapgen/planetary/WasteGenerator.dm
@@ -81,7 +81,7 @@
 			BIOME_LOWEST_HUMIDITY = /datum/biome/cave/waste,
 			BIOME_LOW_HUMIDITY = /datum/biome/cave/waste,
 			BIOME_MEDIUM_HUMIDITY = /datum/biome/cave/waste/metal,
-			BIOME_HIGH_HUMIDITY = /datum/biome/cave/waste/metal/,
+			BIOME_HIGH_HUMIDITY = /datum/biome/cave/waste/metal,
 			BIOME_HIGHEST_HUMIDITY = /datum/biome/cave/waste/metal
 		)
 	)


### PR DESCRIPTION
## About The Pull Request

-Significantly decreases the wall density of metal and concrete cave biomes
-Reduced the amount of caves that generate
-Heavily reduces natural hivebot and hivebot fabricators across the board
-Removes the hivebot metal biome
-Lowers restricted gas amount to a fraction of the amount and limits it only to Sulfur Dioxide like salty sand worlds

## Why It's Good For The Game

Wastes are seldom visited except for wanting to put the crew into the trenches for little reward. They're so dangerous that it is often not worth the time to risk visiting the planet ruin.

Hivebot numbers were decreased because upwards of a hundred or more would often spawn on just one, dwarfing numbers of even the largest and most difficult of ruins. 

Looking to just make Wastes more walkable and able to be traversed without walking into 80 concrete walls, 300 hivebots, and an atmosphere composed of 100% chlorine gas

Old
<img width="999" height="941" alt="image" src="https://github.com/user-attachments/assets/d92b8600-6429-453e-9f99-87e77a8fe3ee" />

New
<img width="1006" height="959" alt="image" src="https://github.com/user-attachments/assets/357d4c84-21d6-4149-8e4a-ca3c07c2d903" />


## Changelog

:cl:
del: Removed hivebot metal biome from wastes
balance: Wastes are now significantly less cavey and have much less hivebots. Current cave biomes have less concrete and wall density
/:cl: