### PR TITLE
FIX: Game Panel - Create Turf

### DIFF
--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -5,6 +5,6 @@
 		turfjs = jointext(typesof(/turf), ";")
 		create_turf_html = file2text('html/create_object.html')
 		create_turf_html = replacetext(create_turf_html, "Create Object", "Create Turf")
-		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
+		create_turf_html = replacetext(create_turf_html, "null; /* object types */", "\"[turfjs]\"")
 
 	user << browse(create_panel_helper(create_turf_html), "window=create_turf;size=425x475")


### PR DESCRIPTION
## About The Pull Request
Allows you to spawn turfs not through a build mod, but also through the game panel.

## Why It's Good For The Game
Missed `;` in code - Game Panel fix create turf
Admins can look up turfs and spawn them again for reasons
- Game Panel: https://github.com/CeladonSS13/Shiptest/pull/2562

## Testing
<details><summary>Screenshot</summary>
<img width="412" height="500" alt="image" src="https://github.com/user-attachments/assets/6e6b48dc-1071-4cbb-848f-ba96dd6c4ce4" />
</details>

## Changelog

:cl:
fix: Game panel create turf list
/:cl: