### PR TITLE
Reverts #1885, Depends #5236

### DIFF
--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -1,10 +1,3 @@
-// Q: Why are there so many C-like for loops in this file? Aren't those bad practice?
-// A: There's a bug in the BYOND compiler that causes runtiming procs in try blocks within for loops,
-//    of the form for(var/i in 1 to N) or similar, to cause the loop to break prematurely if the runtiming proc's
-//    return value is being used (such as to store a value or in an if() statement).
-//    Thus, all loops of that form in this file have been replaced with their C-like equivalent for consistency,
-//    even if the loop can't trigger the bug (such as if it lacks a proc call or try block).
-
 /// This is the main proc. It instantly moves our mobile port to stationary port `new_dock`.
 /obj/docking_port/mobile/proc/initiate_docking(obj/docking_port/stationary/new_dock, movement_direction, force=FALSE)
 	// Crashing this ship with NO SURVIVORS
@@ -108,7 +101,6 @@
 	var/list/exceptions_list = list()
 	// Recount turfs since we've got them all anyways
 	var/new_turf_count = 0
-	// C-like for loop; see top of file for explanation
 	for(var/i = 1, i <= old_turfs.len, i++)
 		try
 			CHECK_TICK
@@ -128,8 +120,7 @@
 			move_mode = old_area.beforeShuttleMove(all_shuttle_areas)											//areas											//areas
 
 			var/list/old_contents = oldT.contents
-			// C-like for loop; see top of file for explanation
-			for(var/k = 1, k <= old_contents.len, k++)
+			for(var/k in 1 to old_contents.len)
 				try
 					CHECK_TICK
 					var/atom/movable/moving_atom = old_contents[k]
@@ -140,6 +131,7 @@
 					exceptions_list += e1
 
 			move_mode = oldT.fromShuttleMove(newT, move_mode)												//turfs
+
 			move_mode = newT.toShuttleMove(oldT, move_mode, src)											//turfs
 
 			if(move_mode & MOVE_AREA)
@@ -171,8 +163,7 @@
 	//Matrix multiply to get from current coords to new coords
 	//Calculate this before this mobile port moves
 	var/matrix/displacement_matrix = matrix(-src.x, -src.y, MATRIX_TRANSLATE) * matrix(rotation, MATRIX_ROTATE) *matrix(new_dock.x, new_dock.y, MATRIX_TRANSLATE)
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			var/turf/oldT = old_turfs[i]
 			var/turf/newT = new_turfs[i]
@@ -190,8 +181,7 @@
 		catch(var/exception/e1)
 			exceptions_list += e1
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			var/turf/oldT = old_turfs[i]
 			var/turf/newT = new_turfs[i]
@@ -204,8 +194,7 @@
 				var/shuttle_layers = -1*A.get_missing_shuttles(oldT)
 
 				//Count the shuttles on this turf as the number of skipovers we'll go down for the baseturf copy.
-				// C-like for loop; see top of file for explanation
-				for(var/index = 1, index <= all_towed_shuttles.len, index++)
+				for(var/index in 1 to all_towed_shuttles.len)
 					M = all_towed_shuttles[index]
 					if(!M.underlying_turf_area[oldT]) //This shuttle isn't on this turf
 						continue
@@ -218,8 +207,7 @@
 		catch(var/exception/e2)
 			exceptions_list += e2
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			var/turf/oldT = old_turfs[i]
 			var/turf/newT = new_turfs[i]
@@ -231,8 +219,7 @@
 
 				//Find the new area, and update the underlying_turf_area of all towed shuttles
 				var/obj/docking_port/mobile/M
-				// C-like for loop; see top of file for explanation
-				for(var/index = 0, index < all_towed_shuttles.len, index++) // note the different start value and end condition
+				for(var/index in 0 to all_towed_shuttles.len-1)
 					M = all_towed_shuttles[all_towed_shuttles.len-index]
 					if(!M.underlying_turf_area[oldT]) //the shuttle isn't on this turf
 						continue
@@ -285,9 +272,7 @@
 	var/new_parallax_dir = FALSE
 	if(istype(new_dock, /obj/docking_port/stationary/transit))
 		new_parallax_dir = preferred_direction
-
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= areas_to_move.len, i++)
+	for(var/i in 1 to areas_to_move.len)
 		try
 			CHECK_TICK
 			var/area/internal_area = areas_to_move[i]
@@ -295,8 +280,7 @@
 		catch(var/exception/e1)
 			exceptions_list += e1
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			CHECK_TICK
 			if(!(old_turfs[old_turfs[i]] & MOVE_TURF))
@@ -307,8 +291,7 @@
 		catch(var/exception/e2)
 			exceptions_list += e2
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= moved_atoms.len, i++)
+	for(var/i in 1 to moved_atoms.len)
 		try
 			CHECK_TICK
 			var/atom/movable/moved_object = moved_atoms[i]
@@ -328,8 +311,7 @@
 		catch(var/exception/e4)
 			exceptions_list += e4
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= areas_to_move.len, i++)
+	for(var/i in 1 to areas_to_move.len)
 		try
 			CHECK_TICK
 			var/area/internal_area = areas_to_move[i]
@@ -337,8 +319,7 @@
 		catch(var/exception/e5)
 			exceptions_list += e5
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			CHECK_TICK
 			if(!(old_turfs[old_turfs[i]] & MOVE_CONTENTS | MOVE_TURF))
@@ -349,8 +330,7 @@
 		catch(var/exception/e6)
 			exceptions_list += e6
 
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= moved_atoms.len, i++)
+	for(var/i in 1 to moved_atoms.len)
 		try
 			CHECK_TICK
 			var/atom/movable/moved_object = moved_atoms[i]
@@ -367,9 +347,7 @@
 
 /obj/docking_port/mobile/proc/reset_air()
 	var/list/turfs = return_ordered_turfs(x, y, z, dir)
-
-	// C-like for loop; see top of file for explanation
-	for(var/i = 1, i <= length(turfs), i++)
+	for(var/i in 1 to length(turfs))
 		var/turf/open/T = turfs[i]
 		if(istype(T))
 			T.air.copy_from_turf(T)

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -101,7 +101,7 @@
 	var/list/exceptions_list = list()
 	// Recount turfs since we've got them all anyways
 	var/new_turf_count = 0
-	for(var/i = 1, i <= old_turfs.len, i++)
+	for(var/i in 1 to old_turfs.len)
 		try
 			CHECK_TICK
 			var/turf/oldT = old_turfs[i]

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -131,7 +131,6 @@
 					exceptions_list += e1
 
 			move_mode = oldT.fromShuttleMove(newT, move_mode)												//turfs
-
 			move_mode = newT.toShuttleMove(oldT, move_mode, src)											//turfs
 
 			if(move_mode & MOVE_AREA)


### PR DESCRIPTION
Basically requires [#5236.](https://github.com/shiptest-ss13/Shiptest/pull/5236)
**Byond ver => 515.1644 on server is required.**

Closes [#3692](https://github.com/shiptest-ss13/Shiptest/issues/3692)

In summary, C style loops cause the DM virtual machine to have to perform context switches and extra ops on each iteration. In style loops do not. There is a 5 to 10x difference in speed each time the loop starts. C style loops had to be used because of a bug that got fixed in 1644, making the workaround no longer necessary.

This isn't going to be a revolutionary speed increase for ships landing and taking off as the contents of these loops are heavier than the time it takes to restart the loop, but a little speedup might be seen as there are a lot of iterations occurring.

Tested this and #5236 on 515.1647 and 516.1667 by taking off and landing.

:cl:
refactor: Byond version 515.1644 fixed a nasty bug with in style loops that led to SGTs. Reverting workaround code as prior PR requires 515.1644 or higher.
/:cl: