### PR TITLE
Fixes Sushi Slicing

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -164,7 +164,7 @@
 	tastes = list("boiled rice" = 4, "fish" = 2, "spicyness" = 2)
 	foodtypes = VEGETABLES | MEAT
 
-/obj/item/food/vegetariansushiroll/make_processable()
+/obj/item/food/spicyfiletsushiroll/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/spicyfiletsushislice, 4, 30, table_required = TRUE)
 
 /obj/item/food/spicyfiletsushislice


### PR DESCRIPTION
## About The Pull Request

Lets you slice sushi into the correct types instead of all sushi becoming spicy or not being slicable at all

## Changelog

:cl:
fix: fixed pathing errors in sushi slicing
/:cl: