### PR TITLE
Frag Grenade Adjustment + Removed Riot Launcher from Cargo

### DIFF
--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -18,6 +18,7 @@
 	name = "HE Grenade"
 	desc = "A compact shrapnel grenade meant to devastate nearby organisms and cause some damage in the process. Pull pin and throw opposite direction."
 	icon_state = "concussion"
+	ex_dev = 0
 	ex_heavy = 2
 	ex_light = 3
 	ex_flame = 3
@@ -28,9 +29,9 @@
 	icon_state = "frag"
 	shrapnel_type = /obj/projectile/bullet/shrapnel
 	shrapnel_radius = 4
-	ex_heavy = 1
+	ex_heavy = 0
 	ex_light = 3
-	ex_flame = 4
+	ex_flame = 1
 
 /obj/item/grenade/frag/mega
 	name = "FRAG grenade"

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -43,7 +43,7 @@
 /datum/supply_pack/sec_supply/flashbangs
 	name = "Flashbang Crate"
 	desc = "Contains one flashbang for use in door breaching and riot control."
-	cost = 100
+	cost = 200
 	contains = list(/obj/item/grenade/flashbang)
 	crate_name = "flashbangs crate"
 
@@ -57,7 +57,7 @@
 /datum/supply_pack/sec_supply/teargas
 	name = "Teargas Grenade Crate"
 	desc = "Contains one teargas grenade for use in crowd dispersion and riot control."
-	cost = 100
+	cost = 200
 	contains = list(/obj/item/grenade/chem_grenade/teargas)
 	crate_name = "teargas grenades crate"
 
@@ -166,7 +166,7 @@
 /datum/supply_pack/sec_supply/frag_grenade
 	name = "Frag Grenade Crate"
 	desc = "Contains one fragmentation grenade. Better not let it go off in your hands."
-	cost = 250
+	cost = 750
 	contains = list(/obj/item/grenade/frag)
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -166,7 +166,7 @@
 /datum/supply_pack/sec_supply/frag_grenade
 	name = "Frag Grenade Crate"
 	desc = "Contains one fragmentation grenade. Better not let it go off in your hands."
-	cost = 750
+	cost = 500
 	contains = list(/obj/item/grenade/frag)
 	crate_name = "frag grenade crate"
 	crate_type = /obj/structure/closet/crate/secure/weapon

--- a/code/modules/cargo/packs/weapon_attachments.dm
+++ b/code/modules/cargo/packs/weapon_attachments.dm
@@ -101,13 +101,6 @@
 	contains = list(/obj/item/storage/guncase/energy/underbarrel_e_gun)
 	crate_name = "underbarrel energy gun crate"
 
-/datum/supply_pack/attachment/riot_launcher
-	name = "Underbarrel Riot Grenade Launcher Crate"
-	desc = "Contains a single shot underbarrel riot grenade launcher to be mounted on a firearm."
-	cost = 750
-	contains = list(/obj/item/storage/guncase/underbarrel_riot_grenade)
-	crate_name = "underbarrel riot grenade launcher crate"
-
 /datum/supply_pack/attachment/flare
 	name = "Underbarrel Flare Gun Crate"
 	desc = "Contains a single shot underbarrel flare gun to be mounted on a firearm. One box of flares included."


### PR DESCRIPTION
## About The Pull Request

- Increased frag grenade cost to 500
- Slightly increased Tear gas and Flash bang cost to 200
- Removed riot grenade launcher underbarrel from cargo
- Removed heavy explosive damage and slightly reduced flame range from frags
- Removed devastation from Concussion grenades

## Why It's Good For The Game

Frags just seemed wayyyyyy too cheap for how effective they are for PVP (and to a lesser extent PVE). See them spammed out a loooot.

Feel like whatever balance grenades have is pretty much negated by the riot. You can just spit it out beyond normal throwing distance (and ludicrously far if you have it on a DMR or Sniper) with a quickie firemode toggle. Was considering simply locking it from DMRs and snipers but I feel like you can still get a pretty similar effect with just normal ADS. Might reconsider, would like to hear thoughts

As of 9/8: Wanted to lean grenades away from the direct explosive damage and more towards the shrapnel. Removing heavy explosive damage reduces the impact of cookoff and puts more emphasis on the shrapnel (which still does a lot of damage but a fair bit less so cause its tied to shrapnel + bullet armour instead of explosives and all the jank with that)

## Changelog

:cl:
del: Removed riot grenade underbarrel from cargo
balance: Increased frag grenade and other auxiliary grenade costs slightly
balance: Removed heavy explosive damage from Frags and devastation from Concussion grenades
/:cl: