### PR TITLE
Fixes paralysis from burn wounds persisting after the limb is removed

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -121,8 +121,7 @@
 					if(0)
 						to_chat(victim, span_deadsay("<b>The last of the nerve endings in your [limb.name] wither away.</b>"))
 						threshold_penalty = 120 // piss easy to destroy
-						var/datum/brain_trauma/severe/paralysis/sepsis = new (limb.body_zone)
-						victim.gain_trauma(sepsis)
+						set_disabling(TRUE)
 				strikes_to_lose_limb--
 
 /datum/wound/burn/get_examine_description(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Burn wounds applied paralysis to the mob via a brain trauma instead of the limb itself, which caused it to persist after having the limb amputated (the intended way to fix it)

## Why It's Good For The Game

A

## Changelog

:cl:
fix: Fixed paralysis from burn wounds persisting after the limb is removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
