### PR TITLE
Allows users in hardsuits to equip knives and sledgehammers in the suit storage slot

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -124,6 +124,7 @@
 /obj/item/clothing/suit/space/hardsuit/Initialize()
 	if(jetpack && ispath(jetpack))
 		jetpack = new jetpack(src)
+	allowed += GLOB.security_vest_allowed
 	. = ..()
 
 /obj/item/clothing/suit/space/hardsuit/attack_self(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds the list of allowed objects from the global list of allowed objects for armor vests to hardsuits -- this allows hardsuits to hold things like sledgehammers in their suit storage slots now

## Why It's Good For The Game

The allowed list for hardsuits only allowed for a small list of engineering items previously -- this made it so that one was unable to hold a sledgehammer in the suit storage slot of a biege-red hardsuit, whereas a standard armor vest could hold one without issue. This change should bring a bit more parity between the two types of armor

## Changelog

:cl:
balance: updated the allowed list for hardsuits to include things that armor vests can hold in their suit storage slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
