### PR TITLE
Die Woke 2: Die Woker (Adds pronouns as something seperate from gender)

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -215,7 +215,33 @@
 		. = "es"
 
 //humans need special handling, because they can have their gender hidden
+/mob/living/carbon/human/proc/get_pronouns()
+	if(pronouns)
+		if(pronouns == "He")
+			return MALE
+		else if(pronouns == "She")
+			return FEMALE
+		else if(pronouns == "It")
+			return NEUTER
+		else
+			return PLURAL
+	return gender
+
+/mob/living/carbon/human/proc/get_default_pronouns()
+	switch(gender)
+		if(MALE)
+			return "He"
+		if(FEMALE)
+			return "She"
+		if(PLURAL)
+			return "They"
+		if(NEUTER)
+			return "It"
+	return "They"
+
 /mob/living/carbon/human/p_they(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -223,6 +249,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_their(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -230,6 +258,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_them(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -237,6 +267,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_have(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -244,6 +276,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_are(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -251,6 +285,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_were(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -258,6 +294,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_do(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -265,6 +303,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_s(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
@@ -272,6 +312,8 @@
 	return ..()
 
 /mob/living/carbon/human/p_es(temp_gender)
+	if(!temp_gender)
+		temp_gender = get_pronouns()
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -48,6 +48,11 @@
 				return default
 	return default
 
+/proc/sanitize_pronouns(pronouns, default="He")
+	if(pronouns == "He" || pronouns == "She" || pronouns == "They" || pronouns == "It")
+		return pronouns
+	return default
+
 /proc/sanitize_hexcolor(color, desired_format = 6, include_crunch = FALSE, default)
 	var/crunch = include_crunch ? "#" : ""
 	if(!istext(color))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/slot_randomized					//keeps track of round-to-round randomization of the character slot, prevents overwriting
 	var/real_name						//our character's name
 	var/gender = MALE					//gender of character (well duh)
+	var/pronouns = "He"					//pronouns of character
 	var/age = 30						//age of character
 	var/underwear = "Nude"				//Type of underwear
 	var/underwear_color = "000"			//Greyscale color of underwear
@@ -144,6 +145,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							"Female" = "female",
 							"Other" = "plural",
 							"None" = "neuter"
+						)
+	var/list/friendlyPronouns = list(
+							"He/Him" = "He",
+							"She/Her" = "She",
+							"They/Them" = "They",
+							"It/Its" = "It"
 						)
 	var/list/prosthetic_limbs = list(
 							BODY_ZONE_HEAD = PROSTHETIC_NORMAL,
@@ -342,7 +349,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(randomise[RANDOM_BODY] || randomise[RANDOM_BODY_ANTAG]) //doesn't work unless random body
 					dat += "<a href='byond://?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER]'>Always Random Gender: [(randomise[RANDOM_GENDER]) ? "Yes" : "No"]</A>"
 					dat += "<a href='byond://?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER_ANTAG]'>When Antagonist: [(randomise[RANDOM_GENDER_ANTAG]) ? "Yes" : "No"]</A>"
-
+			var/dispPronouns
+			if(pronouns == "He")
+				dispPronouns = "He/Him"
+			else if(pronouns == "She")
+				dispPronouns = "She/Her"
+			else if(pronouns == "It")
+				dispPronouns = "It/Its"
+			else
+				dispPronouns = "They/Them"
+			dat += "<br><b>Pronouns:</b> <a href='byond://?_src_=prefs;preference=pronouns'>[dispPronouns]</a>"
 			dat += "<br><b>Age:</b> <a href='byond://?_src_=prefs;preference=age;task=input'>[age]</a>"
 			if(randomise[RANDOM_BODY] || randomise[RANDOM_BODY_ANTAG]) //doesn't work unless random body
 				dat += "<a href='byond://?_src_=prefs;preference=toggle_random;random_type=[RANDOM_AGE]'>Always Random Age: [(randomise[RANDOM_AGE]) ? "Yes" : "No"]</A>"
@@ -2202,7 +2218,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						socks = random_socks()
 						facial_hairstyle = random_facial_hairstyle(gender)
 						hairstyle = random_hairstyle(gender)
-
+				if("pronouns")
+					var/pickedPronouns = input(user, "Choose your pronouns.", "Character Preference", pronouns) as null|anything in friendlyPronouns
+					if(pickedPronouns)
+						pronouns = friendlyPronouns[pickedPronouns]
 				if("fbp")
 					fbp = !fbp
 
@@ -2537,6 +2556,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.name = character.real_name
 
 	character.gender = gender
+	character.pronouns = pronouns
 	character.age = clamp(age, pref_species.species_age_min, pref_species.species_age_max)
 	character.eye_color = eye_color
 	var/obj/item/organ/eyes/organ_eyes = character.getorgan(/obj/item/organ/eyes)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 42
+#define SAVEFILE_VERSION_MAX 43
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -113,6 +113,17 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		var/body_size
 		READ_FILE(S["body_size"], body_size)
 		height_filter = body_size
+	if(current_version < 43)
+		var/gender
+		READ_FILE(S["gender"], gender)
+		if(gender == MALE)
+			pronouns = "He"
+		else if(gender == FEMALE)
+			pronouns = "She"
+		else if(gender == NEUTER)
+			pronouns = "It"
+		else
+			pronouns = "They"
 
 
 /// checks through keybindings for outdated unbound keys and updates them
@@ -417,6 +428,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Character
 	READ_FILE(S["real_name"], real_name)
 	READ_FILE(S["gender"], gender)
+	READ_FILE(S["pronouns"], pronouns)
 	READ_FILE(S["age"], age)
 	READ_FILE(S["hair_color"], hair_color)
 	READ_FILE(S["facial_hair_color"], facial_hair_color)
@@ -529,6 +541,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Sanitize
 	real_name = reject_bad_name(real_name)
 	gender = sanitize_gender(gender)
+	pronouns = sanitize_pronouns(pronouns)
 	if(!real_name)
 		real_name = random_unique_name(gender)
 
@@ -623,6 +636,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Character
 	WRITE_FILE(S["real_name"]					, real_name)
 	WRITE_FILE(S["gender"]						, gender)
+	WRITE_FILE(S["pronouns"]					, pronouns)
 	WRITE_FILE(S["age"]							, age)
 	WRITE_FILE(S["hair_color"]					, hair_color)
 	WRITE_FILE(S["facial_hair_color"]			, facial_hair_color)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -9,6 +9,13 @@
 		gender = gender_override
 	else
 		gender = pick(MALE,FEMALE,PLURAL)
+		switch(gender)
+			if(MALE)
+				pronouns = "He"
+			if(FEMALE)
+				pronouns = "She"
+			if(PLURAL)
+				pronouns = "They"
 	if(randomise[RANDOM_AGE] || randomise[RANDOM_AGE_ANTAG] && antag_override)
 		age = rand(AGE_MIN,AGE_MAX)
 	if(randomise[RANDOM_UNDERWEAR])

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -86,3 +86,6 @@
 
 	/// Height of the mob
 	VAR_PROTECTED/mob_height = HUMAN_HEIGHT_MEDIUM
+
+	/// Pronouns of the mob
+	var/pronouns = null // all pronoun stuff is for players and will read gender for pronouns if this is null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<img width="187" height="52" alt="image" src="https://github.com/user-attachments/assets/b4d28bf7-2be9-494c-9f77-6f77793777c0" />

`/mob/living/carbon/human` now defines `pronouns`. This is `NULL` by default. All human specific human pronoun procs in `pronouns.dm` use the new `get_pronouns()` proc if `temp_gender` is false to grab pronouns. The pronoun helper will use the applicable gender of that specific pronoun  if non-null, using `gender` if null. `get_gender()` will use pronouns to determine noun (Male/Female/Person/Thing) but can be changed to a toggle between reading gender or pronouns if enough people want that.

Savefile version is now `43` and will match gender to pronouns on updated savefiles for ease of updating. 

This should probably be test merged seeing how many problems might come up that I could not see. 
## Why It's Good For The Game
~increases shiptest's wokeness by 100%, bring our wokeness up to modern day standards of other codebases.~

Tying pronouns to gender is restrictive due to some player customization options being restricted behind a specific gender. This allows players to pick whatever gender for the character allowing for more player customization. Humans and lizards (as far as I'm aware) also have sexual dimorphism so if people want to have a male body with they/them pronouns or a female body with he/him pronouns this allows for that. More dimorphism with body types could also be allowed as players won't have to worry about having gender force a specific body type. 

Should work fine for things like pirates if pronouns aren't defined it'll just read gender for pronoun usage as before.

:cl: Goat
add: Pronouns. Your pronouns are now separate from your gender. Be as woke as you want. Pronouns are your gender's default when your save file gets updated so don't worry about having to set them. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
