### PR TITLE
Allowing Crit Emotes

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -52,6 +52,7 @@
 	key = "choke"
 	key_third_person = "chokes"
 	message = "chokes!"
+	stat_allowed = HARD_CRIT
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/cross
@@ -94,6 +95,7 @@
 	key = "cough"
 	key_third_person = "coughs"
 	message = "coughs!"
+	stat_allowed = SOFT_CRIT
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE , intentional)
@@ -224,6 +226,7 @@
 /datum/emote/living/groan
 	key = "groan"
 	key_third_person = "groans"
+	stat_allowed = SOFT_CRIT
 	message = "groans!"
 
 /datum/emote/living/grimace
@@ -372,6 +375,7 @@
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "shivers."
+	stat_allowed = SOFT_CRIT
 	emote_type = EMOTE_AUDIBLE
 
 #define SHIVER_LOOP_DURATION (1 SECONDS)
@@ -548,6 +552,7 @@
 /datum/emote/living/whimper
 	key = "whimper"
 	key_third_person = "whimpers"
+	stat_allowed = SOFT_CRIT
 	message = "whimpers."
 
 /datum/emote/living/wsmile
@@ -565,11 +570,13 @@
 	key = "gurgle"
 	key_third_person = "gurgles"
 	message = "makes an uncomfortable gurgle."
+	stat_allowed = HARD_CRIT
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/custom
 	key = "me"
 	key_third_person = "custom"
+	stat_allowed = SOFT_CRIT
 	message = null
 
 /datum/emote/living/custom/can_run_emote(mob/user, status_check, intentional)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows players to use the following emotes while in soft-crit.
Cough
Wheeze
Groan
Shiver
Whimper
*Me Custom

Also allows players to use the following emotes while in hard-crit.
Choke
Gasp
Gurgle
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most of the newly permitted emotes are thematic for the injury states, but most importantly, allowing custom emotes to those in soft-crit offers a number of opportunities for RPing injuries.

I believe the initial intent behind locking off custom emotes to those in crit was to prevent meta-gaming, but the server's RP culture and expectations are such that anyone using this to metagame would likely get shot then reported to the admins, so it's really harmless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added more emotes to the Crit whitelist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
