### PR TITLE
ammo counter on scope OR railing

### DIFF
--- a/code/game/objects/items/attachments/ammo_counter.dm
+++ b/code/game/objects/items/attachments/ammo_counter.dm
@@ -1,6 +1,6 @@
 /obj/item/attachment/ammo_counter
 	name = "ammunition counter"
-	desc = "A computerized ammunition tracker for use on conventional firearms. Includes a small toggle for telling the user when ammo is depleted."
+	desc = "A computerized ammunition tracker for use on conventional firearms. Includes a small toggle for telling the user when ammo is depleted. Capable of mounting on both a railing or scope, depending on the user's preference."
 	icon_state = "ammo_counter"
 
 	attach_features_flags = ATTACH_REMOVABLE_HAND|ATTACH_TOGGLE

--- a/code/game/objects/items/attachments/ammo_counter.dm
+++ b/code/game/objects/items/attachments/ammo_counter.dm
@@ -5,7 +5,7 @@
 
 	attach_features_flags = ATTACH_REMOVABLE_HAND|ATTACH_TOGGLE
 
-	slot = ATTACHMENT_SLOT_RAIL
+	slot = ATTACHMENT_SLOT_SCOPE
 	pixel_shift_x = 0
 	pixel_shift_y = 0
 	size_mod = 0

--- a/code/game/objects/items/attachments/ammo_counter.dm
+++ b/code/game/objects/items/attachments/ammo_counter.dm
@@ -39,11 +39,10 @@
 /obj/item/attachment/ammo_counter/attack_self(mob/user)
 	. = ..()
 	playsound(src, 'sound/items/flashlight_on.ogg', 25)
-	if(slot == ATTACHMENT_SLOT_SCOPE)
+	if(slot == src::slot)
 		slot = ATTACHMENT_SLOT_RAIL
-
 	else
-		slot = ATTACHMENT_SLOT_SCOPE
+		slot = src::slot
 	to_chat(user, span_notice("You adjust [src] to fit on a gun's [slot]."))
 
 /obj/item/attachment/ammo_counter/toggle_attachment(obj/item/gun/gun, mob/user)

--- a/code/game/objects/items/attachments/ammo_counter.dm
+++ b/code/game/objects/items/attachments/ammo_counter.dm
@@ -36,6 +36,16 @@
 			qdel(our_counter)
 			return TRUE
 
+/obj/item/attachment/ammo_counter/attack_self(mob/user)
+	. = ..()
+	playsound(src, 'sound/items/flashlight_on.ogg', 25)
+	if(slot == ATTACHMENT_SLOT_SCOPE)
+		slot = ATTACHMENT_SLOT_RAIL
+
+	else
+		slot = ATTACHMENT_SLOT_SCOPE
+	to_chat(user, span_notice("You adjust [src] to fit on a gun's [slot]."))
+
 /obj/item/attachment/ammo_counter/toggle_attachment(obj/item/gun/gun, mob/user)
 	. = ..()
 	if(gun::empty_alarm)


### PR DESCRIPTION
## About The Pull Request
Makes ammo counters fit on scope by default, but adds an interaction for them to also fit on railings. 

##### why its good for the game
i think its cool

## Changelog

:cl:
balance: ammo counters now go to the scope slot
/:cl: