### PR TITLE
Reduces the layer of lights so that characters don't render under lights anymore

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -48,7 +48,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-stage1"
 	anchored = TRUE
-	layer = WALL_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	max_integrity = 200
 	armor = list("melee" = 50, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)
 
@@ -210,7 +210,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/light_construct/small, 28)
 	var/base_state = "tube"		// base description and icon_state
 	icon_state = "tube-on"
 	desc = "A lighting fixture."
-	layer = WALL_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	max_integrity = 100
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The layer of light fixtures was reduced to be equal to the same layer as APCs -- I don't envision any problems from this, and I didn't see any visual errors in my limited testing, but I could very easily be wrong

## Why It's Good For The Game

It always felt a little silly for light fixtures to render over a character, and this PR should fix that.

## Changelog

:cl:
fix: fixed characters layering under lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
