### PR TITLE
Adds claymores to the outpost export market, and removes them from outpost cargo

### DIFF
--- a/code/modules/cargo/exports/scraping.dm
+++ b/code/modules/cargo/exports/scraping.dm
@@ -5,6 +5,12 @@
 	elasticity_coeff = 0.1
 	export_types = list(/obj/item/mine/pressure/explosive)
 
+/datum/export/claymore
+	unit_name = "defused claymores"
+	desc = "The Confederated League maintains an active bounty program for the disposal of UXO. Make the frontier a safer place today!"
+	cost = 750
+	export_types = list(/obj/item/mine/directional/claymore)
+
 /datum/export/anomaly
 	unit_name = "stabilized anomaly core"
 	cost = 3000

--- a/code/modules/cargo/exports/scraping.dm
+++ b/code/modules/cargo/exports/scraping.dm
@@ -8,7 +8,7 @@
 /datum/export/claymore
 	unit_name = "defused claymores"
 	desc = "The Confederated League maintains an active bounty program for the disposal of UXO. Make the frontier a safer place today!"
-	cost = 750
+	cost = 1250
 	export_types = list(/obj/item/mine/directional/claymore)
 
 /datum/export/anomaly

--- a/code/modules/cargo/exports/scraping.dm
+++ b/code/modules/cargo/exports/scraping.dm
@@ -9,6 +9,7 @@
 	unit_name = "defused claymores"
 	desc = "The Confederated League maintains an active bounty program for the disposal of UXO. Make the frontier a safer place today!"
 	cost = 1250
+	elasticity_coeff = 0.1
 	export_types = list(/obj/item/mine/directional/claymore)
 
 /datum/export/anomaly

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -216,14 +216,6 @@
 	contains = list(/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
 
-/datum/supply_pack/sec_supply/claymore
-	name = "C-10 Claymore Crate"
-	desc = "Contains one motion-activated directional mine, perfect for ambushing enemy infantry. Still debatably legal to sell!"
-	cost = 750
-	contains = list(/obj/item/paper/fluff/claymore,
-					/obj/item/mine/directional/claymore)
-	crate_name = "C-10 Claymore crate"
-
 /obj/item/paper/fluff/claymore
 	name = "PRODUCT USAGE GUIDE"
 	desc = "A dusty memo stamped with the Scarborough Arms logo."

--- a/code/modules/cargo/packs/sec_supply.dm
+++ b/code/modules/cargo/packs/sec_supply.dm
@@ -215,21 +215,6 @@
 	cost = 2500
 	contains = list(/obj/item/melee/baton/loaded)
 	crate_name = "stun baton crate"
-
-/obj/item/paper/fluff/claymore
-	name = "PRODUCT USAGE GUIDE"
-	desc = "A dusty memo stamped with the Scarborough Arms logo."
-	default_raw_text = "<b>ASSEMBLY:</b><br><br>\
-	-Deploy mounting legs and emplace device. Front should be placed in direction of enemy egress, no more then three meters from intended target area.<br><br> \
-	-<b>INFORM ALLIES OF PLACEMENT LOCATION.</b><br><br> \
-	-Wait for arming sequence to complete.<br><br> \
-	-Enjoy hands-free area denial, courtesy of Scarborough Arms.<br><br><br> \
-	<b>DISASSEMBLY & STORAGE:</b><br><br>\
-	-Insert screwdriver into arming pin access and turn 180 degrees. There will be considerable resistance. <b>DO NOT Step onto or in front of device.</b><br><br> \
-	-When pressure releases, reach below device and lift via underside in one clean motion. Mounting legs will automatically retract. <br><br> \
-	-The device is now safe to handle. <br><br> \
-	-Safely stow device in secure, moisture-free location, away from fire and blunt force. "
-
 /*
 		Factional
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds claymores as a possible export at the outpost market, at 1250 credits each as the base price, and it removes the option to purchase claymores on the market.

## Why It's Good For The Game

No reward without a little risk, right? I remember seeing someone taking the time to carefully defuse a few in order to sell them, only for them to wind up disappointed because they weren't actually a valid export. It makes sense for CLIP to want to get these removed from the sector as much as landmines, I believe, so this PR aims to add that option.

Claymores as they currently are cost too much to be useful for a defensive emplacement, and they're also just a little too destructive when they _do_ catch someone, oftentimes instantly killing someone and shredding much of their equipment.

## Changelog

:cl:
add: Added claymore exports
del: Removed claymore purchases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
