### PR TITLE
Add backpacks to the clothing vendor

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -39,6 +39,8 @@
 	strip_delay = EQUIP_DELAY_BACK * 1.5
 	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 
+	custom_price = 50
+
 /obj/item/storage/backpack/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -7,6 +7,9 @@
 	product_slogans = "Dress for success!;Prepare to look swagalicious!;Look at all this swag!;Why leave style up to fate? Use the ClothesMate!"
 	vend_reply = "Thank you for using the ClothesMate!"
 	products = list(
+		/obj/item/storage/backpack = 4,
+		/obj/item/storage/backpack/satchel = 4,
+		/obj/item/storage/backpack/duffelbag = 4,
 		/obj/item/clothing/head/beanie = 3,
 		/obj/item/clothing/head/soft = 3,
 		/obj/item/clothing/head/beanie/black = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 4 backpacks, satchels and duffel bags to the ClothesMate at the price of 50 credits (same as in cargo).

## Why It's Good For The Game

You shouldn't need your captain to buy a bag.

## Changelog

:cl:
add: Backpacks, satchels and duffel bags are now in the ClothesMate for 50 credits
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
