### PR TITLE
restore typing indicator cancel

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -103,6 +103,9 @@
 		CtrlClickOn(A)
 		return
 
+	if(typing_indicator)
+		set_typing_indicator(FALSE)
+
 	if(incapacitated(ignore_restraints = TRUE))
 		return
 
@@ -200,10 +203,6 @@
 			return TRUE
 	return FALSE
 
-/**
- * A backwards depth-limited breadth-first-search to see if the target is
- * logically "in" anything adjacent to us.
- */
 /**
  * A backwards depth-limited breadth-first-search to see if the target is
  * logically "in" anything adjacent to us.


### PR DESCRIPTION
resolves #5581 

## Changelog

:cl:
fix: Clicking now cancels your typing indicator
/:cl: