### PR TITLE
Enhances the visibility of the helm's lock status

### DIFF
--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -496,6 +496,7 @@
 	else
 		helm_locked = !helm_locked
 		playsound(src, helm_locked ? 'sound/machines/button4.ogg' : 'sound/machines/button3.ogg')
+		user.visible_message(span_notice("[user] presses the keyfob on [shipkey]."), helm_locked ? span_notice("You press the keyfob on [shipkey], locking the helm.") : span_notice("You press the keyfob on [shipkey], unlocking the helm."))
 
 	for(var/obj/machinery/computer/helm/helm as anything in helms)
 		SStgui.close_uis(helm)
@@ -569,6 +570,10 @@
 		update_appearance()
 	name = "ship key ([master_ship.name])"
 
+/obj/item/key/ship/examine(mob/user)
+	. = ..()
+	. += "\nThe ship's helm is currently [master_ship.helm_locked ? span_red("LOCKED") : span_green("UNLOCKED")]."
+
 /obj/item/key/ship/update_overlays()
 	. = ..()
 	if(!random_color) //icon override
@@ -586,6 +591,9 @@
 	if(!master_ship || !Adjacent(user))
 		return ..()
 
+	playsound(src, master_ship.helm_locked ? 'sound/machines/button4.ogg' : 'sound/machines/button3.ogg', 50, TRUE)
+
 	master_ship.attempt_key_usage(user, src, src) // hello I am a helm console I promise
+
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds feedback into the chat when a keyfob is pressed, in the form of a message in the chat, and an audible sound cue. It also displays the status of the helm lock when examined -- because presumably a device that could toggle the status of a ship's helm remotely would feature an LED to indicate this status.

<img width="699" height="278" alt="image" src="https://github.com/user-attachments/assets/5a31e68d-f1cd-4bc1-9c5a-b61f8fd3fcbe" />

## Why It's Good For The Game

Ship keys have the ability to toggle a helm's status remotely, but it doesn't give one feedback in the chat when it's done. These changes should hopefully make it clearer.

## Changelog

:cl:
add: Added feedback upon keyfob toggle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
