### PR TITLE
Fixes metal dupe with surplus

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
@@ -16,6 +16,7 @@
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/surplus
 	ammo_type = /obj/item/ammo_casing/c10mm/surplus
+	custom_materials = list(/datum/material/iron = 4000)
 
 /obj/item/storage/box/ammo/c10mm_surplus
 	name = "box of surplus 10x22mm ammo"
@@ -89,6 +90,7 @@
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/surplus
 	ammo_type = /obj/item/ammo_casing/c9mm/surplus
+	custom_materials = list(/datum/material/iron = 4000)
 
 /obj/item/storage/box/ammo/c9mm_surplus
 	name = "box of surplus 9x18mm ammo"
@@ -160,6 +162,7 @@
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/surplus
 	ammo_type = /obj/item/ammo_casing/c45/surplus
+	custom_materials = list(/datum/material/iron = 4000)
 
 /obj/item/storage/box/ammo/c45_surplus
 	name = "box of surplus .45 ammo"
@@ -384,6 +387,7 @@
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c38/surplus
 	ammo_type = /obj/item/ammo_casing/c38/surplus
+	custom_materials = list(/datum/material/iron = 4000)
 
 /obj/item/storage/box/ammo/c38_surplus
 	name = "box of surplus .38 ammo"

--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_smg_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_smg_stacks.dm
@@ -80,6 +80,7 @@
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c556mm/surplus
 	ammo_type = /obj/item/ammo_casing/caseless/c556mm/surplus
+	custom_materials = list(/datum/material/iron = 4000)
 
 /obj/item/storage/box/ammo/c556mm_surplus
 	name = "box of surplus 5.56mm HITP caseless ammo"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -849,7 +849,7 @@
 	name = "Ammo Box (.38 surplus)"
 	id = "c38_surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 37500)
+	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/storage/box/ammo/c38_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -889,7 +889,7 @@
 	name = "Ammo Box (10x22mm surplus)"
 	id = "c10mm-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 37500)
+	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/storage/box/ammo/c10mm_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -897,7 +897,7 @@
 	name = "Ammo Box (.45 surplus)"
 	id = "c45-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 37500)
+	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/storage/box/ammo/c45_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -905,7 +905,7 @@
 	name = "Ammo Box (9x18mm surplus)"
 	id = "c9mm-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 37500)
+	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/storage/box/ammo/c9mm_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -913,7 +913,7 @@
 	name = "Ammo Box (surplus 5.56mm HITP caseless)"
 	id = "c556mmHITP-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 37500)
+	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/storage/box/ammo/c556mm_surplus
 	category = list("initial", "Security", "Ammo")
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -849,7 +849,7 @@
 	name = "Ammo Box (.38 surplus)"
 	id = "c38_surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 37500)
 	build_path = /obj/item/storage/box/ammo/c38_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -889,7 +889,7 @@
 	name = "Ammo Box (10x22mm surplus)"
 	id = "c10mm-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 37500)
 	build_path = /obj/item/storage/box/ammo/c10mm_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -897,7 +897,7 @@
 	name = "Ammo Box (.45 surplus)"
 	id = "c45-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 37500)
 	build_path = /obj/item/storage/box/ammo/c45_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -905,7 +905,7 @@
 	name = "Ammo Box (9x18mm surplus)"
 	id = "c9mm-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 37500)
 	build_path = /obj/item/storage/box/ammo/c9mm_surplus
 	category = list("initial", "Security", "Ammo")
 
@@ -913,7 +913,7 @@
 	name = "Ammo Box (surplus 5.56mm HITP caseless)"
 	id = "c556mmHITP-surplus"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 37500)
 	build_path = /obj/item/storage/box/ammo/c556mm_surplus
 	category = list("initial", "Security", "Ammo")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A base-level autolathe can print out surplus ammo boxes for 12 sheets of metal. These boxes come with four ammo handfuls, which can each be recycled in an autolathe to produce 7.5 units of metal. With all four handfuls, a total of 30 sheets of metal can be produced. 

This PR changes the cost of both surplus ammo boxes, and the value you can get from recycling the handfuls they hold. Surplus ammo now costs a little more than 12 sheets of metal to print, and each handful can now only be recycled for 2 sheets of metal. With a fully upgraded autolathe, the cost to print surplus ammunition boxes drops to 8 sheets per box.

## Why It's Good For The Game

It's a little silly that you can get more from less out of thin air, but I suppose a lot of things in the frontier are like that.

## Changelog

:cl:
fix: fixes a metal dupe exploit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
