### PR TITLE
Earworn Ribbon Alt-Click

### DIFF
--- a/code/modules/clothing/head/ribbon.dm
+++ b/code/modules/clothing/head/ribbon.dm
@@ -5,6 +5,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/head/color.dmi'
 	icon_state = "ribbonblack"
 	item_state = "ribbonblack"
+	alternate_worn_layer = BODY_FRONT_LAYER
 	supports_variations = KEPORI_VARIATION | VOX_VARIATION
 	unique_reskin = list(
 		"white ribbon" = "ribbonwhite",
@@ -17,6 +18,15 @@
 		"brown ribbon" = "ribbonbrown",
 	)
 	unique_reskin_changes_name = TRUE
+
+/obj/item/clothing/head/ribbon/AltClick(mob/user)
+	. = ..()
+	if(slot_flags == ITEM_SLOT_HEAD)
+		slot_flags = ITEM_SLOT_EARS
+		to_chat(user, span_notice("You adjust [src] to fit on your ear"))
+	else
+		slot_flags = ITEM_SLOT_HEAD
+		to_chat(user, span_notice("You adjust [src] to fit on your head"))
 
 /obj/item/clothing/head/ribbon/white
 	name = "white ribbon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can alt click ribbons to make them wearable on the ears
Also increases their layer so they layer over mutant ears (and most other things)
We deserve to live in this world 
![dreamseeker_Iad0eIySgq](https://github.com/user-attachments/assets/9cb69023-3ced-4f7d-99aa-f17ed1855d73)
![dreamseeker_W5OeE1IzbT](https://github.com/user-attachments/assets/b98a55e9-4c6a-4f0e-bef6-492d0c74570d)

## Changelog

:cl:
add: You can now alt-click ribbons to wear them on your ears
/:cl:
