### PR TITLE
gives the shredder actual armor

### DIFF
--- a/code/modules/mob/living/simple_animal/corpse_spawners/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/corpse_spawners/frontiersman.dm
@@ -105,7 +105,7 @@
 
 /datum/outfit/frontier/trooper/heavy
 	name = "Frontiersman Heavy Corpse"
-	suit = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
+	suit = /obj/item/clothing/suit/armor/vest/marine/frontier
 	head = /obj/item/clothing/head/beret/sec/frontier/officer
 
 /obj/effect/mob_spawn/human/corpse/frontier/ranged/trooper/heavy/internals

--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -437,7 +437,7 @@
 	casingtype = /obj/item/ammo_casing/shotgun
 	r_hand = /obj/item/gun/ballistic/automatic/hmg/shredder
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/ranged/trooper/heavy
-	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
+	armor_base = /obj/item/clothing/suit/armor/vest/marine/frontier
 
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/space
 	icon_state = "frontiersmanranged_mask"


### PR DESCRIPTION

## About The Pull Request
Makes it so the shredder simplemob wears and has the armor base of the frontiersmen tactical armor instead of their hardsuit, which only has 2 bullet resistance iirc.
## Why It's Good For The Game
the guy carrying the big gun shouldnt be dying to one candor mag
might not be worth adding. -->

## Changelog

:cl:
balance: gives the frontiersmen shredder enemy actual armor
/:cl:

