### PR TITLE
Adds 2 Minor Drugs + bugfixies

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -74,6 +74,11 @@
 	mood_change = 9
 	timeout = 3 MINUTES
 
+/datum/mood_event/stimulant_light
+	description = span_nicegreen("I feel so light. So productive!")
+	mood_change = 2
+	timeout = 3 MINUTES
+
 /datum/mood_event/stimulant_medium
 	description = span_nicegreen("I have so much energy! I feel like I could do anything!")
 	mood_change = 4
@@ -83,6 +88,11 @@
 	description = span_nicegreen("Eh ah AAAAH! HA HA HA HA HAA! Uuuh.")
 	mood_change = 6
 	timeout = 3 MINUTES
+
+/datum/mood_event/stimulant_bad
+	description = span_boldwarning("Fuck. Need to move. Need to do something. I'm not doing enough. I'm not DOING ENOUGH!!")
+	mood_change = -10
+	timeout = 6 MINUTES
 
 /datum/mood_event/legion_good
 	mood_change = 5

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -284,6 +284,11 @@
 	mood_change = -18
 	timeout = 3 MINUTES
 
+/datum/mood_event/headache
+	description = span_warning("My head hurts....")
+	mood_change = -3
+	timeout = 5 MINUTES
+
 /datum/mood_event/bad_touch_bear_hug
 	description = span_warning("I just got squeezed way too hard.")
 	mood_change = -3

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -597,8 +597,16 @@
 
 /obj/item/storage/pill_bottle/alvitane
 	name = "bottle of alvitane patches"
-	desc = "Contains alvitane pills, for treating burn injuries."
+	desc = "Contains alvitane patches, for treating burn injuries."
 
 /obj/item/storage/pill_bottle/alvitane/PopulateContents()
 	for(var/i in 1 to 5)
-		new /obj/item/reagent_containers/pill/patch/alvitane
+		new /obj/item/reagent_containers/pill/patch/alvitane(src)
+
+/obj/item/storage/pill_bottle/rcyte
+	name = "bottle of Reflex-Cytodron"
+	desc = "Contains Reflex-Cytodron tablets, a common over-the-counter stimulant."
+
+/obj/item/storage/pill_bottle/alvitane/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/rcyte(src)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -607,6 +607,6 @@
 	name = "bottle of Reflex-Cytodron"
 	desc = "Contains Reflex-Cytodron tablets, a common over-the-counter stimulant."
 
-/obj/item/storage/pill_bottle/alvitane/PopulateContents()
+/obj/item/storage/pill_bottle/rcyte/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/rcyte(src)

--- a/code/modules/cargo/blackmarket/packs/consumables.dm
+++ b/code/modules/cargo/blackmarket/packs/consumables.dm
@@ -324,6 +324,26 @@
 	availability_prob = 10
 	spawn_weighting = FALSE
 
+/datum/blackmarket_item/consumable/combat_inhaler
+	name = "Pressurized Shoalmix"
+	desc = "No-oh-oh-oh fucking idea how we swung this one my guys, but we got it. The ditz in back managed to pressurize a stable mixture of shoalmix and panacea, and we managed to fab some custom inhalers to let you hit on the go. Lemme tell you. I'm gonna be hittin somethin for this innovation."
+	item = /obj/item/inhaler/cocktail
+	cost_min = 1000
+	cost_max = 1500
+	stock_max = 3
+	availability_prob = 30
+	pair_item = /datum/blackmarket_item/consumable/combat_inhaler_cartridge
+	spawn_weighting = FALSE
+
+/datum/blackmarket_item/consumable/combat_inhaler_cartridge
+	name = "Pressurized Shoalmix Vial"
+	desc = "Oh? These? Just vials of shoalmix and panacea. It's supposed to fit into an inhaler. Buy em. Buy em now."
+	item = /obj/item/reagent_containers/inhaler_canister/combat_drug
+	cost_min = 500
+	cost_max = 1000
+	stock_max = 12
+	availability_prob = 20
+
 /datum/blackmarket_item/consumable/horse_pills
 	name = "Strider patches"
 	desc = "Fun lil story, yeah? We were screwin off in a backcounty race, watchin some horse girls run it out. One of em popped some patches beforehand. Managed to easily outrun the rest. We managed to find em and get in with the supplier. Supposed to help ya move fast. Keep your muscles workin when they might burst."

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -28,6 +28,9 @@
 /datum/movespeed_modifier/reagent/shoalmix
 	multiplicative_slowdown = -0.4
 
+/datum/movespeed_modifier/reagent/cytodron
+	multiplicative_slowdown = -0.1
+
 /datum/movespeed_modifier/reagent/cinesia
 	multiplicative_slowdown = -0.55
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -11,7 +11,7 @@
 
 /datum/reagent/drug/space_drugs
 	name = "Dropsight"
-	description = "An illegal chemical compound used as drug."
+	description = "An illegal hallucinogenic chemical compound used as drug."
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 30
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -763,8 +763,8 @@
 
 /datum/reagent/drug/cytodron/overdose_start(mob/living/M)
 	. = ..()
-	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_bad, name)
-	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_bad, name)
+	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
 
 /datum/reagent/drug/cytodron/overdose_process(mob/living/M)
 	. = ..()
@@ -802,7 +802,7 @@
 
 /datum/reagent/drug/cytodron/overdose_start(mob/living/M)
 	. = ..()
-	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/headache, name)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/headache, name)
 
 /datum/reagent/drug/sting/overdose_process(mob/living/M)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -734,3 +734,79 @@
 	M.apply_status_effect(/datum/status_effect/stagger)
 	M.set_timed_status_effect(20 SECONDS * REM, /datum/status_effect/dizziness, only_if_higher = TRUE)
 	..()
+
+/datum/reagent/drug/cytodron
+	name = "Reflex-Cytodron"
+	description = "A popular trade in the Confederated League - although barely legal, Reflex-Cytodron is a chemical that aids in reception of neural impulses at extremities of the body, allowing someone to faster and more precise."
+	reagent_state = SOLID
+	color = "#5a360e"
+	overdose_threshold = 20
+	addiction_threshold = 17
+	metabolization_rate = 0.1
+	taste_description = "pharmacokinetics"
+
+/datum/reagent/drug/cytodron/on_mob_metabolize(mob/living/L)
+	..()
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_light, name)
+	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
+	if(ishuman(L))
+		var/mob/living/carbon/human/drugged = L
+		drugged.physiology.do_after_speed -= 0.1
+
+/datum/reagent/drug/cytodron/on_mob_end_metabolize(mob/living/L)
+	..()
+	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, /datum/reagent/drug/cytodron)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
+	if(ishuman(L))
+		var/mob/living/carbon/human/drugged = L
+		drugged.physiology.do_after_speed += 0.1
+
+/datum/reagent/drug/cytodron/overdose_start(mob/living/M)
+	. = ..()
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_bad, name)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
+
+/datum/reagent/drug/cytodron/overdose_process(mob/living/M)
+	. = ..()
+	if(prob(10))
+		M.drop_all_held_items()
+	if(prob(40))
+		M.set_timed_status_effect(10 SECONDS * REM, /datum/status_effect/jitter, only_if_higher = TRUE)
+
+/datum/reagent/drug/sting
+	name = "Sting"
+	description = "A Sybelnatch-originating 'attention-aide' devised for usage in educational and research setting. Focuses the mind on the task at hand."
+	reagent_state = GAS
+	color = "#5a360e"
+	overdose_threshold = 16
+	addiction_threshold = 15
+	metabolization_rate = 0.2
+	taste_description = "a jolt of pain"
+
+/datum/reagent/drug/sting/on_mob_metabolize(mob/living/L)
+	..()
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_medium, name)
+	ADD_TRAIT(L, TRAIT_SENSITIVE_TONGUE, /datum/reagent/drug/sting)
+	ADD_TRAIT(L, TRAIT_PINPOINT_EYES, /datum/reagent/drug/sting)
+	if(ishuman(L))
+		var/mob/living/carbon/human/drugged = L
+		drugged.physiology.do_after_speed -= 0.2
+
+/datum/reagent/drug/sting/on_mob_end_metabolize(mob/living/L)
+	..()
+	REMOVE_TRAIT(L, TRAIT_SENSITIVE_TONGUE, /datum/reagent/drug/sting)
+	REMOVE_TRAIT(L, TRAIT_PINPOINT_EYES, /datum/reagent/drug/sting)
+	if(ishuman(L))
+		var/mob/living/carbon/human/drugged = L
+		drugged.physiology.do_after_speed += 0.2
+
+/datum/reagent/drug/cytodron/overdose_start(mob/living/M)
+	. = ..()
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/headache, name)
+
+/datum/reagent/drug/sting/overdose_process(mob/living/M)
+	. = ..()
+	if(prob(30))
+		M.blur_eyes(rand(5,12))
+	if(prob(5))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -755,7 +755,6 @@
 
 /datum/reagent/drug/cytodron/on_mob_end_metabolize(mob/living/L)
 	..()
-	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, /datum/reagent/drug/cytodron)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cytodron)
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
@@ -786,16 +785,16 @@
 /datum/reagent/drug/sting/on_mob_metabolize(mob/living/L)
 	..()
 	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_medium, name)
-	ADD_TRAIT(L, TRAIT_SENSITIVE_TONGUE, /datum/reagent/drug/sting)
-	ADD_TRAIT(L, TRAIT_PINPOINT_EYES, /datum/reagent/drug/sting)
+	ADD_TRAIT(L, TRAIT_SENSITIVE_TONGUE, type)
+	ADD_TRAIT(L, TRAIT_PINPOINT_EYES, type)
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.do_after_speed -= 0.2
 
 /datum/reagent/drug/sting/on_mob_end_metabolize(mob/living/L)
 	..()
-	REMOVE_TRAIT(L, TRAIT_SENSITIVE_TONGUE, /datum/reagent/drug/sting)
-	REMOVE_TRAIT(L, TRAIT_PINPOINT_EYES, /datum/reagent/drug/sting)
+	REMOVE_TRAIT(L, TRAIT_SENSITIVE_TONGUE, type)
+	REMOVE_TRAIT(L, TRAIT_PINPOINT_EYES, type)
 	if(ishuman(L))
 		var/mob/living/carbon/human/drugged = L
 		drugged.physiology.do_after_speed += 0.2

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -304,7 +304,7 @@
 
 /obj/item/reagent_containers/inhaler_canister/sting
 	name = "sting canister"
-	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains Sting, a stimulant from Sybelnach!"
+	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains Sting, and the mark of a Syeben'Altch guild."
 	icon_state = "canister_generic"
 	list_reagents = list(/datum/reagent/drug/sting = 30)
 

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -315,6 +315,6 @@
 
 /obj/item/reagent_containers/inhaler_canister/combat_drug
 	name = "shoalmix canister"
-	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains a blend of shoalmix and panacea! Hit it in a fight!"
+	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains a blend of shoalmix and panacea. Hit it in a fight!"
 	icon_state = "canister_syndicate"
 	list_reagents = list(/datum/reagent/drug/combat_drug = 20, /datum/reagent/medicine/panacea = 10)

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -296,3 +296,25 @@
 	name = "rescue inhaler"
 	icon_state = "inhaler_generic"
 	initial_casister_path = /obj/item/reagent_containers/inhaler_canister/salbutamol
+
+/obj/item/inhaler/sting
+	name = "sting inhaler"
+	icon_state = "inhaler_generic"
+	initial_casister_path = /obj/item/reagent_containers/inhaler_canister/sting
+
+/obj/item/reagent_containers/inhaler_canister/sting
+	name = "sting canister"
+	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains Sting, a stimulant from Sybelnach!"
+	icon_state = "canister_generic"
+	list_reagents = list(/datum/reagent/drug/sting = 30)
+
+/obj/item/inhaler/cocktail
+	name = "shoalmix inhaler"
+	icon_state = "inhaler_syndicate"
+	initial_casister_path = /obj/item/reagent_containers/inhaler_canister/combat_drug
+
+/obj/item/reagent_containers/inhaler_canister/combat_drug
+	name = "shoalmix canister"
+	desc = "A small canister filled with aerosolized reagents for use in a inhaler. This one contains a blend of shoalmix and panacea! Hit it in a fight!"
+	icon_state = "canister_syndicate"
+	list_reagents = list(/datum/reagent/drug/combat_drug = 20, /datum/reagent/medicine/panacea = 10)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -316,3 +316,9 @@
 	desc = "A pill composed of a white, powdery substance. Take as prescribed."
 	icon_state = "pill9"
 	list_reagents = list(/datum/reagent/drug/placebatol = 10)
+
+/obj/item/reagent_containers/pill/rcyte
+	name = "R-Cyte tablet"
+	desc = "A pill composed of a white, powdery substance. Take as prescribed."
+	icon_state = "pill0"
+	list_reagents = list(/datum/reagent/drug/cytodron = 10)

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -38,6 +38,8 @@
 		/obj/item/reagent_containers/medigel/hadrakine = 3,
 		/obj/item/reagent_containers/medigel/quardexane = 3,
 		/obj/item/storage/pill_bottle/stardrop = 5,
+		/obj/item/storage/pill_bottle/rcyte = 5,
+		/obj/item/inhaler/sting = 5,
 	)
 
 /obj/item/vending_refill/wallmed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Sting, a low-powered actionspeed altering stimulant with minor side effects. Mostly making your tastebuds oversensitive. You can get it via an inhaler at outpost med. 
Adds Reflex-Cytodron, a low powered stimulant that makes you move a smidge faster, also in the outpostmed.


## Why It's Good For The Game
's cool

## Changelog

:cl:
add: Sting and Cytodron, two outpostmed exclusive chems with minor buffs.
add: shoalmix inhaler to black market.
fix: burn kits will have patches in them again
/:cl: