### PR TITLE
Standardizes premium ion engines

### DIFF
--- a/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -218,12 +218,9 @@
 	thrust = 2
 	power_per_burn = 70000
 
+// This thruster is the same as a standard thruster, but it starts with T3 parts
 /obj/machinery/power/shuttle/engine/electric/premium
-	name = "high performance ion thruster"
-	desc = "An expensive variant of a standard ion thruster, using highest quality components in order to achieve much better performance."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/premium
-	thrust = 10
-	power_per_burn = 50000
 
 /obj/machinery/power/smes/shuttle
 	name = "electric engine precharger"

--- a/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -221,8 +221,9 @@
 /obj/machinery/power/shuttle/engine/electric/premium
 	name = "high performance ion thruster"
 	desc = "An expensive variant of a standard ion thruster, using highest quality components in order to achieve much better performance."
-	thrust = 30
-	power_per_burn = 65000
+	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/premium
+	thrust = 10
+	power_per_burn = 50000
 
 /obj/machinery/power/smes/shuttle
 	name = "electric engine precharger"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1451,10 +1451,13 @@
 		/obj/item/stock_parts/micro_laser = 2)
 
 /obj/item/circuitboard/machine/shuttle/engine/electric/premium
-	name = "High Performance Ion Thruster (Machine Board)"
+	name = "Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/premium
-	req_components = list(/obj/item/stock_parts/capacitor/super = 3,
-		/obj/item/stock_parts/micro_laser/ultra = 3)
+	// this makes maploaded engines of this type start with T3 parts
+	def_components = list(
+		/obj/item/stock_parts/capacitor = /obj/item/stock_parts/capacitor/super,
+		/obj/item/stock_parts/micro_laser = /obj/item/stock_parts/micro_laser/ultra
+		)
 
 /obj/item/circuitboard/machine/shuttle/engine/expulsion
 	name = "Expulsion Thruster (Machine Board)"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1452,7 +1452,6 @@
 
 // Maploaded engines of this type function identically to standard ion engines, but they start with T3 parts
 /obj/item/circuitboard/machine/shuttle/engine/electric/premium
-	name = "Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/premium
 	def_components = list(
 		/obj/item/stock_parts/capacitor = /obj/item/stock_parts/capacitor/super,

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1450,6 +1450,12 @@
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
+/obj/item/circuitboard/machine/shuttle/engine/electric/premium
+	name = "High Performance Ion Thruster (Machine Board)"
+	build_path = /obj/machinery/power/shuttle/engine/electric/premium
+	req_components = list(/obj/item/stock_parts/capacitor/super = 3,
+		/obj/item/stock_parts/micro_laser/ultra = 3)
+
 /obj/item/circuitboard/machine/shuttle/engine/expulsion
 	name = "Expulsion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/fueled/expulsion

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1450,7 +1450,7 @@
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
-// Maploaded engines of this type start function identically to standard ion engines, but they start with T3 parts
+// Maploaded engines of this type function identically to standard ion engines, but they start with T3 parts
 /obj/item/circuitboard/machine/shuttle/engine/electric/premium
 	name = "Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/premium

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1450,10 +1450,10 @@
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
+// Maploaded engines of this type start function identically to standard ion engines, but they start with T3 parts
 /obj/item/circuitboard/machine/shuttle/engine/electric/premium
 	name = "Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/premium
-	// this makes maploaded engines of this type start with T3 parts
 	def_components = list(
 		/obj/item/stock_parts/capacitor = /obj/item/stock_parts/capacitor/super,
 		/obj/item/stock_parts/micro_laser = /obj/item/stock_parts/micro_laser/ultra


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes premium ion engines so that they are the same as standard ion engines, only differing by starting with tier 3 parts upon mapload.

## Why It's Good For The Game

This is a continuation of an earlier PR that changes the behavior of ion engines, and it opens the door for custom ion engines of different make.

## Changelog

:cl:
balance: standardized premium ion engines with standard ion engines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
