### PR TITLE
re-inits client verbs on login

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -85,6 +85,8 @@
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 
+	client.init_verbs()
+
 	return TRUE
 
 


### PR DESCRIPTION
## About The Pull Request

potentially fixes the "none of our verbs load on reconnect"

## Changelog

:cl:
fix: verbs should now load on reconnect
/:cl:

