### PR TITLE
Rocks can now be used as cover

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -19,6 +19,10 @@
 	var/climb_stun = 0
 
 	var/broken = 0 //similar to machinery's stat BROKEN
+	///The chance of a projectile to pass through the structure
+	var/passchance = 0
+	///If projectiles are allowed to pass through a structure at all
+	var/pass_through = FALSE
 
 /obj/structure/Initialize()
 	if (!armor)
@@ -53,6 +57,18 @@
 		return
 	if (O.loc != src.loc)
 		step(O, get_dir(O, src))
+
+/obj/structure/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(istype(mover, /obj/projectile) && pass_through)
+		var/obj/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return TRUE
+		if(prob(passchance))
+			return TRUE
+		return FALSE
+	if((mover.pass_flags & PASSGRILLE) && pass_through)
+		return prob(passchance)
 
 /obj/structure/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -445,8 +445,10 @@
 	icon = 'icons/obj/flora/rocks.dmi'
 	resistance_flags = FIRE_PROOF
 	density = TRUE
+	pass_flags_self = LETPASSTHROW
 	max_integrity = 100
 	var/obj/item/stack/mineResult = /obj/item/stack/ore/glass/basalt
+	var/passchance = 50
 
 	hitsound_type = PROJECTILE_HITSOUND_STONE
 
@@ -475,6 +477,18 @@
 				playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
+
+/obj/structure/flora/rock/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return TRUE
+		if(prob(passchance))
+			return TRUE
+		return FALSE
+	if((mover.pass_flags & PASSGRILLE))
+		return prob(passchance)
 
 /obj/structure/flora/rock/pile
 	icon_state = "lavarocks1"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -448,7 +448,8 @@
 	pass_flags_self = LETPASSTHROW
 	max_integrity = 100
 	var/obj/item/stack/mineResult = /obj/item/stack/ore/glass/basalt
-	var/passchance = 50
+	passchance = 50
+	pass_through = TRUE
 
 	hitsound_type = PROJECTILE_HITSOUND_STONE
 
@@ -478,22 +479,12 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/flora/rock/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
-	if(istype(mover, /obj/projectile))
-		var/obj/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return TRUE
-		if(prob(passchance))
-			return TRUE
-		return FALSE
-	if((mover.pass_flags & PASSGRILLE))
-		return prob(passchance)
 
 /obj/structure/flora/rock/pile
 	icon_state = "lavarocks1"
 	base_icon_state = "lavarocks"
 	desc = "A pile of rocks."
+	density = FALSE
 
 //Jungle grass
 
@@ -679,6 +670,7 @@
 	icon = 'icons/obj/flora/lavarocks.dmi'
 	icon_state = "lavarocks1"
 	base_icon_state = "lavarocks"
+	density = FALSE
 	gender = PLURAL
 
 /obj/structure/flora/rock/asteroid
@@ -798,6 +790,7 @@
 	icon_state = "redrocks1"
 	base_icon_state = "redrocks"
 	mineResult = /obj/item/stack/ore/glass/rockplanet
+	density = FALSE
 
 /obj/structure/flora/grass/rockplanet
 	name = "cottongrass"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -332,13 +332,17 @@
 /obj/structure/flora/rock/icy
 	name = "icy rock"
 	icon_state = "snowrock_1"
+	density = FALSE
 
 /obj/structure/flora/rock/icy/Initialize()
 	. = ..()
 	icon_state = "snowrock_[rand(1,4)]"
 
+	if(icon_state == "snowrock_1")
+		density = TRUE
+
 /obj/structure/flora/rock/pile/icy
-	name = "icey rocks"
+	name = "icy rocks"
 	icon_state = "snowrock_4"
 
 /obj/structure/flora/rock/pile/icy/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR gives planetary rocks the passthrough flag so items (like grenades) can be thrown past them, and it gives them a 50% chance to allow a projectile to whizz past them. Just like with sandbags, if you're adjacent to a rock, you can hunker down next to it and fire over/to the side of the rock. 

Smaller rocks can be walked past entirely, but they offer no cover.

| Can be walked through/Provides no Cover | Cannot be walked through/Provides Cover |
|-----------------------------------------|-----------------------------------------|
|<img width="70" height="70" alt="image" src="https://github.com/user-attachments/assets/f42ff5bd-757f-4f6e-a2bd-0fca2d00ad14" />|<img width="79" height="73" alt="image" src="https://github.com/user-attachments/assets/b42f5e85-bf24-4835-a73f-b817f3e1a6ed" />|

The base passThrough behavior was moved to structures, so it can be used in the future for custom barricades/cover types.

## Why It's Good For The Game

I thought it would be fun to allow someone to take advantage of natural terrain in firefights -- I've also noticed that some rock sprites are a little small, so being able to walk on top of them might feel nicer.

## Changelog

:cl:
balance: rocks now act like sandbags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
