### PR TITLE
Outpost medical vender hourly refills

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -167,6 +167,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/// used for narcing on underages
 	var/obj/item/radio/Radio
 
+	/// restocks venders every hour if this is true
+	var/restock_hourly = FALSE
+
 /**
 	* Initialize the vending machine
 	*
@@ -183,6 +186,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		build_inventory(products, product_records)
 		build_inventory(contraband, hidden_records)
 		build_inventory(premium, coin_records)
+
+	if(restock_hourly)
+		addtimer(CALLBACK(src, PROC_REF(refill_inventory_full)), 2 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
 
 	slogan_list = splittext(product_slogans, ";")
 	// So not all machines speak at the exact same time.
@@ -341,6 +347,12 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			productlist[record.product_path] -= diff
 			record.amount += diff
 			. += diff
+
+/obj/machinery/vending/proc/refill_inventory_full()
+	refill_inventory(products, product_records)
+	refill_inventory(contraband, hidden_records)
+	refill_inventory(premium, coin_records)
+
 /**
 	* Set up a refill canister that matches this machines products
 	*

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -188,7 +188,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		build_inventory(premium, coin_records)
 
 	if(restock_hourly)
-		addtimer(CALLBACK(src, PROC_REF(refill_inventory_full)), 2 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(refill_inventory_full)), 60 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
 
 	slogan_list = splittext(product_slogans, ";")
 	// So not all machines speak at the exact same time.

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -11,6 +11,7 @@
 	default_price = 50
 	extra_price = 100
 	tiltable = FALSE
+	restock_hourly = TRUE
 	light_mask = "wallmed-light-mask"
 
 	products = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds an hourly refill function to vending machines, set OFF by default. The only vender type with this function active currently are OutpostMed vending machines.

## Why It's Good For The Game

It makes sense that an outpost would actively restock their vending machines -- and this also allows players to use the outpost medical vending machine for specific medical supplies without having to worry too much about someone else buying out stock before them. 

## Changelog

:cl:
add: Added an hourly restock function to vending machines, turned off by default
balance: OutpostMed venders now automatically restock themselves every hour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
