### PR TITLE
Rezadone and crystal reagent now fully remove burns instead of reversing

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -253,7 +253,7 @@
 /datum/wound/burn/on_rezadone(power)
 	if(power>=10)
 		// Rapidly regenerating burns isn't so clean, especially when there's an infection to purge
-		to_chat(victim, span_green("The burns on your [limb.name] clear up, leaving you with an ill feeling.")
+		to_chat(victim, span_green("The burns on your [limb.name] clear up, leaving you with an ill feeling."))
 		switch(infestation)
 			if(0 to WOUND_INFECTION_MODERATE)
 				victim.adjustToxLoss(2)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -241,17 +241,19 @@
 	sanitization += amount * 0.1
 	return
 
-//crystal reagent lets you reverse sepsis bcause sepsis sucks rn
+//crystal reagent lets you fully clear burns because they're rare chemicals and burns suck ass
 /datum/wound/burn/on_crystal(power)
 	if(power>=5)
-		strikes_to_lose_limb = min(strikes_to_lose_limb+1, 3)
+		to_chat(victim, span_green("The burns on your [limb.name] have been regenerated, leaving only minor necrosis."))
 		victim.adjustCloneLoss(2)
+		qdel(src)
 	return
 
 //So does rezadone
 /datum/wound/burn/on_rezadone(power)
 	if(power>=10)
-		strikes_to_lose_limb = min(strikes_to_lose_limb+1, 3)
+		to_chat(victim, span_green("The burns on your [limb.name] suddenly clear up."))
+		qdel(src)
 	return
 
 // we don't even care about first degree burns, straight to second

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -241,18 +241,30 @@
 	sanitization += amount * 0.1
 	return
 
-//crystal reagent lets you fully clear burns because they're rare chemicals and burns suck ass
+//crystal reagent lets you fully clear burns because they're rare chemicals and burns suck ass with no cryo
 /datum/wound/burn/on_crystal(power)
 	if(power>=5)
 		to_chat(victim, span_green("The burns on your [limb.name] have been regenerated, leaving only minor necrosis."))
-		victim.adjustCloneLoss(2)
+		victim.adjustCloneLoss(5)
 		qdel(src)
 	return
 
 //So does rezadone
 /datum/wound/burn/on_rezadone(power)
 	if(power>=10)
-		to_chat(victim, span_green("The burns on your [limb.name] suddenly clear up."))
+		// Rapidly regenerating burns isn't so clean, especially when there's an infection to purge
+		to_chat(victim, span_green("The burns on your [limb.name] clear up, leaving you with an ill feeling.")
+		switch(infestation)
+			if(0 to WOUND_INFECTION_MODERATE)
+				victim.adjustToxLoss(2)
+			if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)
+				victim.adjustToxLoss(5)
+			if(WOUND_INFECTION_SEVERE to WOUND_INFECTION_CRITICAL)
+				victim.adjustToxLoss(10)
+			if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
+				victim.adjustToxLoss(15)
+			if(WOUND_INFECTION_SEPTIC to INFINITY)
+				victim.adjustToxLoss(20)
 		qdel(src)
 	return
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2253,7 +2253,7 @@
 		var/mob/living/carbon/patient = M
 		for(var/i in patient.all_wounds)
 			var/datum/wound/iter_wound = i
-			iter_wound.on_rezadone(reac_volume)
+			iter_wound.on_crystal(reac_volume)
 		if(reac_volume >= 5 && HAS_TRAIT_FROM(patient, TRAIT_HUSK, "burn") && patient.stat == DEAD)
 			patient.adjustFireLoss(-500)
 			patient.cure_husk("burn")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes rezadone/crystal reagent just fully qdel the burn instead of reversing sepsis with rezadone causing 5 clone damage and rezadone doing tox damage depending on infection level.

none to moderate tox causes 2, moderate to severe causes 5, severe to critical cause 10, critical to sepsis causes 15, full sepsis does 20.
## Why It's Good For The Game
Rezadone and (especially crystal reagent) are chems people will not be carrying normally and require people to go out of their way to get if they want. Burn infections kind of suck major ass right now. You have about Fuck All in time to clear the burn up and only reversing gives you five seconds to clear the burn up before they immediately get infected again. If Rezadone can cure someone from being a literal pile of charcoal (husk) it can cure a more minor burn wound. 

Rezadone causes toxin damage depending on how long you let the burn sit with more time spent not tending to it leading to more toxin damage. 
## Changelog

:cl: Goat
balance: Rezadone and Crystal Reagent fully remove burns now, at a cost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
