### PR TITLE
Sharplite/Advantage Attachment Offsets

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/ballistics.dm
@@ -73,6 +73,15 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger)
 		ATTACHMENT_SLOT_RAIL = 1,
 	)
 
+		slot_offsets = list(
+		ATTACHMENT_SLOT_MUZZLE = list(
+			"x" = 40,
+			"y" = 21,
+		),
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 24,
+			"y" = 12,
+
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
 	fire_delay = 0.4 SECONDS
@@ -124,15 +133,11 @@ NO_MAG_GUN_HELPER(automatic/pistol/champion)
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
 			"x" = 32,
-			"y" = 23,
-		),
-		ATTACHMENT_SLOT_SCOPE = list(
-			"x" = 15,
-			"y" = 26,
+			"y" = 17,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 23,
-			"y" = 19,
+			"x" = 22,
+			"y" = 11,
 		)
 	)
 
@@ -269,6 +274,20 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	weapon_weight = WEAPON_LIGHT
 	fire_sound = 'sound/weapons/gun/smg/vector_fire.ogg'
 
+		slot_available = list(
+		ATTACHMENT_SLOT_MUZZLE = 1,
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+	slot_offsets = list(
+		ATTACHMENT_SLOT_MUZZLE = list(
+			"x" = 43,
+			"y" = 17,
+		),
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 33,
+			"y" = 13,
+		)
+	)
 
 /obj/item/ammo_box/magazine/m9mm_expedition
 	name = "expedition submachinegun magazine (9x18mm)"
@@ -346,12 +365,12 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	)
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
-			"x" = 32,
-			"y" = 23,
+			"x" = 40,
+			"y" = 18,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 27,
-			"y" = 17,
+			"x" = 29,
+			"y" = 11,
 		),
 		ATTACHMENT_SLOT_STOCK = list(
 			"x" = 17,

--- a/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/ballistics.dm
@@ -72,15 +72,16 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger)
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1,
 	)
-
-		slot_offsets = list(
+	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
-			"x" = 40,
-			"y" = 21,
+			"x" = 41,
+			"y" = 22,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 24,
-			"y" = 12,
+			"x" = 25,
+			"y" = 16,
+		)
+	)
 
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
@@ -132,12 +133,12 @@ NO_MAG_GUN_HELPER(automatic/pistol/champion)
 	)
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
-			"x" = 32,
-			"y" = 17,
+			"x" = 33,
+			"y" = 19,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 22,
-			"y" = 11,
+			"x" = 23,
+			"y" = 15,
 		)
 	)
 
@@ -274,18 +275,19 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	weapon_weight = WEAPON_LIGHT
 	fire_sound = 'sound/weapons/gun/smg/vector_fire.ogg'
 
-		slot_available = list(
+	slot_available = list(
 		ATTACHMENT_SLOT_MUZZLE = 1,
 		ATTACHMENT_SLOT_RAIL = 1,
 	)
+
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
-			"x" = 43,
-			"y" = 17,
+			"x" = 44,
+			"y" = 19,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 33,
-			"y" = 13,
+			"x" = 34,
+			"y" = 17,
 		)
 	)
 
@@ -365,12 +367,12 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	)
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(
-			"x" = 40,
-			"y" = 18,
+			"x" = 41,
+			"y" = 21,
 		),
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 29,
-			"y" = 11,
+			"x" = 30,
+			"y" = 15,
 		),
 		ATTACHMENT_SLOT_STOCK = list(
 			"x" = 17,

--- a/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
@@ -135,6 +135,16 @@
 	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 35,
+			"y" = 12,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/l201
 	name = "SL L201 “Surge” Marksman Plasma Rifle"
@@ -162,6 +172,17 @@
 	spread = 0
 	spread_unwielded = 12
 
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 38,
+			"y" = 9,
+		),
+	)
+
 /obj/item/gun/energy/sharplite/l201/l204
 	name = "SL L204 “Resistor” Plasma Rifle"
 	desc = "A rifle-sized, semi-automatic electroplasma gun known for its low price and surprisingly low energy usage."
@@ -180,6 +201,17 @@
 
 	spread = 2
 	spread_unwielded = 10
+
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 33,
+			"y" = 11,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/l201/l204/empty_cell
 	spawn_no_ammo = TRUE
@@ -209,6 +241,17 @@
 
 	spread = 2
 	spread_unwielded = 10
+
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 32,
+			"y" = 12,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/x12/empty_cell
 	spawn_no_ammo = TRUE
@@ -257,6 +300,17 @@
 
 	zoom_amt = SHOTGUN_ZOOM
 
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 36,
+			"y" = 6,
+		),
+	)
+
 /obj/item/gun/energy/sharplite/x46/zeta
 	name = "\improper SL X-45"
 	desc = "A very old looking X-46, it has no stock or much decoration, and it is from before... Hey! What's this screen next to the mode select button?"
@@ -281,6 +335,17 @@
 	if(!integratedNTOS)
 		return
 	integratedNTOS.interact(user)
+
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 23,
+			"y" = 8,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/al655
 	name = "SL AL655 “Hades” Assault Plasma Rifle"
@@ -314,6 +379,17 @@
 	wield_delay = 0.7 SECONDS
 	wield_slowdown = HEAVY_LASER_RIFLE_SLOWDOWN
 	spread_unwielded = 20
+
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 35,
+			"y" = 7,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/al655/inteq
 	name = "PP20 “Barghest” APR"
@@ -363,6 +439,16 @@
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
 	zoom_out_amt = 5
 
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 34,
+			"y" = 11,
+		),
+	)
 
 /obj/item/gun/energy/sharplite/x11
 	name = "X11 Advanced Stopping Pistol" //wayland is better
@@ -377,6 +463,16 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/sharplite/hos, /obj/item/ammo_casing/energy/laser/sharplite/hos, /obj/item/ammo_casing/energy/trap)
 	ammo_x_offset = 1
 	shaded_charge = TRUE
+	slot_available = list(
+		ATTACHMENT_SLOT_RAIL = 1,
+	)
+
+	slot_offsets = list(
+		ATTACHMENT_SLOT_RAIL = list(
+			"x" = 25,
+			"y" = 11,
+		),
+	)
 
 /obj/item/gun/energy/laser/retro
 	name ="SL L104"

--- a/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/nanotrasen_sharplite/lasers.dm
@@ -141,8 +141,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 35,
-			"y" = 12,
+			"x" = 36,
+			"y" = 16,
 		),
 	)
 
@@ -178,8 +178,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 38,
-			"y" = 9,
+			"x" = 39,
+			"y" = 13,
 		),
 	)
 
@@ -208,8 +208,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 33,
-			"y" = 11,
+			"x" = 34,
+			"y" = 15,
 		),
 	)
 
@@ -248,8 +248,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 32,
-			"y" = 12,
+			"x" = 33,
+			"y" = 16,
 		),
 	)
 
@@ -306,8 +306,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 36,
-			"y" = 6,
+			"x" = 37,
+			"y" = 10,
 		),
 	)
 
@@ -342,8 +342,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 23,
-			"y" = 8,
+			"x" = 24,
+			"y" = 12,
 		),
 	)
 
@@ -386,8 +386,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 35,
-			"y" = 7,
+			"x" = 36,
+			"y" = 11,
 		),
 	)
 
@@ -445,8 +445,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 34,
-			"y" = 11,
+			"x" = 35,
+			"y" = 15,
 		),
 	)
 
@@ -469,8 +469,8 @@
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_RAIL = list(
-			"x" = 25,
-			"y" = 11,
+			"x" = 26,
+			"y" = 15,
 		),
 	)
 


### PR DESCRIPTION
## About The Pull Request

Adds attachment offsets to various Sharplite and Advantage guns. Also adds attachment slots to many Sharplite guns and the Expedition SMG.

## Why It's Good For The Game

No floating attachments.

<img width="534" height="512" alt="image" src="https://github.com/user-attachments/assets/173b0831-7566-42ad-a26a-64ec8b25dee4" />

## Changelog

:cl:
add: Adjusted and added attachment offsets to various Sharplite/Advantage guns.
add: Added attachment slots to various Sharplite guns, as well as the Expedition SMG.
/:cl: