### PR TITLE
Fixes a single area tile on Dwayne

### DIFF
--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -3160,9 +3160,6 @@
 /obj/effect/turf_decal/ntspaceworks_big/six,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
-"UP" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/template_noop)
 "UX" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -3593,7 +3590,7 @@ OJ
 (5,1,1) = {"
 OJ
 OJ
-UP
+mF
 CD
 ea
 mF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
dwayne had an incorrect area tile in the engine room so one of the walls would just come off and this just fixes that
## Why It's Good For The Game
sealed ship by default is GOOD! depressurized ship is BAD!
## Changelog

:cl: Goat
fix: Dwyane's engine no longer leaves a wall behind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
