### PR TITLE
Fauna Trophies are small sized

### DIFF
--- a/code/modules/mining/equipment/trophies.dm
+++ b/code/modules/mining/equipment/trophies.dm
@@ -4,6 +4,7 @@
 	desc = "A strange spike with no usage."
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "tail_spike"
+	w_class = WEIGHT_CLASS_SMALL
 
 //legion
 /obj/item/mob_trophy/legion_skull


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes trophies small instead of normal sized.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fauna trophies are fluff money items like dogtags, and are no longer crusher items. It makes sense for them to be small like them now.

## Changelog

:cl:
balance: Fauna trophies are small sized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
