### PR TITLE
Schnauzer inherits m20 price increase

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -125,7 +125,7 @@
 /datum/supply_pack/gun/podium_inteq
 	name = "P46 Schnauzer"
 	desc = "Contains a compact armor-piercing sidearm, chambered in 4.6mm."
-	cost = 1250
+	cost = 1500
 	contains = list(/obj/item/storage/guncase/pistol/podium_inteq)
 	faction = /datum/faction/inteq
 	faction_discount = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

didn't read ytheir own code award

## Why It's Good For The Game

forgot cargo crates don't do inheritance stuff

## Changelog

:cl:
fix: schnauzer is 1500 credits (it's the m20 painted brown)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
