### PR TITLE
makes rustbase turrets not stupid as fuck

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
@@ -1493,7 +1493,7 @@
 	turret_flags = 62;
 	lethal = 1
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/open/floor/engine/hull/rockplanet,
 /area/ruin/rockplanet/rust_base/mechbay)
 "oW" = (
 /obj/structure/cable{
@@ -2258,7 +2258,7 @@
 	turret_flags = 62;
 	lethal = 1
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/open/floor/engine/hull/rockplanet,
 /area/ruin/rockplanet/rust_base/armory)
 "xq" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
## About The Pull Request

<img width="263" height="645" alt="image" src="https://github.com/user-attachments/assets/6ff1059b-821d-4abc-85cc-4d7568fad591" />

does this so the turrets dont shoot you through two solid walls

## Why It's Good For The Game

fixes good

## Changelog

:cl:
fix: rustbase turrets no longer xray shoot you
/:cl: