### PR TITLE
Slightly increases the effectiveness of partial understanding of languages

### DIFF
--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -285,10 +285,10 @@
 		var/base_word = strip_outer_punctuation(word)
 		var/raw_hash = md5("[lowertext(base_word)]/[GLOB.round_id]")
 		if(translate_prob > 0)
-			// the probability of managing to understand a word is based on how common it is (+10%, -15%)
-			// 1000 words in the list, so words outside the list are just treated as "the 1250th most common word"
-			var/commonness = GLOB.most_common_words[lowertext(base_word)] || 1250
-			translate_prob += (10 * (1 - (min(commonness, 1250) / 500)))
+			// the probability of managing to understand a word is based on how common it is (+10%, -5%)
+			// 1000 words in the list, so words outside the list are just treated as "the 1500th most common word"
+			var/commonness = GLOB.most_common_words[lowertext(base_word)] || 1500
+			translate_prob += (10 * (1 - (min(commonness, 1500) / 1000)))
 			if(HASH_PROB(translate_prob, raw_hash, 1))
 				scrambled_words += word
 				translated_index += FALSE


### PR DESCRIPTION
## About The Pull Request

The chance of understanding a word is now +10% to -5% based on how common the word is, instead of +10% to -15%.

## Why It's Good For The Game

Currently, having a very high but not complete understanding of a language is far less effective than intended because of the -15% penalty the majority of words will have. This is especially noticeable with the mutual intelligibility between Gezenan and Zohilan, where it more than doubles the chance you will not be able to understand a given word.

## Changelog

:cl:
balance: Slightly increased the effectiveness of partial understanding of languages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
