### PR TITLE
Equalizes price of Hardliner X-11 variants

### DIFF
--- a/code/modules/cargo/packs/armor.dm
+++ b/code/modules/cargo/packs/armor.dm
@@ -119,7 +119,7 @@
 
 /datum/supply_pack/armor/hardliner_armor
 	name = "Hardliner Armor Crate"
-	desc = "One set of well-rounded hardliner body armor. Well. Rounded aside from the painfully obvious white. Subsidized by Cybersun Biodynamics."
+	desc = "One set of well-rounded Hardliner body armor. Well. Rounded aside from the painfully obvious white. Subsidized by Cybersun Industries."
 	cost = 500
 	contains = list(/obj/item/clothing/suit/armor/hardliners,
 					/obj/item/clothing/head/helmet/hardliners)
@@ -132,7 +132,7 @@
 /datum/supply_pack/armor/hardliner_mecha_armor
 	name = "Hardliner Pilot Armor Crate"
 	desc = "One set of armor manufactured for Hardliner exosuit pilots. The jacket is often sought out by those outside of it as a keepsake."
-	cost = 1500
+	cost = 500
 	contains = list(/obj/item/clothing/suit/armor/hardliners/jacket,
 					/obj/item/clothing/head/helmet/hardliners/swat)
 	crate_name = "armor crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Hardliner X-11 Armor set and the Hardliner Pilot Armor set, it turns out, are identical in terms of stats and limb coverage, with the only differences being cosmetic. Despite this, the Pilot Armor set is three times higher than that of the normal X-11 set. This PR reduces the price of the Pilot Armor set to be equal to the normal X-11 Armor set.

## Why It's Good For The Game

Removes an unnecessary price difference between two sets of statistically and functionally identical gear available to Hardliner players.

## Changelog

:cl:
balance: Lowered the price of the Hardliner Pilot Armor Crate from 1500 credits to 500 credits.
spellcheck: Capitalized an uncapitalized letter in the description of the X-11 Armors set, and changed the reference to Cybersun Biodynamics to a reference to Cybersun Industries.
/:cl:
