### PR TITLE
replaces the kali command smartfridge with a regular fridge and removes some food in it

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -3466,14 +3466,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/smartfridge,
-/obj/item/food/grown/siti,
-/obj/item/food/grown/sososi,
 /obj/item/food/grown/siti,
 /obj/item/food/grown/sososi,
 /obj/item/food/grown/sososi,
 /obj/item/food/grown/siti,
-/obj/item/food/grown/fara_li,
 /obj/item/food/grown/fara_li,
 /obj/item/food/grown/fara_li,
 /obj/item/food/meat/slab/miras,
@@ -3482,23 +3478,21 @@
 /obj/item/reagent_containers/condiment/tiris_sele,
 /obj/item/reagent_containers/condiment/tiris_milk,
 /obj/item/reagent_containers/condiment/tiris_milk,
-/obj/item/reagent_containers/condiment/tiris_milk,
 /obj/item/food/cheese/wheel/tiris,
 /obj/item/food/cheese/wheel/tiris,
 /obj/item/food/grown/dote_berries,
 /obj/item/food/grown/dote_berries,
-/obj/item/food/grown/dote_berries,
-/obj/item/food/meat/slab/tiris,
-/obj/item/food/grown/refa_li,
-/obj/item/food/grown/refa_li,
-/obj/item/food/grown/dote_berries,
 /obj/item/food/grown/refa_li,
 /obj/item/food/grown/refa_li,
 /obj/item/food/meat/slab/tiris,
 /obj/item/food/meat/slab/tiris,
 /obj/item/food/meat/slab/remes,
 /obj/item/food/meat/slab/remes,
-/obj/item/food/meat/slab/remes,
+/obj/structure/closet/secure_closet/freezer{
+	anchored = 1;
+	locked = 0;
+	name = "fridge"
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/office)
 "sA" = (

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -642,7 +642,7 @@
 	pixel_y = -23
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/ship/crew/toilet)
+/area/ship/bridge)
 "db" = (
 /obj/machinery/shower{
 	pixel_y = 19
@@ -657,7 +657,7 @@
 /obj/structure/curtain,
 /obj/item/soap/syndie,
 /turf/open/floor/plasteel/showroomfloor,
-/area/ship/crew/toilet)
+/area/ship/bridge)
 "dl" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -3933,7 +3933,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/toilet)
+/area/ship/bridge)
 "uK" = (
 /obj/effect/turf_decal/corner/opaque/beige/mono,
 /obj/effect/turf_decal/corner/opaque/tan{
@@ -8514,7 +8514,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/showroomfloor,
-/area/ship/crew/toilet)
+/area/ship/bridge)
 "Sa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10577,7 +10577,7 @@ Mg
 WO
 sf
 ws
-rm
+Mg
 db
 JW
 RB
@@ -10639,7 +10639,7 @@ jr
 Mj
 eA
 bD
-rm
+Mg
 cZ
 kB
 Cn
@@ -10670,8 +10670,8 @@ sI
 YA
 Dl
 Bx
-rm
-rm
+Mg
+Mg
 JW
 JW
 Bb

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -425,12 +425,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/electrical)
-"bO" = (
-/obj/effect/turf_decal/corner/opaque/tan{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/hallway/aft)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -9336,12 +9330,6 @@
 /obj/effect/turf_decal/corner/opaque/red/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
-"WA" = (
-/obj/effect/turf_decal/corner/opaque/tan{
-	dir = 6
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/security/armory)
 "WC" = (
 /obj/effect/turf_decal/corner/opaque/beige/mono,
 /obj/effect/turf_decal/corner/opaque/tan{
@@ -9844,10 +9832,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
-"YL" = (
-/obj/effect/turf_decal/corner/opaque/tan/full,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ship/bridge)
 "YN" = (
 /obj/structure/railing,
 /obj/structure/closet/crate,
@@ -10589,7 +10573,7 @@ hz
 (16,1,1) = {"
 CN
 FQ
-YL
+Mg
 WO
 sf
 ws
@@ -10912,7 +10896,7 @@ NL
 YG
 XX
 gn
-bO
+aH
 IK
 lF
 hs
@@ -11292,7 +11276,7 @@ Gh
 Gh
 cF
 an
-WA
+tX
 tX
 mf
 tX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="661" height="487" alt="image" src="https://github.com/user-attachments/assets/13391c8a-30c1-4b76-b8ce-a4c11ef4356d" />
(it used to be an overloaded smartfridge)

## Why It's Good For The Game

<img width="363" height="259" alt="image" src="https://github.com/user-attachments/assets/e2bba785-409a-40fb-a459-ed24e1b9f753" />


## Changelog

:cl:
fix: The NGR-aligned remnants of a pre-ICW architecture company have written a large number of very angry faxes to Hardline's catering firm, and the officer's mess on the Kali Andhi-class is now less overstocked. Wonderful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
