### PR TITLE
Alphabetically sorts the orbit menu

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
@@ -25,16 +25,16 @@ export const OrbitContent = (props, context) => {
 
   const sections: readonly ContentSection[] = [
     {
-      content: data.alive,
+      content: data.alive.sort((a, b) => a.name.localeCompare(b.name)),
       title: 'Alive',
       color: 'good',
     },
     {
-      content: data.dead,
+      content: data.dead.sort((a, b) => a.name.localeCompare(b.name)),
       title: 'Dead',
     },
     {
-      content: data.ghosts,
+      content: data.ghosts.sort((a, b) => a.name.localeCompare(b.name)),
       title: 'Ghosts',
     },
     {

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -19,6 +19,7 @@ export type OrbitData = {
 
 export type Observable = {
   full_name: string;
+  name: string;
   ref: string;
   // Optionals
 } & Partial<{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that the orbit menu for alive, dead, and ghost players is sorted alphabetically, as shown in the following screenshot:

<img width="323" height="147" alt="image" src="https://github.com/user-attachments/assets/e803f956-e0f9-408a-905b-b0b3c1e7a9b9" />


## Why It's Good For The Game

The current orbit menu is not sorted at all, and it can be a little difficult to quickly select someone to orbit without specifically searching for them. This should fix that issue.

## Changelog

:cl:
add: Adds sorting to the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
