### PR TITLE
switch building material for griddle and oven

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1216,7 +1216,7 @@
 	icon_state = "service"
 	build_path = /obj/machinery/griddle
 	req_components = list(
-		/obj/item/stack/sheet/mineral/titanium = 1,
+		/obj/item/stack/sheet/metal = 1,
 		/obj/item/assembly/igniter = 1,
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stock_parts/micro_laser = 1,
@@ -1227,7 +1227,7 @@
 	icon_state = "service"
 	build_path = /obj/machinery/oven
 	req_components = list(
-		/obj/item/stack/sheet/mineral/titanium = 1,
+		/obj/item/stack/sheet/metal = 1,
 		/obj/item/assembly/igniter = 1,
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stock_parts/micro_laser = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make the circuitboard to build griddles and ovens require iron instead of titanium

## Why It's Good For The Game

It's a weirdly expensive recipe on top of the thousands to purchase them both anyway
