### PR TITLE
New gender option for it/its pronouns

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -143,7 +143,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/friendlyGenders = list(
 							"Male" = "male",
 							"Female" = "female",
-							"Other" = "plural"
+							"Other" = "plural",
+							"None" = "neuter"
 						)
 	var/list/prosthetic_limbs = list(
 							BODY_ZONE_L_ARM = PROSTHETIC_NORMAL,
@@ -332,6 +333,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dispGender = "Male"
 				else if(gender == FEMALE)
 					dispGender = "Female"
+				else if(gender == NEUTER)
+					dispGender = "None"
 				else
 					dispGender = "Other"
 				dat += "<b>Gender:</b> <a href='byond://?_src_=prefs;preference=gender'>[dispGender]</a>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds two lines of code in `preferences` to let people select 'None' as a gender to set gender to `NEUTER`

Pronouns will be it/its with unrecognized faces being referred to as 'Thing'.
Example: Spacy Elzuose Thing

if you have a better name for the option in prefs idk scream at me until i change it, just hard to name it with They/Them being 'other'
## Why It's Good For The Game
~~makes ship test 33% more woke with 33% more genders~~

Everything is already set up to let humanlikes use it/its pronouns, they're just not player accessible. Why not let players create characters with these pronouns. More expression for characters is always nice and this just lets people express their characters with a different set of pronouns. Nothing needs to be changed (as far as i'm aware) to let people use these new pronouns as all of the carbon procs in `Pronouns` defaults to it/its pronouns if `MALE`, `FEMALE`, or `PLURAL` are not selected. (I think cyborgs use it/its pronouns, too?)
## Changelog

:cl: Goat
add: Gender can now be set to 'None' for It/Its pronouns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
