### PR TITLE
makes the bluespace drive fluff machine dense and fixes a typo in its desc

### DIFF
--- a/code/modules/overmap/bluespace_drive.dm
+++ b/code/modules/overmap/bluespace_drive.dm
@@ -20,7 +20,7 @@
 	circuit = /obj/item/circuitboard/computer/shuttle
 	light_color = LIGHT_COLOR_CYAN
 	clicksound = null
-	density = TRUE //why was this not originally set
+	density = TRUE
 
 	/// The ship we reside on for ease of access
 	var/datum/overmap/ship/controlled/current_ship

--- a/code/modules/overmap/bluespace_drive.dm
+++ b/code/modules/overmap/bluespace_drive.dm
@@ -13,13 +13,14 @@
 
 /obj/machinery/bluespace_drive
 	name = "AU/W-class bluespace drive"
-	desc = "Amazing innovations after studying the solarian sun have now compacted the massive AU-class bluespace rooms of the past into barely a 2 meter big machine. This in turn, vastly reduced vessel sizes, resulitng in a new age of space travel across the cosmos... and here the miracle sits silently, gathering dust as you forgot to clean it last week."
+	desc = "Amazing innovations after studying the solarian sun have now compacted the massive AU-class bluespace rooms of the past into barely a 2 meter big machine. This in turn, vastly reduced vessel sizes, resulting in a new age of space travel across the cosmos... and here the miracle sits silently, gathering dust as you forgot to clean it last week."
 	icon = 'icons/obj/machines/bsdrive.dmi'
 	icon_state = "bsdrive_left"
 	var/icon_screen = "bsdrive_left_screen"
 	circuit = /obj/item/circuitboard/computer/shuttle
 	light_color = LIGHT_COLOR_CYAN
 	clicksound = null
+	density = TRUE //why was this not originally set
 
 	/// The ship we reside on for ease of access
 	var/datum/overmap/ship/controlled/current_ship


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #5689 
makes it dense and correctly-spelled

## Why It's Good For The Game

its a GIANT ASS MACHINE THE SIZE OF A THRUSTER. all the interior design featuring it assumes its dense and the lack of such is breaking my immersion (also spellcheck good)

## Changelog

:cl:
fix: Bluespace drive fluff machines are now dense
spellcheck: Corrected a typo in bluespace drive machine description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
