### PR TITLE
deadchat mute button

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -10,6 +10,7 @@ GLOBAL_VAR_INIT(hub_visibility, FALSE)
 
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
+GLOBAL_VAR_INIT(deadchat_allowed, TRUE)
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(shuttle_frozen, FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -588,7 +588,7 @@
 	toggle_deadchat()
 	log_admin("[key_name(usr)] toggled deadchat.")
 	message_admins("[key_name_admin(usr)] toggled deadchat.")
-	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Local OOC", "[GLOB.deadchat_allowed ? "Enabled" : "Disabled"]"))
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead Chat", "[GLOB.deadchat_allowed ? "Enabled" : "Disabled"]"))
 
 /datum/admins/proc/toggleoocdead()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -581,6 +581,15 @@
 	message_admins("[key_name_admin(usr)] toggled LOOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Local OOC", "[GLOB.looc_allowed ? "Enabled" : "Disabled"]"))
 
+/datum/admins/proc/toggledeadchat()
+	set category = "Server"
+	set desc="Toggle dat bitch"
+	set name="Toggle Deadchat"
+	toggle_deadchat()
+	log_admin("[key_name(usr)] toggled deadchat.")
+	message_admins("[key_name_admin(usr)] toggled deadchat.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Local OOC", "[GLOB.deadchat_allowed ? "Enabled" : "Disabled"]"))
+
 /datum/admins/proc/toggleoocdead()
 	set category = "Server"
 	set desc="Toggle dis bitch"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -43,6 +43,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleooclocal,	/*toggles looc on/off for everyone*/
+	/datum/admins/proc/toggledeadchat,	/*toggles deadchat on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/
 	/client/proc/toggle_ship_spawn, /* toggles players spawning ships via the join menu / shuttle creators */

--- a/code/modules/client/verbs/deadchat.dm
+++ b/code/modules/client/verbs/deadchat.dm
@@ -1,0 +1,6 @@
+/proc/toggle_deadchat(toggle = null)
+	if(toggle == null)
+		GLOB.deadchat_allowed = !GLOB.deadchat_allowed
+		return
+	if(toggle != GLOB.deadchat_allowed)
+		GLOB.deadchat_allowed = toggle

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -54,7 +54,7 @@
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	if(!GLOB.deadchat_allowed && !holder)
+	if(!GLOB.deadchat_allowed && !client.holder)
 		to_chat(usr, span_danger("Deadchat is currently muted."))
 		return
 

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -54,6 +54,10 @@
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
+	if(!GLOB.deadchat_allowed && !holder)
+		to_chat(usr, span_danger("Deadchat is currently muted."))
+		return
+
 	var/jb = is_banned_from(ckey, "Deadchat")
 	if(QDELETED(src))
 		return

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -2198,6 +2198,7 @@
 #include "code\modules\client\loadout\loadout_suit.dm"
 #include "code\modules\client\loadout\loadout_uniform.dm"
 #include "code\modules\client\preferences\fov_darkness.dm"
+#include "code\modules\client\verbs\deadchat.dm"
 #include "code\modules\client\verbs\etips.dm"
 #include "code\modules\client\verbs\looc.dm"
 #include "code\modules\client\verbs\ooc.dm"


### PR DESCRIPTION
## About The Pull Request

admins can now mute deadchat

## Changelog

:cl:
admin: admins can now mute deadchat with 'toggle-deadchat'
/:cl: