### PR TITLE
Recoil/Impact modifiers

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -807,7 +807,8 @@
 	if(!P.nodamage && on_hit_state != BULLET_ACT_BLOCK && !QDELETED(src)) //QDELETED literally just for the instagib rifle. Yeah.
 		var/attack_direction = get_dir(P.starting, src)
 		apply_damage(P.damage, P.damage_type, def_zone, armor, sharpness = P.sharpness, attack_direction = attack_direction)
-		recoil_camera(src, clamp((P.damage-armor)/4,0.5,10), clamp((P.damage-armor)/4,0.5,10), P.damage/8, P.Angle)
+		var/impact_intensity = (P.damage/8) * impact_effect
+		recoil_camera(src, clamp((P.damage-armor)/4,0.5,10), clamp((P.damage-armor)/4,0.5,10), impact_intensity, P.Angle)
 		apply_effects(P.stun, P.knockdown, P.unconscious, P.irradiate, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize)
 
 		if(P.dismemberment)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -56,7 +56,6 @@
 	if(!P.nodamage && on_hit_state != BULLET_ACT_BLOCK && !QDELETED(src)) //QDELETED literally just for the instagib rifle. Yeah.
 		var/attack_direction = get_dir(P.starting, src)
 		apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
-		recoil_camera(src, clamp((P.damage-armor)/4,0.5,10), clamp((P.damage-armor)/4,0.5,10), P.damage/8, P.Angle)
 		apply_effects(P.stun, P.knockdown, P.unconscious, P.irradiate, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -191,8 +191,10 @@
 	/// Lazy list of FOV traits that will apply a FOV view when handled.
 	var/list/fov_traits
 
-	///how much recoil do we experience when shooting/being shot. Ideally some.
+	///how much recoil do we experience when shooting. Ideally some.
 	var/recoil_effect = 1 //i hate guncode
+	///how much recoil do we experience from being shot. Ideally some.
+	var/impact_effect = 1
 
 	/// World time of the last time this mob heard a radio crackle, to reduce spamminess.
 	COOLDOWN_DECLARE(radio_crackle_cooldown)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -191,5 +191,8 @@
 	/// Lazy list of FOV traits that will apply a FOV view when handled.
 	var/list/fov_traits
 
+	///how much recoil do we experience when shooting/being shot. Ideally some.
+	var/recoil_effect = 1 //i hate guncode
+
 	/// World time of the last time this mob heard a radio crackle, to reduce spamminess.
 	COOLDOWN_DECLARE(radio_crackle_cooldown)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -867,9 +867,10 @@
 /obj/item/gun/proc/before_firing(atom/target,mob/user)
 	return
 
-/obj/item/gun/proc/calculate_recoil(mob/user, recoil_bonus = 0)
+/obj/item/gun/proc/calculate_recoil(mob/living/user, recoil_bonus = 0)
 	if(HAS_TRAIT(user, TRAIT_GUNSLINGER))
 		recoil_bonus += gunslinger_recoil_bonus
+	recoil_bonus *= user.recoil_effect
 	return clamp(recoil_bonus, min_recoil, INFINITY)
 
 /obj/item/gun/proc/calculate_spread(mob/user, bonus_spread)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -200,6 +200,7 @@
 	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	L.AddComponent(/datum/component/tackler, stamina_cost= 25, base_knockdown= 2 SECONDS, range=6, speed=1, skill_mod=2)
+	L.impact_effect /= 10
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		rage = new()
@@ -209,6 +210,7 @@
 	REMOVE_TRAIT(L, TRAIT_VERY_HARDLY_WOUNDED, /datum/reagent/drug/mammoth)
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	L.impact_effect *= 10
 	if(L.GetComponent(/datum/component/tackler))
 		qdel(L.GetComponent(/datum/component/tackler))
 	if(rage)
@@ -488,6 +490,8 @@
 		drugged.physiology.do_after_speed -= 0.4
 		drugged.physiology.damage_resistance += 10
 		drugged.physiology.hunger_mod += 1
+		drugged.recoil_effect /= 2
+		drugged.impact_effect /= 2
 
 /datum/reagent/drug/combat_drug/on_mob_end_metabolize(mob/living/L)
 	..()
@@ -498,6 +502,8 @@
 		drugged.physiology.do_after_speed += 0.4
 		drugged.physiology.damage_resistance -= 10
 		drugged.physiology.hunger_mod -= 1
+		drugged.recoil_effect *= 2
+		drugged.impact_effect *= 2
 
 /datum/reagent/drug/combat_drug/on_mob_life(mob/living/carbon/M)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -490,7 +490,7 @@
 		drugged.physiology.do_after_speed -= 0.4
 		drugged.physiology.damage_resistance += 10
 		drugged.physiology.hunger_mod += 1
-		drugged.recoil_effect /= 2
+		drugged.recoil_effect *= 0.6
 		drugged.impact_effect /= 2
 
 /datum/reagent/drug/combat_drug/on_mob_end_metabolize(mob/living/L)
@@ -502,7 +502,7 @@
 		drugged.physiology.do_after_speed += 0.4
 		drugged.physiology.damage_resistance -= 10
 		drugged.physiology.hunger_mod -= 1
-		drugged.recoil_effect *= 2
+		drugged.recoil_effect /= 0.6
 		drugged.impact_effect *= 2
 
 /datum/reagent/drug/combat_drug/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
@@ -85,6 +85,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance += 5
+		drugged.physiology.recoil_effect /= 2
 
 /datum/reagent/medicine/morphine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_PAIN_RESIST, type)
@@ -92,6 +93,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance -= 5
+		drugged.recoil_effect *= 2
 	..()
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/M)
@@ -170,6 +172,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance += 15
+		drugged.recoil_effect /= 4
 
 /datum/reagent/medicine/dimorlin/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_ANALGESIA, type)
@@ -180,6 +183,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance -= 15
+		drugged.recoil_effect *= 4
 	..()
 
 /datum/reagent/medicine/dimorlin/on_mob_life(mob/living/carbon/C)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
@@ -85,7 +85,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance += 5
-		drugged.physiology.recoil_effect /= 2
+		drugged.physiology.impact_effect /= 2
 
 /datum/reagent/medicine/morphine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_PAIN_RESIST, type)
@@ -93,7 +93,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance -= 5
-		drugged.recoil_effect *= 2
+		drugged.impact_effect *= 2
 	..()
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/M)
@@ -172,7 +172,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance += 15
-		drugged.recoil_effect /= 4
+		drugged.impact_effect /= 4
 
 /datum/reagent/medicine/dimorlin/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_ANALGESIA, type)
@@ -183,7 +183,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance -= 15
-		drugged.recoil_effect *= 4
+		drugged.impact_effect *= 4
 	..()
 
 /datum/reagent/medicine/dimorlin/on_mob_life(mob/living/carbon/C)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
@@ -85,7 +85,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.damage_resistance += 5
-		drugged.physiology.impact_effect /= 2
+		drugged.impact_effect /= 2
 
 /datum/reagent/medicine/morphine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_PAIN_RESIST, type)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/status_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/status_reagents.dm
@@ -212,9 +212,11 @@
 /datum/reagent/medicine/psicodine/on_mob_metabolize(mob/living/L)
 	..()
 	ADD_TRAIT(L, TRAIT_FEARLESS, type)
+	L.recoil_effect /= 3
 
 /datum/reagent/medicine/psicodine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_FEARLESS, type)
+	L.recoil_effect *= 3
 	..()
 
 /datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/status_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/status_reagents.dm
@@ -212,11 +212,11 @@
 /datum/reagent/medicine/psicodine/on_mob_metabolize(mob/living/L)
 	..()
 	ADD_TRAIT(L, TRAIT_FEARLESS, type)
-	L.recoil_effect /= 3
+	L.recoil_effect *= 0.8
 
 /datum/reagent/medicine/psicodine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_FEARLESS, type)
-	L.recoil_effect *= 3
+	L.recoil_effect /= 0.8
 	..()
 
 /datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
## About The Pull Request

Adds a recoil/impact modifier variable
Adds modifiers to: shoalmix, mammoth, psicodine, morphine, dimorlin
morphine, mammoth, and dimorlin reduce how badly your camera jostles when you get shot
psicodine reduces the recoil from firing
shoalmix does it all baby

this could probably be extended to other things in the future i just wanted it on chems

## Changelog

:cl:
add: Certain chemicals can now reduce camerashake from firing/being fired upon in combat.
balance: removed camera shake from impact on /mob/living. It remains on /mob/carbon
/:cl:

