### PR TITLE
Make the content of blood bags accecible for chemistry.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -113,7 +113,6 @@
 
 		beaker = W
 		to_chat(user, span_notice("You attach [W] to [src]."))
-
 		user.log_message("attached a [W] to [src] at [AREACOORD(src)] containing ([beaker.reagents.log_list()])", LOG_ATTACK)
 		add_fingerprint(user)
 		update_appearance()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -99,8 +99,21 @@
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
+
+		var/obj/item/reagent_containers/blood/bloodbag = W
+		if (istype(bloodbag) && bloodbag.cut && bloodbag.reagents.total_volume)
+			var/floor = get_turf(src)
+			bloodbag.reagents.expose(get_turf(src), TOUCH)
+			bloodbag.reagents.clear_reagents()
+			bloodbag.forceMove(floor)
+			playsound(src, 'sound/items/glass_splash.ogg', 50, 1)
+
+			visible_message(span_warning("[W] falls from [src] and splashes it's content onto [floor]!"))
+			return
+
 		beaker = W
 		to_chat(user, span_notice("You attach [W] to [src]."))
+
 		user.log_message("attached a [W] to [src] at [AREACOORD(src)] containing ([beaker.reagents.log_list()])", LOG_ATTACK)
 		add_fingerprint(user)
 		update_appearance()

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -91,7 +91,7 @@
 			labelled = 0
 			update_name()
 
-	if (!cut && I.get_sharpness() == SHARP_POINTY )
+	if (!cut && I.get_sharpness() == SHARP_POINTY)
 		visible_message(span_warning("[user], begins to slice to slice \the [name],"), span_notice("You begin the slice \the [name]."), vision_distance=COMBAT_MESSAGE_RANGE)
 		if (do_after(user, 3 SECONDS, src))
 			to_chat(user, span_notice("You cut \the [name] open."))

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -113,6 +113,10 @@
 			reagents.expose(target, TOUCH)
 			reagents.clear_reagents()
 			playsound(src, 'sound/items/glass_splash.ogg', 50, 1)
+
+		else if(user.a_intent == INTENT_DISARM)
+			attempt_pour(target, user)
+
 		else if(target.is_refillable()) //Something like a glass. Player probably wants to transfer TO it.
 			if(!reagents.total_volume)
 				to_chat(user, span_warning("[src] is empty!"))
@@ -125,5 +129,3 @@
 			var/trans = reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 			to_chat(user, span_notice("You transfer [trans] unit\s of the solution to [target]."))
 			playsound(src, 'sound/items/glass_transfer.ogg', 50, 1)
-		else
-			attempt_pour(target, user)


### PR DESCRIPTION
## About The Pull Request

- Blood can be drawn out of blood bags with a syringe.
- Blood bags can be cut open.
- The content of a cut bag can be splashed or poured out however if a cut bag is attached to an IV drip it will fall on the floor.

## Why It's Good For The Game

Having to harvest blood from corpses or rely on donation to make synthflesh when  you have a crate of blood bags is not great.

## Changelog

:cl:
add: Blood bag can now be drawn by syringes cut open to access their content.
:cl: