### PR TITLE
ruin mission hard del cleanup

### DIFF
--- a/code/modules/missions/dynamic/_dynamic.dm
+++ b/code/modules/missions/dynamic/_dynamic.dm
@@ -107,13 +107,9 @@
 			can_turn_in = TRUE
 			break
 
-	var/location_x
-	var/location_y
-	var/location_name
+	var/datum/overmap/mission_location = mission_local_weakref.resolve()
 	if(mission_location)
-		location_x = mission_location.x
-		location_y = mission_location.y
-		location_name = mission_location.name
+		update_mission_info(mission_location)
 
 	. += list(
 		"ref" = REF(src),
@@ -122,9 +118,9 @@
 		"desc" = src.desc,
 		"reward" = src.reward_flavortext(),
 		"faction" = SSfactions.faction_name(src.faction),
-		"location" = "X[location_x]/Y[location_y]: [location_name]",
-		"x" = location_x,
-		"y" = location_y,
+		"location" = "X[local_x]/Y[local_y]: [local_name]",
+		"x" = local_x,
+		"y" = local_y,
 		"timeIssued" = time2text(station_time() - time_issued, "mm"),
 		"duration" = src.duration,
 		"remaining" = time_remaining,

--- a/code/modules/missions/dynamic/signaled.dm
+++ b/code/modules/missions/dynamic/signaled.dm
@@ -1,13 +1,12 @@
 /datum/mission/ruin/signaled
 	var/registered_type
-	var/atom/movable/registered_item
 	/// What signal will spawn the required item
 	var/mission_main_signal
 
 /datum/mission/ruin/signaled/spawn_main_piece(obj/effect/landmark/mission_poi/mission_poi)
-	registered_item = mission_poi.use_poi(registered_type, src)
+	var/atom/movable/registered_item = mission_poi.use_poi(registered_type, src)
 	if(isatom(registered_item))
-		registered_item = set_bound(registered_item, null, FALSE, TRUE)
+		set_bound(registered_item, null, FALSE, TRUE)
 		RegisterSignal(registered_item, mission_main_signal, PROC_REF(on_signaled))
 	else
 		stack_trace("[src] did not generate a required item.")
@@ -20,11 +19,6 @@
 	set_bound(required_item, null, FALSE, TRUE)
 	UnregisterSignal(registered_item, mission_main_signal)
 	remove_bound(registered_item)
-
-/datum/mission/ruin/signaled/remove_bound(atom/movable/bound)
-	if(bound == setpiece_item)
-		setpiece_item = null
-	return ..()
 
 /obj/effect/landmark/mission_poi/main/drill
 

--- a/code/modules/missions/mission.dm
+++ b/code/modules/missions/mission.dm
@@ -17,7 +17,10 @@
 
 	var/location_specific = FALSE
 	/// The location the mission is relient on, often pulling varibles from it or will delete itself if the mission_location is deleted. Passed in New().
-	var/datum/overmap/mission_location
+	var/datum/weakref/mission_local_weakref
+	var/local_name
+	var/local_x
+	var/local_y
 	/// If location specific, if it run times when the planet has no pois
 	var/requires_poi = TRUE
 
@@ -59,7 +62,9 @@
 	mission_index = _mission_index
 
 	if(location_specific)
-		mission_location = _location
+		var/datum/overmap/mission_location = _location
+		mission_local_weakref = WEAKREF(mission_location)
+		update_mission_info(mission_location)
 		RegisterSignal(mission_location, COMSIG_PARENT_QDELETING, PROC_REF(on_vital_delete))
 		RegisterSignal(mission_location, COMSIG_OVERMAP_LOADED, PROC_REF(on_planet_load))
 		if(active)
@@ -74,7 +79,9 @@
 /datum/mission/Destroy()
 	//UnregisterSignal(source_outpost, COMSIG_PARENT_QDELETING)
 	if(location_specific)
-		UnregisterSignal(mission_location, COMSIG_PARENT_QDELETING, COMSIG_OVERMAP_LOADED)
+		var/datum/overmap/mission_location = mission_local_weakref.resolve()
+		if(mission_location)
+			UnregisterSignal(mission_location, COMSIG_PARENT_QDELETING, COMSIG_OVERMAP_LOADED)
 		if(active)
 			SSmissions.active_ruin_missions -= src
 		else
@@ -106,6 +113,16 @@
 		author = random_species_name()
 	mission_reward = pick(mission_reward)
 	return
+
+/datum/mission/proc/update_mission_info(datum/overmap/mission_location)
+	if(!istype(mission_location))
+		local_name = "missing location"
+		local_x = "???"
+		local_y = "???"
+		return
+	local_name = mission_location.name
+	local_x = mission_location.x
+	local_y = mission_location.y
 
 /datum/mission/proc/regex_mission_text()
 	name = mission_regexs(name)
@@ -139,7 +156,7 @@
 	SIGNAL_HANDLER
 
 	// Status of mission is handled by items spawned in mission after this
-	UnregisterSignal(mission_location, list(COMSIG_PARENT_QDELETING, COMSIG_OVERMAP_LOADED))
+	UnregisterSignal(planet, list(COMSIG_PARENT_QDELETING, COMSIG_OVERMAP_LOADED))
 	if(!active)
 		qdel(src)
 		return
@@ -172,6 +189,7 @@
 		do_sparks(3, FALSE, get_turf(item_to_turn_in))
 		SSmissions.active_ruin_missions -= src
 		active = FALSE
+		var/datum/overmap/mission_location = mission_local_weakref.resolve()
 		if(istype(mission_location, /datum/overmap/dynamic))
 			var/datum/overmap/dynamic/dynamic_location = mission_location
 			dynamic_location.start_countdown(30 SECONDS)
@@ -252,6 +270,7 @@
 /datum/mission/proc/bound_z_change(atom/movable/bound, new_virtual_z, previous_virtual_z)
 	SIGNAL_HANDLER
 
+	var/datum/overmap/mission_location = mission_local_weakref.resolve()
 	if(istype(mission_location, /datum/overmap/dynamic))
 		var/datum/overmap/dynamic/dynamic_location = mission_location
 		if(!dynamic_location.mapzone.is_in_bounds(bound))

--- a/code/modules/missions/outpost/_outpost.dm
+++ b/code/modules/missions/outpost/_outpost.dm
@@ -3,7 +3,7 @@
 
 /datum/mission/outpost/New(_outpost)
 	source_outpost = _outpost
-	RegisterSignal(mission_location, COMSIG_PARENT_QDELETING, PROC_REF(on_vital_delete))
+	RegisterSignal(source_outpost, COMSIG_PARENT_QDELETING, PROC_REF(on_vital_delete))
 	return ..()
 
 /datum/mission/outpost/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I never acctually used this anywhere, and its my leading suspect for a hard del, could swap it to a weak ref but the only refrence to it is a setter proc and a signal that already has the item in question

moves mission location to a weakref, its barely even needed. main use is for getting x y and name, almost everything else is cleanup or signal related.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less hard dels mabye?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: possible fix to mission hard dels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
