### PR TITLE
M10 and X11 helmet fix

### DIFF
--- a/code/modules/clothing/factions/inteq.dm
+++ b/code/modules/clothing/factions/inteq.dm
@@ -403,6 +403,7 @@
 	can_flashlight = TRUE
 	supports_variations = KEPORI_VARIATION | VOX_VARIATION
 	content_overlays = TRUE
+	unique_reskin = null
 
 /obj/item/clothing/head/helmet/m10/inteq
 	name = "inteq M-10 helmet"
@@ -415,6 +416,7 @@
 	vox_override_icon = 'icons/mob/clothing/faction/inteq/vox.dmi'
 	kepori_override_icon = 'icons/mob/clothing/faction/inteq/kepori.dmi'
 	content_overlays = TRUE
+	unique_reskin = null
 
 // Gloves
 

--- a/code/modules/clothing/factions/nanotrasen.dm
+++ b/code/modules/clothing/factions/nanotrasen.dm
@@ -336,6 +336,7 @@
 	icon_state = "nt_m10helm"
 	icon = 'icons/obj/clothing/faction/nanotrasen/head.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/nanotrasen/head.dmi'
+	unique_reskin = null
 
 /obj/item/clothing/head/helmet/bulletproof/x11/nanotrasen
 	name = "\improper Bulletproof Vigilitas Helmet"
@@ -343,6 +344,7 @@
 	icon_state = "nt_x11helm"
 	icon = 'icons/obj/clothing/faction/nanotrasen/head.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/nanotrasen/head.dmi'
+	unique_reskin = null
 
 /obj/item/clothing/head/helmet/riot/nanotrasen
 	name = "\improper Vigilitas Riot Helmet"

--- a/code/modules/clothing/factions/ramzi.dm
+++ b/code/modules/clothing/factions/ramzi.dm
@@ -198,6 +198,7 @@
 	item_state = "ramzi_m10"
 	can_flashlight = TRUE
 	content_overlays = TRUE
+	unique_reskin = null
 
 /obj/item/clothing/head/helmet/bulletproof/x11/ramzi
 	name = "\improper Ramzi Clique X-11 helmet"
@@ -209,6 +210,7 @@
 	item_state = "ramzi_x11"
 	can_flashlight = TRUE
 	content_overlays = TRUE
+	unique_reskin = null
 
 //////////
 //Masks//


### PR DESCRIPTION
## About The Pull Request

Fixes faction M10 and X11 helmet so they can't turn invisible since they don't have reskins you can switch them to

## Changelog

:cl:
fix: fixed M10 and X11 helmets from reskinning to be invisible
/:cl: