### PR TITLE
Reverts alphabetical orbit menu sorting

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
@@ -25,16 +25,16 @@ export const OrbitContent = (props, context) => {
 
   const sections: readonly ContentSection[] = [
     {
-      content: data.alive.sort((a, b) => a.name.localeCompare(b.name)),
+      content: data.alive,
       title: 'Alive',
       color: 'good',
     },
     {
-      content: data.dead.sort((a, b) => a.name.localeCompare(b.name)),
+      content: data.dead,
       title: 'Dead',
     },
     {
-      content: data.ghosts.sort((a, b) => a.name.localeCompare(b.name)),
+      content: data.ghosts,
       title: 'Ghosts',
     },
     {

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -19,7 +19,6 @@ export type OrbitData = {
 
 export type Observable = {
   full_name: string;
-  name: string;
   ref: string;
   // Optionals
 } & Partial<{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts alphabetical orbit menu sorting

## Why It's Good For The Game

The previous PR broke the orbit menu on the server and I haven't been able to understand what might be happening to cause it -- this PR should resolve the issue, at least

## Changelog

:cl:
fix: fixed the orbit menu breaking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
