### PR TITLE
Add Lioples back to Magpie

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_magpie.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_magpie.dmm
@@ -168,16 +168,20 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/commad)
 "bm" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#543C30";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/hostile/retaliate/gator/steppy{
+	desc = "Exported from one of many Solarian Cantons, this small but domesticated alligator lives aboard this vessel. Be careful not to step on the tail!";
+	gender = "male";
+	name = "Lioples";
+	melee_damage_lower = 10;
+	melee_damage_upper = 15;
+	faction = list("neutral, nanotrasen")
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
 "bo" = (
@@ -2949,10 +2953,10 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/toilet)
 "ve" = (
-/obj/structure/fluff/hedge,
 /obj/effect/turf_decal/corner/opaque/ntbluelight{
 	dir = 10
 	},
+/obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
 "vi" = (
@@ -3107,7 +3111,7 @@
 /area/ship/cargo)
 "wD" = (
 /obj/structure/chair/office{
-	dir = 8
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood/walnut,
@@ -6534,12 +6538,16 @@
 	dir = 1
 	},
 /obj/item/paper_bin{
-	pixel_x = 6;
+	pixel_x = 7;
 	pixel_y = 4
 	},
 /obj/item/pen{
-	pixel_x = 6;
+	pixel_x = 7;
 	pixel_y = 4
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 6
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Lioples to the Magpie dorm. 
<img width="773" height="614" alt="image" src="https://github.com/user-attachments/assets/74cb5f43-0c52-4d53-b11e-fe2223e58415" />
Not particularly sure about his placement but dorms seemed best

## Why It's Good For The Game

i miss him ):

## Changelog

:cl:
add: Magpie's pet alligator has returned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
