### PR TITLE
FIX: Feeding another character Food

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -307,7 +307,7 @@ Behavior that's still missing from this component that original food items had t
 		return
 	var/fullness = eater.nutrition + 10 //The theoretical fullness of the person eating if they were to eat this
 
-	var/time_to_eat = (eater = feeder) ? eat_time : EAT_TIME_FORCE_FEED
+	var/time_to_eat = (eater == feeder) ? eat_time : EAT_TIME_FORCE_FEED
 
 	if(eater == feeder)//If you're eating it yourself.
 		if(eat_time && !do_after(feeder, time_to_eat, eater, timed_action_flags = food_flags & FOOD_FINGER_FOOD ? IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE : NONE)) //Gotta pass the minimal eat time


### PR DESCRIPTION
## About The Pull Request
Feeding another character no longer makes it so that the nursing one eats what he is trying to feed to the other
Yes, i'm tested its last version `shiptest-ss13/master` branch, actually bug.
<details>
<summary>Demonstration</summary>

Before:

https://github.com/user-attachments/assets/64f0ee7f-58ba-4d3c-89c1-5bf38e555282

After:

https://github.com/user-attachments/assets/25742a87-ff61-47b7-8a29-4d61c91ce73e

</details>

## Why It's Good For The Game
`var/time_to_eat` does not assign values, but compares them, replace logic `time_to_eat` - `=` -> `==` 

## Changelog

:cl:
fix: Feeding another character
/:cl:
