### PR TITLE
Adds inacusiate, oculine, and charcoal to the outpost medvender

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -354,6 +354,7 @@
 		new /obj/item/reagent_containers/pill/charcoal(src)
 
 /obj/item/storage/pill_bottle/charcoal/less
+	custom_price = 100
 
 /obj/item/storage/pill_bottle/charcoal/less/PopulateContents()
 	for(var/i in 1 to 3)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -217,6 +217,18 @@
 		return
 	icon_state = "[base_icon_state][(reagents.total_volume > 0) ? 1 : 0]"
 
+/obj/item/reagent_containers/hypospray/medipen/oculine
+	name = "oculine autoinjector"
+	desc = "An autoinjector designed to promote the repair of the cornea and the retina after damage."
+	list_reagents = list(/datum/reagent/medicine/inacusiate = 10)
+	custom_price = 100
+
+/obj/item/reagent_containers/hypospray/medipen/inacusiate
+	name = "inacusiate autoinjector"
+	desc = "An autoinjector designed to rapidly restore hearing after acute hearing loss."
+	list_reagents = list(/datum/reagent/medicine/inacusiate = 10)
+	custom_price = 100
+
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"
 	desc = "A rapid way to save a person from a critical injury state!"

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -22,6 +22,8 @@
 		/obj/item/stack/medical/bone_gel = 8,
 		/obj/item/stack/sticky_tape/surgical = 8,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 4,
+		/obj/item/reagent_containers/hypospray/medipen/oculine = 6,
+		/obj/item/reagent_containers/hypospray/medipen/inacusiate = 6,
 		/obj/item/reagent_containers/hypospray/medipen/diphen = 5,
 		/obj/item/reagent_containers/hypospray/medipen/psicodine = 6,
 		/obj/item/reagent_containers/hypospray/medipen/synap = 6,
@@ -31,6 +33,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/antihol = 10,
 		/obj/item/reagent_containers/hypospray/medipen/anti_rad = 10,
 		/obj/item/storage/pill_bottle/licarb = 4,
+		/obj/item/storage/pill_bottle/charcoal/less = 2,
 		/obj/item/reagent_containers/syringe/stasis = 4,
 		/obj/item/reagent_containers/syringe/antiviral = 4
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds autoinjectors for oculine and inacusiate to the outpost medvender, as well as a pill bottle filled with three pills of charcoal (the charcoal/less pill bottle subtype)

<img width="421" height="383" alt="image" src="https://github.com/user-attachments/assets/b5f97f7d-3636-40b8-b28d-a3482e7d00b8" />

## Why It's Good For The Game

There currently does not exist an accessible way to obtain oculine and inacusiate, and this PR aims to address this issue. There's also nothing in the medical vender that directly treats toxins at all, so a pill bottle for charcoal was added.

## Changelog

:cl:
add: Adds a charcoal pill bottle, and oculine/inacusiate autoinjectors to the outpost medical vender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
