### PR TITLE
Fixes gender being reset when loading a character with none selected

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -33,21 +33,9 @@
 
 //more specialised stuff
 /proc/sanitize_gender(gender, possible_genders = list(MALE, FEMALE, PLURAL, NEUTER))
-	default ||= pick(MALE, FEMALE)
-	switch(gender)
-		if(MALE, FEMALE)
-			return gender
-		if(NEUTER)
-			if(neuter)
-				return gender
-			else
-				return default
-		if(PLURAL)
-			if(plural)
-				return gender
-			else
-				return default
-	return default
+	if(!(gender in possible_genders))
+		return pick(possible_genders)
+	return gender
 
 /proc/sanitize_hexcolor(color, desired_format = 6, include_crunch = FALSE, default)
 	var/crunch = include_crunch ? "#" : ""

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -32,7 +32,8 @@
 			. += value
 
 //more specialised stuff
-/proc/sanitize_gender(gender,neuter=0,plural=1, default="male")
+/proc/sanitize_gender(gender, possible_genders = list(MALE, FEMALE, PLURAL, NEUTER))
+	default ||= pick(MALE, FEMALE)
 	switch(gender)
 		if(MALE, FEMALE)
 			return gender


### PR DESCRIPTION
## About The Pull Request

Fixes a bug that causes a character's gender to be reset to male when loading it, if that character had none selected.

## Why It's Good For The Game

Gender

## Changelog

:cl:
fix: Fixed gender being set to male when loading a character with none selected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
