### PR TITLE
Blacklists IPCs from a few quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -32,7 +32,13 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Trilingual", "Monolingual"),
 	)
 
-	species_blacklist = list("Blood Deficiency" = list(SPECIES_IPC, SPECIES_JELLYPERSON, SPECIES_PLASMAMAN, SPECIES_VAMPIRE))
+	species_blacklist = list(
+		"Blood Deficiency" = list(SPECIES_IPC, SPECIES_JELLYPERSON, SPECIES_PLASMAMAN, SPECIES_VAMPIRE),
+		"Alcohol Tolerance" = list(SPECIES_IPC, SPECIES_PLASMAMAN),
+		"Light Drinker" = list(SPECIES_IPC, SPECIES_PLASMAMAN),
+		"Smoker" = list(SPECIES_IPC, SPECIES_PLASMAMAN),
+		"Asthma" = list(SPECIES_IPC, SPECIES_PLASMAMAN)
+	)
 
 	for(var/client/client in GLOB.clients)
 		client?.prefs.check_quirk_compatibility()


### PR DESCRIPTION
## About The Pull Request
IPCs can no longer take alcohol tolerance/light drinker, smoker, or asthma quirks

## Changelog

:cl:
fix: IPCs can no longer take alcohol tolerance/light drinker, smoker, or asthma quirks
/:cl:

