### PR TITLE
Kali Andhi tweaks

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -963,6 +963,7 @@
 	color = "#791500"
 	},
 /obj/item/clothing/gloves/combat,
+/obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
 "fA" = (
@@ -1203,6 +1204,7 @@
 	mag_count = 3
 	},
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
+/obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "gv" = (
@@ -3134,6 +3136,10 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/directional/north,
+/obj/item/storage/box/ammo/c10mm{
+	pixel_y = -12;
+	pixel_x = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "qy" = (
@@ -4049,6 +4055,7 @@
 /obj/item/storage/belt/military/assault,
 /obj/item/radio/headset/syndicate/alt/leader,
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
+/obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
 "vh" = (
@@ -7097,8 +7104,11 @@
 	dir = 4
 	},
 /obj/item/clothing/glasses/sunglasses,
-/obj/item/storage/guncase/pistol/ringneck,
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
+/obj/item/storage/guncase/pistol/pc76{
+	mag_count = 3
+	},
+/obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
 "MN" = (
@@ -7457,6 +7467,7 @@
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/gear_pack/anglegrinder,
+/obj/item/storage/backpack/duffelbag/engineering,
 /turf/open/floor/pod/dark,
 /area/ship/engineering)
 "Ob" = (
@@ -8370,6 +8381,7 @@
 	secure = 1
 	},
 /obj/item/clothing/gloves/combat,
+/obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
 "RX" = (

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -3136,10 +3136,6 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/item/storage/box/ammo/c10mm{
-	pixel_y = -12;
-	pixel_x = 5
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "qy" = (
@@ -7106,9 +7102,6 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
-/obj/item/storage/guncase/pistol/pc76{
-	mag_count = 3
-	},
 /obj/item/storage/backpack/messenger/sec,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -1202,6 +1202,7 @@
 /obj/item/storage/guncase/pistol/a357{
 	mag_count = 3
 	},
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "gv" = (
@@ -1766,20 +1767,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button{
-	id = "kalicargostar";
-	name = "Starboard Blast Doors";
-	dir = 4;
-	pixel_x = -10;
-	pixel_y = -3
-	},
-/obj/machinery/button{
-	pixel_x = -10;
-	pixel_y = 9;
-	id = "kalicargoport";
-	name = "Portside Blast Doors";
-	dir = 4
-	},
 /obj/machinery/button/shieldwallgen{
 	id = "kali_entrance_holo_port";
 	pixel_x = 3;
@@ -1792,6 +1779,20 @@
 	pixel_x = 3;
 	pixel_y = -5;
 	name = "Starboard Holofield";
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "kalicargoport";
+	pixel_x = -10;
+	pixel_y = 10;
+	name = "Portside Blast Doors";
+	dir = 4
+	},
+/obj/machinery/button/door{
+	name = "Starboard Blast Doors";
+	pixel_x = -10;
+	pixel_y = -4;
+	id = "kalicargostar";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3789,7 +3790,8 @@
 	color = "#791500"
 	},
 /obj/structure/railing{
-	dir = 9
+	dir = 9;
+	layer = 2.89
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
@@ -4046,6 +4048,7 @@
 	},
 /obj/item/storage/belt/military/assault,
 /obj/item/radio/headset/syndicate/alt/leader,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
 "vh" = (
@@ -7094,6 +7097,8 @@
 	dir = 4
 	},
 /obj/item/clothing/glasses/sunglasses,
+/obj/item/storage/guncase/pistol/ringneck,
+/obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
 "MN" = (
@@ -7451,6 +7456,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/clothing/gloves/color/yellow,
+/obj/item/gear_pack/anglegrinder,
 /turf/open/floor/pod/dark,
 /area/ship/engineering)
 "Ob" = (
@@ -9618,8 +9624,14 @@
 /area/ship/crew/canteen)
 "Yr" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/twenty{
+	pixel_y = 2;
+	pixel_x = -2
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "Yu" = (

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -5218,6 +5218,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/electrical)
 "BY" = (
@@ -8795,6 +8796,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/electrical)
 "UD" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a couple of things to the Kali Andhi, fixes a minor bug, and tweaks one other thing
- Goggles are added to the Captain, LT and Ensign's lockers
- The Captain, LT, Ensign, and Operative's lockers are given a security messenger bag in addition to the standard backpack that comes in their lockers (is this appropriate? I'm not sure -- I can instead swap them with a plain messenger bag if not)
- The mechanic's locker is given a standard grinder pack and a dufflebag
- The portside and starboard side cargo buttons on the table in the cargo bay didn't work before, but they should now
- The railing in the cargo bay surrounding the oxygen canister in the bay had its layer adjusted so that the railing now renders under the canister instead of over it
- A few missing pipes to the combustion thrusters were added

Before:
<img width="130" height="121" alt="image" src="https://github.com/user-attachments/assets/2b65e825-4a7e-4602-8679-f9dd68a3794d" />

After:
<img width="131" height="140" alt="image" src="https://github.com/user-attachments/assets/418c18f0-a2d5-4c1b-8616-23d851256b8e" />

## Why It's Good For The Game

The aim of this PR is to add a bit more flexibility to players in order to select the outfit they want to present, and to bring a bit of parity with the previous Kali Andhi iteration.

## Changelog

:cl:
add: Added a bunch of equipment to the Kali Andhi
fix: fixed a few buttons and a mismatched layer
fix: fixed missing pipes to the combustion engines in the Kali Andhi
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
