### PR TITLE
Hivebots have a cap on how much they can grow.

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
@@ -229,6 +229,7 @@
 	if(scrap.salvageable_parts)
 		for(var/path in scrap.salvageable_parts)
 			maxHealth += 5
+			heal_overall_damage(5)
 			growth += 5
 		scrap.salvageable_parts = null
 	scrap.dismantle(src)

--- a/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/_hivebot.dm
@@ -53,6 +53,12 @@
 	///what does a hivebot shooting sound like
 	var/firing_sound = 'sound/weapons/gun/pistol/shot.ogg'
 
+	/// How much extra max health can this hivebot get from scrap?
+	var/growth_cap = 100
+	/// keeps track of how much it's grown for sizing up
+	var/growth = 0
+	var/growth_stage = 0
+
 	///aggro phrases on our hivebot
 	var/list/aggro_quips = list("CODE 7-34!!",
 		"CODE 7-11!!",
@@ -217,14 +223,36 @@
 	if(!COOLDOWN_FINISHED(src, salvage_cooldown))
 		balloon_alert(src, "recharging!")
 		return
+	if(growth >= growth_cap)
+		to_chat(src, span_warning("You don't have any more capacity to integrate more scrap!"))
+		return
 	if(scrap.salvageable_parts)
 		for(var/path in scrap.salvageable_parts)
 			maxHealth += 5
+			growth += 5
 		scrap.salvageable_parts = null
 	scrap.dismantle(src)
+	grow()
 	do_sparks(n = 3, c = TRUE, source = scrap)
 	to_chat(src, span_warning("Salvaging complete!"))
+	qdel(scrap)
 	COOLDOWN_START(src, salvage_cooldown, 50 SECONDS)
+
+/mob/living/basic/hivebot/proc/grow()
+	var/growth_percent = growth/growth_cap
+	switch(growth_stage)
+		if(1)
+			if(growth_percent > 0.33)
+				transform *= 1.1
+				growth_stage++
+		if(2)
+			if(growth_percent > 0.66)
+				transform *= 1.1
+				growth_stage++
+		if(3)
+			if(growth_percent > 0.88)
+				transform *= 1.1
+				growth_stage++
 
 /datum/action/innate/hivebot/foamwall/Activate()
 	var/mob/living/basic/hivebot/our_hivebot = owner

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_behavior.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_behavior.dm
@@ -61,8 +61,6 @@
 /datum/ai_behavior/hunt_target/repair_machines/target_caught(mob/living/basic/hivebot/mechanic/hunter, obj/machinery/repair_target)
 	hunter.repair_machine(repair_target)
 
-/datum/ai_behavior/find_hunt_target/scrap_machines
-
 /datum/ai_behavior/find_hunt_target/scrap_machines/valid_dinner(mob/living/source, obj/structure/salvageable/yummers, radius)
 	if(length(yummers.salvageable_parts))
 		return TRUE

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_behavior.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_behavior.dm
@@ -61,6 +61,8 @@
 /datum/ai_behavior/hunt_target/repair_machines/target_caught(mob/living/basic/hivebot/mechanic/hunter, obj/machinery/repair_target)
 	hunter.repair_machine(repair_target)
 
+/datum/ai_behavior/find_hunt_target/scrap_machines
+
 /datum/ai_behavior/find_hunt_target/scrap_machines/valid_dinner(mob/living/source, obj/structure/salvageable/yummers, radius)
 	if(length(yummers.salvageable_parts))
 		return TRUE

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_subtrees.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_ai_subtrees.dm
@@ -93,5 +93,12 @@
 	hunt_range = 12
 	hunt_chance = 20
 
+/datum/ai_planning_subtree/find_and_hunt_target/salvage_machines/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
+	. = ..()
+	if(istype(controller.pawn, /mob/living/basic/hivebot))
+		var/mob/living/basic/hivebot/our_bot = controller.pawn
+		if(our_bot.growth >= our_bot.growth_cap)
+			return
+
 /datum/ai_planning_subtree/attack_obstacle_in_path/hivebot
 	attack_behaviour = /datum/ai_behavior/attack_obstructions/hivebot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Addresses #5225.

Hivebots now cap out at 100 extra max health from scrap, and visually grow larger depending how they've eaten to communicate how screwed you are.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

3600 HP hivebot is bad.

## Changelog

:cl:
balance: Hivebots have a cap on how they can grow from scrap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
