### PR TITLE
max bodytemp define

### DIFF
--- a/code/__DEFINES/species.dm
+++ b/code/__DEFINES/species.dm
@@ -14,7 +14,7 @@
 /// The natural temperature for a body
 #define HUMAN_BODYTEMP_NORMAL 310.15
 /// The max temperature a body can get to
-#define HUMAN_BODYTEMP_MAX HUMAN_BODYTEMP_NORMAL*3
+#define HUMAN_BODYTEMP_MAX HUMAN_BODYTEMP_NORMAL*2.5
 /// This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
 #define HUMAN_BODYTEMP_AUTORECOVERY_DIVISOR 11
 /// Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.

--- a/code/__DEFINES/species.dm
+++ b/code/__DEFINES/species.dm
@@ -13,6 +13,8 @@
 
 /// The natural temperature for a body
 #define HUMAN_BODYTEMP_NORMAL 310.15
+/// The max temperature a body can get to
+#define HUMAN_BODYTEMP_MAX HUMAN_BODYTEMP_NORMAL*3
 /// This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
 #define HUMAN_BODYTEMP_AUTORECOVERY_DIVISOR 11
 /// Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -549,7 +549,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
  * * use_steps (optional) Use the body temp divisors and max change rates
  * * hardsuit_fix (optional) num HUMAN_BODYTEMP_NORMAL - H.bodytemperature Use hardsuit override until hardsuits fix is done...
  */
-/mob/living/carbon/adjust_bodytemperature(amount, min_temp=0, max_temp=INFINITY, use_insulation=TRUE, use_steps=FALSE, \
+/mob/living/carbon/adjust_bodytemperature(amount, min_temp=0, max_temp=HUMAN_BODYTEMP_MAX, use_insulation=TRUE, use_steps=FALSE, \
 											hardsuit_fix=FALSE)
 	// apply insulation to the amount of change
 	if(use_insulation)


### PR DESCRIPTION
## About The Pull Request

adds a max bodytemp define so you can no longer be the temperature of a small star

## Changelog

:cl:
fix: bodyheat should no longer go over 1000~ whatever units we use for heat
/:cl:

