### PR TITLE
Replaces Moth's Surplus Prosthetics with Humaniform

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -30,6 +30,13 @@
 	species_l_leg = /obj/item/bodypart/leg/left/moth
 	species_r_leg = /obj/item/bodypart/leg/right/moth
 
+	species_robotic_chest = /obj/item/bodypart/chest/robot/human
+	species_robotic_head = /obj/item/bodypart/head/robot/human
+	species_robotic_l_arm = /obj/item/bodypart/l_arm/robot/surplus/human
+	species_robotic_r_arm = /obj/item/bodypart/r_arm/robot/surplus/human
+	species_robotic_l_leg = /obj/item/bodypart/leg/left/robot/surplus/human
+	species_robotic_r_leg = /obj/item/bodypart/leg/right/robot/surplus/human
+
 	min_temp_comfortable = HUMAN_BODYTEMP_NORMAL - 5
 	bodytemp_cold_damage_limit = HUMAN_BODYTEMP_COLD_DAMAGE_LIMIT - 5
 

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -31,7 +31,6 @@
 	species_r_leg = /obj/item/bodypart/leg/right/moth
 
 	species_robotic_chest = /obj/item/bodypart/chest/robot/human
-	species_robotic_head = /obj/item/bodypart/head/robot/human
 	species_robotic_l_arm = /obj/item/bodypart/l_arm/robot/surplus/human
 	species_robotic_r_arm = /obj/item/bodypart/r_arm/robot/surplus/human
 	species_robotic_l_leg = /obj/item/bodypart/leg/left/robot/surplus/human


### PR DESCRIPTION
## About The Pull Request

Says on the tin. Replaces the generic surplus moth prosthetic with humaniform (except for the head it looks cursed otherwise)

## Why It's Good For The Game

Before you say "humaniform is only for humans", take a look at this

<img width="205" height="538" alt="image" src="https://github.com/user-attachments/assets/43abb367-6e41-4c6e-a64a-3f23cd832d06" />

You can't tell me _that_ looks better than this.

<img width="225" height="540" alt="image" src="https://github.com/user-attachments/assets/51cf91e6-57cb-45f0-bb77-5ed05d01bffb" />

There's also the point that moths are human descendants, along with the original point that the generic looks like shit.

## Changelog

:cl:
add: Moths now use humaniform as their prosthetic limb type (except for the head)
/:cl: