### PR TITLE
Tiny Arrowsong Tweaks

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scrapstation.dmm
@@ -7276,7 +7276,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/item/storage/toolbox/ammo/c75,
+/obj/item/storage/toolbox/ammo/c65,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/ramzi_station/solars)
 "Oz" = (

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -15720,10 +15720,6 @@
 "Ya" = (
 /obj/structure/table/reinforced,
 /obj/item/cutting_board,
-/obj/item/melee/knife{
-	pixel_x = 7;
-	pixel_y = 3
-	},
 /obj/item/kitchen/rollingpin{
 	pixel_x = -5;
 	pixel_y = 3
@@ -15734,6 +15730,10 @@
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 8;
 	pixel_x = -32
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_x = 8;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/outpost/crew/canteen)

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -1705,6 +1705,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/clipboard,
+/obj/item/clipboard,
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "fq" = (
@@ -14389,6 +14394,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/clipboard,
+/obj/item/clipboard,
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
 "Ui" = (

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -842,7 +842,7 @@
 	pixel_x = -4;
 	pixel_y = 2;
 	name = "Decommissioned SKM-24u";
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -1521,9 +1521,7 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
 "eP" = (
-/obj/item/clothing/suit/space/hardsuit/security/independent/frontier{
-	anchored = 1
-	},
+/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -2520,13 +2518,11 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/bulletproof/x11/clip{
 	pixel_x = -8;
-	pixel_y = 5;
-	anchored = 1
+	pixel_y = 5
 	},
 /obj/item/clothing/head/helmet/bulletproof/m10/clip_vc{
 	pixel_x = 6;
-	pixel_y = 4;
-	anchored = 1
+	pixel_y = 4
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -4242,12 +4238,12 @@
 /obj/item/gun/ballistic/automatic/assault/skm/cm24{
 	pixel_x = -7;
 	pixel_y = 4;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /obj/item/gun/ballistic/automatic/assault/skm{
 	pixel_x = -6;
 	pixel_y = -2;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -6210,12 +6206,12 @@
 /obj/item/gun/ballistic/automatic/smg/cm5{
 	pixel_x = -1;
 	pixel_y = 8;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /obj/item/gun/ballistic/automatic/smg/cm5/compact{
 	pixel_x = 2;
 	pixel_y = 0;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -6695,7 +6691,7 @@
 	pixel_x = -2;
 	pixel_y = 1;
 	name = "Decommissioned Shredder";
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/dark,
@@ -9862,13 +9858,11 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/frontier{
 	pixel_x = 0;
-	pixel_y = 9;
-	anchored = 1
+	pixel_y = 9
 	},
 /obj/item/clothing/neck/dogtag/frontier{
 	pixel_x = 0;
-	pixel_y = -8;
-	anchored = 1
+	pixel_y = -8
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/dark,
@@ -11213,13 +11207,11 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/vest/bulletproof{
 	pixel_x = -9;
-	pixel_y = 1;
-	anchored = 1
+	pixel_y = 1
 	},
 /obj/item/clothing/suit/armor/vest/bulletproof{
 	pixel_x = 5;
-	pixel_y = 0;
-	anchored = 1
+	pixel_y = 0
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -13437,13 +13429,11 @@
 "Rb" = (
 /obj/item/storage/belt/military/clip{
 	pixel_x = -8;
-	pixel_y = -1;
-	anchored = 1
+	pixel_y = -1
 	},
 /obj/item/storage/belt/military/clip{
 	pixel_x = 7;
-	pixel_y = -4;
-	anchored = 1
+	pixel_y = -4
 	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
@@ -13462,12 +13452,12 @@
 /obj/item/gun/ballistic/automatic/marksman/f4{
 	pixel_x = -4;
 	pixel_y = 7;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /obj/item/gun/ballistic/automatic/marksman/f4/indie{
 	pixel_x = -4;
 	pixel_y = 2;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -15883,13 +15873,13 @@
 	name = "Decommissioned Pounder";
 	pixel_x = -1;
 	pixel_y = 6;
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /obj/item/gun/ballistic/automatic/pistol/spitter{
 	pixel_x = 1;
 	pixel_y = -11;
 	name = "Decommissioned Spitter";
-	anchored = 1
+	spawn_no_ammo = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -841,7 +841,8 @@
 /obj/item/gun/ballistic/automatic/hmg/skm_lmg/extended{
 	pixel_x = -4;
 	pixel_y = 2;
-	name = "Decommissioned SKM-24u"
+	name = "Decommissioned SKM-24u";
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -1520,7 +1521,9 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
 "eP" = (
-/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
+/obj/item/clothing/suit/space/hardsuit/security/independent/frontier{
+	anchored = 1
+	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -2517,11 +2520,13 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/bulletproof/x11/clip{
 	pixel_x = -8;
-	pixel_y = 5
+	pixel_y = 5;
+	anchored = 1
 	},
 /obj/item/clothing/head/helmet/bulletproof/m10/clip_vc{
 	pixel_x = 6;
-	pixel_y = 4
+	pixel_y = 4;
+	anchored = 1
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -4236,11 +4241,13 @@
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/assault/skm/cm24{
 	pixel_x = -7;
-	pixel_y = 4
+	pixel_y = 4;
+	anchored = 1
 	},
 /obj/item/gun/ballistic/automatic/assault/skm{
 	pixel_x = -6;
-	pixel_y = -2
+	pixel_y = -2;
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -6202,11 +6209,13 @@
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/smg/cm5{
 	pixel_x = -1;
-	pixel_y = 8
+	pixel_y = 8;
+	anchored = 1
 	},
 /obj/item/gun/ballistic/automatic/smg/cm5/compact{
 	pixel_x = 2;
-	pixel_y = 0
+	pixel_y = 0;
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -6685,7 +6694,8 @@
 /obj/item/gun/ballistic/automatic/hmg/shredder{
 	pixel_x = -2;
 	pixel_y = 1;
-	name = "Decommissioned Shredder"
+	name = "Decommissioned Shredder";
+	anchored = 1
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/dark,
@@ -9852,11 +9862,13 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/frontier{
 	pixel_x = 0;
-	pixel_y = 9
+	pixel_y = 9;
+	anchored = 1
 	},
 /obj/item/clothing/neck/dogtag/frontier{
 	pixel_x = 0;
-	pixel_y = -8
+	pixel_y = -8;
+	anchored = 1
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/dark,
@@ -11201,11 +11213,13 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/vest/bulletproof{
 	pixel_x = -9;
-	pixel_y = 1
+	pixel_y = 1;
+	anchored = 1
 	},
 /obj/item/clothing/suit/armor/vest/bulletproof{
 	pixel_x = 5;
-	pixel_y = 0
+	pixel_y = 0;
+	anchored = 1
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -13423,11 +13437,13 @@
 "Rb" = (
 /obj/item/storage/belt/military/clip{
 	pixel_x = -8;
-	pixel_y = -1
+	pixel_y = -1;
+	anchored = 1
 	},
 /obj/item/storage/belt/military/clip{
 	pixel_x = 7;
-	pixel_y = -4
+	pixel_y = -4;
+	anchored = 1
 	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
@@ -13445,11 +13461,13 @@
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/marksman/f4{
 	pixel_x = -4;
-	pixel_y = 7
+	pixel_y = 7;
+	anchored = 1
 	},
 /obj/item/gun/ballistic/automatic/marksman/f4/indie{
 	pixel_x = -4;
-	pixel_y = 2
+	pixel_y = 2;
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)
@@ -15864,12 +15882,14 @@
 /obj/item/gun/ballistic/automatic/smg/pounder{
 	name = "Decommissioned Pounder";
 	pixel_x = -1;
-	pixel_y = 6
+	pixel_y = 6;
+	anchored = 1
 	},
 /obj/item/gun/ballistic/automatic/pistol/spitter{
 	pixel_x = 1;
 	pixel_y = -11;
-	name = "Decommissioned Spitter"
+	name = "Decommissioned Spitter";
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/library)

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -1580,6 +1580,7 @@
 	name = "morphine syringe"
 	},
 /obj/machinery/light/directional/east,
+/obj/item/defibrillator/compact/loaded,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "eX" = (
@@ -3132,6 +3133,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
 /turf/open/floor/plasteel/tech/grid,
 /area/outpost/hallway/starboard)
 "kn" = (
@@ -6298,10 +6305,14 @@
 	pixel_y = 1
 	},
 /obj/item/storage/toolbox/ammo/c10mm{
-	pixel_x = 0;
+	pixel_x = 9;
 	pixel_y = -9
 	},
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/item/storage/toolbox/ammo/c75{
+	pixel_x = -9;
+	pixel_y = -9
+	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "va" = (
@@ -7074,8 +7085,6 @@
 	},
 /obj/item/ammo_box/magazine/skm_762_40/extended,
 /obj/item/ammo_box/magazine/skm_762_40/extended,
-/obj/item/ammo_box/magazine/skm_762_40/extended,
-/obj/item/ammo_box/magazine/skm_762_40/extended,
 /obj/item/ammo_box/magazine/rottweiler_308_box,
 /obj/item/ammo_box/magazine/f4_308,
 /obj/item/ammo_box/magazine/f4_308,
@@ -7097,6 +7106,8 @@
 /obj/item/ammo_box/magazine/m12g_bulldog/empty,
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
 /obj/machinery/light/directional/south,
+/obj/item/ammo_box/magazine/f90,
+/obj/item/ammo_box/magazine/f90,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "xq" = (
@@ -9007,8 +9018,8 @@
 /obj/item/gun/ballistic/automatic/hmg/rottweiler,
 /obj/item/gun/ballistic/automatic/marksman/f4/inteq,
 /obj/item/gun/ballistic/automatic/assault/skm/inteq,
-/obj/item/gun/ballistic/automatic/assault/skm/inteq,
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/item/gun/ballistic/automatic/marksman/f90/inteq,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
 "DC" = (
@@ -12407,6 +12418,12 @@
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/head/helmet/bulletproof/x11/clip,
 /obj/item/clothing/suit/armor/vest/bulletproof,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/mask/breath/facemask,
 /turf/open/floor/plasteel/tech/grid,
 /area/outpost/hallway/starboard)
 "NK" = (
@@ -12714,7 +12731,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/outpost/cargo/smeltery)
 "OP" = (
-/obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	pixel_x = 0;
 	pixel_y = 21;
@@ -12724,6 +12740,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 9
 	},
+/obj/machinery/telecomms/allinone/indestructible,
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
 "OQ" = (

--- a/_maps/outpost/clip_ocean.dmm
+++ b/_maps/outpost/clip_ocean.dmm
@@ -6309,7 +6309,7 @@
 	pixel_y = -9
 	},
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/item/storage/toolbox/ammo/c75{
+/obj/item/storage/toolbox/ammo/c65{
 	pixel_x = -9;
 	pixel_y = -9
 	},

--- a/code/game/objects/items/storage/ammo_can.dm
+++ b/code/game/objects/items/storage/ammo_can.dm
@@ -144,7 +144,7 @@
 	for (var/i in 1 to 4)
 		new /obj/item/storage/box/ammo/c46x30mm(src)
 
-/obj/item/storage/toolbox/ammo/c75/PopulateContents()
+/obj/item/storage/toolbox/ammo/c65/PopulateContents()
 	name = "ammo can (6.5mm CLIP)"
 	icon_state = "ammobox_65"
 	current_skin = "6.5mm CLIP"


### PR DESCRIPTION
## About The Pull Request

- All-in-One tcomms in the command area
- Saluki and ammo in the ERT armoury
- Facemasks in both CLIP and Inteq ERT areas
- Defibrillator in ERT corpsman
- Renamed 7.5mm ammo can path back to 6.5 cause it was annoying
- Folders and Clipboards to the fax area
- Takes ammo out of the museum guns (keeps magazines)

## Why It's Good For The Game

Stuff to equip ERTs with

## Changelog

:cl:
add: Added some misc supplies and changes to Arrowsong's ERT armoury and museum. Comms to Arrowsong
/:cl: