### PR TITLE
Fixes fire bypassing all fire protection

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -1101,5 +1101,5 @@
 	burn_clothing(delta_time, times_fired, fire_handler.stacks)
 	var/no_protection = FALSE
 	if(dna && dna.species)
-		no_protection = dna.species.handle_fire(src, delta_time, times_fired, no_protection)
+		no_protection = dna.species.handle_fire(src, no_protection)
 	fire_handler.harm_human(delta_time, times_fired, no_protection)


### PR DESCRIPTION
`handle_fire` only takes two arguments, `delta_time` was being passed into `no_protection` by mistake and causing it to always bypass all fire protection.

:cl:
fix: Fixed fire bypassing all fire protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
