### PR TITLE
Silicon related stuff in cargo

### DIFF
--- a/code/modules/cargo/blackmarket/packs/tech.dm
+++ b/code/modules/cargo/blackmarket/packs/tech.dm
@@ -45,44 +45,12 @@
 	name = "AI Core Board"
 	desc = "The future is now! Become one with your ship with this AI core board! (Some assembly required.)"
 	item = /obj/item/circuitboard/aicore
-	pair_item = list(/datum/blackmarket_item/tech/boris, /datum/blackmarket_item/tech/mmi, /datum/blackmarket_item/tech/borg)
 
 	cost_min = 5000
 	cost_max = 7000
 	stock = 1
 	availability_prob = 10
 	spawn_weighting = FALSE
-
-/datum/blackmarket_item/tech/boris
-	name = "B.O.R.I.S Module"
-	desc = "A Bluespace Optimi-blah blah blah, I'm bored already. This module will convert a cyborg frame into an AI compatible shell."
-	item = /obj/item/borg/upgrade/ai
-
-	cost_min = 100
-	cost_max = 250
-	stock = 3
-	availability_prob = 0
-
-/datum/blackmarket_item/tech/mmi
-	name = "Man Machine Interface"
-	desc = "Transcend the weakness of your flesh with this man machine interface, compatible with AIs, Cyborgs and Mechs!"
-	item = /obj/item/mmi
-
-	cost_min = 250
-	cost_max = 750
-	stock = 3
-	availability_prob = 0
-
-/datum/blackmarket_item/tech/borg
-	name = "Cyborg Construction Kit"
-	desc = "This durable and verastile cyborg frame is capable of fufilling a number of roles and survive situations that would kill the average person. Brain sold seperately."
-	item = /obj/structure/closet/crate/cyborg
-	pair_item = list(/datum/blackmarket_item/tech/boris, /datum/blackmarket_item/tech/mmi)
-
-	cost_min = 1000
-	cost_max = 2000
-	stock = 3
-	availability_prob = 40
 
 /datum/blackmarket_item/tech/t4_capacitor
 	name = "Quadratic Capacitor"

--- a/code/modules/cargo/packs/silicon_modules.dm
+++ b/code/modules/cargo/packs/silicon_modules.dm
@@ -11,6 +11,7 @@
 	desc = "Contains disassembled Silicon chassis within, with nearly all parts included! Cables not included."
 	cost = 1250
 	contains = list(/obj/item/robot_suit,
+					/obj/item/bodypart/head/robot,
 					/obj/item/bodypart/chest/robot,
 					/obj/item/bodypart/l_arm/robot,
 					/obj/item/bodypart/leg/left/robot,

--- a/code/modules/cargo/packs/silicon_modules.dm
+++ b/code/modules/cargo/packs/silicon_modules.dm
@@ -1,0 +1,92 @@
+/datum/supply_pack/silicon
+	category = "Silicon Modules"
+	crate_type = /obj/structure/closet/crate/science
+
+/*
+		Cyborg Kit
+*/
+
+/datum/supply_pack/silicon/borg
+	name = "Silicon Construction Kit"
+	desc = "Contains disassembled Silicon chassis within, with nearly all parts included! Cables not included."
+	cost = 1250
+	contains = list(/obj/item/robot_suit,
+					/obj/item/bodypart/chest/robot,
+					/obj/item/bodypart/l_arm/robot,
+					/obj/item/bodypart/leg/left/robot,
+					/obj/item/bodypart/r_arm/robot,
+					/obj/item/bodypart/leg/right/robot,
+					/obj/item/assembly/flash/handheld,
+					/obj/item/assembly/flash/handheld,
+					/obj/item/stock_parts/cell/super)
+	crate_name = "Cyborg Construction Kit"
+
+/datum/supply_pack/silicon/mmi
+	name = "Man-Machine Interface"
+	desc = "For those dabbling into the prospects of immortality."
+	cost = 500
+	contains = list(/obj/item/mmi)
+
+/datum/supply_pack/silicon/boris
+	name = "B.O.R.I.S. Module"
+	desc = "Perfect for use by Silicon intelligence who desire a "On-hands" experience."
+	cost = 250
+	contains = list(/obj/item/borg/upgrade/ai)
+
+/*
+		Cyborg Upgrades
+*/
+
+datum/supply_pack/silicon/cirapp
+	name = "Circuit Manipulation Apparatus"
+	desc = "Contains a CMA, commonly used to not babysit your Silicon Intelligence Engineer borgs."
+	cost = 500
+	contains = list(/obj/item/borg/upgrade/circuit_app)
+
+datum/supply_pack/silicon/rped
+	name = "Cyborg RPED"
+	desc = "An upgrade chip for Engineer borgs that allows for rapid installation of machine parts to machines!"
+	cost = 750
+	contains = list(/obj/item/borg/upgrade/rped)
+
+datum/supply_pack/silicon/beaker
+	name = "Beaker Storage Apparatus"
+	desc = "A apparatus for Medical borgs that allows them to store beakers within an internal storage."
+	cost = 350
+	contains = list(/obj/item/borg/upgrade/beaker_app)
+
+datum/supply_pack/silicon/pierce
+	name = "Piercing Hypospray Chip"
+	desc = "An upgrade chip for Medical borgs allowing their onboard hyposprays to pierce the thick plating of hardsuits."
+	cost = 500
+	contains = list(/obj/item/borg/upgrade/piercing_hypospray)
+
+datum/supply_pack/silicon/pinpoint
+	name = "Cyborg Pinpointer"
+	desc = "A onboard pinpointer, built for use in Medical borgs in locating deceased."
+	cost = 250
+	contains = list(/obj/item/borg/upgrade/pinpointer)
+
+datum/supply_pack/silicon/ddrill
+	name = "Cyborg Diamond Drill"
+	desc = "A upgrade for the typical borg drill, plating it with diamonds allowing it to handle much tougher rocks."
+	cost = 500
+	contains = list(/obj/item/borg/upgrade/ddrill)
+
+datum/supply_pack/silicon/lavaproof
+	name = "Lavaproof Cyborg Treads"
+	desc = "Brand new lavaproof treads, allowing for the traverse of desginated Mining borgs access across vast pools of lava."
+	cost = 850
+	contains = list(/obj/item/borg/upgrade/lavaproof)
+
+datum/supply_pack/silicon/selfrep
+	name = "Self-Repair Cyborg Module"
+	desc = "Whilst heavily energy inefficient, you can rest easy knowing your borgs are able to return safely, even with a few new dents."
+	cost = 500
+	contains = list(/obj/item/borg/upgrade/selfrepair)
+
+datum/supply_pack/silicon/ionthrust
+	name = "Cyborg Ion Thrusters"
+	desc = "Improvements made to the borg chassis with the installation of this chip, will allow 360 degree movement into gravity deficient areas."
+	cost = 850
+	contains = list(/obj/item/borg/upgrade/thrusters)

--- a/code/modules/cargo/packs/silicon_modules.dm
+++ b/code/modules/cargo/packs/silicon_modules.dm
@@ -30,7 +30,7 @@
 
 /datum/supply_pack/silicon/boris
 	name = "B.O.R.I.S. Module"
-	desc = "Perfect for use by Silicon intelligence who desire a "On-hands" experience."
+	desc = "Perfect for use by Silicon intelligence who desire a \"On-hands\" experience."
 	cost = 250
 	contains = list(/obj/item/borg/upgrade/ai)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As is the title, this PR adds stuff related to cyborgs mostly into cargo without breaking any balance, I hope.

## Why It's Good For The Game

As it is currently with the pseudo-removal of RnD from almost nearly everywhere ingame, obtaining upgrades for cyborgs has become next to impossible without having a Talos in-sector and enough credits to convince them to research such. This'll fix that somewhat, by adding modules that I believe not to be too strong, but still allow cyborgs some form of customization without digging a hole into your pocket.

## Changelog

:cl:
add: Adds the "Silicon Modules" cargo tab, with a handful of useful upgrades meant for Cyborgs.
balance: The Cyborg chassis, MMI, and Boris module have been moved to cargo
/:cl: