### PR TITLE
Fixes Black Market Holster

### DIFF
--- a/code/modules/cargo/blackmarket/packs/misc.dm
+++ b/code/modules/cargo/blackmarket/packs/misc.dm
@@ -4,7 +4,7 @@
 /datum/blackmarket_item/misc/cham_holster
 	name = "Chameleon Shoulder holster"
 	desc = "Looking to pack some heat without attracting attention? This adapative chameleon shoulder holster can disguise itself and your piece!"
-	item = /obj/item/clothing/accessory/holster
+	item = /obj/item/clothing/accessory/holster/chameleon
 
 	cost_min = 200
 	cost_max = 800


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Corrects an item path so that the black market sells the actual chameleon shoulder holster and not a regular one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think people like to get the things they pay for.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: The black market now sells the correct shoulder holster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->