### PR TITLE
Increases Wild Sector Overmap Events to 25

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -379,7 +379,7 @@
 	config_entry_value = 150
 
 /datum/config_entry/number/max_overmap_dynamic_events
-	config_entry_value = 10
+	config_entry_value = 25
 
 /datum/config_entry/string/overmap_generator_type
 	config_entry_value = "solar_system"

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -1159,9 +1159,9 @@ SUBSYSTEM_DEF(overmap)
 	has_outpost = FALSE
 	can_be_selected_randomly = FALSE
 	encounters_refresh = TRUE
-	max_overmap_dynamic_events = 25
 
 /datum/overmap_star_system/shiptest/create_map()
+	CONFIG_GET(number/max_overmap_dynamic_events)
 	. = ..()
 
 /datum/overmap_star_system/admin_sandbox

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -1159,7 +1159,7 @@ SUBSYSTEM_DEF(overmap)
 	has_outpost = FALSE
 	can_be_selected_randomly = FALSE
 	encounters_refresh = TRUE
-	max_overmap_dynamic_events = 15
+	max_overmap_dynamic_events = 25
 
 /datum/overmap_star_system/shiptest/create_map()
 	. = ..()

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -1161,7 +1161,7 @@ SUBSYSTEM_DEF(overmap)
 	encounters_refresh = TRUE
 
 /datum/overmap_star_system/shiptest/create_map()
-	CONFIG_GET(number/max_overmap_dynamic_events)
+	max_overmap_dynamic_events = CONFIG_GET(number/max_overmap_dynamic_events)
 	. = ..()
 
 /datum/overmap_star_system/admin_sandbox


### PR DESCRIPTION
## Why It's Good For The Game

It was 15 before, which sounds a lot less than what it should be prior to Static Sectors

## Changelog

:cl:
fix: Wild Sector should spawn much more planets
/:cl: