### PR TITLE
Leyak Paperwork Buff + windoor

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_hardliners_leyak.dmm
+++ b/_maps/shuttles/syndicate/syndicate_hardliners_leyak.dmm
@@ -1312,11 +1312,8 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
 	dir = 10
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/photocopier,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "nt" = (
@@ -2271,8 +2268,10 @@
 /obj/machinery/door/window/brigdoor/westright{
 	layer = 3.29;
 	req_access = list(3);
-	req_ship_access = 1
+	req_ship_access = 1;
+	dir = 4
 	},
+/obj/machinery/door/window/westleft,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "AT" = (

--- a/_maps/shuttles/syndicate/syndicate_hardliners_leyak.dmm
+++ b/_maps/shuttles/syndicate/syndicate_hardliners_leyak.dmm
@@ -672,6 +672,10 @@
 	pixel_y = -21;
 	id = "leyakgun"
 	},
+/obj/item/stamp/hardliners{
+	pixel_x = 2;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)
 "fS" = (
@@ -1631,6 +1635,10 @@
 /obj/item/megaphone{
 	pixel_x = 0;
 	pixel_y = 11
+	},
+/obj/item/stamp/cybersun{
+	pixel_x = 1;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/bridge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I changed the trashcan in the bridge for a photocopier and made the armoury windoor rotated inward and put a public one on the outside so you can put stuff on the table like the HOP line

<img width="325" height="319" alt="image" src="https://github.com/user-attachments/assets/ca775cee-8707-4ae7-a944-6496bf62492d" />

<img width="319" height="339" alt="image" src="https://github.com/user-attachments/assets/6c1b65b8-c429-470e-a4f9-da8cf870eda3" />


## Why It's Good For The Game
photocopiers are like godsgrace to the land
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: The Leyak has a photocopier now. It also has it's indoor adjusted.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
