### PR TITLE
Wounds should bleed less (visually)

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -183,7 +183,7 @@
 	dry()
 	add_blood_DNA(list("Non-human DNA" = random_blood_type()))
 	if(move_on_init)
-		pixel_x = rand(-5,5)
+		pixel_x = rand(-5, 5)
 		pixel_y = rand(-5, 5)
 
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -183,8 +183,8 @@
 	dry()
 	add_blood_DNA(list("Non-human DNA" = random_blood_type()))
 	if(move_on_init)
-		pixel_x = rand(-16,16)
-		pixel_y = rand(-16, 16)
+		pixel_x = rand(-5,5)
+		pixel_y = rand(-5, 5)
 
 
 /obj/effect/decal/cleanable/blood/drip/can_bloodcrawl_in()

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -116,7 +116,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD) && !isgroundlessturf(src.loc))
-		add_splatter_floor(loc, (amt <= 10))
+		add_splatter_floor(loc, (amt <= 3))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -116,7 +116,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD) && !isgroundlessturf(src.loc))
-		add_splatter_floor(loc, (amt <= 3))
+		add_splatter_floor(loc, (amt <= 5))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -116,7 +116,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD) && !isgroundlessturf(src.loc))
-		add_splatter_floor(loc, (amt <= 5))
+		add_splatter_floor(loc, (amt <= 4))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -116,7 +116,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD) && !isgroundlessturf(src.loc))
-		add_splatter_floor(loc, (amt <= 4))
+		add_splatter_floor(loc, (amt <= 5))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -116,7 +116,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD) && !isgroundlessturf(src.loc))
-		add_splatter_floor(loc, (amt >= 10))
+		add_splatter_floor(loc, (amt <= 10))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod


### PR DESCRIPTION
## About The Pull Request
The code responsible for passive bleeding decals was making it so every passive bleed check that wasn't at least 10 blood lost was a big decal, rather than the other way around.

Brings the amount of bloodloss per tick required for big bleeding decals every tick to 5 from an intended 10 as that would be an insane amount of bloodloss w/ how wounds are currently tuned (initial flow rate of 1/2/3 moderate/severe/critical).

## Changelog

:cl:
fix: People will leave trails of blood droplets around again
fix: blood droplet decals will randomize position less.
/:cl:
