### PR TITLE
Revert "Make it so suit pockets are openable again"

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -137,7 +137,6 @@
 	strip_delay = EQUIP_DELAY_COAT * 1.5
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
-	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		return FALSE
 	if(unique_reskin && !current_skin)


### PR DESCRIPTION
## Why It's Good For The Game

just completely broke the menus for recolourable vests

## Changelog

:cl:
fix: You can recolour clothes again
/:cl: