### PR TITLE
Bodycamera usability improvements

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -237,7 +237,7 @@
 		var/cam_location = active_camera_B.loc
 
 		// Is the camera in the following items? If so, let it transmit an image as normal
-		if((istype(cam_location, /obj/item/clothing/suit)) || (istype(cam_location, /obj/item/clothing/head/helmet)) || istype(cam_location, /obj/item/storage/belt) || istype(cam_location, /obj/item/storage/pouch)) //Should probably be refactored into excluding backpacks and boots instead of the current whitelist if more places need to be added
+		if(!(istype(cam_location, /obj/item/clothing/shoes)))
 			cam_location = active_camera_B.loc.loc
 
 		// If we're not forcing an update for some reason and the cameras are in the same location,

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -20,7 +20,6 @@
 	var/updating = FALSE //portable camera camerachunk update
 	var/mob/tracked_mob //last mob that picked up the bodycamera. needed for cameranet updates
 	var/datum/movement_detector/tracker
-	interaction_flags_item = INTERACT_ITEM_ATTACK_HAND_PICKUP
 
 /obj/item/bodycamera/Initialize()
 	. = ..()

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -48,7 +48,7 @@
 	if(in_range(src, user))
 		. += span_notice("The camera is set to a nametag of '<b>[c_tag]</b>'.")
 		. += span_notice("The camera is set to transmit on the '<b>[network[1]]</b>' network.")
-		. += span_notice("It looks like you can modify the camera settings by using a <b>multitool</b> on it.")
+		. += span_notice("It looks like you can modify the camera settings by using it in your hand, or by using a <b>multitool</b> on it.")
 
 /obj/item/bodycamera/AltClick(mob/user)
 	. = ..()
@@ -118,7 +118,7 @@
 	if(istype(bodycamera_B, /obj/item/bodycamera))
 		var/obj/item/bodycamera/bodycamera2 = bodycamera_B
 		network = bodycamera2.network
-		to_chat(user, "You transfer the network of \the [bodycamera2.name] to \the [name]")
+		to_chat(user, "You tap the cameras together, transferring the network of \the [bodycamera2.name] to \the [name]")
 		return TRUE
 	..()
 

--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -25,11 +25,9 @@
 
 /datum/supply_pack/tools/bodycamera
 	name = "Body Camera Crate"
-	desc = "Contains two portable cameras, designed to help keep track of a working group at all times."
-	cost = 250
-	contains = list(/obj/item/bodycamera,
-					/obj/item/bodycamera,
-					/obj/item/paper/guides/bodycam)
+	desc = "Contains one portable camera, designed to help keep track of a working group at all times."
+	cost = 100
+	contains = list(/obj/item/bodycamera)
 	crate_name = "bodycamera crate"
 
 /datum/supply_pack/tools/assbelt

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -175,7 +175,7 @@
 
 	var/cam_location = active_camera.loc
 
-	if((istype(cam_location, /obj/item/clothing/suit)) || (istype(cam_location, /obj/item/clothing/head/helmet)) || istype(cam_location, /obj/item/storage/belt) || istype(cam_location, /obj/item/storage/pouch)) //Should probably be refactored into excluding backpacks and boots instead of the current whitelist if more places need to be added
+	if((istype(cam_location, /obj/item/clothing/shoes)))
 		cam_location = active_camera.loc.loc
 
 	// If we're not forcing an update for some reason and the cameras are in the same location,

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -175,7 +175,7 @@
 
 	var/cam_location = active_camera.loc
 
-	if((istype(cam_location, /obj/item/clothing/shoes)))
+	if(!(istype(cam_location, /obj/item/clothing/shoes)))
 		cam_location = active_camera.loc.loc
 
 	// If we're not forcing an update for some reason and the cameras are in the same location,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR brings along a few quality of life changes to bodycameras. Namely:

- Bodycameras can now be used inhand in order to set their nametag and their network.
- Bodycameras can now be used on another bodycamera or bodycamera derivative in order to transfer their network. This should reduce the annoyance of having to use a tgui window every time a camera needs to be set.
- Bodycameras now display their tag on the item, making it easy to differentiate bodycameras after they've been set.
- Bodycameras can now be placed inside anything that it can fit inside, except for boots, and still work. This means that they work in bags now.
- Broadcast cameras do not inherit inhand configuration, but they do inherit their object getting renamed in accordance with their tag.
- Bodycamera crates have been modified so that they only carry one camera, and so that they no longer carry the fluff user's guide. Their price has also been decreased per unit camera to 100 credits.

Bodycameras:
<img width="695" height="148" alt="image" src="https://github.com/user-attachments/assets/be6c8b21-381c-4466-a9b4-dc27ea519871" />

Broadcast Cameras:
<img width="697" height="186" alt="image" src="https://github.com/user-attachments/assets/a127f292-15cf-4117-9a76-5d9c1a42b5e3" />


## Why It's Good For The Game
These quality of life changes should address the annoyances of using and configuring bodycameras. 
The guiding design principle here was that of reducing the number of clicks needed to get a particular task done. This should reduce the amount of busywork that setting a bodycamera currently requires. 
Having bodycameras be modifiable from inhand also makes it so that their end users can set their own tags, after their networks have been set by someone like, for instance, their captain. This parallelization of work should further reduce the trouble of getting a set of bodycameras up and running.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added bodycamera and broadcast camera obj tags
add: Added easy bodycamera network transfer
add: Added easy bodycamera configuration
balance: bodycameras now work anywhere except boots
balance: bodycameras now cost 100 credits each
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
