### PR TITLE
removes stuff that shouldn't be there

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_crashed_starwalker.dmm
@@ -3025,13 +3025,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/crashed_starwalker)
-"Xh" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	id = "pcarrier_bridge"
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/crashed_starwalker)
 "Xj" = (
 /turf/open/floor/plating/asteroid/dirt/grass/lavaland,
 /area/overmap_encounter/planetoid/cave/explored)
@@ -4754,7 +4747,7 @@ TI
 TI
 TI
 TI
-Xh
+EV
 tV
 oG
 WM

--- a/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
@@ -2388,9 +2388,6 @@
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "nsmine_canteen"
-	},
 /turf/open/floor/plating,
 /area/ruin/rockplanet/mining_base/canteen)
 "mH" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
noticed these salvaging and they annoyed me
the shutters in the n+s kitchen in the mining facility were doubled up
there was a wall inside of the bridge windows in the crashed starwalker
## Why It's Good For The Game
immersion ruining mapping mistake that must be purged
## Changelog

:cl: Goat
fix: removed random wall that was inside of a window on crashed starwalker
fix: the shutters are no longer doubled up in the n+s rock planet mining facility kitchen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
