### PR TITLE
Fixes every right click action in the game being broken + adds a few more

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -189,6 +189,8 @@
 #define COMSIG_ATOM_CROWBAR_ACT "atom_crowbar_act"
 ///from base of atom/analyser_act(): (mob/living/user, obj/item/I)
 #define COMSIG_ATOM_ANALYSER_ACT "atom_analyser_act"
+///from base of atom/shovel_act(): (mob/living/user, obj/item/I)
+#define COMSIG_ATOM_SHOVEL_ACT "atom_shovel_act"
 ///from base of atom/deconstruct_act(): (mob/living/user, obj/item/I)
 #define COMSIG_ATOM_DECONSTRUCT_ACT "atom_deconstruct_act"
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -289,7 +289,7 @@
  * proximity_flag is not currently passed to attack_hand, and is instead used
  * in human click code to allow glove touches only at melee range.
  */
-/mob/proc/UnarmedAttack(atom/A, proximity_flag)
+/mob/proc/UnarmedAttack(atom/A, proximity_flag, modifiers)
 	if(ismob(A))
 		changeNext_move(CLICK_CD_MELEE)
 	return

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -146,16 +146,16 @@
 				continue
 			if(!S.self_operable && user == src)
 				continue
-			if(S.next_step(user, user.a_intent))
+			if(S.next_step(user, params2list(params)))
 				return TRUE
 	if((I.item_flags & SURGICAL_TOOL) && user.a_intent == INTENT_HELP)
 		if(attempt_initiate_surgery(I, src, user))
 			return TRUE
 	//This should really be in attack but 2 much logic doesnt call parent
 	user.changeNext_move(I.attack_cooldown)
-	return I.attack(src, user)
+	return I.attack(src, user, params)
 
-/mob/living/attack_hand(mob/living/user)
+/mob/living/attack_hand(mob/living/user, list/modifiers)
 	if(..())
 		return TRUE
 	for(var/datum/surgery/S in surgeries)
@@ -163,20 +163,21 @@
 			continue
 		if(!S.self_operable && user == src)
 			continue
-		if(S.next_step(user, user.a_intent))
+		if(S.next_step(user, modifiers))
 			return TRUE
 
 /**
- * Called from [/mob/living/attackby]
+ * Called from [/mob/living/proc/attackby]
  *
  * Arguments:
- * * mob/living/M - The mob being hit by this item
+ * * mob/living/target_mob - The mob being hit by this item
  * * mob/living/user - The mob hitting with this item
+ * * params - Click params of this attack
  */
-/obj/item/proc/attack(mob/living/target_mob, mob/living/user)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, target_mob, user) & COMPONENT_ITEM_NO_ATTACK)
+/obj/item/proc/attack(mob/living/target_mob, mob/living/user, params)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, target_mob, user, params) & COMPONENT_ITEM_NO_ATTACK)
 		return
-	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, target_mob, user)
+	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, target_mob, user, params)
 	if(item_flags & NOBLUDGEON)
 		return
 
@@ -201,7 +202,7 @@
 		user.client.give_award(/datum/award/achievement/misc/selfouch, user)
 
 	user.do_attack_animation(target_mob)
-	target_mob.attacked_by(src, user)
+	target_mob.attacked_by(src, user, params)
 
 	SEND_SIGNAL(src, COMSIG_ITEM_POST_ATTACK, target_mob, user)
 
@@ -223,7 +224,7 @@
 	return
 
 /// Called from [/obj/item/proc/attack_obj] and [/obj/item/proc/attack] if the attack succeeds
-/atom/movable/proc/attacked_by()
+/atom/movable/proc/attacked_by(obj/item/attacking_item, mob/living/user, params)
 	return
 
 /obj/attacked_by(obj/item/attacking_item, mob/living/user)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -10,7 +10,7 @@
 /obj/item/proc/melee_attack_chain(mob/user, atom/target, params)
 	var/is_right_clicking = LAZYACCESS(params2list(params), RIGHT_CLICK)
 
-	if(tool_behaviour && (target.tool_act(user, src, tool_behaviour, is_right_clicking)))
+	if(tool_behaviour && (target.tool_act(user, src, tool_behaviour, params)))
 		return TRUE
 
 	var/pre_attack_result

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -24,14 +24,14 @@
 		return
 
 	SEND_SIGNAL(src, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, A, modifiers)
-	if(modifiers[RIGHT_CLICK])
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		var/secondary_result = A.attack_hand_secondary(src, modifiers)
 		if(secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
 			return
 		else if(secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
 			CRASH("attack_hand_secondary did not return a SECONDARY_ATTACK_* define.")
 
-	A.attack_hand(src)
+	A.attack_hand(src, modifiers)
 
 /// Return TRUE to cancel other attack hand effects that respect it.
 /atom/proc/attack_hand(mob/user)
@@ -215,11 +215,11 @@
 	Simple animals
 */
 
-/mob/living/simple_animal/UnarmedAttack(atom/A, proximity)
+/mob/living/simple_animal/UnarmedAttack(atom/A, proximity, params)
 	if(!dextrous)
 		return ..()
 	if(!ismob(A))
-		A.attack_hand(src)
+		A.attack_hand(src, params2list(params))
 		update_inv_hands()
 
 

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -93,7 +93,7 @@
 	. = ..()
 	if(gloves)
 		var/obj/item/clothing/gloves/G = gloves
-		if(istype(G) && G.Touch(A,0)) // for magic gloves
+		if(istype(G) && G.Touch(A, 0, params2list(mouseparams))) // for magic gloves
 			return
 
 	if(isturf(A) && get_dist(src,A) <= 1)
@@ -103,11 +103,11 @@
 /*
 	Animals & All Unspecified
 */
-/mob/living/UnarmedAttack(atom/A)
+/mob/living/UnarmedAttack(atom/A, proximity, list/modifiers)
 	A.attack_animal(src)
 	return TRUE
 
-/atom/proc/attack_animal(mob/user)
+/atom/proc/attack_animal(mob/user, list/modifiers)
 	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ANIMAL, user)
 
 /atom/proc/attack_basic_mob(mob/user, list/modifiers)
@@ -116,7 +116,7 @@
 /*
 	Monkeys
 */
-/mob/living/carbon/monkey/UnarmedAttack(atom/A)
+/mob/living/carbon/monkey/UnarmedAttack(atom/A, proximity, list/modifiers)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		if(a_intent != INTENT_HARM || is_muzzled())
 			return

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -122,7 +122,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_POST_THROW, PROC_REF(close_all))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
-	RegisterSignals(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_HAND_SECONDARY), PROC_REF(on_open_storage_click))
+	RegisterSignals(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_ITEM_ATTACK_SELF_SECONDARY), PROC_REF(on_open_storage_click))
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY_SECONDARY, PROC_REF(on_open_storage_attackby))
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, PROC_REF(mousedrop_onto))
 	RegisterSignal(parent, COMSIG_MOUSEDROPPED_ONTO, PROC_REF(mousedrop_receive))

--- a/code/datums/elements/food/processable.dm
+++ b/code/datums/elements/food/processable.dm
@@ -32,7 +32,7 @@
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_ATOM_TOOL_ACT(tool_behaviour), COMSIG_PARENT_EXAMINE))
 
-/datum/element/processable/proc/try_process(datum/source, mob/living/user, obj/item/I, list/mutable_recipes)
+/datum/element/processable/proc/try_process(datum/source, mob/living/user, obj/item/I, list/modifiers, list/mutable_recipes)
 	SIGNAL_HANDLER
 
 	if(table_required)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -298,7 +298,7 @@
 	return FALSE
 
 /// Like try_treating() but for unhanded interactions from humans, used by joint dislocations for manual bodypart chiropractice for example. Ignores thick material checks since you can pop an arm into place through a thick suit unlike using sutures
-/datum/wound/proc/try_handling(mob/living/carbon/human/user)
+/datum/wound/proc/try_handling(mob/living/carbon/human/user, list/modifiers)
 	return FALSE
 
 /// Someone is using something that might be used for treating the wound on this limb

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -253,7 +253,7 @@
 		)
 		remove_wound()
 
-/datum/wound/blunt/moderate/try_handling(mob/living/carbon/human/user)
+/datum/wound/blunt/moderate/try_handling(mob/living/carbon/human/user, modifiers)
 	if(user.pulling != victim || user.zone_selected != limb.body_zone || user.a_intent == INTENT_GRAB)
 		return FALSE
 
@@ -269,7 +269,7 @@
 		)
 		to_chat(victim, span_userdanger("[user] begins twisting and straining your dislocated [limb.name]!"))
 
-		if(user.a_intent == INTENT_HELP)
+		if(!LAZYACCESS(modifiers, RIGHT_CLICK))
 			chiropractice(user)
 		else
 			malpractice(user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1244,32 +1244,35 @@
  *
  * Must return  parent proc ..() in the end if overridden
  */
-/atom/proc/tool_act(mob/living/user, obj/item/I, tool_type)
+/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, params)
 	var/signal_result
 
+	var/list/modifiers = params2list(params)
 	var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
-	signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, I, processing_recipes)
+	signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, modifiers, processing_recipes)
 	if(processing_recipes.len)
-		process_recipes(user, I, processing_recipes)
-	if(QDELETED(I))
+		process_recipes(user, tool, processing_recipes)
+	if(QDELETED(tool))
 		return TRUE
 	switch(tool_type)
 		if(TOOL_CROWBAR)
-			. = crowbar_act(user, I)
+			. = crowbar_act(user, tool, modifiers)
 		if(TOOL_MULTITOOL)
-			. = multitool_act(user, I)
+			. = multitool_act(user, tool, modifiers)
 		if(TOOL_SCREWDRIVER)
-			. = screwdriver_act(user, I)
+			. = screwdriver_act(user, tool, modifiers)
 		if(TOOL_WRENCH)
-			. = wrench_act(user, I)
+			. = wrench_act(user, tool, modifiers)
 		if(TOOL_WIRECUTTER)
-			. = wirecutter_act(user, I)
+			. = wirecutter_act(user, tool, modifiers)
 		if(TOOL_WELDER)
-			. = welder_act(user, I)
+			. = welder_act(user, tool, modifiers)
 		if(TOOL_ANALYZER)
-			. = analyzer_act(user, I)
+			. = analyzer_act(user, tool, modifiers)
+		if(TOOL_SHOVEL)
+			. = shovel_act(user, tool, modifiers)
 		if(TOOL_DECONSTRUCT)
-			. |= deconstruct_act(user, I)
+			. |= deconstruct_act(user, tool, modifiers)
 	if(. || signal_result & COMPONENT_BLOCK_TOOL_ATTACK) //Either the proc or the signal handled the tool's events in some way.
 		return TRUE
 
@@ -1330,11 +1333,11 @@
 ///
 
 ///Crowbar act
-/atom/proc/crowbar_act(mob/living/user, obj/item/I)
+/atom/proc/crowbar_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_CROWBAR_ACT, user, I)
 
 ///Multitool act
-/atom/proc/multitool_act(mob/living/user, obj/item/I)
+/atom/proc/multitool_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_MULTITOOL_ACT, user, I)
 
 ///Check if the multitool has an item in it's data buffer
@@ -1346,27 +1349,31 @@
 	return TRUE
 
 ///Screwdriver act
-/atom/proc/screwdriver_act(mob/living/user, obj/item/I)
+/atom/proc/screwdriver_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_SCREWDRIVER_ACT, user, I)
 
 ///Wrench act
-/atom/proc/wrench_act(mob/living/user, obj/item/I)
+/atom/proc/wrench_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_WRENCH_ACT, user, I)
 
 ///Wirecutter act
-/atom/proc/wirecutter_act(mob/living/user, obj/item/I)
+/atom/proc/wirecutter_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_WIRECUTTER_ACT, user, I)
 
 ///Welder act
-/atom/proc/welder_act(mob/living/user, obj/item/I)
+/atom/proc/welder_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_WELDER_ACT, user, I)
 
 ///Analyzer act
-/atom/proc/analyzer_act(mob/living/user, obj/item/I)
+/atom/proc/analyzer_act(mob/living/user, obj/item/I, list/modifiers)
 	return SEND_SIGNAL(src, COMSIG_ATOM_ANALYSER_ACT, user, I)
 
+///Shovel act
+/atom/proc/shovel_act(mob/living/user, obj/item/I, list/modifiers)
+	return SEND_SIGNAL(src, COMSIG_ATOM_SHOVEL_ACT, user, I)
+
 ///Deconstruct act
-/atom/proc/deconstruct_act(mob/living/user, obj/item/I)
+/atom/proc/deconstruct_act(mob/living/user, obj/item/I, list/modifiers)
 	if(flags_1 & NODECONSTRUCT_1)
 		return TRUE
 	return SEND_SIGNAL(src, COMSIG_ATOM_DECONSTRUCT_ACT, user, I)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1117,12 +1117,12 @@
 		return ..()
 
 
-/obj/machinery/door/airlock/try_to_weld(obj/item/weldingtool/W, mob/user)
+/obj/machinery/door/airlock/try_to_weld(obj/item/weldingtool/W, mob/user, list/modifiers)
 	if(!operating && density)
 		if(seal)
 			to_chat(user, span_warning("[src] is blocked by a seal!"))
 			return
-		if(user.a_intent != INTENT_HELP)
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
 			if(!W.tool_start_check(user, src, amount=0))
 				return
 			user.visible_message(span_notice("[user] begins [welded ? "unwelding":"welding"] the airlock."), \

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -224,7 +224,7 @@
 /obj/machinery/door/proc/unrestricted_side(mob/M) //Allows for specific side of airlocks to be unrestrected (IE, can exit maint freely, but need access to enter)
 	return get_dir(src, M) & unres_sides
 
-/obj/machinery/door/proc/try_to_weld(obj/item/weldingtool/W, mob/user)
+/obj/machinery/door/proc/try_to_weld(obj/item/weldingtool/W, mob/user, list/modifiers)
 	return
 
 /obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
@@ -264,7 +264,7 @@
 		try_to_crowbar(I, user, forced_open)
 		return TRUE
 	else if(I.tool_behaviour == TOOL_WELDER)
-		try_to_weld(I, user)
+		try_to_weld(I, user, params2list(params))
 		return TRUE
 	else if(!(I.item_flags & NOBLUDGEON) && user.a_intent != INTENT_HARM)
 		try_to_activate_door(user)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -174,15 +174,13 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
-
-	if(!user.canUseTopic(src, be_close=TRUE))
-		return
 	if(dripfeed)
 		dripfeed = FALSE
 		to_chat(usr, span_notice("You loosen the valve to speed up the [src]."))
 	else
 		dripfeed = TRUE
 		to_chat(usr, span_notice("You tighten the valve to slowly drip-feed the contents of [src]."))
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/iv_drip/verb/eject_beaker()
 	set category = "Object"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -682,7 +682,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src)
+		usr.UnarmedAttack(src, TRUE, list())
 
 /**
  *This proc is executed when someone clicks the on-screen UI button.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -682,7 +682,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src, TRUE, list())
+		usr.UnarmedAttack(src, TRUE)
 
 /**
  *This proc is executed when someone clicks the on-screen UI button.

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -167,10 +167,11 @@
 		return ..()
 	if(!scanning)
 		to_chat(usr, span_warning("[src] must be on to reset its radiation level!"))
-		return 0
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	radiation_count = 0
 	to_chat(usr, span_notice("You flush [src]'s radiation counts, resetting it to normal."))
 	update_appearance()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/geiger_counter/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -205,10 +205,10 @@
 	tapecuff.apply_cuffs(target, user, 0)
 	return
 
-/obj/item/stack/tape/afterattack(obj/O, mob/living/user, proximity)
+/obj/item/stack/tape/afterattack(obj/O, mob/living/user, proximity, click_parameters)
 	if(!istype(O) || !proximity)
 		return TRUE
-	if(user.a_intent == INTENT_DISARM && istype(O, /obj/item))
+	if(LAZYACCESS(params2list(click_parameters), RIGHT_CLICK) && istype(O, /obj/item))
 		var/obj/item/I = O
 		if(I.embedding && I.embedding == conferred_embed)
 			to_chat(user, span_warning("[I] is already coated in [src]!"))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -829,6 +829,7 @@
 	STR.max_items = 1
 	STR.use_sound = null //if youre wondering why this is null, its so you can look in your sheath to prepare to draw, without letting anyone know youre preparing to draw it
 	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.quickdraw = TRUE
 	STR.set_holdable(list(
 		sabre_type
 		))
@@ -836,11 +837,9 @@
 /obj/item/storage/belt/sabre/examine(mob/user)
 	. = ..()
 	if(length(contents))
-		. += span_notice("Alt-click it to quickly draw the blade.")
+		. += span_notice("Right-click it to quickly draw the blade.")
 
 /obj/item/storage/belt/sabre/attack_hand_secondary(mob/user, list/modifiers)
-	if(!iscarbon(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
-		return
 	if(length(contents))
 		var/obj/item/I = contents[1]
 		user.visible_message(span_notice("[user] takes [I] out of [src]."), span_notice("You take [I] out of [src]."))
@@ -848,7 +847,7 @@
 		update_appearance()
 	else
 		to_chat(user, span_warning("[src] is empty!"))
-	. = ..()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/storage/belt/sabre/update_icon_state()
 	icon_state = "[base_icon_state]"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -255,8 +255,12 @@
 /obj/structure/closet/attackby(obj/item/attacking_item, mob/user, params)
 	if(user in src)
 		return
+	if(user.a_intent == INTENT_HARM)
+		return ..()
 	if(attacking_item.GetID()) //if you're hitting with an id item, toggle the lock
 		togglelock(user)
+		return TRUE
+	if(opened && user.transferItemToLoc(attacking_item, drop_location())) //try to transfer the held item to it
 		return TRUE
 	else
 		return ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -406,12 +406,17 @@
 	if(!toggle(user))
 		togglelock(user)
 
-/obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
+/obj/structure/closet/AltClick(mob/user)
+	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
 		return
+	togglelock(user)
+	return TRUE
+
+/obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
 	if(!opened && secure)
 		togglelock(user)
-	return TRUE
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/closet/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -117,7 +117,7 @@
 	if(opened)
 		. += span_notice("The parts are <b>welded</b> together.")
 	else if(secure && !opened)
-		. += span_notice("Alt-click to [locked ? "unlock" : "lock"].")
+		. += span_notice("Right-click to [locked ? "unlock" : "lock"].")
 
 /obj/structure/closet/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -252,11 +252,12 @@
 		bust_open()
 	. = ..()
 
-/obj/structure/closet/attackby(obj/item/W, mob/user, params)
+/obj/structure/closet/attackby(obj/item/attacking_item, mob/user, params)
 	if(user in src)
 		return
-	if(src.tool_interact(W,user))
-		return TRUE // No afterattack
+	if(attacking_item.GetID()) //if you're hitting with an id item, toggle the lock
+		togglelock(user)
+		return TRUE
 	else
 		return ..()
 
@@ -273,45 +274,60 @@
 		deconstruct(TRUE)
 	return TRUE
 
-/obj/structure/closet/proc/tool_interact(obj/item/W, mob/user)//returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
-	. = TRUE
-	if(opened)
-		if(W.tool_behaviour == cutting_tool && user.a_intent != INTENT_HELP)
-			try_deconstruct(W, user)
-			return
-		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
-			return
-		return
-	else if(W.tool_behaviour == TOOL_WELDER && can_weld_shut)
-		if(!W.tool_start_check(user, src, src, amount=0))
-			return
-
+/obj/structure/closet/welder_act(mob/living/user, obj/item/tool, modifiers)
+	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
+		return FALSE
+	if(!tool.tool_start_check(user, amount=0))
+		return FALSE
+	if(opened && !(flags_1 & NODECONSTRUCT_1))
+		if(tool.tool_behaviour != cutting_tool)
+			return FALSE // the wrong tool
+		to_chat(user, span_notice("You begin cutting \the [src] apart..."))
+		if(tool.use_tool(src, user, 4 SECONDS, volume=50))
+			if(!opened)
+				return TRUE
+			user.visible_message(span_notice("[user] slices apart \the [src]."),
+				span_notice("You cut \the [src] apart with \the [tool]."),
+				span_italics("You hear welding."))
+			deconstruct(TRUE)
+		return TRUE
+	if(can_weld_shut)
 		to_chat(user, span_notice("You begin [welded ? "unwelding":"welding"] \the [src]..."))
-		if(W.use_tool(src, user, 40, volume=50))
+		if(tool.use_tool(src, user, 4 SECONDS, volume=50))
 			if(opened)
-				return
+				return TRUE
 			welded = !welded
 			after_weld(welded)
 			user.visible_message(span_notice("[user] [welded ? "welds shut" : "unwelded"] \the [src]."),
-							span_notice("You [welded ? "weld" : "unwelded"] \the [src] with \the [W]."),
-							span_hear("You hear welding."))
+				span_notice("You [welded ? "weld" : "unwelded"] \the [src] with \the [tool]."),
+				span_italics("You hear welding."))
 			update_appearance()
-	else if(W.tool_behaviour == TOOL_WRENCH && anchorable)
-		if(isinspace() && !anchored)
-			return
-		set_anchored(!anchored)
-		W.play_tool_sound(src, 75)
-		user.visible_message(span_notice("[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
-						span_notice("You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
-						span_hear("You hear a ratchet."))
-	else if(user.a_intent != INTENT_HARM)
-		var/item_is_id = W.GetID()
-		if(!item_is_id)
-			return FALSE
-		if(item_is_id || !toggle(user))
-			togglelock(user)
-	else
+		return TRUE
+	return FALSE
+
+/obj/structure/closet/wirecutter_act(mob/living/user, obj/item/tool, modifiers)
+	if(user.a_intent != INTENT_HELP && !(modifiers && modifiers[RIGHT_CLICK]))
 		return FALSE
+	if(tool.tool_behaviour != cutting_tool)
+		return FALSE
+	user.visible_message(span_notice("[user] cut apart \the [src]."), \
+		span_notice("You cut \the [src] apart with \the [tool]."))
+	deconstruct(TRUE)
+	return TRUE
+
+/obj/structure/closet/wrench_act(mob/living/user, obj/item/tool, modifiers)
+	if(user.a_intent != INTENT_HELP && !(modifiers && modifiers[RIGHT_CLICK]))
+		return FALSE
+	if(!anchorable)
+		return FALSE
+	if(isinspace() && !anchored)
+		return FALSE
+	set_anchored(!anchored)
+	tool.play_tool_sound(src, 75)
+	user.visible_message(span_notice("[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
+		span_notice("You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
+		span_italics("You hear a ratchet."))
+	return TRUE
 
 /obj/structure/closet/tool_act(mob/living/user, obj/item/I, tool_type)
 	if(user in src)
@@ -406,14 +422,12 @@
 	if(!toggle(user))
 		togglelock(user)
 
-/obj/structure/closet/AltClick(mob/user)
-	. = ..()
-	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
-		return
-	togglelock(user)
-	return TRUE
-
 /obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
+	if(!opened && secure)
+		togglelock(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/structure/closet/attackby_secondary(obj/item/weapon, mob/user, params)
 	if(!opened && secure)
 		togglelock(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -275,7 +275,7 @@
 	return TRUE
 
 /obj/structure/closet/welder_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(user.a_intent == INTENT_HARM && !LAZYACCESS(modifiers, RIGHT_CLICK))
 		return FALSE
 	if(!tool.tool_start_check(user, amount=0))
 		return FALSE
@@ -306,7 +306,7 @@
 	return FALSE
 
 /obj/structure/closet/wirecutter_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent != INTENT_HELP && !(modifiers && modifiers[RIGHT_CLICK]))
+	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
 		return FALSE
 	if(tool.tool_behaviour != cutting_tool)
 		return FALSE
@@ -316,7 +316,7 @@
 	return TRUE
 
 /obj/structure/closet/wrench_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent != INTENT_HELP && !(modifiers && modifiers[RIGHT_CLICK]))
+	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
 		return FALSE
 	if(!anchorable)
 		return FALSE

--- a/code/game/objects/structures/crates_lockers/crates/graves.dm
+++ b/code/game/objects/structures/crates_lockers/crates/graves.dm
@@ -33,35 +33,28 @@
 	else
 		to_chat(user, span_notice("The grave has already been dug up."))
 
-/obj/structure/closet/crate/grave/shovel_act(mob/living/user, obj/item/S, list/modifiers)
+/obj/structure/closet/crate/grave/shovel_act(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
-	if(user.a_intent == INTENT_HELP) //checks to attempt to dig the grave, must be done on help intent only.
-		if(!opened)
-			if(S.tool_behaviour == cutting_tool)
-				to_chat(user, span_notice("You start start to dig open \the [src]  with \the [S]..."))
-				if (do_after(user,20, target = src))
-					opened = TRUE
-					locked = TRUE
-					dump_contents()
-					update_appearance()
-					SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "graverobbing", /datum/mood_event/graverobbing)
-					return TRUE
-				return TRUE
-			else
-				to_chat(user, span_notice("You can't dig up a grave with \the [S.name]."))
-				return TRUE
+	if(!opened) //checks to attempt to dig the grave
+		if(tool.tool_behaviour == cutting_tool)
+			to_chat(user, span_notice("You start start to dig open \the [src]  with \the [tool]..."))
+			if(tool.use_tool(src, user, 3 SECONDS))
+				opened = TRUE
+				locked = TRUE
+				dump_contents()
+				update_appearance()
+				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "graverobbing", /datum/mood_event/graverobbing)
 		else
-			to_chat(user, span_notice("The grave has already been dug up."))
-			return TRUE
-
-	else if((user.a_intent != INTENT_HELP) && opened) //checks to attempt to remove the grave entirely.
-		if(S.tool_behaviour == cutting_tool)
-			to_chat(user, span_notice("You start to remove \the [src]  with \the [S]."))
-			if (do_after(user,15, target = src))
+			to_chat(user, span_notice("You can't dig up a grave with \the [tool.name]."))
+	else if(LAZYACCESS(modifiers, RIGHT_CLICK)) //checks to attempt to remove the grave entirely.
+		if(tool.tool_behaviour == cutting_tool)
+			to_chat(user, span_notice("You start to remove \the [src]  with \the [tool]."))
+			if(tool.use_tool(src, user, 2 SECONDS))
 				to_chat(user, span_notice("You remove \the [src]  completely."))
 				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "graverobbing", /datum/mood_event/graverobbing)
 				deconstruct(TRUE)
-				return TRUE
+	else
+		to_chat(user, span_notice("The grave has already been dug up."))
 	return TRUE
 
 /obj/structure/closet/crate/grave/bust_open()

--- a/code/game/objects/structures/crates_lockers/crates/graves.dm
+++ b/code/game/objects/structures/crates_lockers/crates/graves.dm
@@ -33,7 +33,8 @@
 	else
 		to_chat(user, span_notice("The grave has already been dug up."))
 
-/obj/structure/closet/crate/grave/tool_interact(obj/item/S, mob/living/carbon/user)
+/obj/structure/closet/crate/grave/shovel_act(mob/living/user, obj/item/S, list/modifiers)
+	. = ..()
 	if(user.a_intent == INTENT_HELP) //checks to attempt to dig the grave, must be done on help intent only.
 		if(!opened)
 			if(S.tool_behaviour == cutting_tool)
@@ -61,7 +62,7 @@
 				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "graverobbing", /datum/mood_event/graverobbing)
 				deconstruct(TRUE)
 				return TRUE
-	return
+	return TRUE
 
 /obj/structure/closet/crate/grave/bust_open()
 	..()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -31,7 +31,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 28)
 
 /obj/structure/extinguisher_cabinet/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click to [opened ? "close":"open"] it.")
+	. += span_notice("Right-click to [opened ? "close":"open"] it.")
 
 /obj/structure/extinguisher_cabinet/Destroy()
 	if(stored_extinguisher)
@@ -99,6 +99,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 28)
 	else
 		toggle_cabinet(user)
 
+/obj/structure/extinguisher_cabinet/attack_hand_secondary(mob/user, list/modifiers)
+	toggle_cabinet(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/extinguisher_cabinet/attack_tk(mob/user)
 	if(stored_extinguisher)

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -113,6 +113,10 @@
 		open = !open
 		update_appearance()
 
+/obj/structure/guncloset/attack_hand_secondary(mob/user, list/modifiers)
+	open = !open
+	update_appearance()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/guncloset/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -171,7 +171,7 @@
 
 /obj/structure/table/attackby(obj/item/I, mob/user, params)
 	var/list/modifiers = params2list(params)
-	if(!(flags_1 & NODECONSTRUCT_1) && modifiers[RIGHT_CLICK])
+	if(!(flags_1 & NODECONSTRUCT_1) && LAZYACCESS(modifiers, RIGHT_CLICK))
 		if((I.tool_behaviour == TOOL_SCREWDRIVER) && deconstruction_ready)
 			to_chat(user, span_notice("You start disassembling [src]..."))
 			if(I.use_tool(src, user, 20, volume=50))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -171,7 +171,7 @@
 
 /obj/structure/table/attackby(obj/item/I, mob/user, params)
 	var/list/modifiers = params2list(params)
-	if(!(flags_1 & NODECONSTRUCT_1) && user.a_intent != INTENT_HELP)
+	if(!(flags_1 & NODECONSTRUCT_1) && modifiers[RIGHT_CLICK])
 		if((I.tool_behaviour == TOOL_SCREWDRIVER) && deconstruction_ready)
 			to_chat(user, span_notice("You start disassembling [src]..."))
 			if(I.use_tool(src, user, 20, volume=50))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -425,7 +425,7 @@
 
 	switch(state)
 		if(RWINDOW_SECURE)
-			if((I.tool_behaviour == TOOL_WELDER) && user.a_intent == INTENT_HARM)
+			if((I.tool_behaviour == TOOL_WELDER) && LAZYACCESS(params2list(params), RIGHT_CLICK))
 				user.visible_message(span_notice("[user] holds \the [I] to the security screws on \the [src]..."),
 										span_notice("You begin heating the security screws on \the [src]..."))
 				if(I.use_tool(src, user, 150, volume = 100))
@@ -555,7 +555,7 @@
 /obj/structure/window/plasma/reinforced/attackby(obj/item/I, mob/living/user, params)
 	switch(state)
 		if(RWINDOW_SECURE)
-			if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HARM)
+			if(I.tool_behaviour == TOOL_WELDER && LAZYACCESS(params2list(params), RIGHT_CLICK))
 				user.visible_message(span_notice("[user] holds \the [I] to the security screws on \the [src]..."),
 										span_notice("You begin heating the security screws on \the [src]..."))
 				if(I.use_tool(src, user, 180, volume = 100))

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -209,8 +209,7 @@
 
 	var/turf/T = user.loc	//get user's location for delay checks
 
-	if(attack_override(W, user, T, params2list(params)))
-		return TRUE
+	attack_override(W, user, T, params2list(params))
 	return ..()
 
 /turf/closed/proc/attack_override(obj/item/W, mob/user, turf/loc, list/modifiers)

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -209,15 +209,16 @@
 
 	var/turf/T = user.loc	//get user's location for delay checks
 
-	attack_override(W,user,T)
+	if(attack_override(W, user, T, params2list(params)))
+		return TRUE
 	return ..()
 
-/turf/closed/proc/attack_override(obj/item/W, mob/user, turf/loc)
+/turf/closed/proc/attack_override(obj/item/W, mob/user, turf/loc, list/modifiers)
 	if(!isclosedturf(src))
 		return
 	//the istype cascade has been spread among various procs for easy overriding or if we want to call something specific
 	if(try_decon(W, user, loc) || try_destroy(W, user, loc))
-		return
+		return TRUE
 
 // catch-all for using most items on the closed turf -- attempt to smash
 /turf/closed/proc/try_destroy(obj/item/used_item, mob/user, turf/T)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -84,19 +84,23 @@
 		return new girder_type(src)
 	return null
 
-/turf/closed/wall/attack_override(obj/item/W, mob/user, turf/loc)
+/turf/closed/wall/attack_override(obj/item/W, mob/user, turf/loc, list/modifiers)
 	if(!iswallturf(src))
 		return
-	if(try_clean(W, user, loc) || try_wallmount(W, user, loc) || try_decon(W, user, loc) || try_destroy(W, user, loc))
-		return
+	if(try_clean(W, user, loc, modifiers) || try_wallmount(W, user, loc) || try_decon(W, user, loc) || try_destroy(W, user, loc))
+		return TRUE
 
-/turf/closed/wall/proc/try_clean(obj/item/W, mob/user, turf/T)
-	if((user.a_intent != INTENT_HELP))
+/turf/closed/wall/proc/try_clean(obj/item/W, mob/user, turf/T, list/modifiers)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		return FALSE
 
 	if(W.tool_behaviour == TOOL_WELDER)
-		if(!W.tool_start_check(user, src, amount=0) || (atom_integrity >= max_integrity))
+		if(!W.tool_start_check(user, src, amount=0))
 			return FALSE
+
+		if(atom_integrity >= max_integrity)
+			to_chat(user, span_notice("[src] doesn't have any visible damage!"))
+			return TRUE
 
 		to_chat(user, span_notice("You begin fixing dents on the wall..."))
 		if(W.use_tool(src, user, breakdown_duration, volume=100))
@@ -105,7 +109,7 @@
 				dent_decals = null
 				update_appearance()
 			alter_integrity(repair_amount)
-			return TRUE
+		return TRUE
 
 	return FALSE
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -943,11 +943,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 	return FALSE
 
 /obj/machinery/airalarm/attack_hand_secondary(mob/user, list/modifiers)
-	..()
-	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
-		return
-	else
-		togglelock(user)
+	togglelock(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/airalarm/proc/togglelock(mob/living/user)
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -173,11 +173,10 @@
 	if(decal)
 		. += decal
 
-/obj/structure/closet/supplypod/tool_interact(obj/item/W, mob/user)
+/obj/structure/closet/supplypod/tool_act(mob/living/user, obj/item/I, tool_type)
 	if(bluespace) //We dont want to worry about interacting with bluespace pods, as they are due to delete themselves soon anyways.
 		return FALSE
-	else
-		..()
+	return ..()
 
 /obj/structure/closet/supplypod/ex_act() //Explosions dont do SHIT TO US! This is because supplypods create explosions when they land.
 	return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -422,6 +422,14 @@
 		return
 	..()
 
+/obj/item/clothing/under/attack_hand_secondary(mob/user, list/modifiers)
+	toggle()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/under/attackby_secondary(obj/item/weapon, mob/user, params)
+	toggle()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/clothing/under/AltClick(mob/user)
 	if(..())
 		return TRUE

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -39,10 +39,8 @@
 	flip(usr)
 
 /obj/item/clothing/head/soft/attack_hand_secondary(mob/user, list/modifiers)
-	. = ..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
-		return FALSE
 	flip()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/head/soft/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))

--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -15,7 +15,7 @@
 /obj/machinery/paystand/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/card/bank))
 		if(W == my_card)
-			if(user.a_intent == INTENT_DISARM)
+			if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 				var/rename_msg = stripped_input(user, "Rename the Paystand:", "Paystand Naming", name)
 				if(!rename_msg || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 					return

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -197,9 +197,14 @@
 		update_appearance()
 		return TRUE
 
-/obj/machinery/microwave/attack_hand_secondary(mob/user, list/modifiers)
+/obj/machinery/microwave/AltClick(mob/user)
 	if(user.canUseTopic(src, !issilicon(usr)))
 		cook()
+
+
+/obj/machinery/microwave/attack_hand_secondary(mob/user, list/modifiers)
+	cook()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/microwave/ui_interact(mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -145,7 +145,7 @@
 	return //so we don't call the carbon's attack_hand().
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
-/mob/living/carbon/attack_hand(mob/living/carbon/human/user)
+/mob/living/carbon/attack_hand(mob/living/carbon/human/user, list/modifiers)
 
 	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		. = TRUE
@@ -155,7 +155,7 @@
 			continue
 		if(!S.self_operable && user == src)
 			continue
-		if(S.next_step(user, user.a_intent))
+		if(S.next_step(user, modifiers))
 			return TRUE
 
 	for(var/thing in diseases)
@@ -170,7 +170,7 @@
 
 	for(var/i in all_wounds)
 		var/datum/wound/W = i
-		if(W.try_handling(user))
+		if(W.try_handling(user, modifiers))
 			return TRUE
 
 	return FALSE

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -490,12 +490,12 @@
 	if(C.getToxLoss() >= heal_threshold)
 		return TRUE
 
-/mob/living/simple_animal/bot/medbot/attack_hand(mob/living/carbon/human/H)
+/mob/living/simple_animal/bot/medbot/attack_hand(mob/living/carbon/human/H, list/modifiers)
 	if(DOING_INTERACTION_WITH_TARGET(H, src))
 		to_chat(H, span_warning("You're already interacting with [src]."))
 		return
 
-	if(H.a_intent == INTENT_DISARM && mode != BOT_TIPPED)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) && mode != BOT_TIPPED)
 		H.visible_message(span_danger("[H] begins tipping over [src]."), span_warning("You begin tipping over [src]..."))
 
 		if(world.time > last_tipping_action_voice + 15 SECONDS)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -113,6 +113,18 @@
 		return FALSE
 	return card_slot.try_insert(inserting_id)
 
+/obj/item/modular_computer/attack_hand_secondary(mob/user, list/modifiers)
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/modular_computer/attackby_secondary(obj/item/weapon, mob/user, params)
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/modular_computer/attack_self_secondary(mob/user, modifiers)
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
 	var/mob/M = usr
 	if((!istype(over_object, /atom/movable/screen)) && usr.canUseTopic(src, BE_CLOSE))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -768,6 +768,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, 25)
 	else
 		togglelock(user)
 
+/obj/machinery/power/apc/attack_hand_secondary(mob/user, list/modifiers)
+	togglelock(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/machinery/power/apc/proc/togglelock(mob/living/user)
 	if(obj_flags & EMAGGED)
 		to_chat(user, span_warning("The interface is broken!"))

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -75,8 +75,8 @@
 /obj/machinery/gravity_generator/part/get_status()
 	return main_part?.get_status()
 
-/obj/machinery/gravity_generator/part/attack_hand(mob/user)
-	return main_part.attack_hand(user)
+/obj/machinery/gravity_generator/part/attack_hand(mob/user, list/modifiers)
+	return main_part.attack_hand(user, modifiers)
 
 /obj/machinery/gravity_generator/part/set_broken()
 	..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -429,7 +429,7 @@
 /obj/item/gun/examine_more(mob/user)
 	. = ..()
 	if(has_safety)
-		. += "The safety is [safety ? span_green("ON") : span_red("OFF")]. Ctrl-Click to toggle the safety."
+		. += "The safety is [safety ? span_green("ON") : span_red("OFF")]. Right-Click to toggle the safety."
 
 	if(gun_firemodes.len > 1)
 		. += "You can change the [src]'s firemode by pressing the <b>secondary action</b> key. By default, this is <b>Shift + Space</b>"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -748,28 +748,32 @@
 
 /obj/item/gun/CtrlClick(mob/user)
 	. = ..()
-	if(!has_safety)
-		return
-	// only checks for first level storage e.g pockets, hands, suit storage, belts, nothing in containers
-	if(!in_contents_of(user))
-		return
-
 	if(isliving(user) && in_range(src, user))
 		toggle_safety(user)
 
 /obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
-	toggle_safety(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
-	toggle_safety(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/item/gun/attack_self_secondary(mob/user, modifiers)
-	toggle_safety(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/item/gun/proc/toggle_safety(mob/user, silent=FALSE)
+	if(!has_safety)
+		return FALSE
+
+	// only checks for first level storage e.g pockets, hands, suit storage, belts, nothing in containers
+	if(!in_contents_of(user))
+		return FALSE
+
 	safety = !safety
 
 	if(!silent)
@@ -780,8 +784,9 @@
 		)
 
 	update_appearance()
+	return TRUE
 
-/obj/item/gun/attack_hand(mob/user)
+/obj/item/gun/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	update_appearance()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -757,6 +757,18 @@
 	if(isliving(user) && in_range(src, user))
 		toggle_safety(user)
 
+/obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
+	toggle_safety(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
+	toggle_safety(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/gun/attack_self_secondary(mob/user, modifiers)
+	toggle_safety(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/gun/proc/toggle_safety(mob/user, silent=FALSE)
 	safety = !safety
 

--- a/code/modules/reagents/chemistry/machinery/chem_press.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_press.dm
@@ -80,18 +80,7 @@
 		balloon_alert(user, "added [item] to output")
 		return TRUE
 	else if(item.tool_behaviour == TOOL_SCREWDRIVER)
-		if(user.a_intent == INTENT_HELP)
-			var/i=0
-			for(var/A in possible_volumes)
-				i++
-				if(A == current_volume)
-					if(i<possible_volumes.len)
-						current_volume = possible_volumes[i+1]
-					else
-						current_volume = possible_volumes[1]
-					balloon_alert(user, "making [current_volume]u pills")
-					return
-		if(user.a_intent == INTENT_DISARM)
+		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 			var/i=0
 			for(var/A in possible_styles)
 				i++
@@ -102,16 +91,24 @@
 						pill_style = possible_styles[1]
 					balloon_alert(user, "making [style_colors["[pill_style]"]] pills")
 					return
+		else
+			var/i=0
+			for(var/A in possible_volumes)
+				i++
+				if(A == current_volume)
+					if(i<possible_volumes.len)
+						current_volume = possible_volumes[i+1]
+					else
+						current_volume = possible_volumes[1]
+					balloon_alert(user, "making [current_volume]u pills")
+					return
 	return ..()
 
-/obj/machinery/chem_press/AltClick(mob/living/user)
-	if(!can_interact(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		return
+/obj/machinery/chem_press/attack_hand_secondary(mob/user, list/modifiers)
 	if(beaker || bottle) // If there's a container in the machine, eject it.
 		handle_container(user)
-		return
-	else
-		return ..() // Having ..() run only if all else fails prevents AltClick from showing the turf's contents when not wanted.
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /*
 This proc attempts to swap a container in the machine

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -92,14 +92,14 @@
 	if(type in opcomputer.advanced_surgeries)
 		return TRUE
 
-/datum/surgery/proc/next_step(mob/user, intent)
+/datum/surgery/proc/next_step(mob/user, list/modifiers)
 	if(location != user.zone_selected)
 		return FALSE
 	if(step_in_progress)
 		return TRUE
 
 	var/try_to_fail = FALSE
-	if(intent == INTENT_DISARM)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		try_to_fail = TRUE
 
 	var/datum/surgery_step/S = get_surgery_step()

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -73,7 +73,7 @@
 		var/datum/surgery_step/next_step = surgery.get_surgery_next_step()
 		if(next_step)
 			surgery.status++
-			if(next_step.try_op(user, target, user.zone_selected, user.get_active_held_item(), surgery))
+			if(next_step.try_op(user, target, user.zone_selected, user.get_active_held_item(), surgery, try_to_fail))
 				return TRUE
 			else
 				surgery.status--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds right-click actions for:
- Suit sensors
- Using modular computers
- Unlocking APCs and air alarms
- Deconstructing tables, windows, and walls
- Welding airlocks closed
- Toggling gun safeties
- Opening/closing fire extinguisher cabinets
- Wrapping items in tape
- Renaming paystands
- Medical malpractice
- Tipping medibots over

Fixes right-click actions for:
- Every single one that was added. I am impressed with the lack of testing.

If you think of something that should be done with right click, make a comment about it and I'll add it.

## Why It's Good For The Game

Fix + QoL

## Changelog

:cl:
add: Added more right-click actions
fix: Fixed existing right-click actions not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
