### PR TITLE
Etherbor compatability

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/lasers.dm
@@ -17,8 +17,10 @@
 
 	default_ammo_type = /obj/item/stock_parts/cell/gun/kalix
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix, /obj/item/ammo_casing/energy/disabler/hitscan)
 

--- a/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
@@ -20,6 +20,8 @@
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/kalix,
 		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix, /obj/item/ammo_casing/energy/disabler/hitscan)
 
@@ -49,8 +51,10 @@
 /obj/item/gun/energy/kalix/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/projectile/beam/hitscan/kalix/nock
@@ -100,16 +104,20 @@
 
 	default_ammo_type = /obj/item/stock_parts/cell/gun/kalix
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/nock, /obj/item/ammo_casing/energy/disabler/hitscan/kalix/nock)
 
 /obj/item/gun/energy/kalix/nock/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/projectile/beam/hitscan/kalix/pgf/nock
@@ -159,16 +167,20 @@
 
 	default_ammo_type = /obj/item/stock_parts/cell/gun/pgf
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/pgf/nock, /obj/item/ammo_casing/energy/disabler/hitscan/kalix/pgf/nock)
 
 /obj/item/gun/energy/kalix/pgf/nock/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/item/gun/energy/kalix/pgf
@@ -185,16 +197,20 @@
 
 	default_ammo_type = /obj/item/stock_parts/cell/gun/pgf
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/pgf , /obj/item/ammo_casing/energy/disabler/hitscan)
 
 /obj/item/gun/energy/kalix/pgf/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/projectile/beam/hitscan/kalix/pgf
@@ -230,6 +246,8 @@
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/kalix,
 		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 	ammo_type = list(/obj/item/ammo_casing/energy/kalix/pistol)
 
@@ -248,8 +266,10 @@
 /obj/item/gun/energy/kalix/pistol/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/item/gun/energy/kalix/pgf/medium
@@ -277,8 +297,10 @@
 /obj/item/gun/energy/kalix/pgf/medium/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/item/gun/energy/kalix/pgf/heavy
@@ -306,8 +328,10 @@
 /obj/item/gun/energy/kalix/pgf/heavy/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)
 
 /obj/item/ammo_casing/energy/pgf/assault
@@ -362,6 +386,8 @@
 /obj/item/gun/energy/kalix/pgf/heavy/sniper/empty_cell
 	spawn_no_ammo = TRUE
 	allowed_ammo_types = list(
-		/obj/item/stock_parts/cell/gun/pgf,
 		/obj/item/stock_parts/cell/gun/kalix,
+		/obj/item/stock_parts/cell/gun/pgf,
+		/obj/item/stock_parts/cell/gun/kalix/empty,
+		/obj/item/stock_parts/cell/gun/pgf/empty,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the Etherbor weapons being unable to use the "start empty" subtype of etherbor cells.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Causes some issues with mapped ruins where people have cells that should work, but don't. Annoying and messes with map balance/loot. Not to mention just annoying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Empty Etherbor cells can fit in Etherbor guns like they should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
