### PR TITLE
Makes the One Half Safe Exposed

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalftwo.dmm
@@ -3009,7 +3009,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/refuelingpost/bridge)
 "FB" = (
 /obj/machinery/mech_bay_recharge_port{


### PR DESCRIPTION
## Why It's Good For The Game

Accidentally covered it

## Changelog

:cl:
fix: Onehalf Safe is now visible again
/:cl: