### PR TITLE
Adds a few modified meson goggles to the Derecho

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_derecho.dmm
@@ -2490,6 +2490,7 @@
 /obj/item/megaphone,
 /obj/item/storage/guncase/pistol/pc76,
 /obj/machinery/light/small/directional/west,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm)
 "vs" = (
@@ -4817,6 +4818,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/melee/knife/survival,
 /obj/item/clothing/mask/breath/ngr,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "QD" = (
@@ -5353,6 +5355,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/knife/survival,
 /obj/item/clothing/mask/breath/ngr,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/pod,
 /area/ship/storage/equip)
 "Uv" = (
@@ -5864,6 +5867,7 @@
 /obj/item/storage/guncase/pistol/a357,
 /obj/machinery/light/small/directional/east,
 /obj/item/storage/belt/military/assault,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "Yq" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a modified meson goggle to the captain's locker, the foreman's locker, and the wrecker's lockers on the Derecho.

## Why It's Good For The Game

This should allow for additional outfit customization options aboard the ship.

## Changelog

:cl:
add: Added a few modified mesons to the Derecho
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
