### PR TITLE
Set Next Outpost properly sets the next outpost

### DIFF
--- a/code/__DEFINES/overmap.dm
+++ b/code/__DEFINES/overmap.dm
@@ -81,7 +81,7 @@
 #define BURN_STOP -1
 
 // The filepath used to store the admin-controlled next round outpost map override.
-#define OUTPOST_OVERRIDE_FILEPATH "data/outpost_override.json"
+#define SAFEZONE_OVERRIDE_FILEPATH "data/safezone_override.json"
 
 // Converts ores to colors, meant for examining planets on the overmap
 #define ORES_TO_COLORS_LIST list(\

--- a/code/controllers/subsystem/overmap.dm
+++ b/code/controllers/subsystem/overmap.dm
@@ -20,8 +20,8 @@ SUBSYSTEM_DEF(overmap)
 	///List of all events
 	var/list/events = list()
 
-	/// The mandatory and default star system
-	var/datum/overmap_star_system/default_system
+	/// The primary star system that holds the outpost
+	var/datum/overmap_star_system/safe_system
 
 	/// The secondary star system that allows planet spawns
 	var/datum/overmap_star_system/wild_system
@@ -58,7 +58,17 @@ SUBSYSTEM_DEF(overmap)
 	events = list()
 
 	var/list/sector_types = pick(subtypesof(/datum/overmap_star_system/safezone))
-	default_system = create_new_star_system(new sector_types)
+
+	if(fexists(SAFEZONE_OVERRIDE_FILEPATH))
+		var/file_text = trim_right(file2text(SAFEZONE_OVERRIDE_FILEPATH)) // trim_right because there's often a trailing newline
+		var/datum/overmap_star_system/safezone/potential_type = text2path(file_text)
+		if(!potential_type || !ispath(potential_type, /datum/overmap_star_system/safezone))
+			stack_trace("SSovermap found an safezone override file at [SAFEZONE_OVERRIDE_FILEPATH], but was unable to find the system type [potential_type]!")
+		else
+			sector_types = potential_type
+		fdel(SAFEZONE_OVERRIDE_FILEPATH) // don't want it to affect 2 rounds in a row.
+
+	safe_system = create_new_star_system(new sector_types)
 	wild_system = create_new_star_system (new /datum/overmap_star_system/shiptest)
 	return ..()
 
@@ -530,15 +540,6 @@ SUBSYSTEM_DEF(overmap)
  */
 /datum/overmap_star_system/proc/spawn_outpost()
 	var/list/location = get_unused_overmap_square_in_radius(rand(4, round(size/5)))
-
-	if(fexists(OUTPOST_OVERRIDE_FILEPATH))
-		var/file_text = trim_right(file2text(OUTPOST_OVERRIDE_FILEPATH)) // trim_right because there's often a trailing newline
-		var/datum/overmap/outpost/potential_type = text2path(file_text)
-		if(!potential_type || !ispath(potential_type, /datum/overmap/outpost))
-			stack_trace("SSovermap found an outpost override file at [OUTPOST_OVERRIDE_FILEPATH], but was unable to find the outpost type [potential_type]!")
-		else
-			default_outpost_type = potential_type
-		fdel(OUTPOST_OVERRIDE_FILEPATH) // don't want it to affect 2 rounds in a row.
 
 	if(!default_outpost_type)
 		var/list/possible_types = subtypesof(/datum/overmap/outpost)
@@ -1063,7 +1064,7 @@ SUBSYSTEM_DEF(overmap)
 	else
 		datum_to_edit.token.add_filter("gloweffect", 5, list("type"="drop_shadow", "color"= "#808080", "size"=2, "offset"=1))
 
-/datum/overmap_star_system/safezone/ngr
+/datum/overmap_star_system/safezone/agni
 	name = "Gorlex Controlled - Value of Public Works"
 	starname = "Ecbatana"
 	startype = /datum/overmap/star/dwarf
@@ -1084,7 +1085,7 @@ SUBSYSTEM_DEF(overmap)
 	override_object_colors = TRUE
 	overmap_icon_state = "overmap_dark"
 
-/datum/overmap_star_system/safezone/clip
+/datum/overmap_star_system/safezone/arrowsong
 	name = "CLIP Controlled - High-Pier"
 	starname = "Chana"
 	startype = /datum/overmap/star/dwarf/orange
@@ -1126,7 +1127,7 @@ SUBSYSTEM_DEF(overmap)
 	override_object_colors = TRUE
 	overmap_icon_state = "overmap"
 
-/datum/overmap_star_system/safezone/nt
+/datum/overmap_star_system/safezone/yebiri
 	name = "Nanotrasen Controlled - Persei-277"
 	starname = "Persei-277"
 	startype = /datum/overmap/star/medium

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 			"\n",
 			"Current Outpost: [SSticker.round_start_timeofday ? SSovermap.get_main_outpost() : "The round hasn't started yet!"]",
-			"Outpost Location: [SSticker.round_start_timeofday ? "[SSovermap.get_main_outpost_coords()] - [SSovermap.default_system]" : "The round hasn't started yet!"]",
+			"Outpost Location: [SSticker.round_start_timeofday ? "[SSovermap.get_main_outpost_coords()] - [SSovermap.safe_system]" : "The round hasn't started yet!"]",
 			"Local Sector Time: [SSticker.round_start_timeofday ? "[station_time_timestamp()] [sector_datestamp()]" : "The round hasn't started yet!"]",
 			"\n",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",

--- a/code/modules/admin/verbs/outpost.dm
+++ b/code/modules/admin/verbs/outpost.dm
@@ -1,18 +1,20 @@
 /client/proc/set_next_outpost()
 	set category = "Server"
-	set name = "Set Next Outpost"
+	set name = "Set Next Outpost System"
 
-	var/list/choices = subtypesof(/datum/overmap/outpost)
-	var/chosen = input("Select the outpost type to use next. Some outposts may not be intended for regular play!", "Select Outpost") as null|anything in choices
-	if(!chosen || !ispath(chosen, /datum/overmap/outpost))
+	var/list/choices = subtypesof(/datum/overmap_star_system/safezone)
+	var/chosen = input("Select the main system to use next round. Some systems may not be intended for regular play!", \
+		"Select Outpost" \
+	) as null|anything in choices
+	if(!chosen || !ispath(chosen, /datum/overmap_star_system/safezone))
 		return
 
 	message_admins("[key_name_admin(usr)] is changing the outpost to [chosen]")
 	log_admin("[key_name(usr)] is changing the outpost to [chosen]")
 
-	if(fexists(OUTPOST_OVERRIDE_FILEPATH))
-		fdel(OUTPOST_OVERRIDE_FILEPATH)
-	var/result = text2file("[chosen]", OUTPOST_OVERRIDE_FILEPATH)
+	if(fexists(SAFEZONE_OVERRIDE_FILEPATH))
+		fdel(SAFEZONE_OVERRIDE_FILEPATH)
+	var/result = text2file("[chosen]", SAFEZONE_OVERRIDE_FILEPATH)
 
 	if(result)
 		message_admins("[key_name_admin(usr)] has changed the outpost to [chosen]")

--- a/code/modules/antagonists/ert/_helpers.dm
+++ b/code/modules/antagonists/ert/_helpers.dm
@@ -38,7 +38,7 @@
 				spawn_location = SSovermap.outposts[1]
 
 		if(!spawn_location)
-			spawn_location = SSovermap.default_system.get_unused_overmap_square()
+			spawn_location = SSovermap.safe_system.get_unused_overmap_square()
 
 		var/datum/overmap/ship/controlled/ship = new(spawn_location, template)
 

--- a/code/modules/overmap/_overmap_datum.dm
+++ b/code/modules/overmap/_overmap_datum.dm
@@ -78,7 +78,7 @@
 		current_overmap = docked_object.current_overmap
 
 	if(!current_overmap)
-		current_overmap = SSovermap.default_system
+		current_overmap = SSovermap.safe_system
 		stack_trace("[src.name] has no overmap on load!! This is very bad!! Set the object's overmap to the default overmap of the round!!")
 	current_overmap.overmap_objects |= src
 	SSovermap.overmap_objects |= src
@@ -177,7 +177,7 @@
 	if(new_x == x && new_y == y)
 		return
 	if(!current_overmap)
-		current_overmap = SSovermap.default_system
+		current_overmap = SSovermap.safe_system
 		CRASH("Overmap datum [src] tried to move() with no valid overmap! What?? Moving to the default sector of SSovermap as a failsafe!")
 	new_x %= current_overmap.size
 	new_y %= current_overmap.size
@@ -681,10 +681,10 @@
  */
 /datum/overmap/proc/fsck()
 	//set the current overmap to the default one. If theres no default overmap shit is truly fucked
-	if(!SSovermap.default_system)
+	if(!SSovermap.safe_system)
 		message_admins(span_userdanger("There is no default overmap set. Consider restarting the round."))
 		CRASH("There is no default overmap set. Consider restarting the round.")
-	current_overmap = SSovermap.default_system
+	current_overmap = SSovermap.safe_system
 
 	//reset all docking timers
 	dock_time = null

--- a/code/modules/unit_tests/overmap.dm
+++ b/code/modules/unit_tests/overmap.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/overmap_move/Run()
-	var/datum/overmap/ship/S = new(list("x" = 1, "y" = 1), SSovermap.default_system)
+	var/datum/overmap/ship/S = new(list("x" = 1, "y" = 1), SSovermap.safe_system)
 
 	S.change_heading(NORTHEAST)
 	S.process(1)
@@ -19,8 +19,8 @@
 	TEST_ASSERT(S.is_still(), "Ship did not stop after burning engines")
 
 /datum/unit_test/overmap_dock/Run()
-	var/datum/overmap/ship/controlled/docker = new(list("x" = 1, "y" = 1), SSovermap.default_system, SSmapping.ship_purchase_list[pick(SSmapping.ship_purchase_list)]) //TODO: debug ship instead of picking random ship
-	var/datum/overmap/dynamic/empty/dockee = new(list("x" = 1, "y" = 1), SSovermap.default_system)
+	var/datum/overmap/ship/controlled/docker = new(list("x" = 1, "y" = 1), SSovermap.safe_system, SSmapping.ship_purchase_list[pick(SSmapping.ship_purchase_list)]) //TODO: debug ship instead of picking random ship
+	var/datum/overmap/dynamic/empty/dockee = new(list("x" = 1, "y" = 1), SSovermap.safe_system)
 
 	docker.dock_time = 0
 

--- a/code/modules/unit_tests/ruin_placement.dm
+++ b/code/modules/unit_tests/ruin_placement.dm
@@ -8,7 +8,7 @@
 	populate_turfs = FALSE
 
 /datum/unit_test/ruin_placement/Run()
-	var/datum/overmap_star_system/dummy_system = SSovermap.default_system
+	var/datum/overmap_star_system/dummy_system = SSovermap.safe_system
 	dummy_system.name = "Ruin Test: Dummy System"
 	for(var/planet_name as anything in SSmapping.planet_types)
 		var/datum/planet_type/planet_type = SSmapping.planet_types[planet_name]

--- a/code/modules/unit_tests/ship_placement.dm
+++ b/code/modules/unit_tests/ship_placement.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/ship_placement/Run()
-	var/datum/overmap/outpost/test_outpost = new /datum/overmap/outpost/no_main_level(system_spawned_in = SSovermap.default_system)
+	var/datum/overmap/outpost/test_outpost = new /datum/overmap/outpost/no_main_level(system_spawned_in = SSovermap.safe_system)
 
 	// checks all shuttle templates, including those
 	// disabled or intended as subshuttles
@@ -11,7 +11,7 @@
 			var/subtimer = REALTIMEOFDAY
 
 			// they'll spawn in empty space, and won't be docked
-			var/datum/overmap/ship/controlled/cur_ship = new /datum/overmap/ship/controlled(list("x" = 1, "y" = 1), SSovermap.default_system, map)
+			var/datum/overmap/ship/controlled/cur_ship = new /datum/overmap/ship/controlled(list("x" = 1, "y" = 1), SSovermap.safe_system, map)
 
 			log_test(" - Loading took [(REALTIMEOFDAY - subtimer) / 10]s")
 			subtimer = REALTIMEOFDAY


### PR DESCRIPTION

## About The Pull Request
Moves the logic for forced outposts up one level to forced systems, so that outposts are (unless adminspawned in round) in their canonical systems

## Changelog

:cl:
admin: Set Next Outpost has been renamed to Set Next Outpost System, and now stores an entire system to force the right outpost to spawn in the right system
/:cl: