### PR TITLE
Bonesetters and Surgical Tape in Medical Belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -228,7 +228,9 @@
 		/obj/item/plunger,
 		/obj/item/reagent_containers/spray,
 		/obj/item/shears,
-		/obj/item/bodycamera
+		/obj/item/bodycamera,
+		/obj/item/bonesetter,
+		/obj/item/stack/sticky_tape/surgical
 		))
 
 /obj/item/storage/belt/medical/paramedic/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Adds bonesetters and surgical tape to medical belts

## Why It's Good For The Game

Medical items in medical belts. All the other medical items go in medical belts

## Changelog

:cl:
balance: Bonesetter and Surgical Tape now fit in Medical Belts
/:cl:

