### PR TITLE
Removes Player-Accessible Rocket Launchers

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
@@ -904,6 +904,7 @@
 	},
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/icemoon/tesla_lab/armory)
 "dP" = (
@@ -4834,18 +4835,13 @@
 /obj/effect/turf_decal/trimline/transparent/blue/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/corner{
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/icemoon/tesla_lab/armory)
 "tU" = (
@@ -8679,20 +8675,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/tesla_lab/dorms)
 "IG" = (
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line,
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/cabinet/oneshot{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/transparent/blue/filled,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/grid,
+/obj/item/storage/backpack/duffelbag/syndie/c4{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/structure/sign/poster/clip/bard{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ruin/icemoon/tesla_lab/armory)
 "IH" = (
 /obj/structure/flippedtable,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -242,7 +242,6 @@ GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 		/obj/item/clothing/suit/space/hardsuit/carp/old = 1,
 		/obj/item/clothing/suit/armor/reactive/repulse = 1,
 		/obj/item/melee/axe/fire = 1,
-		/obj/item/gun/ballistic/rocketlauncher/oneshot = 1,
 		/mob/living/simple_animal/crab = 1,
 		/obj/item/melee/baton/boomerang = 1,
 		/obj/item/circular_saw/best = 1,

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -506,8 +506,8 @@
 
 /obj/item/storage/belt/military/mako/PopulateContents()
 	. = ..()
-	new /obj/item/ammo_casing/caseless/rocket/a70mm/hedp(src)
-	new /obj/item/ammo_casing/caseless/rocket/a70mm/hedp(src)
+	new /obj/item/ammo_casing/caseless/rocket/a70mm(src)
+	new /obj/item/ammo_casing/caseless/rocket/a70mm(src)
 	new /obj/item/ammo_casing/caseless/rocket/a70mm(src)
 	new /obj/item/ammo_casing/caseless/rocket/a70mm(src)
 	new /obj/item/ammo_casing/caseless/rocket/a70mm(src)

--- a/code/modules/cargo/blackmarket/packs/weapons.dm
+++ b/code/modules/cargo/blackmarket/packs/weapons.dm
@@ -496,30 +496,6 @@
 	stock_max = 2
 	availability_prob = 20
 
-/datum/blackmarket_item/weapon/guncase/oneshot
-	name = "Hammer Launcher"
-	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HE rocket. "
-	item = /obj/item/gun/ballistic/rocketlauncher/oneshot
-	mag_number = 0
-	gun_unloaded = FALSE
-
-	cost_min = 3000
-	cost_max = 4500
-	stock_min = 1
-	stock_max = 5
-	availability_prob = 25
-
-/datum/blackmarket_item/weapon/guncase/oneshot/hedp
-	name = "Hammer-DP Launcher"
-	desc = "A one-shot solution to a myriad amount of problems, ranging from Exosuits to obnoxious neighbors. Contains one ready-to-fire 84mm HEDP rocket. "
-	item = /obj/item/gun/ballistic/rocketlauncher/oneshot/hedp
-
-	cost_min = 4000
-	cost_max = 6000
-	stock_min = 1
-	stock_max = 5
-	availability_prob = 10
-
 /datum/blackmarket_item/weapon/guncase/skm_lmg
 	name = "SKM-24u Light Machinegun"
 	desc = "Your regular rifles not have enough oomph for you? This SKM-24 was converted with help from a 'liberated' CM-40 parts shipment into a light machinegun, ready to blow away whatever you point it at. Increased firerate makes it buck like a mule, so keep that bipod on the ground. Drums sold separately!"


### PR DESCRIPTION
## About The Pull Request

Removes the Hammer and Hammer-DP from the Black Market, as well as the Hammer from the icemoon training facility. Raleigh remap is pending (with the Hammer already planned to be removed) so to avoid merge conflicts it isn't removed in this PR.

Also removes HEDP (rockets with devastation) from the Mako belt.

## Why It's Good For The Game

Rocket Launchers have, under every circumstance they've been used, never been seen positively.

https://github.com/user-attachments/assets/fd56de17-ba94-449a-b79c-07151be4d0c0

Despite being meant for use against mechs, the majority of their usage has been against players - both from Hammers obtained in-round and from MAKOs and Hammers given by admins. Usually, this results in someone just getting killed (which is realistic) and having to sit things out. Compared to just being in a firefight, however, these offer little to no counterplay or even time to react.

With the additional fact that combat exosuits are effectively unobtainable outside of niche circumstances and simplemobs not warranting them, the use case of having launchers is becoming less and less prevalent by the day.

## Changelog

:cl:
balance: Rocket launchers are no longer player accessible.
balance: Mako belts no longer have HEDP rockets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
