### PR TITLE
updated required byond server version across several files and refactored to remove some old stuff

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1642"
+byond: "515.1647"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM beestation/byond:515.1633 as base
+FROM beestation/byond:515.1647 as base
 
 # Install the tools needed to compile our rust dependencies
 FROM base as rust-build

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1621
+#define MIN_COMPILER_BUILD 1644
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1621 or higher
+#error You need version 515.1644 or higher
 #endif
 
 // 516.1660 broke (x in vars), which breaks a lot of things.
@@ -17,13 +17,6 @@
 // Keep savefile compatibilty at minimum supported level
 #if DM_VERSION >= 515
 /savefile/byond_version = MIN_COMPILER_VERSION
-#endif
-
-// 515 split call for external libraries into call_ext
-#if DM_VERSION < 515
-#define LIBCALL call
-#else
-#define LIBCALL call_ext
 #endif
 
 // So we want to have compile time guarantees these methods exist on local type

--- a/code/_debugger.dm
+++ b/code/_debugger.dm
@@ -9,5 +9,5 @@
 /datum/debugger/proc/enable_debugger()
 	var/dll = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (dll)
-		LIBCALL(dll, "auxtools_init")()
+		call_ext(dll, "auxtools_init")()
 		enable_debugging()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -282,7 +282,7 @@ GLOBAL_VAR(restart_counter)
 	shutdown_logging() // makes sure the thread is closed before end, else we terminate
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (debug_server)
-		LIBCALL(debug_server, "auxtools_shutdown")()
+		call_ext(debug_server, "auxtools_shutdown")()
 	..()
 
 /world/proc/update_status()

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1642
+export BYOND_MINOR=1647
 
 #rust version
 export RUST_VERSION=1.81.0


### PR DESCRIPTION
Title. A subsequent pull request relies on this. 1644 has a major bugfix for in style loops.

Tested this and #5237 on 515.1647 and 516.1667

## Changelog

:cl:
server: Cleaned up __byond_version_compat.dm, minimum version is now 515.1644
server: updates .tgs.yml, dependencies.sh, and dockerfile to use 515.1647
/:cl: