### PR TITLE
remove curare from magpie

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_magpie.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_magpie.dmm
@@ -2429,9 +2429,9 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/line{
 	dir = 9
 	},
-/obj/item/reagent_containers/glass/bottle/curare,
-/obj/item/reagent_containers/glass/bottle/curare,
 /obj/item/reagent_containers/glass/bottle/indomide,
+/obj/item/reagent_containers/glass/bottle/cureall,
+/obj/item/reagent_containers/glass/bottle/cureall,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "HN" = (

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -426,6 +426,12 @@
 	volume = 50
 	list_reagents = list(/datum/reagent/medicine/gjalrazine = 50)
 
+/obj/item/reagent_containers/glass/bottle/cureall
+	name = "cureall bottle"
+	desc = "A small bottle. Contains cureall, used to treat small amounts of brute, burn, and toxins."
+	volume = 50
+	list_reagents = list(/datum/reagent/medicine/cureall = 50)
+
 /obj/item/reagent_containers/glass/bottle/epinephrine/sleeper
 	cap_on = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes the curare bottles from magpie and replaces them with cureall. created cureall bottles since they don't exist

## Why It's Good For The Game

this was intended in the original med expansion pr
