### PR TITLE
Doubles loadout item slots

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -131,7 +131,7 @@
 	value_mode = VALUE_MODE_FLAG
 
 /datum/config_entry/number/max_loadout_items	//maximum number of items that can be in a player's loadout
-	config_entry_value = 10
+	config_entry_value = 20
 	min_val = 0
 
 /datum/config_entry/flag/no_summon_guns	//No

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -421,7 +421,7 @@ ROUNDSTART_RACES jelly
 #ROUNDSTART_NO_HARD_CHECK felinid
 
 ## The amount of loadout items players are allowed to spawn with. Default 10
-MAX_LOADOUT_ITEMS 10
+MAX_LOADOUT_ITEMS 20
 
 ## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
 OVERFLOW_CAP -1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This doubles the number of available loadout slots from 10 to 20

## Why It's Good For The Game

Now you can carry more outfits on you for maximum style

## Changelog

:cl:
balance: doubles loadout slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
