### PR TITLE
FIX: Priority passthrough solution

### DIFF
--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -60,12 +60,14 @@ const stealFocus = (node: HTMLElement) => {
   releaseStolenFocus();
   focusStolenBy = node;
   focusStolenBy.addEventListener('blur', releaseStolenFocus);
+  globalEvents.emit('input-focus');
 };
 
 const releaseStolenFocus = () => {
   if (focusStolenBy) {
     focusStolenBy.removeEventListener('blur', releaseStolenFocus);
     focusStolenBy = null;
+    globalEvents.emit('input-blur');
   }
 };
 
@@ -117,27 +119,47 @@ window.addEventListener('mousemove', (e) => {
 // Focus event hooks
 // --------------------------------------------------------
 
-window.addEventListener('focusin', (e) => {
-  lastVisitedNode = null;
-  focusedNode = e.target as HTMLElement;
+// Handle stealing focus for textbox elements
+document.addEventListener(
+  'focus',
+  (e) => {
+    // Window
+    if (!(e.target instanceof Element)) {
+      lastVisitedNode = null;
+      focusedNode = null;
+      return;
+    }
+    lastVisitedNode = null;
+    focusedNode = e.target as HTMLElement;
+    if (canStealFocus(e.target as HTMLElement)) {
+      stealFocus(e.target as HTMLElement);
+    }
+  },
+  true
+);
+
+// When we click on any element on the page, untrack the last
+// visited node.
+document.addEventListener(
+  'blur',
+  () => {
+    lastVisitedNode = null;
+  },
+  true
+);
+
+window.addEventListener('focus', () => {
   setWindowFocus(true);
-  if (canStealFocus(e.target as HTMLElement)) {
-    stealFocus(e.target as HTMLElement);
-    return;
-  }
 });
 
-window.addEventListener('focusout', (e) => {
-  lastVisitedNode = null;
-  setWindowFocus(false, true);
-});
-
+// If we blur any element, the window may have unfocused if we didn't
+// click on the background
 window.addEventListener('blur', (e) => {
   lastVisitedNode = null;
   setWindowFocus(false, true);
 });
 
-window.addEventListener('beforeunload', (e) => {
+window.addEventListener('close', () => {
   setWindowFocus(false);
 });
 

--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -185,6 +185,9 @@ export const setupHotKeys = () => {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
+  globalEvents.on('input-focus', () => {
+    releaseHeldKeys();
+  });
   globalEvents.on('key', (key: KeyEvent) => {
     for (const keyListener of keyListeners) {
       keyListener(key);


### PR DESCRIPTION
## About The Pull Request
> TGUI has a feature where it passes through hotkeys to the game. When the user clicks off of a window, the TGUI window needs to know that it should send a 'keyup' event to Byond, so that transfer can be passed over to Byond. If the TGUI window cannot correctly determine whether or not the user has it in focus, then the keyup command will not be sent to Byond, resulting in a stuck movement key.

> This PR refactors the logic for how TGUI windows determine if they are in focus. It now seperates the window focus, from an element such as a textbox stealing focus. It also stops using events that aren't fully supported in Javascript, as this change in behaviour is what results in the difference in behaviour between 515 and 516.

## Why It's Good For The Game
Sticky keys are really annoying and common.
- https://github.com/BeeStation/BeeStation-Hornet/pull/12834

## Changelog

:cl:
fix: Fixes movement keys being stuck
/:cl:
