### PR TITLE
Gives the Arrowsong Refueling Platform the proper overmap sprite

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost_types.dm
+++ b/code/modules/overmap/objects/outpost/outpost_types.dm
@@ -199,7 +199,7 @@
 	)
 
 /datum/overmap/outpost/clip_ocean
-	token_icon_state = "station_asteroid"
+	token_icon_state = "station_planet"
 	main_template = /datum/map_template/outpost/clip_ocean
 	elevator_template = /datum/map_template/outpost/elevator_clip
 	weather_controller_type = /datum/weather_controller/lush


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tin

## Why It's Good For The Game

<img width="151" height="152" alt="dreamseeker_sRmqMOJdS8" src="https://github.com/user-attachments/assets/ada2464a-f90b-4591-8d3a-3ae0caf1a611" />


## Changelog

:cl:
add: Arrowhead outpost gives the proper planetary outpost sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
