### PR TITLE
Disables Prayers

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -1,6 +1,6 @@
 /mob/verb/pray(msg as text)
-	set category = "IC"
 	set name = "Pray"
+	set hidden = TRUE
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."), confidential = TRUE)


### PR DESCRIPTION
## About The Pull Request

Disables the Prayer verb for use.

Saycode scares me and there's weird other stuff interlinked so disabling it seemed like the best option.

## Why It's Good For The Game

Admins don't read Prayers, they're not how you're supposed to bring up issues that need admin intervention. Chaplains have ceased to exist entirely (usually the main reason for Prayers to even be used), and most admins can attest that with no sound notification and no easily spottable special text that they are incredibly hard to even notice and respond to.

The nature of them being "IC" requests also makes it very strange to respond to them in general.

This disables them entirely so people who have actual requests will take them through the proper channels rather than using a verb that nobody will read, and makes no IC interactions at all for any observers.

## Changelog

:cl:
balance: You keep screaming but God won't hear your Prayers.
/:cl:

