### PR TITLE
strips zoom from the Resistor

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
@@ -173,6 +173,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/sharplite)
 
 	zoomable = FALSE
+	zoom_amt = PISTOL_ZOOM
 	wield_slowdown = SMG_SLOWDOWN
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	wield_delay = 0.4 SECONDS


### PR DESCRIPTION
## Why It's Good For The Game

shouldnt have it. its not supposed to be like this

## Changelog

:cl:
fix: L204 Resistor no longer zooms like a DMR
/:cl:
