### PR TITLE
Grinder packs are no longer huge

### DIFF
--- a/code/game/objects/items/gear_packs.dm
+++ b/code/game/objects/items/gear_packs.dm
@@ -6,7 +6,7 @@
 	item_state = "waterbackpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK
 	item_flags = SLOWS_WHILE_IN_HAND
 	max_integrity = 300
@@ -221,7 +221,7 @@
 
 	force = 0
 	throwforce = 6
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = INDESTRUCTIBLE
 	base_icon_state = "mister"
 

--- a/code/game/objects/items/gear_packs.dm
+++ b/code/game/objects/items/gear_packs.dm
@@ -6,7 +6,7 @@
 	item_state = "waterbackpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	item_flags = SLOWS_WHILE_IN_HAND
 	max_integrity = 300
@@ -221,7 +221,7 @@
 
 	force = 0
 	throwforce = 6
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = INDESTRUCTIBLE
 	base_icon_state = "mister"
 

--- a/code/modules/mining/equipment/angle_grinder.dm
+++ b/code/modules/mining/equipment/angle_grinder.dm
@@ -9,6 +9,7 @@
 	gear_handle_type = /obj/item/gear_handle/anglegrinder
 	slowdown = 0.3
 	drag_slowdown = 0.3
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gear_handle/anglegrinder
 	name = "angle grinder"
@@ -21,7 +22,7 @@
 	flags_1 = CONDUCT_1
 	force = 13
 	armour_penetration = 5
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT
 	attack_verb = list("lacerated", "ripped", "sliced", "sawed", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/anglegrinder.ogg'
@@ -108,6 +109,7 @@
 	item_state = "energyanglegrinderpack"
 	icon_state = "energyanglegrinderpack"
 	gear_handle_type = /obj/item/gear_handle/anglegrinder/energy
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gear_handle/anglegrinder/energy
 	name = "energy saw"
@@ -117,7 +119,7 @@
 	force = 5
 	two_hand_force = 28
 	armour_penetration = 16
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT
 	attack_verb = list("lacerated", "ripped", "burned", "sliced", "cauterized", "seared", "diced")
 	hitsound = 'sound/weapons/blade1.ogg'

--- a/code/modules/mining/equipment/angle_grinder.dm
+++ b/code/modules/mining/equipment/angle_grinder.dm
@@ -22,7 +22,7 @@
 	flags_1 = CONDUCT_1
 	force = 13
 	armour_penetration = 5
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_NORMAL
 	item_flags = ABSTRACT
 	attack_verb = list("lacerated", "ripped", "sliced", "sawed", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/anglegrinder.ogg'
@@ -119,7 +119,7 @@
 	force = 5
 	two_hand_force = 28
 	armour_penetration = 16
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_NORMAL
 	item_flags = ABSTRACT
 	attack_verb = list("lacerated", "ripped", "burned", "sliced", "cauterized", "seared", "diced")
 	hitsound = 'sound/weapons/blade1.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR brings the weight class of grinder packs down from huge to bulky, which allows them to now fit inside backpacks and dufflebags.

## Why It's Good For The Game

Oftentimes when I'm on EVA with a grinder, I find it cumbersome to have to carry both it and my bag in my hands -- doubly so if I have to bring a jetpack with me, too. I think it makes sense for a dufflebag to be able to hold one, as they seem to be about torso sized in length, and about half the diameter of a typical torso.

## Changelog

:cl:
balance: grinder pack weight classes were brought down from huge to bulky
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
