### PR TITLE
Maintains buckling on the elevator

### DIFF
--- a/code/modules/overmap/objects/outpost/elevator/elevator_platform.dm
+++ b/code/modules/overmap/objects/outpost/elevator/elevator_platform.dm
@@ -134,4 +134,12 @@
 		if(QDELETED(thing)) // if we let nulls stick around they fuck EVERYTHING
 			lift_load -= thing
 			continue
+		if(istype(thing, /mob/living/carbon))
+			var/mob/living/carbon/buckled_mob = thing
+			if(buckled_mob.buckled)
+				var/obj/temp_buckling_item = buckled_mob.buckled
+				temp_buckling_item.forceMove(destination)
+				thing.forceMove(destination)
+				temp_buckling_item.buckle_mob(thing, TRUE, FALSE)
+				continue
 		thing.forceMove(destination)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that people in seats, wheelchairs, gurneys, or other buckleable moveables stay buckled when moving between floors

## Why It's Good For The Game

I figure this is a small little quality of life addition so that one doesn't need to keep rebuckling things between floors

## Changelog

:cl:
fix: fixed buckling between floors on an elevator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
