### PR TITLE
adds riot helm to medium marine armour cargo

### DIFF
--- a/code/modules/cargo/packs/armor.dm
+++ b/code/modules/cargo/packs/armor.dm
@@ -57,7 +57,7 @@
 	desc = "One set of well-rounded medium tactical body armor. Plates are attached to the vest and cover the limbs. The set includes a helmet and chestpiece."
 	cost = 3000
 	contains = list(/obj/item/clothing/suit/armor/vest/marine/medium,
-					/obj/item/clothing/head/helmet/bulletproof/x11)
+					/obj/item/clothing/head/helmet/riot)
 	crate_name = "armor crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="558" height="261" alt="image" src="https://github.com/user-attachments/assets/fce4ed66-17a7-4ef5-8991-62e8487ee4e8" />

## Why It's Good For The Game

it was supposed to be there in https://github.com/shiptest-ss13/Shiptest/pull/5321

## Changelog

:cl:
add: Riot helmets now replace the X-11s bundled with medium tactical armour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
