### PR TITLE
Don't Include Unknown Faction in Autowiki Shiptable

### DIFF
--- a/code/modules/autowiki/pages/shiptable.dm
+++ b/code/modules/autowiki/pages/shiptable.dm
@@ -29,6 +29,8 @@
 		var/datum/faction/current = SSfactions.factions[faction_type]
 		var/list/subfactions = factions[faction_type]
 
+		if(current.wiki_hidden)
+			continue
 		if(!length(subfactions))
 			output += generate_row(current, subfactions, FALSE)
 			continue

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -20,6 +20,8 @@
 	var/check_prefix = TRUE
 	/// Sorting order for factions
 	var/order = FACTION_SORT_DEFAULT
+	/// Whether or not this faction is hidden from the autowiki ships table (see: Unknown, used for ruins but has no ships)
+	var/wiki_hidden = FALSE
 
 /datum/faction/New()
 	if(!short_name)
@@ -165,3 +167,4 @@
 	color = "#504c4c"
 	check_prefix = FALSE
 	order = FACTION_SORT_ASPAWN
+	wiki_hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new variable to the faction datum to not include the faction in the autowiki shiptable generation, currently only used by the Unknown faction (added in #5289)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks nicer ! 
No player-facing changes
I can't escape the wiki
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
