### PR TITLE
Make suits with pockets recolorable again

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -137,9 +137,13 @@
 	strip_delay = EQUIP_DELAY_COAT * 1.5
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
-	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		return FALSE
+
+	. = SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
+	if(. & COMPONENT_CANCEL_CLICK_ALT)
+		return
+
 	if(unique_reskin && !current_skin)
 		reskin_obj(user)
 	else


### PR DESCRIPTION
## About The Pull Request

Fixes the bug discovered in #5229 that causes the toggleable and recolorable suits to not be recolorable (example /obj/item/clothing/suit/toggle/pufferjacket) while keeping the pockets accecible.

## Changelog
:cl:
fix: Suits with pockets are recolorable again.
:cl:
