### PR TITLE
strategic blunder (removes a doubled apc on the kali)

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -4564,28 +4564,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
-"yE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/corner/opaque/tan{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/opaque/bar/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
 "yF" = (
 /obj/effect/turf_decal/corner/opaque/tan/mono,
 /turf/open/floor/plasteel/mono/dark,
@@ -11081,7 +11059,7 @@ Eo
 Pv
 Tq
 gv
-yE
+ZK
 Qb
 IK
 IK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="474" height="346" alt="image" src="https://github.com/user-attachments/assets/958f8a23-c2e3-438e-834e-8f558dc5ee47" />

every time i dont test a pr the boulder drops
<img width="687" height="446" alt="image" src="https://github.com/user-attachments/assets/961949a2-7a48-4d85-8f31-5021a3c5437b" />

## Why It's Good For The Game

i fucked up

## Changelog

:cl:
fix: hardline has sent a few very angry faxes to the previously-mentioned bankrupt architecture firm, reminding them of why they went bankrupt (kali doesnt have doubled central hall APCs anymore)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
