### PR TITLE
Removes Lobotomy and Pacification Surgery from Surgical Disks

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -174,9 +174,7 @@
 	var/list/req_tech_surgeries = list(
 		/datum/surgery/healing/brute/upgraded/femto,
 		/datum/surgery/healing/burn/upgraded/femto,
-		/datum/surgery/healing/combo/upgraded,
-		/datum/surgery/advanced/pacify,
-		/datum/surgery/advanced/lobotomy)
+		/datum/surgery/healing/combo/upgraded)
 	for(var/i in req_tech_surgeries)
 		var/datum/surgery/beep = i
 		if(initial(beep.requires_tech))


### PR DESCRIPTION
## About The Pull Request

Removes the lobotomy and pacification surgery from the purchasable and findable surgical disks.

## Why It's Good For The Game

The last time I saw someone talking about these it was for a pipedream of torturing players. These are remnants of R&D surgeries from /tg/, really. The only reason they aren't full-removed is because I know admins use at least pacification in events for certain things (including one recently) and I feel that their value as an event tool is still worth it.

## Changelog

:cl:
balance: You can't get Pacification and Lobotomy surgeries off surgical disks anymore.
/:cl:
