### PR TITLE
Adds hardsuit jetpack upgrades to cargo and makes them a little more versatile

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -172,7 +172,7 @@
 
 /obj/item/tank/jetpack/suit
 	name = "hardsuit jetpack upgrade"
-	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It draws propellant from an active air line, or if one is not available, an external air tank."
+	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It draws propellant from an external air tank."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "jetpack_upgrade"
 	item_state = "jetpack-black"

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -172,7 +172,7 @@
 
 /obj/item/tank/jetpack/suit
 	name = "hardsuit jetpack upgrade"
-	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It is fueled by a tank inserted into the suit's storage compartment."
+	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It draws propellant from an active air line, or if one is not available, an external air tank."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "jetpack_upgrade"
 	item_state = "jetpack-black"
@@ -200,8 +200,8 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	if(!istype(H.s_store, /obj/item/tank/internals))
-		to_chat(user, span_warning("You need a tank in your suit storage!"))
+	if((!istype(H.s_store, /obj/item/tank/internals)) && (!istype(H.back, /obj/item/tank/internals)) && (!istype(H.belt, /obj/item/tank/internals)) && (!istype(H.l_store, /obj/item/tank/internals)) && (!istype(H.r_store, /obj/item/tank/internals)))
+		to_chat(user, span_warning("You need to equip a tank!"))
 		return
 	..()
 
@@ -209,7 +209,24 @@
 	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc) || loc.loc != user)
 		return
 	var/mob/living/carbon/human/H = user
-	tank = H.s_store
+
+	//Cascades down a priority list, taking air from first the active internal tank, then the suit storage, then the back, the belt, the left pocket and the right pocket
+	if(H.internal)
+		tank = H.internal
+	else if(istype(H.back, /obj/item/tank))
+		tank = H.back
+	else if(istype(H.s_store, /obj/item/tank))
+		tank = H.s_store
+	else if(istype(H.belt, /obj/item/tank))
+		tank = H.belt
+	else if(istype(H.l_store, /obj/item/tank))
+		tank = H.l_store
+	else if (istype(H.r_store, /obj/item/tank))
+		tank = H.r_store
+	else
+		tank = null
+		return
+
 	air_contents = tank.air_contents
 	START_PROCESSING(SSobj, src)
 	cur_user = user
@@ -226,8 +243,9 @@
 	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc))
 		turn_off(cur_user)
 		return
-	var/mob/living/carbon/human/H = loc.loc
-	if(!tank || tank != H.s_store)
+
+	if(!tank)
+		to_chat(usr, span_warning("\The [src] shuts down!"))
 		turn_off(cur_user)
 		return
 	..()

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -210,10 +210,8 @@
 		return
 	var/mob/living/carbon/human/H = user
 
-	//Cascades down a priority list, taking air from first the active internal tank, then the suit storage, then the back, the belt, the left pocket and the right pocket
-	if(H.internal)
-		tank = H.internal
-	else if(istype(H.back, /obj/item/tank))
+	//Cascades down a priority list, taking air from first the suit storage slot, then the back, the belt, the left pocket and the right pocket
+	if(istype(H.back, /obj/item/tank))
 		tank = H.back
 	else if(istype(H.s_store, /obj/item/tank))
 		tank = H.s_store

--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -113,6 +113,12 @@
 	cost = 1500
 	contains = list(/obj/item/tank/jetpack/oxygen/harness)
 
+/datum/supply_pack/tools/jetpack/suit
+	name = "Hardsuit Jetpack Upgrade Crate"
+	desc = "A standardized jetpack attachment designed for direct integration with hardsuits. For when every gram matters."
+	cost = 2000
+	contains = list(/obj/item/tank/jetpack/suit)
+
 /datum/supply_pack/tools/anglegrinder
 	name = "Angle Grinder"
 	desc = "Contains one angle grinder pack, a tool used for quick structure deconstruction and salvaging"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds hardsuit jetpack upgrades to the cargo market for 2000 credits, and it changes their behavior so that they are no longer restricted to just taking air from a tank in the suit storage slot. They work on a priority list now, first drawing air from the suit storage slot, then checking the back slot, then the belt, then the left pocket, and finally the right pocket, for a tank to draw propellant from.

## Why It's Good For The Game

This is a minor little addition that provides a more accessible option if one doesn't want to make use of a bulky jetpack.

## Changelog

:cl:
add: Added hardsuit jetpack upgrades to cargo for 2000 credits each
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
