### PR TITLE
Re-enables verbose health scanning for observers

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -61,7 +61,7 @@
 
 /mob/living/attack_ghost(mob/dead/observer/user)
 	if(user.client && user.health_scan)
-		healthscan(user, src, 0, TRUE, TRUE)
+		healthscan(user, src, 2, TRUE, TRUE)
 	if(user.client && user.chem_scan)
 		chemscan(user, src)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Verbose health scanning seemed to have been cut for observers, and this PR should fix that.

<img width="466" height="465" alt="image" src="https://github.com/user-attachments/assets/ba38b366-dd06-4b42-be71-cd04b8401c5e" />


## Why It's Good For The Game

It can be nice to see the precise health values that someone might have if you're observing them -- it's not super important, but I like having it as an option

## Changelog

:cl:
balance: readds verbose health scanning for observers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
