### PR TITLE
Fixes being unable to place certain tools inside crates or lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -279,7 +279,7 @@
 	return TRUE
 
 /obj/structure/closet/welder_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent == INTENT_HARM && !LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(user.a_intent == INTENT_HARM)
 		return FALSE
 	if(!tool.tool_start_check(user, amount=0))
 		return FALSE
@@ -310,7 +310,7 @@
 	return FALSE
 
 /obj/structure/closet/wirecutter_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(user.a_intent == INTENT_HARM)
 		return FALSE
 	if(tool.tool_behaviour != cutting_tool)
 		return FALSE
@@ -320,7 +320,7 @@
 	return TRUE
 
 /obj/structure/closet/wrench_act(mob/living/user, obj/item/tool, modifiers)
-	if(user.a_intent != INTENT_HELP && !LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(user.a_intent == INTENT_HARM)
 		return FALSE
 	if(!anchorable)
 		return FALSE
@@ -333,9 +333,12 @@
 		span_italics("You hear a ratchet."))
 	return TRUE
 
-/obj/structure/closet/tool_act(mob/living/user, obj/item/I, tool_type)
+/obj/structure/closet/tool_act(mob/living/user, obj/item/tool, tool_type, params)
 	if(user in src)
 		return FALSE
+	var/list/modifiers = params2list(params)
+	if(opened && !LAZYACCESS(modifiers, RIGHT_CLICK) && user.transferItemToLoc(tool, drop_location()))
+		return TRUE
 	return ..()
 
 /obj/structure/closet/deconstruct_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION
Minor oversight. If the crate/locker is open it now requires right-clicking for the tool's special interaction, making it possible to place the tool inside using left click.

:cl:
fix: Fixed being unable to place certain tools inside crates or lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
