### PR TITLE
Small CLIP Outfit and Corpse Changes

### DIFF
--- a/_maps/RandomRuins/MoonRuins/moon_moonbase.dmm
+++ b/_maps/RandomRuins/MoonRuins/moon_moonbase.dmm
@@ -3627,7 +3627,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ruin/moon/moonbase/dorms)
 "GU" = (
-/obj/effect/mob_spawn/human/corpse/clip/bombsuitguy,
+/obj/effect/mob_spawn/human/corpse/clip/minuteman/eod/bombsuit,
 /obj/item/mine/pressure/explosive{
 	pixel_x = -9;
 	pixel_y = 6

--- a/code/game/objects/structures/crates_lockers/closets/secure/clip.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/clip.dm
@@ -93,14 +93,14 @@
 	icon_state = "eng_secure"
 
 /obj/structure/closet/secure_closet/clip/minutemen/engineer/PopulateContents()
-	new /obj/item/clothing/under/clip/minutemen(src)
+	new /obj/item/clothing/under/clip(src)
 	new /obj/item/clothing/shoes/workboots(src)
 	new /obj/item/storage/belt/utility/full/engi(src)
 	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/clothing/suit/hazardvest(src)
 	new /obj/item/storage/backpack/satchel/eng(src)
-	new /obj/item/clothing/head/clip(src)
+	new /obj/item/clothing/head/soft/utility_navy(src)
 	new /obj/item/clothing/head/hardhat/dblue(src)
 	new /obj/item/clothing/glasses/welding(src)
 	new /obj/item/storage/box/emptysandbags(src)

--- a/code/modules/clothing/outfits/factions/clip.dm
+++ b/code/modules/clothing/outfits/factions/clip.dm
@@ -479,7 +479,7 @@
 	courierbag = /obj/item/storage/backpack/messenger/engi
 
 	uniform = /obj/item/clothing/under/clip
-	head = /obj/item/clothing/head/clip
+	head = /obj/item/clothing/head/soft/utility_navy
 	suit =  /obj/item/clothing/suit/hazardvest
 
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)

--- a/code/modules/clothing/outfits/factions/clip.dm
+++ b/code/modules/clothing/outfits/factions/clip.dm
@@ -478,7 +478,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	courierbag = /obj/item/storage/backpack/messenger/engi
 
-	uniform = /obj/item/clothing/under/clip/minutemen
+	uniform = /obj/item/clothing/under/clip
 	head = /obj/item/clothing/head/clip
 	suit =  /obj/item/clothing/suit/hazardvest
 
@@ -537,11 +537,6 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/clip_spotter
 	suit_store = /obj/item/tank/internals/oxygen
 
-/datum/outfit/job/clip/minutemen/grunt/dressed/bombsuit
-	name = "CLIP Minutmemen - Minuteman (Bombsuit)"
-	suit = /obj/item/clothing/suit/space/hardsuit/bomb/clip
-	head = /obj/item/clothing/head/helmet/space/hardsuit/bomb/clip
-
 /datum/outfit/job/clip/minutemen/grunt/dressed/armed
 	name = "CLIP Minutemen - Minuteman (Armed - CM-82)"
 
@@ -594,6 +589,14 @@
 	belt = /obj/item/storage/belt/military/clip/engi
 
 	backpack_contents = list(/obj/item/clothing/mask/gas/clip=1, /obj/item/storage/ration/chili_macaroni=1, /obj/item/grenade/c4=2, /obj/item/ammo_box/magazine/p16=3)
+
+/datum/outfit/job/clip/minutemen/grunt/eod
+	name = "CLIP Minutemen - EOD Specialist"
+	id_assignment = "Explosive Ordnance Disposal Technician"
+
+/datum/outfit/job/clip/minutemen/grunt/eod/bombsuit
+	name = "CLIP Minutemen - EOD Specialist (Bombsuit)"
+	suit = /obj/item/clothing/suit/space/hardsuit/bomb/clip
 
 // combat medic
 

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -387,8 +387,3 @@
 	id_job = "Captain"
 	outfit = /datum/outfit/job/gezena/captain
 
-/* clip ig */
-
-/obj/effect/mob_spawn/human/corpse/clip/bombsuitguy
-	name = "CLIP Bombsuit Spawner"
-	outfit = /datum/outfit/job/clip/minutemen/grunt/dressed/bombsuit

--- a/code/modules/mob/living/simple_animal/corpse_spawners/clip.dm
+++ b/code/modules/mob/living/simple_animal/corpse_spawners/clip.dm
@@ -1,0 +1,37 @@
+// confed league
+
+/obj/effect/mob_spawn/human/corpse/clip
+	name = "CLIP Corpse Spawner"
+	outfit = /datum/outfit/job/clip/assistant
+
+/obj/effect/mob_spawn/human/corpse/clip/researcher
+	name = "CLIP Researcher Spawner"
+	outfit = /datum/outfit/job/clip/scientist
+
+/obj/effect/mob_spawn/human/corpse/clip/vc
+	name = "CLIP Vehicle Pilot Spawner"
+	outfit = /datum/outfit/job/clip/minutemen/vehicle_pilot/dressed
+
+/obj/effect/mob_spawn/human/corpse/clip/captain
+	name = "CLIP Captain Corpse Spawner"
+	outfit = /datum/outfit/job/clip/captain
+
+/obj/effect/mob_spawn/human/corpse/clip/medtech
+	name = "CLIP Medtech Corpse Spawner"
+	outfit = /datum/outfit/job/clip/medtech
+
+
+// minutemen
+
+/obj/effect/mob_spawn/human/corpse/clip/minuteman
+	name = "CLIP Minuteman Spawner"
+	outfit = /datum/outfit/job/clip/minutemen/grunt/dressed
+
+/obj/effect/mob_spawn/human/corpse/clip/minuteman/forcefem
+	name = "CLIP Minuteman Spawner (Forcefem)"
+	mob_gender = FEMALE
+
+/obj/effect/mob_spawn/human/corpse/clip/minuteman/eod/bombsuit
+	name = "CLIP Bombsuit Corpse Spawner"
+	outfit = /datum/outfit/job/clip/minutemen/grunt/eod/bombsuit
+

--- a/code/modules/ruins/icemoonruin_code/tesla_lab.dm
+++ b/code/modules/ruins/icemoonruin_code/tesla_lab.dm
@@ -92,23 +92,3 @@
 	icon_state = "phaseout"
 	layer = 4
 	duration = 5
-
-/obj/effect/mob_spawn/human/corpse/clip
-	name = "CLIP corpse spawner"
-
-/obj/effect/mob_spawn/human/corpse/clip/researcher
-	name = "CLIP Researcher Spawner"
-	outfit = /datum/outfit/job/clip/scientist
-
-/obj/effect/mob_spawn/human/corpse/clip/vc
-	name = "CLIP VC Spawner"
-	outfit = /datum/outfit/job/clip/minutemen/vehicle_pilot
-
-/obj/effect/mob_spawn/human/corpse/clip/minuteman
-	name = "CLIP Minuteman Spawner"
-	outfit = /datum/outfit/job/clip/minutemen/grunt/dressed
-
-/obj/effect/mob_spawn/human/corpse/clip/minuteman/forcefem
-	name = "CLIP Minuteman Spawner"
-	outfit = /datum/outfit/job/clip/minutemen/grunt/dressed
-	mob_gender = FEMALE

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -2912,6 +2912,7 @@
 #include "code\modules\mob\living\simple_animal\bot\secbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\SuperBeepsky.dm"
 #include "code\modules\mob\living\simple_animal\bot\vibebot.dm"
+#include "code\modules\mob\living\simple_animal\corpse_spawners\clip.dm"
 #include "code\modules\mob\living\simple_animal\corpse_spawners\frontiersman.dm"
 #include "code\modules\mob\living\simple_animal\friendly\beachcarp.dm"
 #include "code\modules\mob\living\simple_animal\friendly\butterfly.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Replaces the C-MM Naval Engineer's fatigues with a deck worker uniform and an utility cap
* Creates a file for all CLIP corpses to fall into
* Formalizes bombsuit guy into a minuteman EOD guy

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<img width="403" height="86" alt="image" src="https://github.com/user-attachments/assets/e391126b-c903-4ea2-8020-c174ef3fb00b" />

this was kind of pissing me off

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: CLIP Naval Engineer now starts with a standard deck worker uniform
code: CLIP corpse spawners have a dedicated file now
code: CLIP EOD Tech corpse and outfit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
