### PR TITLE
Fixes some typos with lotteries

### DIFF
--- a/code/modules/events/ship/lottery.dm
+++ b/code/modules/events/ship/lottery.dm
@@ -27,10 +27,10 @@
 /datum/round_event/ship/lottery/announce(fake)
 	if(fake)
 		creds_won = 1000000000
-	priority_announce("congracts to [target_ship.name] who has won a sweep stakes for [creds_won] creds!",
+	priority_announce("Congratulations to the [target_ship.name]! They've won a prize of [creds_won] credits!",
 		null,
 		null,
-		"Sweep stakes!",
+		"Sweepstakes lottery!",
 		sender_override = "[target_outpost] Communications",
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a few typos present in the announcement of lotteries -- those being 'Congracts' and 'sweep stakes' (sweepstakes is meant to be one word all together)

## Why It's Good For The Game

Minor typo fix to help polish things a little

## Changelog

:cl:
fix: fixed a few lottery typos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
