### PR TITLE
Fixes the RILENA Fan quirk having the wrong gain text

### DIFF
--- a/code/datums/traits/neutral/rilena_fan.dm
+++ b/code/datums/traits/neutral/rilena_fan.dm
@@ -4,7 +4,7 @@
 	value = 0
 	mob_traits = list(TRAIT_FAN_RILENA)
 	gain_text = span_notice("You are a huge fan of a certain combination webcomic and bullet hell game.")
-	gain_text = span_danger("Suddenly, bullet hell games and webcomics don't seem all that interesting anymore...")
+	lose_text = span_danger("Suddenly, bullet hell games and webcomics don't seem all that interesting anymore...")
 	detectable = FALSE
 
 /datum/quirk/fan_rilena/on_spawn()


### PR DESCRIPTION
Minor spelling mistake

:cl:
fix: Fixed incorrect text when gaining the RILENA Fan quirk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
