### PR TITLE
Dwayne-remap

### DIFF
--- a/_maps/configs/independent_mkii_dwayne.json
+++ b/_maps/configs/independent_mkii_dwayne.json
@@ -43,7 +43,7 @@
 		},
 		"Deckhand": {
 			"outfit": "/datum/outfit/job/independent/assistant",
-			"slots": 1
+			"slots": 2
 		}
 	},
 	"enabled": true

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -178,8 +178,8 @@
 /area/ship/cargo/port)
 "bR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/turf_decal/borderfloor{
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -847,12 +847,17 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
 "iY" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm/captain)
+/obj/structure/sink/kitchen{
+	dir = 1;
+	pixel_x = 16;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
 "iZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2501,8 +2506,8 @@
 /area/ship/crew/toilet)
 "xo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/siding/thinplating{
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -4173,6 +4178,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm/captain)
 "LM" = (
@@ -4496,18 +4505,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/atmospherics)
-"Oc" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/obj/structure/sink/kitchen{
-	dir = 1;
-	pixel_x = 16;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
 "On" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 4
@@ -5981,7 +5978,7 @@ iu
 Fi
 MG
 JB
-xo
+bR
 fN
 QG
 Ny
@@ -6271,7 +6268,7 @@ Dv
 Pl
 Ex
 tQ
-Oc
+iY
 ck
 OX
 Wa
@@ -6361,7 +6358,7 @@ vw
 Pl
 FN
 Mz
-bR
+xo
 gx
 zb
 Xw
@@ -6383,7 +6380,7 @@ XC
 hB
 Jx
 BX
-iY
+vi
 vi
 AC
 vi

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -252,6 +252,10 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "dh" = (
@@ -2792,6 +2796,30 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/warning,
+/obj/structure/closet/crate/internals{
+	name = "surplus EVA crate"
+	},
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/effect/mapping_helpers/crate_shelve,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Ak" = (
@@ -3956,6 +3984,10 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Lo" = (
@@ -4305,37 +4337,52 @@
 /turf/open/floor/plating,
 /area/ship/cargo/starboard)
 "NQ" = (
+/obj/structure/closet/crate/science{
+	name = "mining crate"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
 /obj/item/clothing/under/rank/cargo/miner/hazard{
 	pixel_x = 11;
-	pixel_y = 2
+	pixel_y = 4
 	},
 /obj/item/clothing/under/rank/cargo/miner/hazard{
 	pixel_x = 11;
-	pixel_y = -1
+	pixel_y = 1
 	},
 /obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = -2
+	},
+/obj/item/radio/weather_monitor{
 	pixel_x = -1;
-	pixel_y = 2
+	pixel_y = 0
 	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
+/obj/item/radio/weather_monitor{
 	pixel_x = -1;
-	pixel_y = -1
+	pixel_y = -2
 	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
+/obj/item/radio/weather_monitor{
+	pixel_x = -1;
+	pixel_y = -4
 	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
+/obj/item/mining_scanner{
+	pixel_x = 9;
+	pixel_y = 0
 	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
+/obj/item/mining_scanner{
+	pixel_x = 9;
+	pixel_y = -2
 	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
+/obj/item/mining_scanner{
+	pixel_x = 9;
+	pixel_y = -4
 	},
 /obj/item/clothing/head/hardhat/mining{
 	pixel_x = -11;
@@ -4349,30 +4396,18 @@
 	pixel_x = -11;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = 7
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
 	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = 1
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
 	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
 	},
-/obj/structure/closet/crate/science{
-	name = "mining crate"
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/structure/crate_shelf,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/effect/turf_decal/box/corners,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "NW" = (
@@ -4635,6 +4670,10 @@
 	},
 /obj/structure/railing/thin{
 	dir = 4
+	},
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = -7
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -354,12 +354,6 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
-"ec" = (
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "eg" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/can/food/beans,
@@ -1185,6 +1179,19 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/crew/canteen)
+"lT" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "lU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
 	dir = 9
@@ -2701,6 +2708,12 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"yC" = (
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "yD" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -2747,19 +2760,6 @@
 	pixel_x = -11;
 	pixel_y = 29
 	},
-/obj/structure/rack,
-/obj/item/towel{
-	pixel_y = -5;
-	pixel_x = -5
-	},
-/obj/item/towel{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/soap/nanotrasen{
-	pixel_y = -1;
-	pixel_x = -3
-	},
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/button/door{
 	pixel_y = -10;
@@ -2769,6 +2769,19 @@
 	name = "Bathroom Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
+	},
+/obj/structure/table,
+/obj/item/towel{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/towel{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/soap/nanotrasen{
+	pixel_y = -1;
+	pixel_x = -3
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
@@ -4780,19 +4793,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
-"Qu" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/caution/red,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "QG" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 2;
@@ -6162,7 +6162,7 @@ Dv
 (18,1,1) = {"
 Dv
 AB
-Qu
+lT
 kV
 kV
 TR
@@ -6464,7 +6464,7 @@ eq
 Pl
 aX
 RV
-ec
+yC
 vi
 HB
 Op

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -9,13 +9,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/atmospherics)
 "am" = (
-/obj/machinery/griddle,
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "aq" = (
@@ -177,12 +177,13 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "bR" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned,
+/area/ship/hallway/central)
 "bW" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -846,15 +847,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
 "iY" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm/captain)
 "iZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1487,7 +1485,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "oa" = (
 /obj/effect/turf_decal/solarpanel,
@@ -2091,11 +2089,21 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tD" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_y = 12;
+	pixel_x = 0
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = -5;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "tG" = (
@@ -2117,24 +2125,32 @@
 /area/ship/storage/equip)
 "tI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/coffeemaker{
-	pixel_y = 14;
-	pixel_x = -4
-	},
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = 2;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
 /obj/structure/sign/poster/retro/radio{
 	desc = "A poster advertising one of Nanotrasen's earliest products, a radio. One of its main selling points was a integrated OS and two way automatic translation for Solarian Common and Gezenan, which made it a smash hit. This thing is ancient.";
 	pixel_x = -28
+	},
+/obj/item/cutting_board{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 10;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -10;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -2485,8 +2501,8 @@
 /area/ship/crew/toilet)
 "xo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/turf_decal/borderfloor{
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -3275,33 +3291,10 @@
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "Ex" = (
-/obj/structure/table/reinforced,
-/obj/structure/sink/kitchen{
-	pixel_y = 21;
-	layer = 2.79;
-	dir = 2
-	},
-/obj/item/cutting_board{
-	pixel_y = 2;
-	pixel_x = 1
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 4
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 7;
-	pixel_x = -15
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -15;
-	pixel_y = 0
-	},
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "EE" = (
@@ -4503,6 +4496,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/atmospherics)
+"Oc" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/structure/sink/kitchen{
+	dir = 1;
+	pixel_x = 16;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
 "On" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 4
@@ -4810,7 +4815,7 @@
 /obj/structure/table/wood/poker{
 	name = "billiards table"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "Rm" = (
 /obj/machinery/shower{
@@ -4847,7 +4852,7 @@
 	pixel_y = 4;
 	pixel_x = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "RS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
@@ -5049,14 +5054,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
-"Ti" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/hallway/central)
 "Tl" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -5292,7 +5289,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "Wa" = (
 /obj/machinery/door/firedoor/border_only,
@@ -5984,7 +5981,7 @@ iu
 Fi
 MG
 JB
-Ti
+xo
 fN
 QG
 Ny
@@ -6274,7 +6271,7 @@ Dv
 Pl
 Ex
 tQ
-xh
+Oc
 ck
 OX
 Wa
@@ -6295,7 +6292,7 @@ Dv
 ir
 am
 tQ
-iY
+xh
 ck
 qg
 Pl
@@ -6364,7 +6361,7 @@ vw
 Pl
 FN
 Mz
-xo
+bR
 gx
 zb
 Xw
@@ -6386,7 +6383,7 @@ XC
 hB
 Jx
 BX
-bR
+iY
 vi
 AC
 vi

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -215,7 +215,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
 	},
@@ -228,6 +227,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "cw" = (
@@ -252,7 +252,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "dh" = (
 /obj/machinery/light/small/directional/south,
@@ -317,24 +317,15 @@
 /turf/open/floor/noslip,
 /area/ship/cargo/port)
 "ea" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/caution/red,
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "eg" = (
@@ -342,14 +333,14 @@
 /obj/item/trash/can/food/beans,
 /obj/item/trash/sosjerky,
 /obj/item/trash/candy,
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -435,9 +426,6 @@
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light_switch{
 	dir = 8;
@@ -447,7 +435,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "fr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -497,9 +488,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "fU" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/chair/handrail{
 	dir = 4
@@ -572,7 +560,7 @@
 	pixel_x = -8;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
@@ -658,9 +646,6 @@
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "hQ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "dwayne_port";
 	name = "Port Blast Doors";
@@ -678,10 +663,10 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "hZ" = (
@@ -746,9 +731,6 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "iu" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 2
-	},
 /obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
@@ -807,8 +789,15 @@
 	pixel_x = -9;
 	pixel_y = -11
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/corner,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "iR" = (
 /obj/effect/turf_decal/siding/wood,
@@ -998,11 +987,14 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
 "ku" = (
-/obj/effect/turf_decal/ntspaceworks_small/right{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/ntspaceworks_small/right{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
@@ -1036,19 +1028,7 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "kV" = (
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "lb" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1399,9 +1379,6 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "nB" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_y = 0;
@@ -1409,14 +1386,13 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "nG" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
 	},
@@ -1426,6 +1402,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "nR" = (
@@ -1434,7 +1411,6 @@
 	id = "dwayne_starboard_field";
 	locked = 1
 	},
-/obj/structure/cable/cyan,
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable/cyan{
@@ -1673,25 +1649,33 @@
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
 "qm" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "qp" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030
+	},
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "qq" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -1880,6 +1864,9 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "rQ" = (
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
 /obj/effect/turf_decal/ntspaceworks_small/left{
 	dir = 1
 	},
@@ -1943,9 +1930,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "ss" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 6
 	},
@@ -1972,7 +1956,14 @@
 /obj/structure/railing/thin/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030;
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "sD" = (
 /obj/machinery/light/directional/south,
@@ -2069,7 +2060,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "tI" = (
 /obj/structure/table/reinforced,
@@ -2155,12 +2146,10 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Starboard Hangar"
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/starboard)
 "uh" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/chair/handrail{
 	dir = 4
@@ -2177,17 +2166,19 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "uk" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "uq" = (
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
@@ -2217,12 +2208,9 @@
 /obj/structure/railing/thin{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "uK" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 4
 	},
@@ -2249,32 +2237,28 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Port Hangar"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/port)
 "vm" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
 	},
 /obj/effect/turf_decal/industrial/caution/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "vs" = (
@@ -2352,13 +2336,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo/starboard)
 "vP" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -2431,9 +2415,6 @@
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "xd" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
 	dir = 8
@@ -2443,6 +2424,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -2562,10 +2546,13 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "xZ" = (
-/obj/effect/turf_decal/ntspaceworks_small/left,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/ntspaceworks_small/left,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "yb" = (
@@ -2584,17 +2571,27 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "yp" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/structure/railing/thin/corner{
 	dir = 1
 	},
 /obj/structure/railing/thin/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "yq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2782,7 +2779,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage/equip)
 "zP" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
@@ -2795,7 +2791,7 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Ak" = (
@@ -2816,9 +2812,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "Am" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 4
 	},
@@ -2997,15 +2990,12 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Co" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
@@ -3135,18 +3125,18 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/ntspaceworks_small,
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/ntspaceworks_small,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "DT" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
@@ -3155,15 +3145,12 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Ee" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
 	dir = 4
@@ -3171,10 +3158,10 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/industrial/warning/corner,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Ep" = (
@@ -3250,17 +3237,27 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "EG" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/structure/railing/thin/corner{
 	dir = 4
 	},
 /obj/structure/railing/thin/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "EV" = (
 /obj/effect/turf_decal/box/corners{
@@ -3345,8 +3342,11 @@
 	pixel_x = -9;
 	pixel_y = -11
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/black/line{
+	layer = 2.030
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Fj" = (
 /obj/effect/turf_decal/industrial/outline/blue,
@@ -3428,9 +3428,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "FM" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/structure/chair/handrail{
 	dir = 8
@@ -3461,7 +3458,6 @@
 	pixel_x = 11;
 	pixel_y = -19
 	},
-/obj/effect/turf_decal/box,
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
@@ -3478,8 +3474,11 @@
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "FT" = (
 /obj/structure/grille,
@@ -3514,24 +3513,23 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "GG" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "GL" = (
-/obj/effect/turf_decal/box,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "GQ" = (
 /obj/effect/turf_decal/box/corners{
@@ -3639,9 +3637,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Ia" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/structure/chair/handrail{
 	dir = 8
@@ -3656,9 +3651,6 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "If" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
 	dir = 4
 	},
@@ -3668,6 +3660,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Im" = (
@@ -3704,7 +3697,6 @@
 	pixel_x = -2;
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -3715,7 +3707,7 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "IF" = (
@@ -3730,21 +3722,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"IM" = (
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
 "IW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	name = "exhaust injector";
@@ -3760,7 +3737,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Jc" = (
@@ -3958,7 +3934,6 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "KJ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
 	dir = 1
@@ -3969,6 +3944,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Ln" = (
@@ -3980,7 +3956,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Lo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -4055,6 +4031,11 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
 	dir = 4
 	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(20,41)
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "LB" = (
@@ -4098,14 +4079,17 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/ntspaceworks_small{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/ntspaceworks_small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
@@ -4242,7 +4226,7 @@
 /obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/item/gun/energy/sharplite/x12,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "MW" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4297,7 +4281,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "NF" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
 	},
@@ -4307,6 +4290,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "NO" = (
@@ -4451,9 +4435,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4461,6 +4442,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -4593,9 +4577,12 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/box,
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "Qg" = (
 /obj/structure/table/reinforced,
@@ -4654,7 +4641,7 @@
 /obj/structure/railing/thin{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "QK" = (
 /obj/effect/turf_decal/box/corners,
@@ -4664,9 +4651,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "Ra" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 6
 	},
@@ -4712,19 +4696,13 @@
 /turf/open/floor/noslip,
 /area/ship/cargo/starboard)
 "RE" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -4763,11 +4741,6 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-10"
@@ -4824,19 +4797,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Sn" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -4968,25 +4935,22 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Tw" = (
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
 /obj/effect/turf_decal/ntspaceworks_small/right,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "TO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
@@ -5000,21 +4964,15 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "TR" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
@@ -5042,6 +5000,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/white,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Office"
 	},
@@ -5067,19 +5026,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo/starboard)
 "UV" = (
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "UX" = (
 /obj/structure/cable/cyan{
@@ -5106,7 +5053,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Vm" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
@@ -5116,7 +5062,7 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Vo" = (
@@ -5151,9 +5097,12 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm)
 "VX" = (
-/obj/effect/turf_decal/box,
 /obj/machinery/drill,
-/turf/open/floor/plasteel/patterned,
+/obj/effect/turf_decal/borderfloor/full{
+	layer = 2.038
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "VZ" = (
 /obj/structure/table/wood/poker{
@@ -5501,6 +5450,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
 	name = "Engineering"
@@ -5589,7 +5541,6 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "ZX" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
 /obj/machinery/button/door{
 	id = "dwayne_starboard";
 	name = "Starboard Blast Doors";
@@ -5609,11 +5560,11 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -6032,7 +5983,7 @@ Fd
 yZ
 Tw
 RE
-IM
+UV
 UV
 vm
 wm

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -1188,7 +1188,9 @@
 	dir = 1
 	},
 /obj/machinery/advanced_airlock_controller{
-	pixel_x = -26
+	pixel_x = -26;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
@@ -3236,6 +3238,13 @@
 /obj/item/bodycamera,
 /obj/item/bodycamera,
 /obj/item/pen,
+/obj/machinery/button/door{
+	id = "dwayne_bridge";
+	name = "Privacy Shutter Control";
+	pixel_x = -21;
+	pixel_y = -3;
+	dir = 4
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "DP" = (
@@ -5083,17 +5092,11 @@
 /obj/machinery/button/door{
 	id = "dwayne_windows";
 	name = "Bridge Window Control";
-	pixel_x = 5;
+	pixel_x = -5;
 	pixel_y = 20
 	},
 /obj/machinery/computer/helm{
 	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "dwayne_bridge";
-	name = "Privacy Shutter Control";
-	pixel_x = -6;
-	pixel_y = 20
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -1820,7 +1820,9 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 1
 	},
-/obj/machinery/computer/crew,
+/obj/machinery/computer/crew{
+	icon_state = "computer-right"
+	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -2116,10 +2118,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
-	},
-/obj/item/reagent_containers/glass/maunamug{
-	pixel_x = 7;
-	pixel_y = 2
 	},
 /obj/item/book/fish_catalog{
 	pixel_x = -6;
@@ -4422,10 +4420,17 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_x = 5;
-	pixel_y = 3
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/stamp/captain{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/pen/fountain{
+	pixel_x = 2;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -4615,23 +4620,24 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "Qg" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 1
 	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 8;
-	pixel_y = 7
-	},
 /obj/machinery/newscaster/directional/west,
-/obj/item/paper_bin{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/structure/table/emptycomputer{
+	icon_state = "emptycomputer-left"
 	},
-/obj/item/pen/fountain,
-/obj/item/stamp/captain{
-	pixel_x = -7;
-	pixel_y = 9
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_x = 9;
+	pixel_y = 13
+	},
+/obj/machinery/emergency_panel{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/glass/maunamug{
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -731,9 +731,6 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "iu" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/wall/directional/south{
 	icon_state = "cargo_wall";
 	name = "miner's locker";
@@ -795,6 +792,9 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/yellow/corner,
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -1660,7 +1660,6 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "qp" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1671,10 +1670,11 @@
 	layer = 2.030;
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "qq" = (
@@ -1949,9 +1949,6 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/railing/thin/corner{
 	dir = 1
@@ -1961,6 +1958,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -2173,11 +2173,11 @@
 /obj/effect/turf_decal/trimline/opaque/black/line{
 	layer = 2.030
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "uq" = (
@@ -2577,9 +2577,6 @@
 /obj/structure/railing/thin/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/opaque/black/line{
 	layer = 2.030;
 	dir = 1
@@ -2587,8 +2584,11 @@
 /obj/effect/turf_decal/trimline/opaque/black/line{
 	layer = 2.030
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -3243,9 +3243,6 @@
 /obj/structure/railing/thin/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/opaque/black/line{
 	layer = 2.030;
 	dir = 1
@@ -3253,8 +3250,11 @@
 /obj/effect/turf_decal/trimline/opaque/black/line{
 	layer = 2.030
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -3293,7 +3293,6 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
@@ -3346,6 +3345,7 @@
 	layer = 2.030
 	},
 /obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Fj" = (
@@ -4742,9 +4742,6 @@
 	},
 /obj/effect/turf_decal/corner/opaque/black{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -1,20 +1,50 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
 "ak" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/atmospherics)
 "am" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
+/obj/machinery/griddle,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"an" = (
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"aq" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_port";
+	name = "Engine Shutter Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"aA" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
 "aI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -29,26 +59,36 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"aM" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/effect/turf_decal/industrial/warning/corner{
+"aK" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner,
+/obj/structure/cable/cyan{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"aO" = (
+/obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "dwayne_starboard";
-	name = "Starboard Blast Doors";
-	pixel_x = -8;
-	pixel_y = -20;
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_starboard_field";
-	pixel_x = 1;
-	pixel_y = -19;
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -76,57 +116,37 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
-"bc" = (
+"bj" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "9-10"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 1
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"bg" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 24;
-	pixel_y = 3
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
-"bj" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_cryo";
-	name = "Cryo Shutter Control"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
 "bv" = (
 /obj/structure/chair/comfy/beige/old{
 	dir = 4
@@ -144,55 +164,11 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm)
 "bE" = (
-/obj/item/stack/sheet/metal/twenty{
-	pixel_y = 0
-	},
-/obj/item/stack/sheet/glass/twenty{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/box/corners,
-/obj/structure/crate_shelf,
-/obj/structure/closet/crate/engineering{
-	name = "material crate"
+/obj/effect/turf_decal/box/corners{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"bO" = (
-/obj/structure/platform/ship_two{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/item/radio/old{
-	pixel_x = 6;
-	pixel_y = 21
-	},
-/obj/item/toy/prize/ripley{
-	pixel_x = -11;
-	pixel_y = 29
-	},
-/obj/structure/rack,
-/obj/item/towel{
-	pixel_y = -5;
-	pixel_x = -5
-	},
-/obj/item/towel{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/soap/nanotrasen{
-	pixel_y = -1;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/button/door{
-	pixel_y = -10;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_bathroom";
-	name = "Bathroom Bolt Control"
-	},
-/turf/open/floor/plastic,
-/area/ship/crew/toilet)
+/area/ship/cargo/port)
 "bR" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
@@ -200,11 +176,11 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/poddoor/shutters{
-	id = "dwayne_equipment";
+	id = "dwayne_cryo";
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/cargo/port)
+/area/ship/cargo/starboard)
 "bW" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -215,16 +191,13 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "cf" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/railing/thin{
-	dir = 8
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
 "ck" = (
 /obj/structure/chair/stool/bar{
 	dir = 1;
@@ -252,57 +225,37 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"cP" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
+"cV" = (
+/obj/item/clothing/head/helmet/space/syndicate/generic{
+	pixel_y = 0
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"cV" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_starboard_field";
-	locked = 1
+/obj/item/clothing/suit/space/syndicate/generic/grey,
+/obj/item/clothing/mask/gas,
+/obj/structure/railing/thin{
+	dir = 8
 	},
-/obj/structure/cable/cyan,
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_starboard"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "dh" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "dx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
 "dy" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -311,6 +264,19 @@
 /area/ship/hallway/central)
 "dK" = (
 /obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "dO" = (
@@ -329,62 +295,43 @@
 	},
 /turf/open/floor/noslip,
 /area/ship/cargo/port)
-"dP" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public{
-	name = "Cryogenics"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
 "ea" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/cable/cyan{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
-"ef" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+"eg" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/can/food/beans,
+/obj/item/trash/sosjerky,
+/obj/item/trash/candy,
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"eo" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half,
+/obj/machinery/computer/cargo{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"en" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_port_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_port"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"eq" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/sofa/brown/old/right/directional/north,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
 "eu" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -399,42 +346,85 @@
 /obj/effect/turf_decal/solarpanel,
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"eH" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
-	dir = 1
+"eD" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "5-6"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_starboard";
+	name = "Engine Shutter Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"eH" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering)
 "eL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"ff" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/atmospherics)
-"fp" = (
-/obj/effect/turf_decal/industrial/warning{
+"eU" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/computer/helm/viewscreen/directional/north,
-/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"fp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"fq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "fr" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo/starboard)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "fz" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -444,68 +434,51 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"fA" = (
-/obj/machinery/atmospherics/components/unary/tank/toxins{
-	dir = 4
+"fJ" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 9
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "dwayne_exhaust"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
+/turf/open/floor/plating,
+/area/ship/engineering)
+"fN" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
 	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = -21;
-	id = "dwayne_engines_port";
-	name = "Engine Shutter Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"fG" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"fL" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"fU" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"ge" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/atmospherics/components/unary/tank/nitrogen{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -522,31 +495,18 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
-"gk" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
+"gq" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
-"gl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
 "gs" = (
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/structure/closet/secure_closet/armorycage{
@@ -585,58 +545,44 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
-"gz" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+"gu" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"hp" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"gw" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/structure/cable/yellow{
-	icon_state = "2-5"
+	icon_state = "0-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/obj/machinery/button/door{
-	dir = 2;
-	pixel_y = 20;
-	id = "dwayne_engines_starboard"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
-"hx" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
+"gx" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"ht" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window{
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_equipment";
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ship/cargo/port)
-"hy" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/chair/sofa/brown/old/right/directional/north,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
 "hB" = (
 /obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
 	dir = 1
@@ -644,46 +590,64 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "hC" = (
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/chair/stool,
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"hF" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/machinery/light/directional/north,
-/obj/structure/railing/thin{
-	dir = 8
-	},
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"hQ" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 1
 	},
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "dwayne_recycling"
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"hT" = (
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 2;
-	name = "Supply to Output";
-	layer = 2.43
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"hL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"hQ" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_port";
+	name = "Port Blast Doors";
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_port_field";
+	pixel_x = 1;
+	pixel_y = 19
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "hZ" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -706,8 +670,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
 "in" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
 "iq" = (
 /obj/machinery/washing_machine{
 	layer = 2.8;
@@ -736,28 +705,62 @@
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/poddoor{
-	id = "dwayne_dorms"
+	id = "dwayne_kitchen"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/dorm)
-"iE" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 10
+/area/ship/crew/canteen)
+"iu" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 2
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/end,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"iO" = (
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "miner's locker";
+	req_access_txt = "48";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/obj/item/clothing/gloves/explorer{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/machinery/button/door{
+	pixel_y = -16;
+	dir = 4;
+	id = "dwayne_equipment";
+	name = "Equipment Room Shutter Control";
+	pixel_x = -21
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"iR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -774,28 +777,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
-"iU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/dresser{
-	dir = 4;
-	pixel_y = 0;
-	pixel_x = 4
-	},
-/obj/item/radio/intercom/table{
-	dir = 4;
-	pixel_y = 6;
-	pixel_x = 6
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
 "iY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
@@ -827,12 +808,89 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "jh" = (
-/obj/structure/chair/sofa/brown/old/left/directional/south,
-/turf/open/floor/carpet,
+/turf/closed/wall/mineral/titanium,
 /area/ship/crew/canteen)
+"ju" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
 "jz" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm/captain)
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_port";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"jH" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"jR" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "5-9"
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/stock_parts/manipulator/nano{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/screwdriver{
+	pixel_y = -9;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
 "jS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo/port)
@@ -863,60 +921,57 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
-"kk" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+"ki" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
-"ku" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/drill,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/port)
-"kx" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"ky" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
-"kL" = (
+"kp" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"ku" = (
+/obj/effect/turf_decal/ntspaceworks_small/right{
+	dir = 1
+	},
 /obj/structure/cable/cyan{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"kJ" = (
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "kO" = (
 /obj/structure/dresser{
 	dir = 8;
@@ -938,43 +993,41 @@
 "kV" = (
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
-"ld" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+"lb" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "2-9"
 	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"lg" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"ld" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_canteen"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
 "ll" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -984,6 +1037,24 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"lm" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "lv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1020,6 +1091,75 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
+"lQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew/canteen)
+"lU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1;
+	piping_layer = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"lW" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/wall/orange/directional/west{
+	name = "Mechanic's locker";
+	dir = 2;
+	pixel_y = -28;
+	pixel_x = 0
+	},
+/obj/item/storage/backpack/duffelbag/engineering{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/obj/item/storage/backpack/satchel/eng{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/overalls/olive{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -1;
+	pixel_y = -13
+	},
+/obj/item/storage/belt/utility/full/engi{
+	pixel_x = -1;
+	pixel_y = -15
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/hardhat/dblue{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1031,17 +1171,15 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "mf" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
 "ms" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1065,53 +1203,19 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/dorm/captain)
-"mw" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "5-9"
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = -7;
-	pixel_y = 14
-	},
-/obj/item/stock_parts/manipulator/nano{
-	pixel_y = 2;
-	pixel_x = 7
-	},
-/obj/item/stock_parts/scanning_module/adv{
-	pixel_x = 8;
-	pixel_y = -9
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_y = -2;
-	pixel_x = -7
-	},
-/obj/item/screwdriver{
-	pixel_y = -9;
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
 "my" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo/port)
-"mz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
-	dir = 9
+/obj/machinery/power/ship_gravity{
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "6-10"
 	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 1;
-	piping_layer = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "mA" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -1126,60 +1230,21 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"mD" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering)
 "mF" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/hallway/central)
-"mR" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/machinery/door/window/westleft,
+/obj/effect/turf_decal/steeldecal/steel_decals6,
+/obj/effect/turf_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"na" = (
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/light/engineer,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
-"nr" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 9
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/corner,
-/obj/structure/cable/cyan{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"nB" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"nK" = (
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew/toilet)
+"mH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
 	dir = 4
 	},
@@ -1207,6 +1272,93 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
+"mR" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"na" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"nr" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
+"ns" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"nu" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/autolathe,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"nB" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"nR" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
 "nV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1233,31 +1385,28 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
-"nZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
 "oa" = (
-/obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/canteen)
+"ol" = (
+/obj/structure/window{
+	dir = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
 	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
 "or" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1277,29 +1426,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"oz" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
 "oB" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1310,25 +1436,32 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "oE" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window{
-	pixel_y = 0
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_cryo";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/hallway/central)
 "oF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "dwayne_captain"
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"oK" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
-/area/ship/crew/dorm/captain)
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
 "oR" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -1344,34 +1477,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"oY" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/layer_manifold{
+"pl" = (
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
 	},
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "dwayne_exhaust"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"pl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
 "pt" = (
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
@@ -1385,60 +1497,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "px" = (
-/obj/structure/table,
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/item/radio{
-	pixel_y = 13;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 9;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 13;
-	pixel_x = -8
-	},
-/obj/item/radio{
-	pixel_y = 9;
-	pixel_x = -8
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"pz" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew/toilet)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
 "pS" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -1450,6 +1513,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
+"qd" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew/dorm/captain)
 "qg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1471,56 +1542,64 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"qk" = (
-/obj/effect/turf_decal/ntspaceworks_small/right{
+"ql" = (
+/obj/structure/chair/sofa/brown/old/left/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"qp" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"qq" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"ql" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 16;
-	pixel_x = 7
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"qz" = (
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/item/reagent_containers/glass/maunamug{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/book/fish_catalog{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
-"qA" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Office"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ship/engineering)
+"qE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
 "qJ" = (
 /obj/structure/closet/secure_closet/wall/directional/north{
 	name = "captain's locker";
@@ -1581,35 +1660,12 @@
 	pixel_x = -9;
 	pixel_y = -8
 	},
+/obj/item/storage/box/ammo/c38{
+	pixel_x = -8;
+	pixel_y = -6
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm/captain)
-"qK" = (
-/obj/structure/window{
-	dir = 2
-	},
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plastic,
-/area/ship/crew/toilet)
-"qN" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	name = "Input to Waste";
-	dir = 1;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
 "qO" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -1625,24 +1681,33 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "qY" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/turf/open/floor/engine/hull,
+/area/ship/engineering/atmospherics)
+"rk" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/obj/machinery/computer/crew,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"ro" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/head/helmet/space/light/engineer,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
+"rw" = (
+/obj/machinery/pipedispenser{
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
 "rE" = (
 /obj/structure/closet/crate/medical,
 /obj/item/clothing/gloves/color/latex/nitrile,
@@ -1668,25 +1733,6 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
-"rW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "dwayne_lounge";
-	dir = 2
-	},
-/turf/open/floor/plating/airless,
-/area/ship/crew/canteen)
-"sa" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "sb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
@@ -1723,6 +1769,52 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"sl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"ss" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"sA" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "sD" = (
 /obj/machinery/light/directional/south,
 /obj/structure/chair/handrail{
@@ -1735,18 +1827,23 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "sM" = (
-/obj/effect/turf_decal/industrial/warning/corner{
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"sY" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/fragile,
-/obj/item/clothing/head/helmet/space/fragile,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public{
+	name = "Cryogenics"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
 "tg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1767,7 +1864,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/structure/ore_box,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "tj" = (
@@ -1784,21 +1880,37 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"tw" = (
-/obj/machinery/computer/monitor{
-	dir = 8;
-	icon_state = "computer-left"
+"tD" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/button/door{
-	pixel_y = -15;
+	pixel_y = 0;
 	dir = 8;
-	pixel_x = -8;
-	id = "dwayne_exhaust";
-	name = "Exhaust Window Control"
+	pixel_x = 21;
+	id = "dwayne_cryo";
+	name = "Cryo Shutter Control"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"tG" = (
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "tI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/coffeemaker{
@@ -1822,12 +1934,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
+"tL" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"tM" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "dwayne_dorms"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
 "tQ" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
+"tT" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/maunamug{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/book/fish_catalog{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
 "tX" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
@@ -1864,6 +2008,19 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
+"uk" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "uq" = (
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/structure/rack,
@@ -1894,23 +2051,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
-"uD" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
 "uK" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
@@ -1918,21 +2058,46 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "vi" = (
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm/captain)
+"vj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"vm" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/cyan{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Port Hangar"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo/port)
+"vm" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
+"vs" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "vw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1957,6 +2122,22 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
+"vA" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "engine fuel pump"
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4;
+	name = "Air to Supply"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "vB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -1964,21 +2145,26 @@
 /obj/structure/chair/sofa/brown/old/right/directional/south,
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
-"vL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
+"vF" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"vP" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = 4;
-	pixel_x = 4
+/obj/machinery/door/poddoor{
+	id = "dwayne_recycling"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"vL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo/starboard)
+"vP" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "vQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2006,28 +2192,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo/starboard)
-"wq" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"wy" = (
-/obj/effect/turf_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
 "wW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2046,6 +2210,36 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"xb" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"xd" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "xh" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
@@ -2057,24 +2251,6 @@
 /obj/effect/turf_decal/solarpanel,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
-"xn" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_port";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
 "xo" = (
 /obj/structure/chair/stool/bar{
 	dir = 1;
@@ -2103,54 +2279,59 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
-"xR" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
-/obj/machinery/atmospherics/components/binary/pump{
+"xP" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northright{
 	dir = 4;
-	name = "engine fuel pump"
+	name = "Engine Access"
 	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 4;
-	name = "Air to Supply"
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"xT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/area/ship/engineering)
+"xZ" = (
+/obj/effect/turf_decal/ntspaceworks_small/left,
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Port Hangar"
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"yb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sign/warning/fire{
+	pixel_x = -6;
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/cargo/port)
-"xX" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 5
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 10
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 2
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"yp" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
+/obj/structure/railing/thin/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "yq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2166,15 +2347,10 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"yt" = (
+"yD" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "yJ" = (
@@ -2196,34 +2372,48 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
-"yQ" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/chair/handrail{
-	dir = 4;
-	name = "overhead handrail"
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 9
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 6
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/starboard)
-"yW" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
 "yZ" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/cargo/starboard)
+"zb" = (
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/radio/old{
+	pixel_x = 6;
+	pixel_y = 21
+	},
+/obj/item/toy/prize/ripley{
+	pixel_x = -11;
+	pixel_y = 29
+	},
+/obj/structure/rack,
+/obj/item/towel{
+	pixel_y = -5;
+	pixel_x = -5
+	},
+/obj/item/towel{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/soap/nanotrasen{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_bathrooms";
+	name = "Bathroom Bolt Control"
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
 "zi" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -2243,56 +2433,26 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_x = 5;
-	pixel_y = 3
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"zs" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-6"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/autolathe,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
-"zy" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
 "zz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/blackbox_recorder,
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0;
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -2303,6 +2463,13 @@
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
+"zB" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 2;
+	piping_layer = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
 "zC" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2314,64 +2481,63 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
-"zX" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/machinery/light/small/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north,
+"zI" = (
 /obj/structure/cable/cyan{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/double/black,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	pixel_y = -10;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_captain";
-	name = "Captain's Window Control"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/mining{
+	name = "Equipment Room"
 	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
-"Ai" = (
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage/equip)
+"zP" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/industrial/caution/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Ak" = (
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
+/obj/item/stack/sheet/metal/twenty{
 	pixel_y = 0
 	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 0
+/obj/item/stack/sheet/glass/twenty{
+	pixel_y = 3
 	},
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -25
+/obj/effect/turf_decal/box/corners,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"An" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"Am" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
 	},
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "AB" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/storage/equip)
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
 "AC" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 8
@@ -2423,31 +2589,72 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"AQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"Bm" = (
-/obj/machinery/power/ship_gravity{
-	pixel_y = 0
-	},
+"AL" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow{
-	icon_state = "6-10"
-	},
-/obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"AQ" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"AS" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 2
+	},
+/obj/structure/curtain/bounty,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"AT" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
+"AZ" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"Bg" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
 "Bx" = (
 /obj/structure/railing{
 	dir = 2
@@ -2466,51 +2673,16 @@
 	color = "#555555"
 	},
 /area/ship/bridge)
-"BH" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 6
+"BU" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 4;
-	piping_layer = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-9"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"BM" = (
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
 "BX" = (
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
@@ -2524,129 +2696,32 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"Cf" = (
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "dwayne_captain"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
-"Ci" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_starboard"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_starboard_field";
-	locked = 1
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
-"Cl" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"Cr" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/canteen)
-"Cw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Cy" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/computer/helm/viewscreen/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"CF" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"CI" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	name = "exhaust injector";
+"Co" = (
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/engine/hull/reinforced,
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Dm" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"CJ" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "5-6"
-	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = -21;
-	id = "dwayne_engines_starboard";
-	name = "Engine Shutter Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"Da" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "dwayne_port";
-	name = "Port Blast Doors";
-	pixel_x = -8;
-	pixel_y = 20
-	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_port_field";
-	pixel_x = 1;
-	pixel_y = 19
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Dq" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
 "Ds" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
@@ -2676,39 +2751,17 @@
 "Dv" = (
 /turf/template_noop,
 /area/space)
-"Dy" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"DF" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
+"DE" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6-9"
+	icon_state = "1-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Engineering"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
 "DJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2719,6 +2772,41 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"DL" = (
+/obj/structure/filingcabinet/filingcabinet{
+	dir = 4;
+	pixel_x = -10;
+	density = 0
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/gun/ballistic/revolver/detective,
+/obj/item/megaphone/cargo,
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/item/bodycamera,
+/obj/item/bodycamera,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"DP" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/engineering)
 "DR" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2753,6 +2841,22 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
+"DT" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "Ee" = (
 /obj/effect/turf_decal/industrial/warning/corner,
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
@@ -2761,6 +2865,32 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
+"Ep" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Eu" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
 "Ex" = (
 /obj/structure/table/reinforced,
 /obj/structure/sink/kitchen{
@@ -2809,14 +2939,19 @@
 /obj/effect/turf_decal/dept/mining,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"ET" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+"EG" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "EV" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -2824,36 +2959,17 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
-"EX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"EZ" = (
+/obj/machinery/computer/solar_control{
+	dir = 8;
+	icon_state = "computer-right"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "5-10"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Common Room"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/canteen)
-"Fa" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/dorm)
-"Fc" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/can/food/beans,
-/obj/item/trash/sosjerky,
-/obj/item/trash/candy,
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/crate_shelve,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
 "Fd" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2863,32 +2979,70 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Fi" = (
-/obj/machinery/door/window/westleft,
-/obj/effect/turf_decal/steeldecal/steel_decals6,
-/obj/effect/turf_decal/steeldecal/steel_decals6{
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 4
 	},
-/obj/machinery/shower{
-	dir = 8
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
-/obj/structure/chair/handrail{
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "miner's locker";
+	req_access_txt = "48";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/clothing/gloves/explorer{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Fj" = (
+/obj/effect/turf_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
 	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew/toilet)
-"Fn" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
+"Fn" = (
+/obj/structure/chair/handrail{
+	dir = 4;
+	name = "overhead handrail"
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 5
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/port)
 "Fq" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -2902,16 +3056,8 @@
 /turf/open/floor/plating/airless,
 /area/ship/crew/canteen)
 "Fw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/turf/closed/wall/mineral/titanium,
+/area/ship/storage/equip)
 "Fz" = (
 /obj/item/caution,
 /obj/item/caution,
@@ -2948,41 +3094,49 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "FM" = (
-/obj/structure/filingcabinet/filingcabinet{
-	dir = 4;
-	pixel_x = -10;
-	density = 0
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/ntblue/border{
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/handrail{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/gun/ballistic/revolver/detective,
-/obj/item/megaphone/cargo,
-/obj/structure/railing{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/item/bodycamera,
-/obj/item/bodycamera,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "FN" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-8"
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"FQ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"FT" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
 "Gr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -2995,18 +3149,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"Gs" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east{
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "Gx" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -3028,29 +3170,114 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
-"GJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
+"GL" = (
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"GQ" = (
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"GL" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_canteen"
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"Hh" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/obj/machinery/button/door{
+	dir = 2;
+	pixel_y = 20;
+	id = "dwayne_engines_starboard"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"HB" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/black,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_captain";
+	name = "Captain's Window Control"
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"HG" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 4;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 6
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"HI" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/canteen)
-"GQ" = (
+/area/ship/cargo/port)
+"HV" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Ia" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 4
 	},
@@ -3059,8 +3286,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"GU" = (
+/area/ship/cargo/port)
+"If" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Im" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
 	},
@@ -3073,193 +3306,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"Hg" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Hh" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Hm" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_equipment";
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/ship/storage/equip)
-"Hq" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half,
-/obj/machinery/computer/cargo{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Hv" = (
-/obj/structure/chair/handrail{
-	dir = 4;
-	name = "overhead handrail"
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 5
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/port)
-"Hx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 24
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
-"HD" = (
-/obj/machinery/griddle,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"HI" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor{
-	id = "dwayne_port"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"HJ" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"HL" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"HW" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"Ia" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"Ib" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Ic" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"Id" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
 "Ip" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "Is" = (
@@ -3278,13 +3329,6 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
-"IA" = (
-/obj/machinery/pipedispenser{
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
 "IF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -3297,6 +3341,13 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"IW" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	name = "exhaust injector";
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
 "IZ" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -3307,6 +3358,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"Jc" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
 "Jk" = (
 /obj/structure/sink{
 	pixel_y = 2;
@@ -3349,1491 +3408,68 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Jy" = (
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"JD" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 12
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"JH" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "miner's locker";
-	req_access_txt = "48";
-	dir = 8;
-	pixel_y = 0;
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/hazardvest{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/storage/belt/mining/alt{
-	pixel_x = -7;
-	pixel_y = -7
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/item/clothing/gloves/explorer{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"JT" = (
 /obj/structure/cable/yellow{
-	icon_state = "5-10"
+	icon_state = "0-8"
 	},
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"JB" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_equipment";
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ship/storage/equip)
+"JH" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Ka" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"Kh" = (
-/obj/machinery/power/terminal,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"KJ" = (
-/obj/structure/table/reinforced,
-/obj/structure/closet/wall/orange/directional/west{
-	name = "Mechanic's locker";
-	dir = 2;
-	pixel_y = -28;
-	pixel_x = 0
-	},
-/obj/item/storage/backpack/duffelbag/engineering{
-	pixel_x = -1;
-	pixel_y = -8
-	},
-/obj/item/storage/backpack/satchel/eng{
-	pixel_x = 0;
-	pixel_y = 2
-	},
-/obj/item/clothing/under/overalls/olive{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/gloves/color/yellow{
-	pixel_x = -1;
-	pixel_y = -13
-	},
-/obj/item/storage/belt/utility/full/engi{
-	pixel_x = -1;
-	pixel_y = -15
-	},
-/obj/item/clothing/glasses/welding{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/hardhat/dblue{
-	pixel_x = 0;
-	pixel_y = 9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = -1;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
-"Lt" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"LB" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/chair/handrail{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"LF" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 4;
-	piping_layer = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"LL" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"LM" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ntspaceworks_small{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"LN" = (
+/area/ship/hallway/central)
+"Ku" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"LZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"Mg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
-/obj/structure/closet/emcloset/wall/directional/west,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
-"Mr" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Mt" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Mw" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"My" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Kw" = (
+/obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"Mz" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"MB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"MG" = (
-/obj/structure/guncloset,
-/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
-/obj/item/gun/energy/sharplite/x26/empty_cell,
-/obj/item/gun/energy/sharplite/x12/empty_cell,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"Nf" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/engineering)
-"Nh" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 1;
-	name = "Scrubbers to Recycling"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_recycling";
-	name = "Recycling Window Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Ny" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
-"NG" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9-10"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"NQ" = (
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = 11;
-	pixel_y = 2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = 11;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = -5
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = 7
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate/science{
-	name = "mining crate"
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"NS" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 2
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"NW" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/engineering/atmospherics)
-"Oh" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"Op" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"Ov" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Oy" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"OJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 8;
-	pixel_x = -1
-	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"OP" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 8
-	},
-/obj/structure/chair/handrail{
-	dir = 1;
-	name = "overhead handrail"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"OT" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"OV" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"OW" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/turf/open/floor/carpet/black{
-	name = "bathroom mat"
-	},
-/area/ship/crew/toilet)
-"OZ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 22
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/starboard)
-"Pl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"Pw" = (
-/obj/effect/turf_decal/box,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/starboard)
-"PD" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "dwayne_windows";
-	name = "Bridge Window Control";
-	pixel_x = -5;
-	pixel_y = 20
-	},
-/obj/machinery/computer/helm{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"PF" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/industrial/caution/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"PM" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/atmospherics/components/unary/tank/nitrogen{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"PO" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"PY" = (
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"Qg" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 1
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/item/paper_bin{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/pen/fountain,
-/obj/item/stamp/captain{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Qp" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"QB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Common Room"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/canteen)
-"QI" = (
-/obj/item/clothing/head/helmet/space/syndicate/generic{
-	pixel_y = 0
-	},
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/item/clothing/suit/space/syndicate/generic/grey,
-/obj/item/clothing/mask/gas,
-/obj/structure/railing/thin{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"QQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Rb" = (
-/obj/item/toy/eightball{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/structure/table/wood/poker{
-	name = "billiards table"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Rm" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/chair/handrail{
-	dir = 8;
-	name = "overhead handrail"
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 10
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/starboard)
-"RE" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"RJ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/port)
-"RN" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 2;
-	piping_layer = 1
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external/dark)
-"RV" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-10"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4;
-	color = "#555555"
-	},
-/area/ship/bridge)
-"Se" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"SA" = (
-/obj/structure/closet/secure_closet/wall/directional/north{
-	name = "foreman's locker";
-	req_access_txt = "20";
-	icon_state = "solgov_wall";
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/item/storage/backpack/duffelbag/engineering{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/storage/backpack/satchel/eng{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/clothing/shoes/workboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/clothing/suit/jacket/leather/duster{
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/clothing/under/rank/security/detective{
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/storage/belt/utility/full{
-	pixel_x = 8;
-	pixel_y = -7
-	},
-/obj/item/clothing/gloves/fingerless{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/clothing/head/cowboy/sec{
-	pixel_x = 13;
-	pixel_y = 11
-	},
-/obj/item/clothing/head/hardhat/white{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"SB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "dwayne_captain";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
-"SR" = (
-/obj/machinery/computer/solar_control{
-	dir = 8;
-	icon_state = "computer-right"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
-"Td" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Tl" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Tw" = (
-/obj/effect/turf_decal/ntspaceworks_small/right,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"TO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"TP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "dwayne_lounge";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"TR" = (
-/obj/structure/mirror{
-	pixel_y = 4;
-	layer = 2.8;
-	pixel_x = 7
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm)
-"TT" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 4
-	},
-/obj/structure/curtain/bounty,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"TW" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
-	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Uj" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Uq" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
-"UH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"UN" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/mining{
-	name = "Equipment Room"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage/equip)
-"UQ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"US" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_port_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_port"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"UV" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"UX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Vb" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Vr" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/corner/opaque/ntblue/border{
-	dir = 8
-	},
-/obj/machinery/blackbox_recorder,
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Vs" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
-"VH" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"VL" = (
-/obj/effect/turf_decal/industrial/outline,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"VO" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"VX" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"VZ" = (
-/obj/structure/table/wood/poker{
-	name = "billiards table"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Wa" = (
-/obj/effect/turf_decal/ntspaceworks_small/left,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"Wg" = (
-/obj/structure/table/wood,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Wh" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Ww" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/storage/equip)
-"Wy" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"WE" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"WL" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
-"Xa" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Xl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xw" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew/toilet)
-"Xy" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "dwayne_kitchen"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"XC" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
-"XP" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"XQ" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 2
-	},
-/obj/structure/curtain/bounty,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Yd" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/structure/chair/sofa/brown/old/left/directional/north,
-/obj/machinery/button/door{
-	pixel_y = -20;
-	dir = 1;
-	id = "dwayne_lounge";
-	name = "Canteen Window Control";
-	pixel_x = 6
-	},
-/obj/machinery/button/door{
-	pixel_y = -20;
-	dir = 1;
-	id = "dwayne_canteen";
-	name = "Canteen Shutter Control";
-	pixel_x = -6
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"Yl" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east{
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"YD" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"YH" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "miner's locker";
-	req_access_txt = "48";
-	dir = 8;
-	pixel_y = 0;
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/hazardvest{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/storage/belt/mining/alt{
-	pixel_x = -7;
-	pixel_y = -7
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/obj/item/clothing/gloves/explorer{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/machinery/button/door{
-	pixel_y = -16;
-	dir = 4;
-	id = "dwayne_equipment";
-	name = "Equipment Room Shutter Control";
-	pixel_x = -21
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"YV" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"YY" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_y = -21;
-	id = "dwayne_engines_port"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Ze" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Zf" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 1
-	},
-/obj/structure/curtain/bounty,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Zj" = (
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
-	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
-	},
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Zk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"Zp" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/industrial/caution/red,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Zq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm/captain)
-"Zt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/sign/warning/fire{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Zv" = (
+"KF" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
@@ -4906,14 +3542,114 @@
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
-"Zy" = (
-/obj/effect/turf_decal/box/corners{
+"KJ" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Ln" = (
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Lo" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
 	dir = 4
 	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"ZK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -21;
+	id = "dwayne_engines_port"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Ls" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Lt" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"LB" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"LL" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -4933,35 +3669,584 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm/captain)
-"ZL" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+"LM" = (
 /obj/structure/cable/cyan{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"ZV" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
+/obj/effect/turf_decal/ntspaceworks_small{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"LN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
+/obj/effect/turf_decal/techfloor{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"LZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Me" = (
+/obj/machinery/power/terminal,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"ZY" = (
+"Mg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer4,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/closet/emcloset/wall/directional/west,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"Mj" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"Mt" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Mz" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"MA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"MB" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"MG" = (
+/obj/structure/guncloset,
+/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
+/obj/item/gun/energy/sharplite/x26/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"MW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Nf" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering)
+"No" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
+"Ny" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/industrial/hatch/blue,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"NO" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"NQ" = (
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/science{
+	name = "mining crate"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/crate_shelf,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"NW" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering/atmospherics)
+"On" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Op" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/dresser{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 4
+	},
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"Ov" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Oy" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Oz" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"OE" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"OJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 8;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"OP" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	dir = 1;
+	name = "overhead handrail"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"OR" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"OV" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"OW" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/turf/open/floor/carpet/black{
+	name = "bathroom mat"
+	},
+/area/ship/crew/toilet)
+"OX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Pl" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/canteen)
+"Pr" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Pw" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 22
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"Qg" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 1
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/item/paper_bin{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/pen/fountain,
+/obj/item/stamp/captain{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Qp" = (
+/obj/machinery/computer/monitor{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door{
+	pixel_y = -15;
+	dir = 8;
+	pixel_x = -8;
+	id = "dwayne_exhaust";
+	name = "Exhaust Window Control"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"QG" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 2;
+	name = "Supply to Output";
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"QI" = (
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/machinery/light/directional/north,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"QK" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"Ra" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Rb" = (
+/obj/item/toy/eightball{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/structure/table/wood/poker{
+	name = "billiards table"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Rm" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 8;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 10
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"RE" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"RJ" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"RS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 4;
 	piping_layer = 1
@@ -4983,6 +4268,738 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"RV" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(20,41)
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4;
+	color = "#555555"
+	},
+/area/ship/bridge)
+"Sa" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Se" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"SA" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "foreman's locker";
+	req_access_txt = "20";
+	icon_state = "solgov_wall";
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/item/storage/backpack/duffelbag/engineering{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/storage/backpack/satchel/eng{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/clothing/suit/jacket/leather/duster{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/rank/security/detective{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/storage/belt/utility/full{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/fingerless{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/cowboy/sec{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/clothing/head/hardhat/white{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"SB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"SP" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "dwayne_windows";
+	name = "Bridge Window Control";
+	pixel_x = -5;
+	pixel_y = 20
+	},
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Th" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Tl" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Tm" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 1;
+	name = "Scrubbers to Recycling"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_recycling";
+	name = "Recycling Window Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Tw" = (
+/obj/effect/turf_decal/ntspaceworks_small/right,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"TO" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"TP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"TR" = (
+/obj/structure/mirror{
+	pixel_y = 4;
+	layer = 2.8;
+	pixel_x = 7
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
+"TT" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"TZ" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Office"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Uj" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"UH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"UN" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/starboard)
+"UV" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"UX" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Vb" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Vm" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Vo" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Vv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/computer/helm/viewscreen/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"VH" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Input to Waste";
+	dir = 1;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"VO" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/dorm)
+"VX" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/drill,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"VZ" = (
+/obj/structure/table/wood/poker{
+	name = "billiards table"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Wa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Common Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/canteen)
+"Wg" = (
+/obj/structure/table/wood,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Wh" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"WE" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"WM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xa" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Xl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xu" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/port)
+"Xw" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
+"XC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Common Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/canteen)
+"XT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Yd" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/structure/chair/sofa/brown/old/left/directional/north,
+/obj/machinery/button/door{
+	pixel_y = -20;
+	dir = 1;
+	id = "dwayne_lounge";
+	name = "Canteen Window Control";
+	pixel_x = 6
+	},
+/obj/machinery/button/door{
+	pixel_y = -20;
+	dir = 1;
+	id = "dwayne_canteen";
+	name = "Canteen Shutter Control";
+	pixel_x = -6
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Yg" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Yq" = (
+/obj/structure/table,
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
+"YD" = (
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"YH" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"Zd" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	name = "Engineering"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Zf" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 1
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Zj" = (
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Zk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Zo" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/computer/helm/viewscreen/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"Zq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"Zv" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/storage/equip)
+"ZK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"ZL" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ZX" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_starboard";
+	name = "Starboard Blast Doors";
+	pixel_x = -8;
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_starboard_field";
+	pixel_x = 1;
+	pixel_y = -19;
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 
 (1,1,1) = {"
 Dv
@@ -4990,16 +5007,16 @@ Dv
 Dv
 Dv
 ak
-ff
+qY
 ak
 Dv
 Dv
 Dv
 Dv
 Dv
-in
-mD
-in
+eH
+DP
+eH
 Dv
 Dv
 Dv
@@ -5018,19 +5035,19 @@ Dv
 Dv
 Dv
 Dv
-in
-Wy
-in
+eH
+LB
+eH
 Nf
 Nf
-in
+eH
 Dv
 "}
 (3,1,1) = {"
 Dv
 ak
-xn
-xn
+jz
+jz
 ak
 Tl
 ak
@@ -5039,138 +5056,138 @@ Dv
 Dv
 Dv
 Dv
-in
+eH
 Uj
-in
-ZV
-cP
-in
+eH
+lm
+xP
+eH
 Dv
 "}
 (4,1,1) = {"
 Dv
 ak
-ZL
-Fn
-fA
-dx
+kJ
+vs
+aq
+Oz
 ak
 Dv
 Dv
 Dv
 Dv
 Dv
-in
-mf
-CJ
-sa
-Mw
-in
+eH
+gq
+eD
+ZL
+qz
+eH
 Dv
 "}
 (5,1,1) = {"
 Dv
 ak
-nr
-nK
-BM
-YY
+aK
+mH
+YD
+Lo
 ak
-mF
-mF
+oE
+oE
 kf
-mF
-mF
-in
-hp
-qY
-zy
-iE
-in
+oE
+oE
+eH
+Hh
+Eu
+lb
+jH
+eH
 Dv
 "}
 (6,1,1) = {"
 Dv
 ak
-xX
-BH
-mz
-Hg
-VL
-mF
+OE
+Sa
+lU
+Vo
+pl
+oE
 Mg
 gf
 lC
-mF
-Bm
-fL
-ef
-Kh
-bg
-in
+oE
+my
+hL
+gw
+Me
+Xa
+eH
 Dv
 "}
 (7,1,1) = {"
 Dv
 ak
-IA
-ZY
-xR
-VO
-wy
-mF
-sM
+rw
+RS
+vA
+eU
+Fj
+oE
+AZ
 ma
-XC
-mF
-in
-DF
-ky
-ky
-in
-in
+aA
+oE
+eH
+Zd
+tL
+tL
+eH
+eH
 Dv
 "}
 (8,1,1) = {"
 Dv
 ak
 ak
-LF
-QQ
-VO
-PM
+Pr
+gu
+eU
+ge
 ak
-mF
-Hx
-mF
-in
-zs
-Ic
-mw
-KJ
-in
-in
+oE
+sl
+oE
+eH
+nu
+qq
+jR
+lW
+eH
+eH
 Dv
 "}
 (9,1,1) = {"
 Dv
-RN
-hQ
-Nh
-bc
-oz
-PO
-HW
-ld
-kL
-OT
-qA
-JD
-NG
-gk
-HJ
-oY
-CI
+zB
+vF
+Tm
+Bg
+xb
+Ls
+kp
+oK
+MB
+ns
+TZ
+Mj
+bj
+WB
+ki
+fJ
+IW
 Dv
 "}
 (10,1,1) = {"
@@ -5182,56 +5199,56 @@ ak
 ak
 ak
 ak
-Zt
-NS
-GU
-in
-in
-na
-tw
-SR
-in
-in
+yb
+OR
+Im
+eH
+eH
+ro
+Qp
+EZ
+eH
+eH
 Dv
 "}
 (11,1,1) = {"
 Dv
-Ww
-AB
+Fw
+Zv
 uq
-YH
-JH
+iu
+Fi
 MG
-Hm
-Jy
-JT
-hT
+JB
+sM
+fN
+QG
 Ny
 OV
 OV
 OV
 OV
 OV
-WL
+nr
 Dv
 "}
 (12,1,1) = {"
 Dv
 Dv
-AB
-QI
-Ka
-gz
+Zv
+cV
+EG
+qp
 gs
-Hm
-MB
-Hh
-qN
-eH
+JB
+WM
+JH
+VH
+cf
 OV
-kx
-px
-XP
+dx
+Yq
+mf
 OV
 Dv
 Dv
@@ -5239,20 +5256,20 @@ Dv
 (13,1,1) = {"
 Dv
 Dv
-AB
-hF
-Oh
-gz
-Ak
-AB
-Cw
-VH
+Zv
+QI
+yp
+qp
+tG
+Zv
+dL
+Ka
 Zj
 OV
 OV
-fp
-kk
-Uq
+Zo
+aO
+BU
 OV
 Dv
 Dv
@@ -5260,117 +5277,117 @@ Dv
 (14,1,1) = {"
 Dv
 Dv
-AB
-cf
-Dq
-lg
-pl
-UN
+Zv
+Ln
+sA
+uk
+fq
+zI
 aI
 AD
 Gx
-dP
-nZ
-Pl
-gl
-bj
+sY
+qE
+Th
+ag
+tD
 OV
 Dv
 Dv
 "}
 (15,1,1) = {"
 Dv
-my
+Xu
 jS
 jS
-bR
-bR
+ht
+ht
 jS
 jS
 LN
-GJ
+na
 mA
-fr
-fr
-oE
-oE
-fr
-fr
-Ai
+vL
+vL
+bR
+bR
+vL
+vL
+UN
 Dv
 "}
 (16,1,1) = {"
 Dv
 jS
 nB
-Xa
-hx
-Mr
-ku
+fU
+Am
+If
+VX
 jS
 wW
 lv
 sg
-fr
-Pw
-UV
+vL
+GL
+vP
 uK
 uh
 Ee
-fr
+vL
 Dv
 "}
 (17,1,1) = {"
 Dv
-US
-ea
+HI
+Co
 th
 EV
 TO
-RJ
+FQ
 jS
 or
-UX
+XT
 sD
-fr
-OZ
-Fc
+vL
+Pw
+eg
 Fz
 NQ
-vm
-cV
+Vm
+nR
 Dv
 "}
 (18,1,1) = {"
 Dv
-HI
-HL
+AB
+ea
 kV
 kV
 TO
-qk
+ku
 sb
 IZ
 WE
 dK
 yZ
-Wa
+xZ
 RE
-YD
-YD
-UQ
+UV
+UV
+vm
 wm
 Dv
 "}
 (19,1,1) = {"
 wh
-HI
-Zp
+AB
+DT
 Ip
-Ip
+px
 cn
 LM
-xT
+vj
 EE
 zi
 tj
@@ -5379,71 +5396,71 @@ DS
 Oy
 rE
 zA
-PF
+zP
 wm
 Jq
 "}
 (20,1,1) = {"
 Dv
-HI
-HL
+AB
+ea
 kV
 kV
 TO
 rQ
-Cl
+AQ
 fz
-Hh
+JH
 Fd
 yZ
 Tw
 RE
-YD
-YD
-UQ
+UV
+UV
+vm
 wm
 Dv
 "}
 (21,1,1) = {"
 Dv
-en
+ju
 GG
-VX
-an
+bE
+QK
 TO
 dO
 jS
 kb
 FH
 pt
-fr
+vL
 Rm
 RE
-Zy
-bE
+GQ
+Ak
 Is
-Ci
+NO
 Dv
 "}
 (22,1,1) = {"
 Dv
 jS
-Da
-LB
-Gs
-Dy
-Hv
+hQ
+Ia
+ss
+KJ
+Fn
 jS
 wW
 DR
 sg
-fr
-yQ
-CF
-Yl
-GQ
-aM
-fr
+vL
+HG
+xd
+Ra
+FM
+ZX
+vL
 Dv
 "}
 (23,1,1) = {"
@@ -5458,26 +5475,26 @@ jS
 DJ
 oR
 dy
-fr
-fr
-fr
-fr
-fr
-fr
-fr
+vL
+vL
+vL
+vL
+vL
+vL
+vL
 Dv
 "}
 (24,1,1) = {"
 Dv
-Xy
+ir
 OJ
 xr
 tI
 xo
 dh
-LL
+Pl
 vQ
-VH
+Ka
 yJ
 bx
 Zf
@@ -5485,131 +5502,131 @@ kO
 TT
 iZ
 Mt
-ir
+tM
 Dv
 "}
 (25,1,1) = {"
 Dv
-LL
+Pl
 Ex
 tQ
 xh
 xo
-AQ
-QB
+OX
+Wa
 sk
-Ze
+UX
 Xo
-iO
+iR
 ms
-My
-Fw
-uD
+MW
+fr
+hC
 Wg
 bx
 Dv
 "}
 (26,1,1) = {"
 Dv
-Xy
-HD
+ir
+am
 tX
 iY
 ck
 qg
-LL
+Pl
 Xl
-VH
+Ka
 OP
 bx
-XQ
+AS
 aY
 SA
-Cy
-Zv
-ir
+Vv
+KF
+tM
 Dv
 "}
 (27,1,1) = {"
 Dv
-Cr
-LL
+jh
+Pl
 AG
-hC
+Kw
 Zk
-wq
-GL
+ll
+ld
 Se
-VH
-Jy
+Ka
+sM
 bx
 bx
 Ds
 TR
 bx
 bx
-Fa
+VO
 Dv
 "}
 (28,1,1) = {"
 Dv
 Dv
-LL
+Pl
 nY
 LZ
 VZ
-ll
-GL
+fp
+ld
 Ov
 zC
 Gr
-Ia
+oF
 iq
-pz
+No
 Jk
 OW
-Ia
+oF
 Dv
 Dv
 "}
 (29,1,1) = {"
 Dv
 Dv
-LL
-vP
+Pl
+RJ
 LZ
 Rb
 vw
-LL
+Pl
 FN
 Mz
-Jy
-PY
-bO
+sM
+gx
+zb
 Xw
-qK
-Fi
-Ia
+ol
+mF
+oF
 Dv
 Dv
 "}
 (30,1,1) = {"
 Dv
 Dv
-LL
-LL
+Pl
+Pl
 tg
 nV
 yq
-EX
+XC
 hB
 Jx
 BX
-jz
-jz
+vi
+vi
 AC
-jz
-jz
+vi
+vi
 xl
 Dv
 Dv
@@ -5617,20 +5634,20 @@ Dv
 (31,1,1) = {"
 Dv
 Dv
-Id
+Dm
 Fq
 vB
 UH
 Yd
-LL
+Pl
 Wh
 Lt
-fG
-ZK
+Yg
+LL
 qJ
 Zq
 bv
-Cf
+FT
 bW
 Dv
 Dv
@@ -5639,19 +5656,19 @@ Dv
 Dv
 Dv
 pS
-rW
-jh
-Op
-hy
-LL
+lQ
+ql
+Ep
+eq
+Pl
 aX
 RV
 IF
-jz
-zX
-iU
-ql
-oF
+vi
+HB
+Op
+tT
+qd
 pS
 Dv
 Dv
@@ -5659,21 +5676,21 @@ Dv
 (33,1,1) = {"
 Dv
 Dv
-ET
-Qp
+Jc
+oa
 TP
 yN
-LL
+Pl
 IF
-FM
+DL
 Bx
-Vr
+zz
 IF
-jz
+vi
 SB
 mv
 ig
-ET
+Jc
 Dv
 Dv
 "}
@@ -5681,19 +5698,19 @@ Dv
 Dv
 Dv
 Dv
-YV
-oa
+Ku
+AL
 qO
-vL
+ZK
 Qg
 eL
-zz
+MA
 aR
 IJ
-vi
+in
 eu
 Vb
-Ib
+HV
 Dv
 Dv
 Dv
@@ -5703,17 +5720,17 @@ Dv
 Dv
 Dv
 Dv
-YV
-yt
-vL
-Td
+Ku
+DE
+ZK
+rk
 mR
 cw
 oB
-Hq
-vi
-An
-yW
+eo
+in
+Jy
+yD
 Dv
 Dv
 Dv
@@ -5726,13 +5743,13 @@ Dv
 Dv
 Dv
 Dv
-Vs
+AT
 IF
-PD
+SP
+On
 zl
-TW
 IF
-Vs
+AT
 Dv
 Dv
 Dv
@@ -5748,11 +5765,11 @@ Dv
 Dv
 Dv
 Dv
-Vs
-am
-am
-am
-Vs
+AT
+YH
+YH
+YH
+AT
 Dv
 Dv
 Dv

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -167,6 +167,9 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "bR" = (
@@ -199,23 +202,30 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "ck" = (
-/obj/structure/chair/stool/bar{
-	dir = 1;
-	pixel_y = 8
+/obj/structure/sign/number/random{
+	color = "Black";
+	pixel_y = 4;
+	pixel_x = 0
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/atmospherics)
 "cn" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "cw" = (
@@ -244,6 +254,9 @@
 /area/ship/storage/equip)
 "dh" = (
 /obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "dx" = (
@@ -254,6 +267,9 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/structure/sign/poster/official/get_your_legs{
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "dy" = (
@@ -293,17 +309,29 @@
 /obj/effect/turf_decal/spline/fancy/opaque/orange{
 	dir = 9
 	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
 /turf/open/floor/noslip,
 /area/ship/cargo/port)
 "ea" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
@@ -316,6 +344,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/crate_shelve,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "eo" = (
@@ -469,6 +502,13 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "ge" = (
@@ -505,6 +545,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/structure/closet/firecloset/wall/directional/north,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "gs" = (
@@ -514,14 +555,12 @@
 	name = "ammo locker"
 	},
 /obj/item/storage/box/ammo/a12g_buckshot{
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = 2
 	},
 /obj/item/storage/box/ammo/a12g_buckshot{
-	pixel_y = -4
-	},
-/obj/item/stock_parts/cell/gun/sharplite{
-	pixel_x = -8;
-	pixel_y = 6
+	pixel_y = -4;
+	pixel_x = 2
 	},
 /obj/item/stock_parts/cell/gun/sharplite{
 	pixel_x = -8;
@@ -529,18 +568,6 @@
 	},
 /obj/item/stock_parts/cell/gun/sharplite{
 	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell/gun/sharplite/mini{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/stock_parts/cell/gun/sharplite/mini{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/cell/gun/sharplite/mini{
-	pixel_x = 10;
 	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech,
@@ -629,9 +656,6 @@
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "hQ" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
 	dir = 8
 	},
@@ -646,6 +670,16 @@
 	pixel_x = 1;
 	pixel_y = 19
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "hZ" = (
@@ -758,6 +792,20 @@
 	name = "Equipment Room Shutter Control";
 	pixel_x = -21
 	},
+/obj/item/extinguisher/mini{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/gps/mining{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/obj/item/melee/knife/survival,
+/obj/item/stack/marker_beacon/ten{
+	pixel_x = -9;
+	pixel_y = -11
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
 "iR" = (
@@ -785,9 +833,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "iZ" = (
@@ -803,7 +848,7 @@
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 0;
-	pixel_x = -28
+	pixel_x = -31
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
@@ -988,10 +1033,23 @@
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "kV" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "lb" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1013,6 +1071,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "ld" = (
@@ -1034,6 +1093,9 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -1123,7 +1185,8 @@
 	name = "Mechanic's locker";
 	dir = 2;
 	pixel_y = -28;
-	pixel_x = 0
+	pixel_x = 0;
+	req_one_access = list(11,41)
 	},
 /obj/item/storage/backpack/duffelbag/engineering{
 	pixel_x = -1;
@@ -1178,6 +1241,9 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/structure/sign/poster/contraband/space_cola{
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "ms" = (
@@ -1228,6 +1294,7 @@
 	pixel_x = -12;
 	pixel_y = -19
 	},
+/obj/structure/closet/emcloset/wall/directional/south,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "mF" = (
@@ -1333,13 +1400,20 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "nB" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_y = 0;
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "nR" = (
@@ -1389,6 +1463,20 @@
 /obj/effect/turf_decal/solarpanel,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/canteen)
+"oe" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
 "ol" = (
 /obj/structure/window{
 	dir = 2
@@ -1500,6 +1588,43 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/structure/closet/crate/wooden,
+/obj/item/storage/box/glowsticks{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/storage/box/glowsticks{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/storage/box/glowsticks{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/storage/box/glowsticks{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/item/shovel{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/pickaxe{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/pickaxe{
+	pixel_x = 6;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "pS" = (
@@ -1539,6 +1664,9 @@
 /obj/item/radio/intercom/directional/south{
 	pixel_y = -31;
 	pixel_x = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -1652,17 +1780,22 @@
 	pixel_x = -9;
 	pixel_y = 9
 	},
-/obj/item/clothing/accessory/holster{
-	pixel_x = -10;
-	pixel_y = 0
-	},
 /obj/item/clothing/gloves/color/white{
 	pixel_x = -9;
 	pixel_y = -8
 	},
-/obj/item/storage/box/ammo/c38{
+/obj/item/storage/guncase/pistol/candor{
 	pixel_x = -8;
-	pixel_y = -6
+	pixel_y = -9;
+	mag_count = 3
+	},
+/obj/item/storage/box/ammo/c45{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = -9;
+	pixel_y = 0
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm/captain)
@@ -1699,6 +1832,10 @@
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
 /obj/item/clothing/mask/gas,
+/obj/structure/sign/warning/enginesafety{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "rw" = (
@@ -1725,6 +1862,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "rQ" = (
@@ -1767,6 +1910,7 @@
 /obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "sl" = (
@@ -1800,6 +1944,13 @@
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = -6
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "sA" = (
@@ -1864,6 +2015,9 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "tj" = (
@@ -1875,9 +2029,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/dept/cargo{
-	dir = 1
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "tD" = (
@@ -1892,6 +2043,7 @@
 	id = "dwayne_cryo";
 	name = "Cryo Shutter Control"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "tG" = (
@@ -1929,7 +2081,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/retro/radio{
-	desc = "A poster advertising one of Nanotrasen's earliest products, a radio. One of its main selling points was a integrated OS and two way automatic translation for Solarian Common and Gezenan, which made it a smash hit. This thing is ancient."d";
+	desc = "A poster advertising one of Nanotrasen's earliest products, a radio. One of its main selling points was a integrated OS and two way automatic translation for Solarian Common and Gezenan, which made it a smash hit. This thing is ancient.";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
@@ -1973,14 +2125,20 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm/captain)
 "tX" = (
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/white{
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "uc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -2005,6 +2163,15 @@
 /obj/machinery/light/directional/west,
 /obj/structure/chair/handrail{
 	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -2055,6 +2222,15 @@
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "vi" = (
@@ -2079,10 +2255,25 @@
 /area/ship/cargo/port)
 "vm" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/caution/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "vs" = (
@@ -2163,6 +2354,11 @@
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
 	dir = 4
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "vQ" = (
@@ -2238,6 +2434,15 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "xh" = (
@@ -2256,7 +2461,6 @@
 	dir = 1;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
@@ -2265,7 +2469,7 @@
 "xr" = (
 /obj/structure/table/reinforced,
 /obj/structure/closet/wall/white/directional/west{
-	name = "refrigerator"
+	name = "kitchen cabinet"
 	},
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
@@ -2276,6 +2480,71 @@
 	pixel_x = -21;
 	pixel_y = 17;
 	dir = 4
+	},
+/obj/item/food/grown/cabbage{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/food/grown/cabbage{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/food/grown/potato{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/food/grown/potato{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/food/grown/chili{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/food/grown/chili{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/storage/fancy/egg_box,
+/obj/item/food/meat/slab{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/food/meat/slab{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/food/fishmeat{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/food/fishmeat{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = -7
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = -7
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -2372,6 +2641,25 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
+"yW" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "yZ" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
@@ -2409,8 +2697,10 @@
 	pixel_y = -10;
 	dir = 8;
 	pixel_x = 21;
-	id = "dwayne_bathrooms";
-	name = "Bathroom Bolt Control"
+	id = "dwayne_bathroom";
+	name = "Bathroom Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
@@ -2452,7 +2742,7 @@
 /obj/machinery/blackbox_recorder,
 /obj/structure/sign/poster/contraband/cardinal_port_starboard{
 	pixel_y = 0;
-	pixel_x = -28
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
@@ -2461,6 +2751,25 @@
 	icon_state = "1-2"
 	},
 /obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/closet/crate/freezer{
+	name = "provisions crate"
+	},
+/obj/item/storage/cans/sixbeer{
+	pixel_y = 2
+	},
+/obj/item/storage/cans/sixsoda{
+	pixel_y = -2
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "zB" = (
@@ -2496,20 +2805,40 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage/equip)
+"zM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
 "zP" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/industrial/caution/red{
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
+"zZ" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "Ak" = (
 /obj/item/stack/sheet/metal/twenty{
 	pixel_y = 0
@@ -2522,12 +2851,22 @@
 /obj/structure/closet/crate/engineering{
 	name = "material crate"
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "Am" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "AB" = (
@@ -2564,7 +2903,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ship/crew/dorm/captain)
+/area/ship/crew/toilet)
 "AD" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -2586,6 +2925,9 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -2639,12 +2981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -2653,6 +2989,12 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 9
+	},
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "Bx" = (
@@ -2697,17 +3039,36 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Co" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
+"Di" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "Dm" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -2747,7 +3108,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ship/crew/dorm)
+/area/ship/crew/toilet)
 "Dv" = (
 /turf/template_noop,
 /area/space)
@@ -2782,9 +3143,6 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/gun/ballistic/revolver/detective,
 /obj/item/megaphone/cargo,
 /obj/structure/railing{
 	dir = 2
@@ -2799,6 +3157,7 @@
 	pixel_x = -12;
 	pixel_y = 22
 	},
+/obj/item/gps,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "DP" = (
@@ -2839,13 +3198,12 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "DT" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /obj/structure/cable/cyan{
@@ -2854,15 +3212,28 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Ee" = (
-/obj/effect/turf_decal/industrial/warning/corner,
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Ep" = (
@@ -2935,8 +3306,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/dept/mining,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "EG" = (
@@ -2957,6 +3326,7 @@
 	dir = 8
 	},
 /obj/structure/ore_box,
+/obj/effect/turf_decal/box/corners,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "EZ" = (
@@ -2968,6 +3338,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/sign/poster/rilena/random{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "Fd" = (
@@ -3018,6 +3391,20 @@
 	pixel_x = -8;
 	pixel_y = -5
 	},
+/obj/item/extinguisher/mini{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/gps/mining{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/obj/item/melee/knife/survival,
+/obj/item/stack/marker_beacon/ten{
+	pixel_x = -9;
+	pixel_y = -11
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
 "Fj" = (
@@ -3040,6 +3427,9 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/orange{
 	dir = 5
+	},
+/obj/structure/railing/thin{
+	dir = 8
 	},
 /turf/open/floor/noslip,
 /area/ship/cargo/port)
@@ -3076,6 +3466,9 @@
 	dir = 1
 	},
 /obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "FH" = (
@@ -3101,6 +3494,13 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "FN" = (
@@ -3124,6 +3524,20 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/extinguisher/mini{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "FT" = (
@@ -3159,20 +3573,23 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "GG" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "GL" = (
 /obj/effect/turf_decal/box,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/starboard)
 "GQ" = (
@@ -3180,6 +3597,9 @@
 	dir = 4
 	},
 /obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "Hh" = (
@@ -3250,6 +3670,9 @@
 /obj/effect/turf_decal/spline/fancy/opaque/orange{
 	dir = 6
 	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
 /turf/open/floor/noslip,
 /area/ship/cargo/starboard)
 "HI" = (
@@ -3285,11 +3708,27 @@
 /obj/structure/chair/handrail{
 	dir = 8
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "If" = (
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
 	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
@@ -3311,6 +3750,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/ore_box,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "Is" = (
@@ -3322,11 +3767,17 @@
 	pixel_y = -4
 	},
 /obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "IF" = (
@@ -3356,6 +3807,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Jc" = (
@@ -3380,6 +3832,11 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/structure/mirror{
+	pixel_y = 4;
+	layer = 2.8;
+	pixel_x = -25
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
@@ -3467,6 +3924,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "KF" = (
@@ -3474,7 +3934,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/closet/cabinet,
 /obj/item/clothing/under/overalls/black{
 	pixel_x = 1;
 	pixel_y = 1
@@ -3514,10 +3973,6 @@
 	pixel_x = -8;
 	pixel_y = 1
 	},
-/obj/item/clothing/under/pants/cargo/grey{
-	pixel_x = -8;
-	pixel_y = -2
-	},
 /obj/item/clothing/suit/jacket/leather/coat{
 	pixel_x = -8;
 	pixel_y = 5
@@ -3540,11 +3995,27 @@
 	id = "dwayne_dorms";
 	name = "Dormitory Window Control"
 	},
+/obj/structure/closet/cabinet{
+	name = "wardrobe"
+	},
+/obj/item/clothing/under/pants/cargo{
+	pixel_x = -8;
+	pixel_y = -2
+	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "KJ" = (
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Ln" = (
@@ -3582,6 +4053,7 @@
 	pixel_y = -21;
 	id = "dwayne_engines_port"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "Ls" = (
@@ -3679,6 +4151,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "LN" = (
@@ -3745,11 +4221,20 @@
 /area/ship/engineering)
 "Mt" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
+/obj/machinery/airalarm/directional/west,
+/obj/item/kirbyplants{
+	icon_state = "plant-18";
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 10;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Mz" = (
@@ -3802,9 +4287,8 @@
 "MG" = (
 /obj/structure/guncloset,
 /obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
-/obj/item/gun/energy/sharplite/x26/empty_cell,
-/obj/item/gun/energy/sharplite/x12/empty_cell,
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/item/gun/energy/sharplite/x12,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
 "MW" = (
@@ -3828,6 +4312,23 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
+"Ne" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "Nf" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -3939,10 +4440,11 @@
 	dir = 8
 	},
 /obj/structure/crate_shelf,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/effect/turf_decal/box/corners,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
 "NW" = (
@@ -4003,6 +4505,14 @@
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Oz" = (
@@ -4015,6 +4525,7 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 8
 	},
+/obj/structure/closet/firecloset/wall/directional/south,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "OE" = (
@@ -4030,6 +4541,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "OJ" = (
@@ -4066,6 +4578,7 @@
 	dir = 2
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "OV" = (
@@ -4090,6 +4603,9 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -4193,6 +4709,9 @@
 /area/ship/storage/equip)
 "QK" = (
 /obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "Ra" = (
@@ -4205,12 +4724,19 @@
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = -6
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Rb" = (
 /obj/item/toy/eightball{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_x = 5;
+	pixel_y = 10
 	},
 /obj/structure/table/wood/poker{
 	name = "billiards table"
@@ -4231,11 +4757,19 @@
 /obj/effect/turf_decal/spline/fancy/opaque/orange{
 	dir = 10
 	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
 /turf/open/floor/noslip,
 /area/ship/cargo/starboard)
 "RE" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -4337,7 +4871,7 @@
 "SA" = (
 /obj/structure/closet/secure_closet/wall/directional/north{
 	name = "foreman's locker";
-	req_access_txt = "20";
+	req_access_txt = "41";
 	icon_state = "solgov_wall";
 	pixel_y = 0;
 	dir = 4;
@@ -4378,6 +4912,15 @@
 /obj/item/clothing/head/hardhat/white{
 	pixel_x = 2;
 	pixel_y = 10
+	},
+/obj/item/storage/guncase/pistol/miniegun{
+	pixel_x = 7;
+	pixel_y = -9;
+	mag_count = 3
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = 6;
+	pixel_y = -5
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
@@ -4436,13 +4979,8 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	dir = 1;
-	name = "Scrubbers to Recycling"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
+	name = "Scrubbers to Recycling";
+	layer = 2.43
 	},
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -4454,7 +4992,8 @@
 	id = "dwayne_recycling";
 	name = "Recycling Window Control"
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Tw" = (
 /obj/effect/turf_decal/ntspaceworks_small/right,
@@ -4462,6 +5001,21 @@
 /area/ship/cargo/starboard)
 "TO" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "TP" = (
@@ -4474,13 +5028,18 @@
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "TR" = (
-/obj/structure/mirror{
-	pixel_y = 4;
-	layer = 2.8;
-	pixel_x = 7
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm)
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "TT" = (
 /obj/effect/spawner/bunk_bed{
 	dir = 4
@@ -4530,7 +5089,19 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo/starboard)
 "UV" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "UX" = (
 /obj/structure/cable/cyan{
@@ -4557,11 +5128,17 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "Vm" = (
-/obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "Vo" = (
@@ -4604,6 +5181,30 @@
 /obj/structure/table/wood/poker{
 	name = "billiards table"
 	},
+/obj/item/dice/d6{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/dice/d6{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/dice/d6{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/dice/d6/ebony{
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "Wa" = (
@@ -4630,6 +5231,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/directional/south,
+/obj/item/toy/cards/deck{
+	pixel_x = 5;
+	pixel_y = 0
+	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Wh" = (
@@ -4644,6 +5249,10 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
 /obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
 	dir = 1
+	},
+/obj/item/kirbyplants/fullysynthetic{
+	pixel_x = 10;
+	pixel_y = 21
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
@@ -4664,6 +5273,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "WE" = (
@@ -4761,6 +5371,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Yd" = (
@@ -4909,6 +5520,7 @@
 	dir = 1
 	},
 /obj/structure/curtain/bounty,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Zj" = (
@@ -4922,6 +5534,7 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Zk" = (
@@ -4929,6 +5542,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Zo" = (
@@ -4982,9 +5598,6 @@
 /area/ship/engineering)
 "ZX" = (
 /obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "dwayne_starboard";
 	name = "Starboard Blast Doors";
@@ -4996,6 +5609,18 @@
 	id = "dwayne_starboard_field";
 	pixel_x = 1;
 	pixel_y = -19;
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
@@ -5066,7 +5691,7 @@ Dv
 "}
 (4,1,1) = {"
 Dv
-ak
+ck
 kJ
 vs
 aq
@@ -5087,7 +5712,7 @@ Dv
 "}
 (5,1,1) = {"
 Dv
-ak
+ck
 aK
 mH
 YD
@@ -5108,7 +5733,7 @@ Dv
 "}
 (6,1,1) = {"
 Dv
-ak
+ck
 OE
 Sa
 lU
@@ -5129,7 +5754,7 @@ Dv
 "}
 (7,1,1) = {"
 Dv
-ak
+ck
 rw
 RS
 vA
@@ -5220,7 +5845,7 @@ iu
 Fi
 MG
 JB
-sM
+zM
 fN
 QG
 Ny
@@ -5343,7 +5968,7 @@ HI
 Co
 th
 EV
-TO
+zZ
 FQ
 jS
 or
@@ -5364,7 +5989,7 @@ AB
 ea
 kV
 kV
-TO
+yW
 ku
 sb
 IZ
@@ -5372,7 +5997,7 @@ WE
 dK
 yZ
 xZ
-RE
+Di
 UV
 UV
 vm
@@ -5414,8 +6039,8 @@ JH
 Fd
 yZ
 Tw
-RE
-UV
+Ne
+tX
 UV
 vm
 wm
@@ -5427,7 +6052,7 @@ ju
 GG
 bE
 QK
-TO
+TR
 dO
 jS
 kb
@@ -5530,13 +6155,13 @@ Dv
 Dv
 ir
 am
-tX
+tQ
 iY
-ck
+xo
 qg
 Pl
 Xl
-Ka
+oe
 OP
 bx
 AS
@@ -5562,7 +6187,7 @@ sM
 bx
 bx
 Ds
-TR
+bx
 bx
 bx
 VO
@@ -5600,7 +6225,7 @@ vw
 Pl
 FN
 Mz
-sM
+zM
 gx
 zb
 Xw

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -57,7 +57,11 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "aK" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
@@ -173,17 +177,12 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "bR" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window{
-	pixel_y = 0
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_cryo";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm/captain)
 "bW" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -290,14 +289,20 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "dy" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dK" = (
 /obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dL" = (
 /obj/structure/cable/yellow{
@@ -310,7 +315,11 @@
 /obj/structure/chair/handrail{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dO" = (
 /obj/structure/chair/handrail{
@@ -467,13 +476,14 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "fz" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "fJ" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
@@ -499,7 +509,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "fU" = (
@@ -616,10 +626,14 @@
 /turf/open/floor/plating,
 /area/ship/cargo/port)
 "hB" = (
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "hC" = (
 /obj/structure/chair/stool,
@@ -943,18 +957,21 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo/port)
 "kb" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/chair/handrail,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "kf" = (
 /obj/machinery/door/airlock/external{
@@ -1133,7 +1150,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "lC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer2{
@@ -1277,19 +1294,22 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "mA" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = -12;
 	pixel_y = -19
 	},
 /obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "mF" = (
 /obj/machinery/door/window/westleft,
@@ -1352,10 +1372,14 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/borderfloor{
+	layer = 2.030;
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "nr" = (
 /turf/closed/wall/mineral/titanium,
@@ -1366,9 +1390,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -1377,7 +1398,13 @@
 /obj/effect/turf_decal/trimline/opaque/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "nu" = (
 /obj/structure/cable/yellow{
@@ -1489,19 +1516,20 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/handrail,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/north{
 	pixel_x = -6
 	},
 /obj/machinery/firealarm/directional/north{
 	pixel_x = 6
 	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "oB" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1524,9 +1552,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -1537,7 +1562,11 @@
 /obj/effect/turf_decal/trimline/opaque/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "oR" = (
 /obj/structure/cable/cyan{
@@ -1549,10 +1578,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "pl" = (
 /obj/effect/turf_decal/industrial/outline,
@@ -1562,16 +1594,19 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
 "pt" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "px" = (
 /obj/structure/cable/cyan{
@@ -1903,7 +1938,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "sk" = (
 /obj/structure/cable/yellow{
@@ -1914,11 +1949,14 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "sl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1982,14 +2020,21 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
 	},
 /obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "sM" = (
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "sY" = (
 /obj/structure/cable/cyan{
@@ -2032,7 +2077,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "tj" = (
-/obj/effect/turf_decal/industrial/warning,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -2040,20 +2084,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tD" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_cryo";
-	name = "Cryo Shutter Control"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
@@ -2151,10 +2192,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/siding/white,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Starboard Hangar"
 	},
-/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/starboard)
 "uh" = (
@@ -2234,10 +2275,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
 "vj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
@@ -2246,6 +2283,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/airlock/mining/glass{
@@ -2347,10 +2388,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "wh" = (
 /obj/docking_port/stationary{
@@ -2386,7 +2431,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "xb" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
@@ -2440,7 +2485,11 @@
 /area/ship/crew/toilet)
 "xo" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "xr" = (
 /obj/structure/table/reinforced,
@@ -2565,7 +2614,11 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "yp" = (
 /obj/structure/railing/thin/corner{
@@ -2613,10 +2666,12 @@
 /area/ship/external/dark)
 "yJ" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 2
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "yN" = (
 /obj/structure/cable/yellow{
@@ -2686,7 +2741,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "zl" = (
@@ -2757,7 +2812,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "zI" = (
@@ -2770,6 +2825,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /obj/machinery/door/airlock/mining{
 	name = "Equipment Room"
 	},
@@ -2889,7 +2947,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "AG" = (
@@ -3007,8 +3065,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Co" = (
 /obj/structure/cable/cyan{
@@ -3080,10 +3142,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/emcloset/wall/directional/north,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "DL" = (
 /obj/structure/filingcabinet/filingcabinet{
@@ -3140,7 +3203,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "DS" = (
 /obj/structure/cable/cyan{
@@ -3242,9 +3305,6 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "EE" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -3255,7 +3315,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "EG" = (
 /obj/structure/railing/thin/corner{
@@ -3303,12 +3367,14 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "Fd" = (
-/obj/effect/turf_decal/industrial/warning,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Fi" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
@@ -3443,10 +3509,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "FM" = (
 /obj/machinery/airalarm/directional/east,
@@ -3467,10 +3536,14 @@
 	icon_state = "5-8"
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "FQ" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3522,7 +3595,11 @@
 /obj/structure/extinguisher_cabinet/directional/south{
 	pixel_x = 7
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Gx" = (
 /obj/structure/cable/cyan{
@@ -3530,8 +3607,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/warning,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "GG" = (
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
@@ -3695,7 +3776,12 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	layer = 2.030;
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Ip" = (
 /obj/structure/cable/cyan{
@@ -3751,14 +3837,15 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "IZ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Jc" = (
 /obj/machinery/power/solar,
@@ -3811,7 +3898,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Jy" = (
@@ -3845,7 +3932,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Ka" = (
@@ -3858,7 +3945,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Ku" = (
@@ -4038,9 +4125,6 @@
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering/atmospherics)
 "Lt" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -4053,10 +4137,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	layer = 2.030;
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "LB" = (
 /obj/structure/window/plasma/reinforced{
@@ -4089,10 +4180,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm/captain)
 "LM" = (
@@ -4118,13 +4205,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "LZ" = (
 /obj/effect/turf_decal/siding/wood,
@@ -4207,7 +4297,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "MA" = (
@@ -4233,13 +4323,16 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "MG" = (
 /obj/structure/guncloset,
@@ -4459,7 +4552,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Oy" = (
 /obj/structure/cable/cyan{
@@ -4521,14 +4618,18 @@
 /area/ship/crew/canteen)
 "OP" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 8
-	},
 /obj/structure/chair/handrail{
 	dir = 1;
 	name = "overhead handrail"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "OR" = (
 /obj/structure/cable/cyan{
@@ -4540,8 +4641,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 2
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "OV" = (
@@ -4657,7 +4758,7 @@
 	name = "Supply to Output";
 	layer = 2.43
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "QI" = (
@@ -4792,14 +4893,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "dwayne_bridge"
+	},
 /obj/machinery/door/airlock/command/glass{
 	dir = 4;
 	name = "Bridge";
 	req_one_access = list(20,41)
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "dwayne_bridge"
 	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4;
@@ -4835,7 +4936,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Sn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4944,6 +5049,14 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
+"Ti" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/hallway/central)
 "Tl" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -5087,7 +5200,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Vb" = (
@@ -5137,7 +5250,7 @@
 	dir = 1;
 	layer = 2.43
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "VO" = (
@@ -5212,17 +5325,10 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Wh" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 20;
 	pixel_y = -12
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
 	},
 /obj/item/kirbyplants/fullysynthetic{
 	pixel_x = 10;
@@ -5236,7 +5342,17 @@
 	dir = 8;
 	req_one_access = list(20,41)
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Wy" = (
 /obj/structure/cable/cyan{
@@ -5248,8 +5364,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "WB" = (
@@ -5279,15 +5395,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "WM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-10"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Xa" = (
 /obj/effect/turf_decal/industrial/hatch/yellow,
@@ -5305,13 +5425,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
-	},
 /obj/structure/chair/handrail{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Xo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5319,8 +5443,12 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/warning,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Xu" = (
 /turf/closed/wall/mineral/titanium,
@@ -5339,7 +5467,6 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/toilet)
 "XC" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -5349,6 +5476,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock{
 	name = "Common Room"
 	},
@@ -5364,11 +5492,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	layer = 2.030;
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Yd" = (
 /obj/structure/cable/yellow{
@@ -5400,9 +5531,6 @@
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
 "Yg" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
@@ -5412,13 +5540,17 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/warning,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Yq" = (
 /obj/structure/table,
@@ -5528,7 +5660,6 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Zj" = (
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
 /obj/machinery/firealarm/directional/south{
 	pixel_x = -5
 	},
@@ -5538,8 +5669,13 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/borderfloor{
+	layer = 2.030;
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/neutral/filled/corner,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Zk" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5848,7 +5984,7 @@ iu
 Fi
 MG
 JB
-xo
+Ti
 fN
 QG
 Ny
@@ -5937,8 +6073,8 @@ na
 mA
 vL
 vL
-bR
-bR
+vL
+vL
 vL
 vL
 UN
@@ -6250,7 +6386,7 @@ XC
 hB
 Jx
 BX
-vi
+bR
 vi
 AC
 vi

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -4757,6 +4757,10 @@
 	name = "Bridge";
 	req_one_access = list(20,41)
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "dwayne_bridge"
+	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4;
 	color = "#555555"
@@ -4879,11 +4883,17 @@
 /obj/machinery/button/door{
 	id = "dwayne_windows";
 	name = "Bridge Window Control";
-	pixel_x = -5;
+	pixel_x = 5;
 	pixel_y = 20
 	},
 /obj/machinery/computer/helm{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_bridge";
+	name = "Privacy Shutter Control";
+	pixel_x = -6;
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -3,6 +3,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/machinery/computer/cryopod/directional/east,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "ak" = (
@@ -529,6 +530,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
+"ga" = (
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "ge" = (
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/machinery/atmospherics/components/unary/tank/nitrogen{
@@ -628,12 +635,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo/port)
-"hu" = (
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "hB" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -1042,6 +1043,19 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"kv" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "kJ" = (
 /obj/machinery/power/terminal{
@@ -1560,19 +1574,6 @@
 "oF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
-"oH" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/caution/red,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
@@ -6163,7 +6164,7 @@ Dv
 (18,1,1) = {"
 Dv
 AB
-oH
+kv
 kV
 kV
 TR
@@ -6465,7 +6466,7 @@ eq
 Pl
 aX
 RV
-hu
+ga
 vi
 HB
 Op

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -1,78 +1,1079 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ak" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /obj/structure/cable/cyan{
-	icon_state = "5-8"
+	icon_state = "1-2"
 	},
-/obj/item/kirbyplants/fullysynthetic{
-	pixel_x = 10
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"as" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	icon_state = "6-8"
+"aI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-6"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"aM" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"ax" = (
+/area/ship/cargo/port)
+"aR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"aW" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
+"aX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"aY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"bj" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"bs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sign/warning/fire{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"bv" = (
+/obj/structure/chair/comfy/beige/old{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"bx" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
+"bE" = (
+/obj/item/stack/sheet/metal/twenty{
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/glass/twenty{
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/engineering{
+	name = "material crate"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"bR" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window{
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"bW" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"aI" = (
+"cf" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/atmospherics)
+"ck" = (
+/obj/structure/chair/stool/bar{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"cn" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"cw" = (
+/obj/machinery/holopad/emergency/command,
+/obj/effect/turf_decal/box/white{
+	color = "#283674"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"cI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"cO" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"cV" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/computer/helm/viewscreen/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"da" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"dh" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 12;
+	pixel_y = -19
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"do" = (
+/obj/machinery/griddle,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"dx" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm/captain)
+"dy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dI" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"dK" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dN" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "5-9"
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/stock_parts/manipulator/nano{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/screwdriver{
+	pixel_y = -9;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"dO" = (
+/obj/structure/chair/handrail{
+	dir = 8;
+	name = "overhead handrail"
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 9
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/port)
+"dY" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_port";
+	name = "Port Blast Doors";
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_port_field";
+	pixel_x = 1;
+	pixel_y = 19
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"ea" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"ec" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_dorms"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
+"ei" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"eu" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"eH" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"eL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"fl" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"fp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Port Hangar"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo/port)
+"fr" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "5-6"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_starboard";
+	name = "Engine Shutter Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"fz" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"fU" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/autolathe,
 /obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"gf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"gg" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"gp" = (
+/obj/structure/window{
+	dir = 2
+	},
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"gq" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"gs" = (
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null;
+	name = "ammo locker"
+	},
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_y = 6
+	},
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_y = -4
+	},
+/obj/item/stock_parts/cell/gun/sharplite{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/gun/sharplite{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/gun/sharplite{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/gun/sharplite/mini{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/gun/sharplite/mini{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/gun/sharplite/mini{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"gS" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"hh" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 22
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"hx" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"hB" = (
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"hC" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"hN" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"hR" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"hS" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_lounge"
+	},
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/crew/canteen)
+"hZ" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ig" = (
+/obj/effect/turf_decal/solarpanel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm/captain)
+"ij" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"im" = (
+/obj/effect/turf_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"in" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_kitchen"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"iq" = (
+/obj/machinery/washing_machine{
+	layer = 2.8;
+	pixel_y = 1
+	},
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/bedsheetbin{
+	pixel_y = 17;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -12
+	},
+/obj/item/radio/intercom/directional/west{
+	pixel_y = 2
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"ir" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering)
+"is" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"iG" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"iH" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"iY" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"iZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/mob/living/simple_animal/turtle{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"jh" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm/captain)
+"jp" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"jz" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"jI" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"jS" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo/port)
+"jX" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/port)
+"kb" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/chair/handrail,
 /obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"kf" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 4;
+	name = "mining_ship_all";
+	port_direction = 2;
+	preferred_direction = 4
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"kg" = (
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"kj" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"ku" = (
+/obj/effect/turf_decal/ntspaceworks_small/right{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"kO" = (
+/obj/structure/dresser{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 12
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_y = -9
+	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = 3
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"kV" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/atmospherics/components/unary/tank/nitrogen{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"ld" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"ll" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"lo" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_port";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"lv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"aR" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -10
-	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"aS" = (
+/area/ship/hallway/central)
+"lC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer2{
 	dir = 1
 	},
@@ -83,237 +1084,746 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"aV" = (
+/area/ship/hallway/central)
+"ma" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"mf" = (
 /obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/dresser{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 4
+	},
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"ms" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/ship/crew/dorm)
-"aY" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_y = -6
+"mu" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/sign/poster/official/bless_this_spess{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"bb" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/item/stack/packageWrap{
-	pixel_y = 2;
-	pixel_x = -7
-	},
-/obj/structure/chair/handrail,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"bf" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"bj" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"bl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"bo" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"bv" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable/cyan{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
+"mv" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_captain";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /turf/open/floor/plating,
-/area/ship/hallway/central)
-"bx" = (
-/obj/structure/chair/sofa/brown/old/left/directional/south,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/newscaster/directional/north{
-	pixel_x = -13
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"bE" = (
-/obj/machinery/door/airlock/public{
-	id_tag = "dwayne_bathroom"
+/area/ship/crew/dorm/captain)
+"my" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/toilet)
-"bO" = (
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"bP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/power/terminal{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/item/cigbutt,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"bW" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"mA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -19
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"mF" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window{
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"mP" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"mR" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"na" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 2;
+	name = "Supply to Output";
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"nk" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"nr" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"nB" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"nV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"nX" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"nY" = (
+/obj/machinery/jukebox{
+	pixel_y = 6;
+	pixel_x = 13
+	},
+/obj/structure/reagent_dispensers/water_cooler{
+	density = 0;
+	pixel_y = 6;
+	pixel_x = -5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"oa" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"or" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/handrail,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -6
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"oB" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"oE" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/hallway/central)
+"oF" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_captain"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/crew/dorm/captain)
+"oR" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"pl" = (
+/obj/machinery/computer/solar_control{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"pt" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"pu" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"px" = (
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"pS" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"cc" = (
+"qg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"ql" = (
+/obj/structure/chair/sofa/brown/old/left/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"qr" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 2
+	},
+/obj/structure/curtain/bounty,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"qJ" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "captain's locker";
+	req_access_txt = "20";
+	icon_state = "solgov_wall";
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/item/storage/backpack/duffelbag/captain{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/storage/backpack/satchel/cap{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/cowboy/fancy{
+	pixel_x = -10;
+	pixel_y = -9
+	},
+/obj/item/clothing/suit/jacket/leather/duster/command{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/rank/command/captain/skirt{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/rank/command/captain{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/head/caphat/cowboy{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/caphat{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/white{
+	pixel_x = -9;
+	pixel_y = -8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"qO" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/tracker,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"qQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"rs" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"rE" = (
+/obj/structure/closet/crate/medical,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/storage/firstaid/regular,
+/obj/item/roller,
+/obj/item/reagent_containers/hypospray/medipen/survival,
+/obj/item/reagent_containers/hypospray/medipen/survival{
+	pixel_y = -4
+	},
+/obj/item/storage/pill_bottle/charcoal/less{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"rG" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"rP" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_lounge"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/crew/canteen)
+"rQ" = (
+/obj/effect/turf_decal/ntspaceworks_small/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"sb" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"sg" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"sk" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"sp" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_captain"
+	},
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"st" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"sD" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning/corner,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"sM" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"te" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"cf" = (
-/obj/structure/sign/poster/rilena/random{
-	pixel_x = -32
+/area/ship/cargo/starboard)
+"tg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "Captain's wardobe";
-	req_access_txt = "20";
-	close_sound = 'sound/machines/wooden_closet_close.ogg';
-	open_sound = 'sound/machines/wooden_closet_open.ogg';
-	desc = "It's a card-locked cabinet."
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
-/obj/item/storage/backpack/satchel/cap,
-/obj/item/storage/backpack/messenger/com,
-/obj/item/clothing/under/rank/command/captain,
-/obj/item/clothing/under/rank/command/captain/skirt,
-/obj/item/clothing/shoes/cowboy/fancy,
-/obj/item/clothing/suit/jacket/leather/duster/command,
-/obj/item/clothing/suit/armor/vest/capcarapace/duster,
-/obj/item/clothing/gloves/color/white,
-/obj/item/clothing/head/caphat,
-/obj/item/clothing/head/caphat/cowboy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"th" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"tj" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/dept/cargo{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"tl" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/computer/helm/viewscreen/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"tu" = (
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 11;
 	pixel_y = -19
 	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/obj/effect/turf_decal/box,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/area/ship/crew/dorm)
-"cw" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"cL" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"tA" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/structure/closet/crate,
-/obj/machinery/firealarm/directional/north,
-/obj/item/circuitboard/machine/pipedispenser,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"cV" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/canteen)
-"dh" = (
-/obj/structure/sign/number/random{
-	color = "Black";
-	pixel_y = -7
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"dq" = (
-/obj/machinery/conveyor{
-	id = "smelter_dwayne"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"dx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/ammo/c38,
-/obj/item/storage/box/ammo/c38,
-/obj/item/storage/box/ammo/c38,
-/obj/structure/closet/crate/secure/plasma{
-	name = "ammo crate";
-	desc = "A secure ammo crate."
-	},
-/obj/effect/turf_decal/ntspaceworks_big/two{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"dy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"dK" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"tI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker{
+	pixel_y = 14;
+	pixel_x = -4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"dQ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"ea" = (
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/structure/sign/poster/retro/radio{
+	desc = "A poster advertising one of Nanotrasen's earliest products, a radio. One of its main selling points was a integrated OS and two way automatic translation for Solarian Common and Gezenan, which made it a smash hit. This thing is ancient."d";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"tQ" = (
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"tX" = (
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"tY" = (
 /obj/machinery/power/smes/shuttle/precharged,
 /obj/machinery/door/window/northright{
 	dir = 4;
@@ -322,41 +1832,1180 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
 	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"uc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Starboard Hangar"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo/starboard)
+"uh" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"uq" = (
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/rack,
+/obj/item/storage/bag/ore{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/storage/bag/ore{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/pinpointer/mineral{
+	pixel_y = 3;
+	pixel_x = -7
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_y = 3;
+	pixel_x = 6
+	},
+/obj/item/pickaxe/drill{
+	pixel_y = -2
+	},
+/obj/item/pickaxe/drill{
+	pixel_y = -6
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"uw" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"uJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"uK" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"uS" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"vf" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"eu" = (
+"vi" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"vm" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"vw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"vx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Common Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/canteen)
+"vy" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "miner's locker";
+	req_access_txt = "48";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/clothing/gloves/explorer{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"vB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/sofa/brown/old/right/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"vH" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/dorm)
+"vL" = (
+/obj/effect/turf_decal/ntspaceworks_small/left,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"vQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"vZ" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/wall/orange/directional/west{
+	name = "Mechanic's locker";
+	dir = 2;
+	pixel_y = -28;
+	pixel_x = 0
+	},
+/obj/item/storage/backpack/duffelbag/engineering{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/obj/item/storage/backpack/satchel/eng{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/overalls/olive{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/toggle/hazard,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -1;
+	pixel_y = -13
+	},
+/obj/item/storage/belt/utility/full/engi{
+	pixel_x = -1;
+	pixel_y = -15
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/hardhat/dblue{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"wh" = (
+/obj/docking_port/stationary{
+	dheight = 1;
+	dwidth = 20;
+	height = 30;
+	name = "Dwayne Port Beam Dock";
+	width = 40
+	},
+/turf/template_noop,
+/area/space)
+"wm" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"wn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	name = "exhaust injector";
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"wC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"wE" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"wW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"xg" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"xh" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xl" = (
+/obj/effect/turf_decal/solarpanel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"xo" = (
+/obj/structure/chair/stool/bar{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xr" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/wall/white/directional/west{
+	name = "refrigerator"
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "dwayne_kitchen";
+	name = "Kitchen Window Control";
+	pixel_x = -21;
+	pixel_y = 17;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xS" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/can/food/beans,
+/obj/item/trash/sosjerky,
+/obj/item/trash/candy,
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"yb" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/head/helmet/space/light/engineer,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"ye" = (
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/overalls/black{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/clothing/under/overalls/brown{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/jacket{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/toggle/windbreaker{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/cowboy{
+	pixel_x = -9;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/cowboy/black{
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/sneakers/black{
+	pixel_x = 9;
+	pixel_y = -14
+	},
+/obj/item/clothing/under/pants/blackjeans{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/clothing/under/pants/khaki{
+	pixel_y = -6
+	},
+/obj/item/clothing/under/overalls{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/clothing/under/pants/cargo/grey{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/jacket/leather/coat{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/cowboy{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/item/clothing/head/soft{
+	pixel_x = -9;
+	pixel_y = 14
+	},
+/obj/item/clothing/head/soft/utility_olive{
+	pixel_y = 14
+	},
+/obj/machinery/button/door{
+	pixel_y = 13;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_dorms";
+	name = "Dormitory Window Control"
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"yq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"eH" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/industrial/loading,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"yw" = (
+/obj/structure/filingcabinet/filingcabinet{
+	dir = 4;
+	pixel_x = -10;
+	density = 0
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/gun/ballistic/revolver/detective,
+/obj/item/megaphone/cargo,
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/item/bodycamera,
+/obj/item/bodycamera,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"yJ" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"yN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_lounge";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"yV" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/arrows,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"yZ" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"zi" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"zl" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"eL" = (
+/area/ship/bridge)
+"zz" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/obj/machinery/blackbox_recorder,
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"zA" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"zC" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"zX" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_port";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Ak" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Ao" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 2;
+	piping_layer = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"AB" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"AC" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Bathroom";
+	dir = 4;
+	req_access_txt = "20";
+	id = "dwayne_bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"AD" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"AG" = (
+/obj/structure/sign/poster/radio/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"AQ" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"AS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"Bd" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/drill,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"Bg" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Dormitory";
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm)
+"Bx" = (
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4;
+	color = "#555555"
+	},
+/area/ship/bridge)
+"BB" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"BK" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"BX" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Co" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/maunamug{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/book/fish_catalog{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"CE" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/storage/equip)
+"CK" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"CX" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/canteen)
+"Ds" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Bathroom";
+	dir = 4;
+	id = "dwayne_bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Dv" = (
+/turf/template_noop,
+/area/space)
+"DJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/emcloset/wall/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"DM" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"DR" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"DS" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ntspaceworks_small,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"Eb" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Ed" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"Ee" = (
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Eo" = (
+/obj/machinery/power/terminal,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Ex" = (
+/obj/structure/table/reinforced,
+/obj/structure/sink/kitchen{
+	pixel_y = 21;
+	layer = 2.79;
+	dir = 2
+	},
+/obj/item/cutting_board{
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_y = 4
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 7;
+	pixel_x = -15
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -15;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"EC" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"EE" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/dept/mining,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"EI" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"EV" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"Fd" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Fi" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"Fq" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"Fz" = (
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/soap{
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/item/mop,
+/obj/structure/closet/crate/trashcart/laundry{
+	name = "cleaning cart"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"FH" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"FJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"FM" = (
+/obj/machinery/computer/monitor{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door{
+	pixel_y = -15;
+	dir = 8;
+	pixel_x = -8;
+	id = "dwayne_exhaust";
+	name = "Exhaust Window Control"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"FN" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-8"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"FR" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"FU" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 4
 	},
 /obj/machinery/button/door{
 	id = "dwayne_windows";
-	name = "Fore Window Control";
-	pixel_x = -10;
+	name = "Bridge Window Control";
+	pixel_x = -5;
 	pixel_y = 20
 	},
 /obj/machinery/computer/helm{
@@ -364,152 +3013,354 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"eM" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
-"fi" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
+"Gr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ship/engineering)
-"fl" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "fuel mixer";
-	node1_concentration = 0.33;
-	node2_concentration = 0.67;
-	target_pressure = 500
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
 	},
-/obj/item/paper/guides/jobs/engi/combustion_thruster,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"fp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
 	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Gs" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"fy" = (
-/obj/item/clothing/head/cone{
-	pixel_x = 3;
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"fz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 32
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
 	},
-/obj/structure/chair/handrail,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Gx" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"fV" = (
-/obj/structure/closet/cabinet{
-	name = "wardrobe"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "0-6"
-	},
-/obj/item/storage/backpack/satchel/explorer,
-/obj/item/storage/backpack/satchel/explorer,
-/obj/item/storage/backpack/satchel/explorer,
-/obj/item/clothing/under/utility,
-/obj/item/clothing/under/utility,
-/obj/item/clothing/under/utility/skirt,
-/obj/item/clothing/under/utility/skirt,
-/obj/item/clothing/shoes/workboots/mining,
-/obj/item/clothing/shoes/workboots/mining,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/suit/jacket/leather/duster,
-/obj/item/clothing/suit/jacket/leather/duster,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/cowboy,
-/obj/item/clothing/head/cowboy,
-/obj/item/clothing/glasses/heat,
-/obj/item/clothing/glasses/heat,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"fY" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/insectguts,
+"GG" = (
 /obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"GL" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Input to Waste";
+	dir = 1;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"GO" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /obj/structure/chair/handrail{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"gf" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"GQ" = (
+/obj/structure/table,
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"gm" = (
-/obj/machinery/atmospherics/components/unary/shuttle/fire_heater,
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
+"Hh" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"Hv" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"HI" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
 	},
 /turf/open/floor/plating,
-/area/ship/engineering)
-"gs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/area/ship/cargo/port)
+"HW" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"gu" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
-"gF" = (
-/obj/machinery/power/shuttle/engine/fire,
-/turf/open/floor/plating/airless,
-/area/ship/engineering)
-"he" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"HX" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner,
+/obj/structure/cable/cyan{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Ia" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"Ip" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"Is" = (
+/obj/structure/closet/crate/engineering/electrical{
+	name = "fuel crate"
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"It" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Ix" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/sofa/brown/old/right/directional/north,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Iy" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
-"hg" = (
+"IF" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "miner's locker";
+	req_access_txt = "48";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/obj/item/clothing/gloves/explorer{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"II" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"IJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/ntblue/half,
+/obj/machinery/fax/indie{
+	pixel_y = 7
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"IZ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Jh" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half,
+/obj/machinery/computer/cargo{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Jk" = (
+/obj/structure/sink{
+	pixel_y = 2;
+	dir = 4;
+	pixel_x = -13
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"Jq" = (
 /obj/docking_port/stationary{
 	dheight = 1;
 	dir = 2;
@@ -519,384 +3370,631 @@
 	width = 40
 	},
 /turf/template_noop,
-/area/template_noop)
-"hv" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dwidth = 20;
-	height = 30;
-	name = "Dwayne Port Beam Dock";
-	width = 40
+/area/space)
+"Jx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/turf/template_noop,
-/area/template_noop)
-"hy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"hB" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"hK" = (
-/obj/structure/sign/poster/contraband/gec{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	name = "connector port (Fuel)"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"hO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "5-10"
-	},
-/obj/effect/turf_decal/ntspaceworks_big/three,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"hS" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/dorm)
-"hZ" = (
-/obj/structure/chair/office{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Jy" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"JS" = (
+/obj/machinery/cryopod{
+	dir = 4
 	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"ig" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1;
-	piping_layer = 2
+/area/ship/crew/cryo)
+"JX" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"in" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_mining_field";
-	locked = 1
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Ka" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
 	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_mining"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"KJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /obj/structure/cable/cyan{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/storage/eva)
-"iq" = (
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"KL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	name = "Engineering"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Lf" = (
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Lq" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/storage/equip)
+"Lt" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Lv" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"Lz" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"LB" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 4;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 6
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"LC" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/starboard)
+"LL" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_recycling"
+	},
+/turf/open/space/basic,
+/area/ship/engineering/atmospherics)
+"LM" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ntspaceworks_small{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"LN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"LZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Mg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer4,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
 	},
 /obj/structure/closet/emcloset/wall/directional/west,
 /turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"ir" = (
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"iZ" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/cyan{
-	icon_state = "0-9"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"ja" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/structure/closet/crate/engineering/electrical,
-/obj/item/radio/intercom/directional/east,
-/obj/item/stack/sheet/mineral/plasma/ten,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"jz" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"jS" = (
-/obj/structure/chair/sofa/brown/old/left/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"kb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/closet/emcloset/wall/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"kf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 24
-	},
-/obj/machinery/door/airlock/external/glass{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"kM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "5-10"
-	},
-/obj/effect/turf_decal/ntspaceworks_big/three{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"kO" = (
-/obj/effect/decal/cleanable/food/tomato_smudge,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"kQ" = (
-/obj/structure/table,
-/obj/machinery/computer/helm/viewscreen/directional/north,
-/obj/machinery/power/terminal{
-	dir = 4;
-	layer = 2.30
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-6"
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 10;
-	pixel_y = 3
-	},
-/obj/item/newspaper{
+"Mt" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"ll" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/obj/machinery/airalarm/directional/east,
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
-"lv" = (
+"Mz" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"lC" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/button/door{
-	id = "dwayne_engines";
-	name = "Aft Window Control";
-	pixel_x = -20;
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"lD" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-9"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"ma" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"mf" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/item/c_tube{
-	pixel_y = 3
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"mr" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"ms" = (
-/obj/machinery/computer/helm/viewscreen/directional/north,
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"MB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"ME" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Common Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/canteen)
-"mv" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow,
+"MG" = (
+/obj/structure/guncloset,
+/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
+/obj/item/gun/energy/sharplite/x26/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"MJ" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Nf" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"my" = (
+/area/ship/engineering)
+"Ni" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Nm" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
+"Np" = (
+/obj/effect/turf_decal/solarpanel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/canteen)
+"Ny" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/industrial/hatch/blue,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"Nz" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"NF" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/engineering)
+"NQ" = (
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/science{
+	name = "mining crate"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"NW" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering/atmospherics)
+"Oa" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"Om" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Op" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Ov" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"mA" = (
-/obj/effect/turf_decal/industrial/warning/corner,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"mC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
+"Oy" = (
 /obj/structure/cable/cyan{
-	icon_state = "1-10"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"mF" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"OJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 8;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"OP" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	dir = 1;
+	name = "overhead handrail"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"OV" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
-"mJ" = (
+/area/ship/crew/cryo)
+"OW" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/turf/open/floor/carpet/black{
+	name = "bathroom mat"
+	},
+/area/ship/crew/toilet)
+"Pl" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/storage/equip)
+"Pw" = (
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"PC" = (
+/obj/machinery/pipedispenser{
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"PS" = (
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/radio/old{
+	pixel_x = 6;
+	pixel_y = 21
+	},
+/obj/item/toy/prize/ripley{
+	pixel_x = -11;
+	pixel_y = 29
+	},
+/obj/structure/rack,
+/obj/item/towel{
+	pixel_y = -5;
+	pixel_x = -5
+	},
+/obj/item/towel{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/soap/nanotrasen{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_bathroom";
+	name = "Bathroom Bolt Control"
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"Qc" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Qg" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 1
@@ -917,1689 +4015,885 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"mR" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
-"mX" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning/corner,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"nf" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/mineral/processing_unit_console{
-	pixel_y = -18;
-	machinedir = 8;
-	output_dir = 1;
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"nr" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"nJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	name = "connector port (Air)"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"nL" = (
-/obj/effect/turf_decal/ntspaceworks_big/seven{
-	dir = 1
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"nY" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"oa" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/cyan,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"of" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
+"Qp" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/inherit,
+/turf/open/floor/engine/hull,
+/area/ship/engineering/atmospherics)
+"QI" = (
 /obj/item/clothing/suit/space/hardsuit/mining/independent,
 /obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"om" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/structure/closet/wall/orange/directional/west{
-	name = "Mechanic's locker"
-	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/storage/backpack/messenger/engi,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/toggle/hazard,
-/obj/item/clothing/head/hardhat/dblue,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/machinery/light/directional/north,
+/obj/structure/railing/thin{
 	dir = 8
 	},
-/obj/item/clothing/under/overalls/olive,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"or" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/dept/mining,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"ow" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"oy" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/obj/structure/railing/thin{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/quartermaster{
-	populate = 0;
-	name = "\proper Foreman's locker"
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Rb" = (
+/obj/item/toy/eightball{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/under/rank/security/detective,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/jacket/leather/duster,
-/obj/item/storage/belt/utility/full,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/cowboy/sec,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/white,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"oB" = (
-/obj/machinery/conveyor_switch/oneway{
-	pixel_y = 15;
-	pixel_x = 11;
-	id = "smelter_dwayne"
+/obj/structure/table/wood/poker{
+	name = "billiards table"
 	},
-/obj/structure/railing{
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Rm" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 8;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
 	dir = 10
 	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 10
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"oE" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/table,
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = 32
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "0-6"
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/crew/cryo)
-"oJ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"Ru" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor,
-/obj/item/toy/crayon/spraycan{
-	pixel_x = -9;
-	pixel_y = 17
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"oQ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "1-10"
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-6"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"oR" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"pl" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"pq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	icon_state = "4-10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"pt" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"pS" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"qg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"ql" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"qt" = (
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/glass{
-	name = "Common Room"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/canteen)
-"qK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"qO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"rE" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"sg" = (
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"sp" = (
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 8
+	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -26
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"sD" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+/obj/structure/chair/handrail{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/button/door{
+	dir = 2;
+	pixel_y = 20;
+	id = "dwayne_engines_starboard"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"RE" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/dept/cargo{
-	dir = 1
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"RJ" = (
+/obj/item/clothing/head/helmet/space/syndicate/generic{
+	pixel_y = 0
 	},
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/item/clothing/suit/space/syndicate/generic/grey,
+/obj/item/clothing/mask/gas,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"sM" = (
+/area/ship/storage/equip)
+"RV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
 	},
 /obj/machinery/door/airlock/command/glass{
 	dir = 4;
 	name = "Bridge";
 	req_one_access = list(20,41)
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-10"
+	},
 /obj/effect/turf_decal/corner/opaque/black{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4;
 	color = "#555555"
 	},
 /area/ship/bridge)
-"sP" = (
+"Se" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"sS" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"sZ" = (
-/obj/machinery/cryopod,
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/light/dim/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Sh" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
-"tj" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/item/cigbutt,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"tJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/item/stack/sheet/cardboard,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"tX" = (
-/obj/effect/turf_decal/ntspaceworks_big/eight{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"uc" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/storage/eva)
-"uk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "6-9"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"ul" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"uN" = (
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/obj/docking_port/mobile{
-	can_move_docking_ports = 1;
-	dir = 4;
-	name = "mining_ship_all";
-	port_direction = 2;
-	preferred_direction = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"vb" = (
-/obj/machinery/conveyor/inverted{
-	dir = 9;
-	id = "smelter_dwayne"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"ve" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/stack/sheet/cardboard{
-	amount = 2
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"vf" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"vh" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"vi" = (
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"vj" = (
-/obj/structure/sign/poster/contraband/winchester{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"vm" = (
-/obj/structure/sign/number/random{
-	color = "Black";
-	pixel_y = -7
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"vw" = (
-/obj/structure/table/reinforced,
-/obj/item/cutting_board{
-	anchored = 1
-	},
-/obj/item/melee/knife/kitchen,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "0-5"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"vA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"vJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"vL" = (
-/obj/machinery/door/poddoor{
-	id = "dwayne_cargo"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_cargo_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan,
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"vQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/handrail,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"wh" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -20
-	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"ww" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/closet/crate/secure/exo,
-/obj/item/clothing/under/rank/cargo/miner/hazard,
-/obj/item/clothing/under/rank/cargo/miner/hazard,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/storage/belt/mining/alt,
-/obj/item/storage/belt/mining/alt,
-/obj/item/clothing/head/hardhat/mining,
-/obj/item/clothing/head/hardhat/mining,
-/obj/item/clothing/head/hardhat/mining,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"wW" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"xh" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"xl" = (
-/obj/machinery/door/poddoor{
-	id = "dwayne_cargo"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_cargo_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan,
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"xr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"xP" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"yu" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "5-8"
-	},
-/obj/machinery/light/directional/east,
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"yx" = (
-/obj/structure/closet/wall/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/item/towel{
-	pixel_y = 4;
-	pixel_x = 4
-	},
-/obj/item/towel{
-	pixel_y = 4;
-	pixel_x = -3
-	},
-/obj/item/soap{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
-"yJ" = (
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"yN" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"za" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plating,
-/area/ship/external/dark)
-"zc" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/chair/handrail,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"zi" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plating,
-/area/ship/external/dark)
-"zl" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Hangar"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/ship/storage/eva)
-"zq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"zt" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"zz" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"zF" = (
-/obj/structure/ore_box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "6-9"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"zI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/item/cigbutt,
-/obj/effect/turf_decal/ntspaceworks_big/two,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"zK" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"zQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/structure/closet/firecloset/wall/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "2-5"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"zY" = (
-/obj/structure/sign/warning/fire{
-	pixel_y = -20;
-	pixel_x = -10
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	name = "connector port (Fuel)"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Aw" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"AD" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/item/kirbyplants/fullysynthetic{
-	pixel_x = -10
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"AE" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+"Sp" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 9
 	},
-/obj/item/radio/intercom/directional/south,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"AG" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/computer/solar_control{
-	dir = 8;
-	icon_state = "computer-right"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"AQ" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Bx" = (
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"BX" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Cj" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"Cp" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/mineral/unloading_machine{
-	input_dir = 1;
-	output_dir = 2
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"CB" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering)
-"CD" = (
-/obj/machinery/atmospherics/components/unary/shuttle/fire_heater,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"CP" = (
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"CS" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Ds" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"Dv" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	disable_on_owner_ship_dock = 1;
-	dwidth = 15;
-	height = 36;
-	name = "Dwayne Stern Dock";
-	width = 40
-	},
-/turf/template_noop,
-/area/template_noop)
-"DG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Dormitory"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/dorm)
-"DJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"DR" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/item/paperplane{
-	dir = 4;
-	pixel_x = 14;
-	pixel_y = -8
-	},
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Ee" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/structure/mirror{
-	pixel_y = 28;
-	layer = 2.89
+	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
-"Ex" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/storage/eva)
-"Ez" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"EE" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Fd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Fn" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -21;
+	id = "dwayne_engines_port"
 	},
-/obj/structure/ore_box,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"SA" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "foreman's locker";
+	req_access_txt = "20";
+	icon_state = "solgov_wall";
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = 28
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Fq" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/closed/wall/mineral/titanium,
+/obj/item/storage/backpack/duffelbag/engineering{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/storage/backpack/satchel/eng{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/clothing/suit/jacket/leather/duster{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/rank/security/detective{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/storage/belt/utility/full{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/fingerless{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/cowboy/sec{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/clothing/head/hardhat/white{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
 /area/ship/crew/dorm)
-"Fz" = (
-/obj/structure/table/wood,
+"SB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/item/food/chips{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_captain";
+	dir = 4
 	},
-/obj/item/toy/cards/deck/kotahi{
-	pixel_x = -11;
-	pixel_y = 6
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"SG" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"FH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Equipment Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage/equip)
+"SV" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
-"FN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"Tl" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Tw" = (
+/obj/effect/turf_decal/ntspaceworks_small/right,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"TO" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"TP" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_lounge";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"TQ" = (
+/obj/machinery/door/window/westleft,
+/obj/effect/turf_decal/steeldecal/steel_decals6,
+/obj/effect/turf_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"FP" = (
-/obj/structure/closet/crate/large,
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"FR" = (
-/obj/structure/closet/cardboard,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
-/obj/item/mop,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"FS" = (
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew/toilet)
+"TR" = (
+/obj/structure/mirror{
+	pixel_y = 4;
+	layer = 2.8;
+	pixel_x = 7
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
+"TT" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Ug" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/black,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_captain";
+	name = "Captain's Window Control"
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"Ui" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 1;
+	name = "Scrubbers to Recycling"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_recycling";
+	name = "Recycling Window Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Uj" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Uk" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"Gr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/stairs{
+"Uu" = (
+/obj/structure/chair/handrail{
 	dir = 4;
-	color = "#555555"
+	name = "overhead handrail"
 	},
-/area/ship/bridge)
-"Gx" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"GH" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/ntspaceworks_big/four,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"GN" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 5
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/port)
+"UF" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/obj/structure/closet/crate/engineering,
-/obj/item/radio/weather_monitor,
-/obj/item/radio/weather_monitor,
-/obj/item/t_scanner/adv_mining_scanner/lesser{
-	pixel_y = -3
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
 	},
-/obj/item/pickaxe/drill{
-	pixel_y = -2
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
 	},
-/obj/item/pickaxe/drill{
-	pixel_y = -2
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_port";
+	name = "Engine Shutter Control"
 	},
-/obj/item/pinpointer/mineral{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"GW" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
-"He" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	icon_state = "5-6"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-5"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Hh" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"HE" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/canteen)
-"HI" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_mining_field";
-	locked = 1
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_mining"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/storage/eva)
-"HP" = (
-/obj/machinery/light/dim/directional/east,
-/obj/structure/toilet{
-	dir = 8;
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_y = 13;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
-"Ia" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "1-10"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Ip" = (
-/obj/machinery/door/poddoor{
-	id = "dwayne_cargo"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"Is" = (
-/obj/structure/closet/crate/science,
-/obj/item/paicard,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"IF" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half,
-/obj/machinery/computer/cargo{
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"IJ" = (
-/obj/machinery/vending/cigarette,
-/obj/item/toy/figure/miner{
-	pixel_y = 17;
-	toysay = "Careful out there! Frontier is deadly this time of the year!... Or any time of the year, actually...";
-	pixel_x = -4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"IK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/cigbutt,
-/obj/effect/turf_decal/ntspaceworks_big/five{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"IZ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"UH" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Jk" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"UP" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"Jn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Jq" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/metal/twenty,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Jy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/handrail{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"JE" = (
-/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"UV" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"UX" = (
 /obj/structure/cable/cyan{
-	icon_state = "1-10"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"JZ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/computer/helm/viewscreen/directional/north,
-/obj/item/decal_painter{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/hand_labeler{
-	pixel_x = 13;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Ka" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
-"Kc" = (
+"Va" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Vb" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Vg" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_starboard";
+	name = "Starboard Blast Doors";
+	pixel_x = -8;
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_starboard_field";
+	pixel_x = 1;
+	pixel_y = -19;
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Vm" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_exhaust"
+	},
+/turf/open/space/basic,
+/area/ship/engineering)
+"VH" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"VO" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"VZ" = (
+/obj/structure/table/wood/poker{
+	name = "billiards table"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Wa" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "engine fuel pump"
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4;
+	name = "Air to Supply"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Wg" = (
+/obj/structure/table/wood,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Wh" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"WE" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"WF" = (
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"WN" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 6
+/obj/structure/railing/thin/corner{
+	dir = 1
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Xa" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/canteen)
+"Xc" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Xj" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Xk" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"Xl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xn" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Office"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
-"Kp" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
+"Xo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xw" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"KJ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/dorm)
-"KO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/cyan{
-	icon_state = "6-9"
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
+"Xx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"XA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"XC" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo/starboard)
+"XD" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/industrial/caution/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"LH" = (
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
+/area/ship/cargo/starboard)
+"XQ" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Yd" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-10"
 	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
+/obj/structure/chair/sofa/brown/old/left/directional/north,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -19
+	},
+/obj/machinery/button/door{
+	pixel_y = -20;
+	dir = 1;
+	id = "dwayne_lounge";
+	name = "Lounge Window Control"
 	},
 /turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"LJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
-"LK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+"Yx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 1;
-	name = "Air to Distro"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+	piping_layer = 4
 	},
 /turf/open/floor/plating,
-/area/ship/engineering)
-"LN" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
+/area/ship/engineering/atmospherics)
+"YD" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"YH" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"YM" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"YR" = (
+/obj/machinery/power/ship_gravity{
+	pixel_y = 0
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"LZ" = (
-/obj/structure/table/reinforced,
-/obj/structure/closet/secure_closet/freezer/wall/directional/south{
-	name = "kitchen cabinet"
-	},
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/item/storage/cans/sixbeer,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/food/canned/beans,
-/obj/item/food/canned/beans,
-/obj/item/food/candy,
-/obj/item/food/candy,
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Mb" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Hangar"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+	icon_state = "6-10"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"Mg" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
-"Mk" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Mn" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Mo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	icon_state = "5-10"
-	},
-/obj/effect/turf_decal/ntspaceworks_big/six{
+"Za" = (
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Mz" = (
-/obj/machinery/holopad/emergency/command,
-/obj/effect/turf_decal/box/white{
-	color = "#283674"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"MB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cryogenics"
-	},
-/obj/machinery/door/firedoor/border_only{
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"Zf" = (
+/obj/effect/spawner/bunk_bed{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"MG" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
 /area/ship/crew/dorm)
-"MN" = (
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 20
+"Zj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/chair,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"MT" = (
-/obj/effect/turf_decal/corner/opaque/yellow/full,
-/obj/effect/turf_decal/industrial/warning/corner{
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Nf" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Nw" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
+/obj/structure/chair/handrail{
+	dir = 2
 	},
-/obj/structure/catwalk/over/plated_catwalk,
-/obj/structure/cable/cyan{
-	icon_state = "6-8"
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Zk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"NC" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"NN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Zq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
 /obj/structure/cable/cyan{
-	icon_state = "6-9"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"NT" = (
-/obj/structure/closet/cardboard,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/obj/item/storage/box/glowsticks,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"NW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/ntspaceworks_big/five,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Op" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/tracker,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Ou" = (
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"Zv" = (
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
@@ -2611,1567 +4905,814 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"Ov" = (
-/obj/structure/closet/cardboard,
-/obj/item/chair/plastic,
-/obj/item/chair/plastic{
-	pixel_y = 4
-	},
-/obj/item/chair/plastic{
-	pixel_y = 8
-	},
-/obj/item/chair/plastic{
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/ntspaceworks_big/one,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Oz" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/ntblue/half,
-/obj/machinery/fax/indie{
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"OJ" = (
-/turf/template_noop,
-/area/template_noop)
-"OL" = (
-/obj/machinery/light/directional/west,
-/obj/structure/filingcabinet/filingcabinet{
-	dir = 4;
-	pixel_x = -10;
-	density = 0
-	},
-/obj/effect/turf_decal/corner/opaque/ntblue/border{
-	dir = 8
-	},
-/obj/item/flashlight/flare,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/gun/ballistic/revolver/detective,
-/obj/item/megaphone/cargo,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"OP" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"OQ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_cargo_field";
-	pixel_x = 1;
-	pixel_y = -19;
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "dwayne_cargo";
-	name = "Blast Doors";
-	pixel_x = -8;
-	pixel_y = -20;
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"OT" = (
-/obj/structure/sign/poster/rilena/random{
-	pixel_x = 32
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan,
-/obj/structure/cable/yellow{
-	icon_state = "9-10"
-	},
-/obj/machinery/computer/monitor{
-	dir = 8;
-	icon_state = "computer-left"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"OW" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/spawner/random/entertainment/plushie,
-/obj/effect/spawner/random/entertainment/plushie,
-/obj/effect/spawner/random/entertainment/plushie,
-/obj/effect/spawner/random/entertainment/plushie,
-/obj/effect/spawner/random/entertainment/plushie,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Pd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/ntspaceworks_big/four{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Pe" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/external/dark)
-"Pl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-6"
+"ZD" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-6"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Po" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/mob/living/simple_animal/turtle{
-	dir = 4
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/ship/crew/dorm)
-"Px" = (
-/obj/effect/turf_decal/corner/opaque/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/computer/cryopod/directional/east,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -19
-	},
-/obj/item/radio/intercom/directional/south{
-	pixel_x = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"PH" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"PU" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled{
-	dir = 8
-	},
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/folder/blue,
-/obj/item/folder,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/obj/item/pen,
-/obj/effect/turf_decal/ntspaceworks_big/eight,
-/obj/item/stamp,
-/obj/item/stamp/denied,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Qg" = (
-/obj/machinery/power/ship_gravity,
-/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
-"Qj" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/item/stack/sheet/cardboard{
-	amount = 2
-	},
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Qp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"QG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/structure/closet/crate/miningcar{
-	name = "mining cart"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"QI" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-10"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"QO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
-/obj/item/cigbutt,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"RA" = (
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/item/cigbutt,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"RJ" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"RN" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/storage/eva)
-"RS" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_mining_field";
-	pixel_x = 1;
-	pixel_y = 19
-	},
-/obj/machinery/button/door{
-	id = "dwayne_mining";
-	name = "Blast Doors";
-	pixel_x = -8;
-	pixel_y = 20
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"RT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"RU" = (
-/obj/structure/closet/crate/internals,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/oxygen/yellow,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/turf_decal/ntspaceworks_big/one{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Se" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-10"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4;
-	color = "#555555"
-	},
-/area/ship/bridge)
-"Sf" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"Sg" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "6-10"
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Si" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/item/bikehorn/rubberducky/plasticducky{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/machinery/door/window/northleft{
-	name = "Shower Door"
-	},
-/obj/structure/catwalk/over/plated_catwalk/white,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/crew/toilet)
-"St" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/dorm)
-"SA" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_engines"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"SB" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"SI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Tl" = (
-/obj/machinery/washing_machine,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
-"Tw" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 13
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable/cyan,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	pixel_x = -21;
-	pixel_y = -13;
-	dir = 4;
-	id = "dwayne_bathroom";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	name = "Bathroom Lock"
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/crew/toilet)
-"Tz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"TO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"TP" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"TR" = (
-/obj/structure/chair/sofa/brown/old/right/directional/north,
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"Ub" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/cryopod,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/crew/cryo)
-"Uj" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Un" = (
-/obj/effect/decal/cleanable/ash,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/obj/item/gun/ballistic/shotgun/flamingarrow,
-/obj/item/gun/ballistic/shotgun/flamingarrow,
-/obj/item/gun/ballistic/shotgun/flamingarrow,
-/obj/structure/guncloset/shotgun{
-	name = "rifle locker";
-	desc = "A locker that holds rifles."
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"UD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/closet/crate/medical,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/storage/firstaid/regular,
-/obj/item/roller,
-/obj/item/reagent_containers/hypospray/medipen/survival,
-/obj/item/reagent_containers/hypospray/medipen/survival{
-	pixel_y = -4
-	},
-/obj/item/storage/pill_bottle/charcoal/less,
-/obj/structure/cable/cyan{
-	icon_state = "5-10"
-	},
-/obj/effect/turf_decal/ntspaceworks_big/six,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"UX" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"UY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"Vb" = (
-/obj/structure/dresser{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/item/reagent_containers/food/drinks/soda_cans/cola{
-	pixel_y = 14;
-	pixel_x = 3
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"Vg" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/cryo)
-"Vv" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"VP" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"VZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/dorm)
-"Wi" = (
-/obj/machinery/mineral/processing_unit{
-	output_dir = 4;
-	input_dir = 8
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/storage/eva)
-"Wm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/structure/cable/cyan{
-	icon_state = "2-5"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
-"WE" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"WK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/ntspaceworks_big/seven,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"WZ" = (
-/obj/item/kirbyplants/random{
-	pixel_y = 18;
-	pixel_x = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/ship/crew/dorm)
-"Xa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4;
-	color = "#555555"
-	},
-/area/ship/bridge)
-"Xh" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/machinery/autolathe,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Xk" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Xl" = (
-/obj/machinery/firealarm/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xn" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"Xo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xw" = (
-/obj/structure/table/wood,
-/obj/item/food/soup/oatmeal{
-	pixel_y = 14;
-	pixel_x = 10;
-	desc = "A nice bowl of oatmeal. You aren't quite sure how long it's been sitting here."
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/cola{
-	pixel_y = 1;
-	pixel_x = -5
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"XC" = (
-/obj/structure/chair/sofa/brown/old/right/directional/south,
-/obj/item/radio/intercom/directional/north,
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"YA" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"YE" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"YY" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/candy,
-/obj/item/trash/sosjerky,
-/obj/item/trash/can/food/beans,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable/cyan{
-	icon_state = "2-5"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "5-8"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo)
-"Zj" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Zk" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Zv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"ZA" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/storage/eva)
 "ZK" = (
-/obj/machinery/door/poddoor{
-	id = "dwayne_mining"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/turf/open/floor/plating,
-/area/ship/storage/eva)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public{
+	name = "Cryogenics"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
 "ZL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/industrial/caution{
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"ZR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"ZS" = (
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 20
-	},
-/obj/machinery/vending/coffee,
-/obj/item/trash/candle{
-	pixel_y = 18;
-	pixel_x = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
 
 (1,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
 Dv
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
+Dv
+Dv
+Dv
+cf
+Qp
+cf
+Dv
+Dv
+Dv
+Dv
+Dv
+ir
+NF
+ir
+Dv
+Dv
+Dv
+Dv
 "}
 (2,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-CB
-mF
-uN
-mF
-CB
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
+Dv
+cf
+NW
+NW
+cf
+zX
+cf
+Dv
+Dv
+Dv
+Dv
+Dv
+ir
+hZ
+ir
+Nf
+Nf
+ir
+Dv
 "}
 (3,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-CP
-iq
-ZL
-aS
-CP
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
+Dv
+cf
+lo
+lo
+cf
+Tl
+cf
+Dv
+Dv
+Dv
+Dv
+Dv
+ir
+Uj
+ir
+vf
+tY
+ir
+Dv
 "}
 (4,1,1) = {"
-OJ
-OJ
-mF
-gF
-fi
-mF
-fy
-SA
-Ou
-Qp
-PH
-SA
-Pe
-mF
-fi
-gF
-mF
-OJ
-OJ
+Dv
+cf
+jp
+yV
+UF
+nk
+cf
+Dv
+Dv
+Dv
+Dv
+Dv
+ir
+Lv
+fr
+gg
+da
+ir
+Dv
 "}
 (5,1,1) = {"
-OJ
-OJ
-mF
-CD
-ea
-mF
-Mk
-mF
-mF
+Dv
+cf
+HX
+ld
+Lf
+Sp
+cf
+oE
+oE
 kf
-mF
-mF
-vJ
-mF
-Kp
-gm
-mF
-OJ
-OJ
+oE
+oE
+ir
+Ru
+BK
+AS
+AB
+ir
+Dv
 "}
 (6,1,1) = {"
-OJ
-OJ
-mF
-YE
-bP
-om
-He
-he
+Dv
+cf
+Ni
+is
+Yx
+Om
+Za
+oE
 Mg
 gf
 lC
-nr
-fY
-zQ
-oa
-AE
-mF
-OJ
-OJ
+oE
+YR
+CK
+ZD
+Eo
+uS
+ir
+Dv
 "}
 (7,1,1) = {"
-OJ
-OJ
-mF
-kQ
-hZ
-QI
-qO
-Pl
-Xn
+Dv
+cf
+PC
+II
+Wa
+MB
+im
+oE
+Zv
 ma
+hN
+oE
 ir
-LK
-mC
-Vv
-fl
-VP
-mF
-OJ
-OJ
+KL
+XQ
+XQ
+ir
+ir
+Dv
 "}
 (8,1,1) = {"
-OJ
-OJ
-mF
-Ez
-OT
-AG
-Qg
-ow
-lD
-Nw
-RA
-nJ
-Kc
-ig
-hK
-zY
-mF
-OJ
-OJ
+Dv
+cf
+cf
+rs
+iG
+MB
+kV
+cf
+oE
+hQ
+oE
+ir
+fU
+iH
+dN
+vZ
+ir
+ir
+Dv
 "}
 (9,1,1) = {"
-OJ
-RN
-uc
-uc
-uc
-uc
-uc
-uc
-Cj
-yu
-iZ
-eM
-eM
-eM
-eM
-eM
-eM
-gu
-OJ
+Dv
+Ao
+LL
+Ui
+JX
+Gs
+hR
+gS
+MJ
+bj
+Va
+Xn
+Iy
+Lz
+Oa
+xg
+Vm
+wn
+Dv
 "}
 (10,1,1) = {"
-OJ
-uc
-MT
-eH
-Cp
-dq
-vb
-uc
-Sg
-mF
-Zj
-eM
-pS
-ve
-xP
-SI
-mX
-eM
-OJ
+Dv
+cf
+cf
+cf
+cf
+cf
+cf
+cf
+bs
+VO
+Ka
+ir
+ir
+yb
+FM
+pl
+ir
+ir
+Dv
 "}
 (11,1,1) = {"
-OJ
-in
-mr
-as
-Un
-oB
-Wi
-uc
-aI
-AD
-ZR
-eM
-CS
-Ov
-NW
-YY
-mf
-xl
-OJ
+Dv
+CE
+Lq
+uq
+IF
+vy
+MG
+Pl
+Jy
+Eb
+na
+Ny
+OV
+OV
+OV
+OV
+OV
+aW
+Dv
 "}
 (12,1,1) = {"
-OJ
-ZK
-Fn
-vA
-NN
-pq
-nf
-uc
-LN
-lv
-mA
-eM
-cL
-zI
-UD
+Dv
+Dv
+Lq
+RJ
+WN
 FR
-Nf
-Ip
-OJ
+gs
+Pl
+uJ
+UX
+GL
+eH
+OV
+Sh
+GQ
+JS
+OV
+Dv
+Dv
 "}
 (13,1,1) = {"
-OJ
-ZK
-ZA
-QG
-UY
-zF
-QO
-Ex
-wW
-lv
-sg
+Dv
+Dv
+Lq
+QI
+Nz
+FR
+WF
+Lq
+Zj
+VH
+kg
+OV
+OV
+tl
+dI
 Hh
-bb
-hO
-WK
-ul
-Qj
-Ip
-OJ
+OV
+Dv
+Dv
 "}
 (14,1,1) = {"
-hv
+Dv
+Dv
+Lq
+px
+YM
+HW
+wW
+SG
+aI
+AD
+Gx
 ZK
-eu
-NT
-tX
-Pd
-Wm
-zl
-or
-UX
-sD
-Mb
-oQ
-GH
-PU
-Is
-Xk
-Ip
-hg
+Xx
+wC
+XA
+Xc
+OV
+Dv
+Dv
 "}
 (15,1,1) = {"
-OJ
-ZK
-eu
-bO
-nL
-kM
+Dv
+jX
+jS
+jS
+mF
+mF
+jS
+jS
+LN
+qQ
+mA
+XC
+XC
+bR
+bR
+XC
+XC
+LC
+Dv
+"}
+(16,1,1) = {"
+Dv
+jS
+It
+GO
+aM
+Qc
+Bd
+jS
+my
+lv
+sg
+XC
+Pw
+UV
+uK
+uh
+Ee
+XC
+Dv
+"}
+(17,1,1) = {"
+Dv
+nX
+nr
+th
+EV
 TO
-Ex
+tu
+jS
+or
+cI
+sD
+XC
+hh
+xS
+Fz
+NQ
+kj
+sM
+Dv
+"}
+(18,1,1) = {"
+Dv
+HI
+nB
+YH
+YH
+TO
+ku
+sb
 IZ
 WE
 dK
-Hh
-zc
-uk
-Jq
-FP
-Nf
-Ip
-OJ
-"}
-(16,1,1) = {"
-OJ
-ZK
-eu
-ww
-Mo
-dx
-wh
-uc
-EE
-lv
-tj
-eM
-Xh
-tJ
-KO
-vf
-bf
-Ip
-OJ
-"}
-(17,1,1) = {"
-OJ
-HI
-zK
-JE
-IK
-RU
-of
-uc
-fz
-lv
-Fd
-eM
-JZ
-bl
-Jn
-bo
-OW
+yZ
 vL
-OJ
+RE
+YD
+YD
+vm
+wm
+Dv
 "}
-(18,1,1) = {"
-OJ
+(19,1,1) = {"
+wh
+HI
+ea
+Ip
+Ip
+cn
+LM
+fp
+EE
+zi
+tj
 uc
-RS
-Uj
-GN
-zq
-zt
-uc
+DS
+Oy
+rE
+zA
+XD
+wm
+Jq
+"}
+(20,1,1) = {"
+Dv
+HI
+nB
+YH
+YH
+TO
+rQ
+Ed
+fz
+UX
+Fd
+yZ
+Tw
+RE
+YD
+YD
+vm
+wm
+Dv
+"}
+(21,1,1) = {"
+Dv
+jz
+GG
+uw
+hx
+TO
+dO
+jS
 kb
 FH
 pt
-eM
-oJ
-ja
-oy
-cc
-OQ
-eM
-OJ
+XC
+Rm
+RE
+ZL
+bE
+Is
+rG
+Dv
 "}
-(19,1,1) = {"
-OJ
-RN
-uc
-uc
-uc
-uc
-uc
-uc
+(22,1,1) = {"
+Dv
+jS
+dY
+UP
+EI
+ei
+Uu
+jS
 my
 DR
-Gx
-eM
-eM
-eM
-eM
-eM
-eM
-gu
-OJ
+sg
+XC
+LB
+BB
+te
+wE
+Vg
+XC
+Dv
 "}
-(20,1,1) = {"
-OJ
-OJ
-mR
-dQ
-oE
-sp
-dQ
-MN
+(23,1,1) = {"
+Dv
+jS
+jS
+jS
+jS
+jS
+jS
+jS
 DJ
 oR
 dy
-bE
-Tw
-yx
-Si
-bj
-vm
-OJ
-OJ
-"}
-(21,1,1) = {"
-OJ
-OJ
-zi
-Vg
-Ub
-gs
-MB
-Zv
-qK
-bv
-yJ
-bj
-Ee
-HP
-Tl
-bj
-vm
-OJ
-OJ
-"}
-(22,1,1) = {"
-OJ
-OJ
-za
-Vg
-sZ
-Px
-dQ
-IJ
-DJ
-xh
-vj
-nY
-nY
-nY
-nY
-nY
-dh
-OJ
-OJ
-"}
-(23,1,1) = {"
-OJ
-OJ
-FS
-MG
-MG
-MG
-MG
-MG
-Xl
-AQ
-OP
-nY
-ZS
-aY
-vw
-LJ
-nY
-OJ
-OJ
+XC
+XC
+XC
+XC
+XC
+XC
+XC
+Dv
 "}
 (24,1,1) = {"
+Dv
+in
 OJ
-OJ
-FS
-MG
-fV
-Vb
-cf
-MG
-vQ
-Ka
-Zv
-qt
-fp
-Ia
 xr
-LZ
-nY
-OJ
-OJ
+tI
+xo
+dh
+Xa
+vQ
+VH
+yJ
+bx
+Zf
+kO
+TT
+iZ
+Mt
+ec
+Dv
 "}
 (25,1,1) = {"
-OJ
-OJ
-FS
-KJ
-WZ
-Po
-Tz
-DG
-Zv
-qg
-Mn
-nY
+Dv
+Xa
+Ex
+tQ
+xh
+xo
+FJ
+ME
+sk
+SV
+Xo
+Bg
 ms
-kO
-hy
-nY
-HE
-OJ
-OJ
+ll
+ij
+tA
+Wg
+bx
+Dv
 "}
 (26,1,1) = {"
-OJ
-OJ
-YA
-hS
-aV
-sP
-LH
-MG
-Xo
-ak
-RT
-nY
-XC
-Xw
-jS
-Sf
-Aw
-OJ
-OJ
+Dv
+in
+do
+tX
+iY
+ck
+qg
+Xa
+Xl
+VH
+OP
+bx
+qr
+aY
+SA
+cV
+ye
+ec
+Dv
 "}
 (27,1,1) = {"
-OJ
-OJ
-RJ
-KJ
-sS
+Dv
+CX
+Xa
+AG
+hC
 Zk
-ll
-MG
+mP
+pu
 Se
-rE
-sM
-nY
+VH
+Jy
 bx
-Fz
+bx
+Ds
 TR
-cV
-RJ
-OJ
-OJ
+bx
+bx
+vH
+Dv
 "}
 (28,1,1) = {"
-OJ
-OJ
-bW
-Fq
-St
-VZ
-rE
-rE
+Dv
+Dv
 Xa
-OL
+nY
+LZ
+VZ
+KJ
+pu
+Ov
+zC
 Gr
-rE
-rE
-Ds
+Ia
+iq
+mu
 Jk
-HE
-bW
-OJ
-OJ
+OW
+Ia
+Dv
+Dv
 "}
 (29,1,1) = {"
-OJ
-OJ
-OJ
-TP
-ax
-Op
-vh
-mJ
+Dv
+Dv
+Xa
+fl
+LZ
+Rb
+vw
+Xa
 FN
 Mz
 Jy
-Oz
-vi
-NC
-ql
-jz
-OJ
-OJ
-OJ
+Xk
+PS
+Xw
+gp
+TQ
+Ia
+Dv
+Dv
 "}
 (30,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-TP
-yN
-vh
-pl
+Dv
+Dv
+Xa
+Xa
+tg
+nV
+yq
+vx
 hB
-Bx
+Jx
 BX
-IF
-vi
-SB
-mv
-OJ
-OJ
-OJ
-OJ
+jh
+jh
+AC
+jh
+jh
+xl
+Dv
+Dv
 "}
 (31,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-GW
-rE
-eL
-zz
-aR
-rE
-GW
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
+Dv
+Dv
+bW
+hS
+vB
+UH
+Yd
+Xa
+Wh
+Lt
+ak
+dx
+qJ
+Zq
+bv
+sp
+DM
+Dv
+Dv
 "}
 (32,1,1) = {"
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-GW
+Dv
+Dv
+pS
+rP
+ql
+Op
+Ix
+Xa
+aX
+RV
+Fi
+jh
+Ug
+mf
+Co
+oF
+pS
+Dv
+Dv
+"}
+(33,1,1) = {"
+Dv
+Dv
+AQ
+Np
+TP
+yN
+Xa
+Fi
+yw
+Bx
+zz
+Fi
+jh
+SB
+mv
+ig
+AQ
+Dv
+Dv
+"}
+(34,1,1) = {"
+Dv
+Dv
+Dv
+Xj
+oa
+qO
+Fq
+Qg
+eL
+Ak
+aR
+IJ
+vi
+eu
+Vb
+st
+Dv
+Dv
+Dv
+"}
+(35,1,1) = {"
+Dv
+Dv
+Dv
+Dv
+Xj
+cO
+Fq
+EC
+mR
 cw
-cw
-cw
-GW
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
-OJ
+oB
+Jh
+vi
+Uk
+Hv
+Dv
+Dv
+Dv
+Dv
+"}
+(36,1,1) = {"
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
+Nm
+Fi
+FU
+zl
+jI
+Fi
+Nm
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
+"}
+(37,1,1) = {"
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
+Nm
+gq
+gq
+gq
+Nm
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
+Dv
 "}

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -4031,11 +4031,6 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "LB" = (
@@ -4759,6 +4754,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(20,41)
 	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4;

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -628,6 +628,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/cargo/port)
+"hu" = (
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "hB" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -735,14 +741,6 @@
 	layer = 2.8;
 	pixel_y = 1
 	},
-/obj/structure/platform/ship_two{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/bedsheetbin{
-	pixel_y = 17;
-	pixel_x = -1
-	},
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light_switch{
 	dir = 4;
@@ -751,6 +749,15 @@
 	},
 /obj/item/radio/intercom/directional/west{
 	pixel_y = 2
+	},
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/bedsheetbin{
+	pixel_y = 17;
+	pixel_x = -1;
+	layer = 3
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
@@ -1179,19 +1186,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/crew/canteen)
-"lT" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/caution/red,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "lU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
 	dir = 9
@@ -1566,6 +1560,19 @@
 "oF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
+"oH" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden,
@@ -2708,12 +2715,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"yC" = (
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "yD" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -2748,10 +2749,6 @@
 /turf/open/floor/plating,
 /area/ship/cargo/starboard)
 "zb" = (
-/obj/structure/platform/ship_two{
-	dir = 1;
-	layer = 2.9
-	},
 /obj/item/radio/old{
 	pixel_x = 6;
 	pixel_y = 21
@@ -2782,6 +2779,10 @@
 /obj/item/soap/nanotrasen{
 	pixel_y = -1;
 	pixel_x = -3
+	},
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
@@ -6162,7 +6163,7 @@ Dv
 (18,1,1) = {"
 Dv
 AB
-lT
+oH
 kV
 kV
 TR
@@ -6464,7 +6465,7 @@ eq
 Pl
 aX
 RV
-yC
+hu
 vi
 HB
 Op

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -202,13 +202,15 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "ck" = (
-/obj/structure/sign/number/random{
-	color = "Black";
-	pixel_y = 4;
-	pixel_x = 0
+/obj/structure/chair/stool/bar{
+	dir = 1;
+	pixel_y = 8
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/atmospherics)
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
 "cn" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -861,9 +863,6 @@
 	id = "dwayne_port_field";
 	locked = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable/cyan{
@@ -1416,6 +1415,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
+"nG" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "nR" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 4;
@@ -1463,20 +1475,6 @@
 /obj/effect/turf_decal/solarpanel,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/canteen)
-"oe" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
 "ol" = (
 /obj/structure/window{
 	dir = 2
@@ -1674,6 +1672,17 @@
 /obj/structure/chair/sofa/brown/old/left/directional/south,
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
+"qm" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "qp" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 1
@@ -1878,7 +1887,6 @@
 /area/ship/cargo/port)
 "sb" = (
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/door/firedoor/window,
 /obj/structure/window/reinforced/fulltile/shuttle,
 /turf/open/floor/plating,
@@ -2125,20 +2133,13 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm/captain)
 "tX" = (
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 4
+/obj/structure/sign/number/random{
+	color = "Black";
+	pixel_y = 4;
+	pixel_x = 0
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/atmospherics)
 "uc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -2457,15 +2458,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
 "xo" = (
-/obj/structure/chair/stool/bar{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
 "xr" = (
 /obj/structure/table/reinforced,
 /obj/structure/closet/wall/white/directional/west{
@@ -2641,25 +2636,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
-"yW" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "yZ" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
@@ -2805,10 +2781,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/storage/equip)
-"zM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
 "zP" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
@@ -2826,19 +2798,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
-"zZ" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "Ak" = (
 /obj/item/stack/sheet/metal/twenty{
 	pixel_y = 0
@@ -2980,7 +2939,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -3052,23 +3010,6 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
-"Di" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
 "Dm" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -3681,9 +3622,6 @@
 	id = "dwayne_port_field";
 	locked = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable/cyan{
@@ -3792,6 +3730,21 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
+"IM" = (
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "IW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	name = "exhaust injector";
@@ -4312,23 +4265,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
-"Ne" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
 "Nf" = (
 /obj/machinery/power/shuttle/engine/electric,
 /obj/structure/cable{
@@ -4360,6 +4296,19 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
+"NF" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "NO" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -4766,8 +4715,14 @@
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -4868,6 +4823,23 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"Sn" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
 "SA" = (
 /obj/structure/closet/secure_closet/wall/directional/north{
 	name = "foreman's locker";
@@ -5029,13 +5001,19 @@
 /area/ship/crew/canteen)
 "TR" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/grid,
@@ -5255,6 +5233,20 @@
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Wy" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
 "WB" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
@@ -5691,7 +5683,7 @@ Dv
 "}
 (4,1,1) = {"
 Dv
-ck
+tX
 kJ
 vs
 aq
@@ -5712,7 +5704,7 @@ Dv
 "}
 (5,1,1) = {"
 Dv
-ck
+tX
 aK
 mH
 YD
@@ -5733,7 +5725,7 @@ Dv
 "}
 (6,1,1) = {"
 Dv
-ck
+tX
 OE
 Sa
 lU
@@ -5754,7 +5746,7 @@ Dv
 "}
 (7,1,1) = {"
 Dv
-ck
+tX
 rw
 RS
 vA
@@ -5845,7 +5837,7 @@ iu
 Fi
 MG
 JB
-zM
+xo
 fN
 QG
 Ny
@@ -5968,7 +5960,7 @@ HI
 Co
 th
 EV
-zZ
+nG
 FQ
 jS
 or
@@ -5989,7 +5981,7 @@ AB
 ea
 kV
 kV
-yW
+TR
 ku
 sb
 IZ
@@ -5997,7 +5989,7 @@ WE
 dK
 yZ
 xZ
-Di
+Sn
 UV
 UV
 vm
@@ -6039,8 +6031,8 @@ JH
 Fd
 yZ
 Tw
-Ne
-tX
+RE
+IM
 UV
 vm
 wm
@@ -6052,7 +6044,7 @@ ju
 GG
 bE
 QK
-TR
+NF
 dO
 jS
 kb
@@ -6060,7 +6052,7 @@ FH
 pt
 vL
 Rm
-RE
+qm
 GQ
 Ak
 Is
@@ -6115,7 +6107,7 @@ ir
 OJ
 xr
 tI
-xo
+ck
 dh
 Pl
 vQ
@@ -6136,7 +6128,7 @@ Pl
 Ex
 tQ
 xh
-xo
+ck
 OX
 Wa
 sk
@@ -6157,11 +6149,11 @@ ir
 am
 tQ
 iY
-xo
+ck
 qg
 Pl
 Xl
-oe
+Wy
 OP
 bx
 AS
@@ -6225,7 +6217,7 @@ vw
 Pl
 FN
 Mz
-zM
+xo
 gx
 zb
 Xw

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -1,25 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ak" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/atmospherics)
+"am" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"an" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
 "aI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35,20 +30,31 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "aM" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = "dwayne_starboard";
+	name = "Starboard Blast Doors";
+	pixel_x = -8;
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_starboard_field";
+	pixel_x = 1;
+	pixel_y = -19;
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
+/area/ship/cargo/starboard)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"aW" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
 "aX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -70,43 +76,57 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
-"bj" = (
+"bc" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"bg" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable/cyan{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 24;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"bj" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"bs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/sign/warning/fire{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_cryo";
+	name = "Cryo Shutter Control"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/area/ship/crew/cryo)
 "bv" = (
 /obj/structure/chair/comfy/beige/old{
 	dir = 4
@@ -137,31 +157,74 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
+"bO" = (
+/obj/structure/platform/ship_two{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/radio/old{
+	pixel_x = 6;
+	pixel_y = 21
+	},
+/obj/item/toy/prize/ripley{
+	pixel_x = -11;
+	pixel_y = 29
+	},
+/obj/structure/rack,
+/obj/item/towel{
+	pixel_y = -5;
+	pixel_x = -5
+	},
+/obj/item/towel{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/soap/nanotrasen{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_bathroom";
+	name = "Bathroom Bolt Control"
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
 "bR" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window{
 	pixel_y = 0
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_equipment";
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/ship/cargo/starboard)
+/area/ship/cargo/port)
 "bW" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "cf" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/atmospherics)
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "ck" = (
 /obj/structure/chair/stool/bar{
 	dir = 1;
@@ -189,139 +252,67 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"cI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+"cP" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"cO" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"cV" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/machinery/computer/helm/viewscreen/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"da" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"cV" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
 "dh" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = -19
-	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"do" = (
-/obj/machinery/griddle,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
 "dx" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
 	},
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
 "dy" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"dI" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
 "dK" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"dN" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "5-9"
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = -7;
-	pixel_y = 14
-	},
-/obj/item/stock_parts/manipulator/nano{
-	pixel_y = 2;
-	pixel_x = 7
-	},
-/obj/item/stock_parts/scanning_module/adv{
-	pixel_x = 8;
-	pixel_y = -9
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_y = -2;
-	pixel_x = -7
-	},
-/obj/item/screwdriver{
-	pixel_y = -9;
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
 "dO" = (
 /obj/structure/chair/handrail{
 	dir = 8;
@@ -338,54 +329,61 @@
 	},
 /turf/open/floor/noslip,
 /area/ship/cargo/port)
-"dY" = (
-/obj/effect/turf_decal/industrial/warning/corner{
+"dP" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public{
+	name = "Cryogenics"
 	},
-/obj/machinery/button/door{
-	id = "dwayne_port";
-	name = "Port Blast Doors";
-	pixel_x = -8;
-	pixel_y = 20
-	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_port_field";
-	pixel_x = 1;
-	pixel_y = 19
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
 "ea" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
 	},
 /obj/structure/cable/cyan{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/industrial/caution/red,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
-"ec" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_dorms"
+"ef" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
-/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"en" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
 /turf/open/floor/plating,
-/area/ship/crew/dorm)
-"ei" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "eu" = (
 /obj/structure/cable/yellow{
@@ -415,49 +413,28 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
-"fl" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = 4;
-	pixel_x = 4
+"ff" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
+/turf/open/floor/engine/hull,
+/area/ship/engineering/atmospherics)
 "fp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Port Hangar"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/cargo/port)
-"fr" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 10
-	},
+/obj/machinery/computer/helm/viewscreen/directional/north,
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "5-6"
-	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = -21;
-	id = "dwayne_engines_starboard";
-	name = "Engine Shutter Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"fr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo/starboard)
 "fz" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -467,19 +444,67 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"fU" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-6"
+"fA" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_port";
+	name = "Engine Shutter Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"fG" = (
+/obj/effect/turf_decal/corner/opaque/black{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 10
 	},
-/obj/machinery/autolathe,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/mono/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"fL" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -497,43 +522,31 @@
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
-"gg" = (
-/obj/machinery/power/terminal{
-	dir = 8
+"gk" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"gp" = (
-/obj/structure/window{
-	dir = 2
-	},
-/obj/structure/toilet{
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plastic,
-/area/ship/crew/toilet)
-"gq" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows";
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"gl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
 "gs" = (
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/structure/closet/secure_closet/armorycage{
@@ -572,42 +585,58 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
-"gS" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+"gz" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"hp" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"hh" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 22
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "0-4"
+	icon_state = "4-10"
 	},
-/obj/effect/turf_decal/box,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/starboard)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/obj/machinery/button/door{
+	dir = 2;
+	pixel_y = 20;
+	id = "dwayne_engines_starboard"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
 "hx" = (
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
+"hy" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/sofa/brown/old/right/directional/north,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
 "hB" = (
 /obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning{
 	dir = 1
@@ -621,78 +650,45 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"hN" = (
-/obj/effect/turf_decal/industrial/warning/corner{
+"hF" = (
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/machinery/light/directional/north,
+/obj/structure/railing/thin{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "hQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 24
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
-"hR" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"hS" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_lounge"
 	},
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor{
+	id = "dwayne_recycling"
 	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/canteen)
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"hT" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 2;
+	name = "Supply to Output";
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
 "hZ" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/window/northleft{
+/obj/machinery/door/window/northright{
 	dir = 4;
 	name = "Engine Access"
 	},
@@ -700,41 +696,18 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
+	id = "dwayne_engines_port";
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/engineering)
+/area/ship/engineering/atmospherics)
 "ig" = (
 /obj/effect/turf_decal/solarpanel,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
-"ij" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"im" = (
-/obj/effect/turf_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
 "in" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_kitchen"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering)
 "iq" = (
 /obj/machinery/washing_machine{
 	layer = 2.8;
@@ -760,62 +733,69 @@
 /turf/open/floor/plastic,
 /area/ship/crew/toilet)
 "ir" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
-"is" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 6
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "dwayne_dorms"
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 4;
-	piping_layer = 1
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
+"iE" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-9"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"iG" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"iH" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/white{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
+"iO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Dormitory";
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm)
+"iU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/dresser{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 4
+	},
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
 "iY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
@@ -847,57 +827,14 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "jh" = (
+/obj/structure/chair/sofa/brown/old/left/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"jz" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/captain)
-"jp" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"jz" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_port_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_port"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"jI" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
-	},
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
 "jS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo/port)
-"jX" = (
-/turf/closed/wall/mineral/titanium,
 /area/ship/cargo/port)
 "kb" = (
 /obj/effect/turf_decal/industrial/warning/corner{
@@ -926,36 +863,60 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
-"kg" = (
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
+"kk" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
-	},
-/obj/structure/chair/handrail{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"kj" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"ku" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/drill,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"kx" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
+"ky" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"kL" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"ku" = (
-/obj/effect/turf_decal/ntspaceworks_small/right{
-	dir = 1
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
 "kO" = (
 /obj/structure/dresser{
 	dir = 8;
@@ -975,80 +936,54 @@
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "kV" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/atmospherics/components/unary/tank/nitrogen{
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"ld" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"ld" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"lg" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"ll" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"ll" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
 /turf/open/floor/wood,
-/area/ship/crew/dorm)
-"lo" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_port";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
+/area/ship/crew/canteen)
 "lv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1096,27 +1031,17 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "mf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 8
 	},
-/obj/structure/dresser{
-	dir = 4;
-	pixel_y = 0;
-	pixel_x = 4
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
 	},
-/obj/item/radio/intercom/table{
-	dir = 4;
-	pixel_y = 6;
-	pixel_x = 6
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
 "ms" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1131,49 +1056,62 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
-"mu" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew/toilet)
 "mv" = (
-/obj/machinery/door/poddoor/preopen{
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
 	id = "dwayne_captain";
 	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew/dorm/captain)
-"my" = (
+"mw" = (
+/obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "5-9"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/stock_parts/manipulator/nano{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/screwdriver{
+	pixel_y = -9;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"my" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/port)
+"mz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1;
+	piping_layer = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
 "mA" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -1188,29 +1126,15 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"mF" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window{
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"mP" = (
-/obj/effect/turf_decal/siding/wood/corner{
+"mD" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
+/turf/open/floor/engine/hull,
+/area/ship/engineering)
+"mF" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/hallway/central)
 "mR" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1221,50 +1145,68 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "na" = (
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 2;
-	name = "Supply to Output";
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"nk" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/head/helmet/space/light/engineer,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"nr" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 9
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner,
+/obj/structure/cable/cyan{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"nB" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/opaque/yellow/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"nr" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"nB" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
 "nV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1278,25 +1220,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"nX" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_port_field";
-	locked = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_port"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/port)
 "nY" = (
 /obj/machinery/jukebox{
 	pixel_y = 6;
@@ -1310,6 +1233,20 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
+"nZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
 "oa" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -1340,6 +1277,29 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
+"oz" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
 "oB" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1350,14 +1310,23 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "oE" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/hallway/central)
-"oF" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_captain"
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window{
+	pixel_y = 0
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_cryo";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"oF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain"
+	},
 /turf/open/floor/plating/airless,
 /area/ship/crew/dorm/captain)
 "oR" = (
@@ -1375,17 +1344,34 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"pl" = (
-/obj/machinery/computer/solar_control{
-	dir = 8;
-	icon_state = "computer-right"
+"oY" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "dwayne_exhaust"
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
+"pl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
 "pt" = (
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 8
@@ -1398,21 +1384,61 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"pu" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
 "px" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/railing/thin{
+/obj/structure/table,
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/radio{
+	pixel_y = 13;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/obj/item/radio{
+	pixel_y = 5;
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
+"pz" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
 "pS" = (
 /obj/machinery/power/solar,
 /obj/effect/turf_decal/solarpanel,
@@ -1434,21 +1460,67 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -19
+	},
+/obj/item/radio/intercom/directional/south{
+	pixel_y = -31;
+	pixel_x = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"ql" = (
-/obj/structure/chair/sofa/brown/old/left/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"qr" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 2
+"qk" = (
+/obj/effect/turf_decal/ntspaceworks_small/right{
+	dir = 1
 	},
-/obj/structure/curtain/bounty,
-/obj/item/radio/intercom/directional/north,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"ql" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/maunamug{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/book/fish_catalog{
+	pixel_x = -6;
+	pixel_y = 3
+	},
 /turf/open/floor/carpet,
-/area/ship/crew/dorm)
+/area/ship/crew/dorm/captain)
+"qA" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Office"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "qJ" = (
 /obj/structure/closet/secure_closet/wall/directional/north{
 	name = "captain's locker";
@@ -1511,6 +1583,33 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm/captain)
+"qK" = (
+/obj/structure/window{
+	dir = 2
+	},
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"qN" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Input to Waste";
+	dir = 1;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
 "qO" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -1525,44 +1624,25 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
-"qQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"qY" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"rs" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 4;
-	piping_layer = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
 "rE" = (
 /obj/structure/closet/crate/medical,
 /obj/item/clothing/gloves/color/latex/nitrile,
@@ -1582,41 +1662,36 @@
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/starboard)
-"rG" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_starboard"
-	},
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 8;
-	id = "dwayne_starboard_field";
-	locked = 1
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
-"rP" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_lounge"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/crew/canteen)
 "rQ" = (
 /obj/effect/turf_decal/ntspaceworks_small/left{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
+"rW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew/canteen)
+"sa" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "sb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
-/obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/firedoor/window,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /turf/open/floor/plating,
 /area/ship/cargo/port)
 "sg" = (
@@ -1648,23 +1723,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"sp" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_captain"
-	},
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
-"st" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
 "sD" = (
 /obj/machinery/light/directional/south,
 /obj/structure/chair/handrail{
@@ -1677,34 +1735,18 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "sM" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 4;
-	id = "dwayne_starboard_field";
-	locked = 1
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
 	},
-/obj/structure/cable/cyan,
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_starboard"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
-"te" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east{
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
 "tg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1742,49 +1784,21 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
-"tl" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+"tw" = (
+/obj/machinery/computer/monitor{
+	dir = 8;
+	icon_state = "computer-left"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door{
+	pixel_y = -15;
+	dir = 8;
+	pixel_x = -8;
+	id = "dwayne_exhaust";
+	name = "Exhaust Window Control"
 	},
-/obj/machinery/computer/helm/viewscreen/directional/north,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
-"tu" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -19
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/port)
-"tA" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
 "tI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/coffeemaker{
@@ -1823,24 +1837,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
-"tY" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "uc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -1898,54 +1894,29 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
-"uw" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
+"uD" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"uJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "uK" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
-"uS" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 24;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"vf" = (
-/obj/machinery/power/smes/shuttle/precharged,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engine Access"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_starboard";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
 "vi" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
@@ -1955,10 +1926,10 @@
 /turf/open/floor/plating/airless,
 /area/ship/bridge)
 "vm" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
 /obj/structure/cable/cyan{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
@@ -1973,14 +1944,887 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/directional/south{
-	pixel_x = -5
+	pixel_x = -9;
+	pixel_y = -32
 	},
 /obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
+	pixel_x = 3
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 12;
+	pixel_y = -19
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
-"vx" = (
+"vB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/sofa/brown/old/right/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"vL" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "dwayne_windows"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating/airless,
+/area/ship/bridge)
+"vP" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"vQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"wh" = (
+/obj/docking_port/stationary{
+	dheight = 1;
+	dwidth = 20;
+	height = 30;
+	name = "Dwayne Port Beam Dock";
+	width = 40
+	},
+/turf/template_noop,
+/area/space)
+"wm" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"wq" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"wy" = (
+/obj/effect/turf_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"wW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"xh" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xl" = (
+/obj/effect/turf_decal/solarpanel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"xn" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_port";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"xo" = (
+/obj/structure/chair/stool/bar{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xr" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/wall/white/directional/west{
+	name = "refrigerator"
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "dwayne_kitchen";
+	name = "Kitchen Window Control";
+	pixel_x = -21;
+	pixel_y = 17;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"xR" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "engine fuel pump"
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4;
+	name = "Air to Supply"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"xT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Port Hangar"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo/port)
+"xX" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"yq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"yt" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"yJ" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"yN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"yQ" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 4;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 6
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"yW" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"yZ" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"zi" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"zl" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband/table{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"zs" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/autolathe,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"zy" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"zz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"zA" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"zC" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"zX" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/black,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/obj/machinery/button/door{
+	pixel_y = -10;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_captain";
+	name = "Captain's Window Control"
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/dorm/captain)
+"Ai" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo/starboard)
+"Ak" = (
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"An" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"AB" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/storage/equip)
+"AC" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Bathroom";
+	dir = 4;
+	req_access_txt = "20";
+	id_tag = "dwayne_bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"AD" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"AG" = (
+/obj/structure/sign/poster/radio/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"AQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Bm" = (
+/obj/machinery/power/ship_gravity{
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Bx" = (
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4;
+	color = "#555555"
+	},
+/area/ship/bridge)
+"BH" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"BM" = (
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"BX" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Cf" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"Ci" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_starboard"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "dwayne_starboard_field";
+	locked = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/starboard)
+"Cl" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"Cr" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/canteen)
+"Cw" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Cy" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/computer/helm/viewscreen/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"CF" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"CI" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	name = "exhaust injector";
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"CJ" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "5-6"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -21;
+	id = "dwayne_engines_starboard";
+	name = "Engine Shutter Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering)
+"Da" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "dwayne_port";
+	name = "Port Blast Doors";
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "dwayne_port_field";
+	pixel_x = 1;
+	pixel_y = 19
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Dq" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Ds" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Bathroom";
+	dir = 4;
+	id_tag = "dwayne_bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Dv" = (
+/turf/template_noop,
+/area/space)
+"Dy" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"DF" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	name = "Engineering"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"DJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/emcloset/wall/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"DR" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"DS" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ntspaceworks_small,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"Ee" = (
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Ex" = (
+/obj/structure/table/reinforced,
+/obj/structure/sink/kitchen{
+	pixel_y = 21;
+	layer = 2.79;
+	dir = 2
+	},
+/obj/item/cutting_board{
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_y = 4
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 7;
+	pixel_x = -15
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -15;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"EE" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/dept/mining,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"ET" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"EV" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"EX" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1991,12 +2835,550 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/door/airlock/glass{
+/obj/machinery/door/airlock{
 	name = "Common Room"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/canteen)
-"vy" = (
+"Fa" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/dorm)
+"Fc" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/can/food/beans,
+/obj/item/trash/sosjerky,
+/obj/item/trash/candy,
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"Fd" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Fi" = (
+/obj/machinery/door/window/westleft,
+/obj/effect/turf_decal/steeldecal/steel_decals6,
+/obj/effect/turf_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew/toilet)
+"Fn" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Fq" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/ship/crew/canteen)
+"Fw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Fz" = (
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/soap{
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/item/mop,
+/obj/structure/closet/crate/trashcart/laundry{
+	name = "cleaning cart"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"FH" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"FM" = (
+/obj/structure/filingcabinet/filingcabinet{
+	dir = 4;
+	pixel_x = -10;
+	density = 0
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38,
+/obj/item/gun/ballistic/revolver/detective,
+/obj/item/megaphone/cargo,
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/item/bodycamera,
+/obj/item/bodycamera,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"FN" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-8"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Gr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Gs" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Gx" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"GG" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"GJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"GL" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_canteen"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"GQ" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"GU" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Hg" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Hh" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Hm" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters{
+	id = "dwayne_equipment";
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ship/storage/equip)
+"Hq" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half,
+/obj/machinery/computer/cargo{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Hv" = (
+/obj/structure/chair/handrail{
+	dir = 4;
+	name = "overhead handrail"
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 5
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/port)
+"Hx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"HD" = (
+/obj/machinery/griddle,
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"HI" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"HJ" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"HL" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"HW" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"Ia" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/toilet)
+"Ib" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Ic" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"Id" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Ip" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"Is" = (
+/obj/structure/closet/crate/engineering/electrical{
+	name = "fuel crate"
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/mapping_helpers/crate_shelve,
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"IA" = (
+/obj/machinery/pipedispenser{
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/industrial,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"IF" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"IJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/ntblue/half,
+/obj/machinery/fax/indie{
+	pixel_y = 7
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"IZ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Jk" = (
+/obj/structure/sink{
+	pixel_y = 2;
+	dir = 4;
+	pixel_x = -13
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plastic,
+/area/ship/crew/toilet)
+"Jq" = (
+/obj/docking_port/stationary{
+	dheight = 1;
+	dir = 2;
+	dwidth = 20;
+	height = 30;
+	name = "Dwayne Starboard Beam Dock";
+	width = 40
+	},
+/turf/template_noop,
+/area/space)
+"Jx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Jy" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"JD" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/cyan,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"JH" = (
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 4
 	},
@@ -2038,33 +3420,44 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage/equip)
-"vB" = (
+"JT" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "5-10"
 	},
-/obj/structure/chair/sofa/brown/old/right/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"vH" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/dorm)
-"vL" = (
-/obj/effect/turf_decal/ntspaceworks_small/left,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"vQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Ka" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
 	dir = 4
 	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"vZ" = (
+/area/ship/storage/equip)
+"Kh" = (
+/obj/machinery/power/terminal,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"KJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/closet/wall/orange/directional/west{
 	name = "Mechanic's locker";
@@ -2107,39 +3500,28 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
-"wh" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dwidth = 20;
-	height = 30;
-	name = "Dwayne Port Beam Dock";
-	width = 40
+"Lt" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
 	},
-/turf/template_noop,
-/area/space)
-"wm" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor{
-	id = "dwayne_starboard"
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
-"wn" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	name = "exhaust injector";
-	dir = 1
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external/dark)
-"wC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"wE" = (
+/area/ship/hallway/central)
+"LB" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 4
 	},
@@ -2148,95 +3530,1310 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"wW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+/area/ship/cargo/port)
+"LF" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 4;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"LL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/canteen)
+"LM" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ntspaceworks_small{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"LN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"LZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Mg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer4,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/closet/emcloset/wall/directional/west,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"Mr" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Mt" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Mw" = (
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"My" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"Mz" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"MB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"MG" = (
+/obj/structure/guncloset,
+/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
+/obj/item/gun/energy/sharplite/x26/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Nf" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering)
+"Nh" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 1;
+	name = "Scrubbers to Recycling"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/button/door{
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = 21;
+	id = "dwayne_recycling";
+	name = "Recycling Window Control"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Ny" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/industrial/hatch/blue,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hallway/central)
+"NG" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9-10"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"NQ" = (
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/radio/weather_monitor{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/science{
+	name = "mining crate"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"NS" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"NW" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/engineering/atmospherics)
+"Oh" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/line,
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"Op" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Ov" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Oy" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"OJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 8;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
+"OP" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 8
+	},
+/obj/structure/chair/handrail{
+	dir = 1;
+	name = "overhead handrail"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"OT" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"OV" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"OW" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable/cyan{
+	icon_state = "0-1"
+	},
+/turf/open/floor/carpet/black{
+	name = "bathroom mat"
+	},
+/area/ship/crew/toilet)
+"OZ" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 22
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"Pl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Pw" = (
+/obj/effect/turf_decal/box,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/starboard)
+"PD" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "dwayne_windows";
+	name = "Bridge Window Control";
+	pixel_x = -5;
+	pixel_y = 20
+	},
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"PF" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/industrial/caution/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"PM" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/atmospherics/components/unary/tank/nitrogen{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"PO" = (
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 20;
 	pixel_y = -12
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"xg" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"PY" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "6-9"
 	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"xh" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"xl" = (
-/obj/effect/turf_decal/solarpanel,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
-"xo" = (
-/obj/structure/chair/stool/bar{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"xr" = (
+"Qg" = (
 /obj/structure/table/reinforced,
-/obj/structure/closet/wall/white/directional/west{
-	name = "refrigerator"
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
+/obj/item/radio/weather_monitor{
+	pixel_x = 8;
+	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "dwayne_kitchen";
-	name = "Kitchen Window Control";
-	pixel_x = -21;
-	pixel_y = 17;
-	dir = 4
+/obj/machinery/newscaster/directional/west,
+/obj/item/paper_bin{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
+/obj/item/pen/fountain,
+/obj/item/stamp/captain{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Qp" = (
+/obj/effect/turf_decal/solarpanel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/canteen)
-"xS" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/can/food/beans,
-/obj/item/trash/sosjerky,
-/obj/item/trash/candy,
+"QB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Common Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/canteen)
+"QI" = (
+/obj/item/clothing/head/helmet/space/syndicate/generic{
+	pixel_y = 0
+	},
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/corner/opaque/yellow/mono,
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/item/clothing/suit/space/syndicate/generic/grey,
+/obj/item/clothing/mask/gas,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"QQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Rb" = (
+/obj/item/toy/eightball{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/structure/table/wood/poker{
+	name = "billiards table"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Rm" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/chair/handrail{
+	dir = 8;
+	name = "overhead handrail"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/orange{
+	dir = 10
+	},
+/turf/open/floor/noslip,
+/area/ship/cargo/starboard)
+"RE" = (
 /obj/effect/turf_decal/corner/opaque/yellow/half{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/crate_shelve,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
-"yb" = (
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/light/engineer,
-/obj/item/clothing/mask/gas,
+"RJ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
+"RN" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 2;
+	piping_layer = 1
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"RV" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(20,41)
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4;
+	color = "#555555"
+	},
+/area/ship/bridge)
+"Se" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"SA" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "foreman's locker";
+	req_access_txt = "20";
+	icon_state = "solgov_wall";
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/item/storage/backpack/duffelbag/engineering{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/storage/backpack/satchel/eng{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/obj/item/clothing/suit/jacket/leather/duster{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/rank/security/detective{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/storage/belt/utility/full{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/fingerless{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/cowboy/sec{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/clothing/head/hardhat/white{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"SB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_captain";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/crew/dorm/captain)
+"SR" = (
+/obj/machinery/computer/solar_control{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
-"ye" = (
+"Td" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Tl" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"Tw" = (
+/obj/effect/turf_decal/ntspaceworks_small/right,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"TO" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"TP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "dwayne_lounge";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"TR" = (
+/obj/structure/mirror{
+	pixel_y = 4;
+	layer = 2.8;
+	pixel_x = 7
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
+"TT" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"TW" = (
+/obj/effect/turf_decal/corner/opaque/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Uj" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	layer = 2.43
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Uq" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ship/crew/cryo)
+"UH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"UN" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/mining{
+	name = "Equipment Room"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/storage/equip)
+"UQ" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"US" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "dwayne_port_field";
+	locked = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_port"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo/port)
+"UV" = (
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"UX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Vb" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"Vr" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/obj/machinery/blackbox_recorder,
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Vs" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
+"VH" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"VL" = (
+/obj/effect/turf_decal/industrial/outline,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/atmospherics)
+"VO" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/atmospherics)
+"VX" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/port)
+"VZ" = (
+/obj/structure/table/wood/poker{
+	name = "billiards table"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/canteen)
+"Wa" = (
+/obj/effect/turf_decal/ntspaceworks_small/left,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"Wg" = (
+/obj/structure/table/wood,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Wh" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Ww" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/storage/equip)
+"Wy" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engine Access"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "dwayne_engines_starboard";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"WE" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"WL" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
+"Xa" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Xl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xw" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/toilet)
+"Xy" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "dwayne_kitchen"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/canteen)
+"XC" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"XP" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/cryo)
+"XQ" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 2
+	},
+/obj/structure/curtain/bounty,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Yd" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/structure/chair/sofa/brown/old/left/directional/north,
+/obj/machinery/button/door{
+	pixel_y = -20;
+	dir = 1;
+	id = "dwayne_lounge";
+	name = "Canteen Window Control";
+	pixel_x = 6
+	},
+/obj/machinery/button/door{
+	pixel_y = -20;
+	dir = 1;
+	id = "dwayne_canteen";
+	name = "Canteen Shutter Control";
+	pixel_x = -6
+	},
+/turf/open/floor/carpet,
+/area/ship/crew/canteen)
+"Yl" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/starboard)
+"YD" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"YH" = (
+/obj/effect/turf_decal/trimline/opaque/yellow/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/wall/directional/south{
+	icon_state = "cargo_wall";
+	name = "miner's locker";
+	req_access_txt = "48";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/rank/cargo/miner/hazard{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/hardhat/mining{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/obj/item/clothing/gloves/explorer{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/machinery/button/door{
+	pixel_y = -16;
+	dir = 4;
+	id = "dwayne_equipment";
+	name = "Equipment Room Shutter Control";
+	pixel_x = -21
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/storage/equip)
+"YV" = (
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ship/external/dark)
+"YY" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/yellow{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -21;
+	id = "dwayne_engines_port"
+	},
+/turf/open/floor/plasteel/patterned/grid/dark,
+/area/ship/engineering/atmospherics)
+"Ze" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Zf" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 1
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/carpet,
+/area/ship/crew/dorm)
+"Zj" = (
+/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 7
+	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Zk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
+"Zp" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
+"Zq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/dorm/captain)
+"Zt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sign/warning/fire{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Zv" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
@@ -2309,73 +4906,34 @@
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
-"yq" = (
-/obj/effect/turf_decal/siding/wood{
+"Zy" = (
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo/starboard)
+"ZK" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"yw" = (
-/obj/structure/filingcabinet/filingcabinet{
-	dir = 4;
-	pixel_x = -10;
-	density = 0
-	},
-/obj/effect/turf_decal/corner/opaque/ntblue/border{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/ammo_box/c38,
-/obj/item/ammo_box/c38,
-/obj/item/gun/ballistic/revolver/detective,
-/obj/item/megaphone/cargo,
-/obj/structure/railing{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/item/bodycamera,
-/obj/item/bodycamera,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"yJ" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"yN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "6-9"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_lounge";
-	dir = 4
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"yV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
 	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm/captain)
+"ZL" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -2385,916 +4943,25 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"yZ" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/cargo/starboard)
-"zi" = (
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"zl" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"zz" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/corner/opaque/ntblue/border{
-	dir = 8
-	},
-/obj/machinery/blackbox_recorder,
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"zA" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"zC" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"zX" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
+"ZV" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Engine Access"
 	},
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	id = "dwayne_engines_port";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Ak" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Ao" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 2;
-	piping_layer = 1
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external/dark)
-"AB" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/end,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"AC" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Bathroom";
-	dir = 4;
-	req_access_txt = "20";
-	id = "dwayne_bathroom"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm/captain)
-"AD" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"AG" = (
-/obj/structure/sign/poster/radio/random{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"AQ" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"AS" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-9"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"Bd" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/drill,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/port)
-"Bg" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock{
-	name = "Dormitory";
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/dorm)
-"Bx" = (
-/obj/structure/railing{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4;
-	color = "#555555"
-	},
-/area/ship/bridge)
-"BB" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"BK" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"BX" = (
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Co" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 16;
-	pixel_x = 7
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/item/reagent_containers/glass/maunamug{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/book/fish_catalog{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
-"CE" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/storage/equip)
-"CK" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"CX" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/canteen)
-"Ds" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Bathroom";
-	dir = 4;
-	id = "dwayne_bathroom"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"Dv" = (
-/turf/template_noop,
-/area/space)
-"DJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/emcloset/wall/directional/north,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"DM" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"DR" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/central)
-"DS" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ntspaceworks_small,
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"Eb" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Ed" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/cargo/port)
-"Ee" = (
-/obj/effect/turf_decal/industrial/warning/corner,
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"Eo" = (
-/obj/machinery/power/terminal,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Ex" = (
-/obj/structure/table/reinforced,
-/obj/structure/sink/kitchen{
-	pixel_y = 21;
-	layer = 2.79;
-	dir = 2
-	},
-/obj/item/cutting_board{
-	pixel_y = 2;
-	pixel_x = 1
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 4
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 7;
-	pixel_x = -15
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -15;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"EC" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"EE" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/dept/mining,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"EI" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east{
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"EV" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"Fd" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Fi" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"Fq" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_windows"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating/airless,
-/area/ship/bridge)
-"Fz" = (
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
-/obj/item/soap{
-	pixel_x = 0;
-	pixel_y = -9
-	},
-/obj/item/mop,
-/obj/structure/closet/crate/trashcart/laundry{
-	name = "cleaning cart"
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"FH" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"FJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"FM" = (
-/obj/machinery/computer/monitor{
-	dir = 8;
-	icon_state = "computer-left"
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/button/door{
-	pixel_y = -15;
-	dir = 8;
-	pixel_x = -8;
-	id = "dwayne_exhaust";
-	name = "Exhaust Window Control"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
-"FN" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-8"
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"FR" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"FU" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "dwayne_windows";
-	name = "Bridge Window Control";
-	pixel_x = -5;
-	pixel_y = 20
-	},
-/obj/machinery/computer/helm{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Gr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
-	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Gs" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Gx" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"GG" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"GL" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	name = "Input to Waste";
-	dir = 1;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"GO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/chair/handrail{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"GQ" = (
-/obj/structure/table,
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/item/radio{
-	pixel_y = 13;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 9;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = 1
-	},
-/obj/item/radio{
-	pixel_y = 13;
-	pixel_x = -8
-	},
-/obj/item/radio{
-	pixel_y = 9;
-	pixel_x = -8
-	},
-/obj/item/radio{
-	pixel_y = 5;
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"Hh" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/crew/cryo)
-"Hv" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"HI" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor{
-	id = "dwayne_port"
+	id = "dwayne_engines_starboard";
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/cargo/port)
-"HW" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"HX" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/corner,
-/obj/structure/cable/cyan{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Ia" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"Ip" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"Is" = (
-/obj/structure/closet/crate/engineering/electrical{
-	name = "fuel crate"
-	},
-/obj/item/stack/sheet/mineral/plasma/twenty{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/mapping_helpers/crate_shelve,
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"It" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Ix" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/chair/sofa/brown/old/right/directional/north,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"Iy" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 12
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan,
-/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
-"IF" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/wall/directional/south{
-	icon_state = "cargo_wall";
-	name = "miner's locker";
-	req_access_txt = "48";
-	dir = 8;
-	pixel_y = 0;
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/hazardvest{
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/storage/belt/mining/alt{
-	pixel_x = -7;
-	pixel_y = -7
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/obj/item/clothing/gloves/explorer{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"II" = (
+"ZY" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 4;
 	piping_layer = 1
@@ -3316,1645 +4983,23 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"IJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/ntblue/half,
-/obj/machinery/fax/indie{
-	pixel_y = 7
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"IZ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Jh" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/half,
-/obj/machinery/computer/cargo{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Jk" = (
-/obj/structure/sink{
-	pixel_y = 2;
-	dir = 4;
-	pixel_x = -13
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plastic,
-/area/ship/crew/toilet)
-"Jq" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 2;
-	dwidth = 20;
-	height = 30;
-	name = "Dwayne Starboard Beam Dock";
-	width = 40
-	},
-/turf/template_noop,
-/area/space)
-"Jx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Jy" = (
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"JS" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"JX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Ka" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"KJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"KL" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Engineering"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Lf" = (
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Lq" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/storage/equip)
-"Lt" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Lv" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"Lz" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9-10"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"LB" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/chair/handrail{
-	dir = 4;
-	name = "overhead handrail"
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 9
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 6
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/starboard)
-"LC" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo/starboard)
-"LL" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_recycling"
-	},
-/turf/open/space/basic,
-/area/ship/engineering/atmospherics)
-"LM" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ntspaceworks_small{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"LN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"LZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"Mg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
-/obj/structure/closet/emcloset/wall/directional/west,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
-"Mt" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Mz" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"MB" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"ME" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Common Room"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/canteen)
-"MG" = (
-/obj/structure/guncloset,
-/obj/item/gun/ballistic/shotgun/flamingarrow/conflagration/empty,
-/obj/item/gun/energy/sharplite/x26/empty_cell,
-/obj/item/gun/energy/sharplite/x12/empty_cell,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"MJ" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Nf" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/engineering)
-"Ni" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 2
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Nm" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
-"Np" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"Ny" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/hallway/central)
-"Nz" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"NF" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering)
-"NQ" = (
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = 11;
-	pixel_y = 2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = 11;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/clothing/under/rank/cargo/miner/hazard{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
-	},
-/obj/item/clothing/shoes/workboots/mining{
-	pixel_y = -8;
-	pixel_x = 7
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = -5
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/hardhat/mining{
-	pixel_x = -11;
-	pixel_y = 7
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate/science{
-	name = "mining crate"
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"NW" = (
-/obj/machinery/power/shuttle/engine/electric,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/engineering/atmospherics)
-"Oa" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"Om" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Op" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"Ov" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Oy" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"OJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 8;
-	pixel_x = -1
-	},
-/obj/effect/turf_decal/corner/opaque/white/diagonal{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
-"OP" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 8
-	},
-/obj/structure/chair/handrail{
-	dir = 1;
-	name = "overhead handrail"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"OV" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"OW" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/turf/open/floor/carpet/black{
-	name = "bathroom mat"
-	},
-/area/ship/crew/toilet)
-"Pl" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/ship/storage/equip)
-"Pw" = (
-/obj/effect/turf_decal/box,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo/starboard)
-"PC" = (
-/obj/machinery/pipedispenser{
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/industrial,
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"PS" = (
-/obj/structure/platform/ship_two{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/item/radio/old{
-	pixel_x = 6;
-	pixel_y = 21
-	},
-/obj/item/toy/prize/ripley{
-	pixel_x = -11;
-	pixel_y = 29
-	},
-/obj/structure/rack,
-/obj/item/towel{
-	pixel_y = -5;
-	pixel_x = -5
-	},
-/obj/item/towel{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/soap/nanotrasen{
-	pixel_y = -1;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/button/door{
-	pixel_y = -10;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_bathroom";
-	name = "Bathroom Bolt Control"
-	},
-/turf/open/floor/plastic,
-/area/ship/crew/toilet)
-"Qc" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"Qg" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/corner/opaque/ntblue/half{
-	dir = 1
-	},
-/obj/item/radio/weather_monitor{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/item/paper_bin{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/pen/fountain,
-/obj/item/stamp/captain{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Qp" = (
-/obj/machinery/power/shuttle/engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering/atmospherics)
-"QI" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/machinery/light/directional/north,
-/obj/structure/railing/thin{
-	dir = 8
-	},
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"Rb" = (
-/obj/item/toy/eightball{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/structure/table/wood/poker{
-	name = "billiards table"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Rm" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/chair/handrail{
-	dir = 8;
-	name = "overhead handrail"
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 10
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/starboard)
-"Ru" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/obj/machinery/button/door{
-	dir = 2;
-	pixel_y = 20;
-	id = "dwayne_engines_starboard"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering)
-"RE" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"RJ" = (
-/obj/item/clothing/head/helmet/space/syndicate/generic{
-	pixel_y = 0
-	},
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/railing/thin{
-	dir = 4
-	},
-/obj/item/clothing/suit/space/syndicate/generic/grey,
-/obj/item/clothing/mask/gas,
-/obj/structure/railing/thin{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"RV" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-10"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4;
-	color = "#555555"
-	},
-/area/ship/bridge)
-"Se" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Sh" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"Sp" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_y = -21;
-	id = "dwayne_engines_port"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"SA" = (
-/obj/structure/closet/secure_closet/wall/directional/north{
-	name = "foreman's locker";
-	req_access_txt = "20";
-	icon_state = "solgov_wall";
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/item/storage/backpack/duffelbag/engineering{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/storage/backpack/satchel/eng{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/clothing/shoes/workboots{
-	pixel_y = -7;
-	pixel_x = 8
-	},
-/obj/item/clothing/suit/jacket/leather/duster{
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/clothing/under/rank/security/detective{
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/storage/belt/utility/full{
-	pixel_x = 8;
-	pixel_y = -7
-	},
-/obj/item/clothing/gloves/fingerless{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/clothing/head/cowboy/sec{
-	pixel_x = 13;
-	pixel_y = 11
-	},
-/obj/item/clothing/head/hardhat/white{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"SB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_captain";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/dorm/captain)
-"SG" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Equipment Room"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage/equip)
-"SV" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Tl" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Tw" = (
-/obj/effect/turf_decal/ntspaceworks_small/right,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"TO" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"TP" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "dwayne_lounge";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/canteen)
-"TQ" = (
-/obj/machinery/door/window/westleft,
-/obj/effect/turf_decal/steeldecal/steel_decals6,
-/obj/effect/turf_decal/steeldecal/steel_decals6{
-	dir = 4
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/chair/handrail{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew/toilet)
-"TR" = (
-/obj/structure/mirror{
-	pixel_y = 4;
-	layer = 2.8;
-	pixel_x = 7
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm)
-"TT" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 4
-	},
-/obj/structure/curtain/bounty,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Ug" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/machinery/light/small/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/double/black,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = 22
-	},
-/obj/machinery/button/door{
-	pixel_y = -10;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_captain";
-	name = "Captain's Window Control"
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/dorm/captain)
-"Ui" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 1;
-	name = "Scrubbers to Recycling"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/opaque/black/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 8;
-	pixel_x = 21;
-	id = "dwayne_recycling";
-	name = "Recycling Window Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"Uj" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	layer = 2.43
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Uk" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Uu" = (
-/obj/structure/chair/handrail{
-	dir = 4;
-	name = "overhead handrail"
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/orange{
-	dir = 5
-	},
-/turf/open/floor/noslip,
-/area/ship/cargo/port)
-"UF" = (
-/obj/machinery/atmospherics/components/unary/tank/toxins{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/machinery/button/door{
-	pixel_y = 0;
-	dir = 4;
-	pixel_x = -21;
-	id = "dwayne_engines_port";
-	name = "Engine Shutter Control"
-	},
-/turf/open/floor/plasteel/patterned/grid/dark,
-/area/ship/engineering/atmospherics)
-"UH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"UP" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/chair/handrail{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
-"UV" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"UX" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"Va" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Vb" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Vg" = (
-/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "dwayne_starboard";
-	name = "Starboard Blast Doors";
-	pixel_x = -8;
-	pixel_y = -20;
-	dir = 1
-	},
-/obj/machinery/button/shieldwallgen{
-	id = "dwayne_starboard_field";
-	pixel_x = 1;
-	pixel_y = -19;
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"Vm" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "dwayne_exhaust"
-	},
-/turf/open/space/basic,
-/area/ship/engineering)
-"VH" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"VO" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 2
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"VZ" = (
-/obj/structure/table/wood/poker{
-	name = "billiards table"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ship/crew/canteen)
-"Wa" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "engine fuel pump"
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 4;
-	name = "Air to Supply"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"Wg" = (
-/obj/structure/table/wood,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Wh" = (
-/obj/effect/turf_decal/corner/opaque/black{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = -12
-	},
-/obj/effect/turf_decal/trimline/opaque/blue/filled/corner,
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"WE" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"WF" = (
-/obj/effect/turf_decal/corner/opaque/yellow/mono,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 0
-	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 0
-	},
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"WN" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/line,
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/structure/railing/thin/corner{
-	dir = 4
-	},
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"Xa" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen)
-"Xc" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"Xj" = (
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external/dark)
-"Xk" = (
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/toilet)
-"Xl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/corner{
-	dir = 1
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xn" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer5,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Office"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Xo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/opaque/lightgrey/filled/warning,
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Xw" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/crew/toilet)
-"Xx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/cyan{
-	icon_state = "0-1"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"XA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/cryo)
-"XC" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo/starboard)
-"XD" = (
-/obj/effect/turf_decal/corner/opaque/yellow/half,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/industrial/caution/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/starboard)
-"XQ" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"Yd" = (
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/structure/chair/sofa/brown/old/left/directional/north,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -19
-	},
-/obj/machinery/button/door{
-	pixel_y = -20;
-	dir = 1;
-	id = "dwayne_lounge";
-	name = "Lounge Window Control"
-	},
-/turf/open/floor/carpet,
-/area/ship/crew/canteen)
-"Yx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 1;
-	piping_layer = 4
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
-"YD" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
-"YH" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/port)
-"YM" = (
-/obj/effect/turf_decal/trimline/opaque/yellow/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/railing/thin/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage/equip)
-"YR" = (
-/obj/machinery/power/ship_gravity{
-	pixel_y = 0
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-10"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Za" = (
-/obj/effect/turf_decal/industrial/outline,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/atmospherics)
-"Zf" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 1
-	},
-/obj/structure/curtain/bounty,
-/turf/open/floor/carpet,
-/area/ship/crew/dorm)
-"Zj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
-/obj/structure/chair/handrail{
-	dir = 2
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/hallway/central)
-"Zk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood,
-/area/ship/crew/canteen)
-"Zq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 2
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm/captain)
-"Zv" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/fragile,
-/obj/item/clothing/head/helmet/space/fragile,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/hallway/central)
-"ZD" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"ZK" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public{
-	name = "Cryogenics"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/cryo)
-"ZL" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/structure/crate_shelf,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo/starboard)
 
 (1,1,1) = {"
 Dv
 Dv
 Dv
 Dv
-cf
-Qp
-cf
+ak
+ff
+ak
 Dv
 Dv
 Dv
 Dv
 Dv
-ir
-NF
-ir
+in
+mD
+in
 Dv
 Dv
 Dv
@@ -4962,231 +5007,231 @@ Dv
 "}
 (2,1,1) = {"
 Dv
-cf
+ak
 NW
 NW
-cf
-zX
-cf
-Dv
-Dv
-Dv
-Dv
-Dv
-ir
+ak
 hZ
-ir
+ak
+Dv
+Dv
+Dv
+Dv
+Dv
+in
+Wy
+in
 Nf
 Nf
-ir
+in
 Dv
 "}
 (3,1,1) = {"
 Dv
-cf
-lo
-lo
-cf
+ak
+xn
+xn
+ak
 Tl
-cf
+ak
 Dv
 Dv
 Dv
 Dv
 Dv
-ir
+in
 Uj
-ir
-vf
-tY
-ir
+in
+ZV
+cP
+in
 Dv
 "}
 (4,1,1) = {"
 Dv
-cf
-jp
-yV
-UF
-nk
-cf
+ak
+ZL
+Fn
+fA
+dx
+ak
 Dv
 Dv
 Dv
 Dv
 Dv
-ir
-Lv
-fr
-gg
-da
-ir
+in
+mf
+CJ
+sa
+Mw
+in
 Dv
 "}
 (5,1,1) = {"
 Dv
-cf
-HX
-ld
-Lf
-Sp
-cf
-oE
-oE
+ak
+nr
+nK
+BM
+YY
+ak
+mF
+mF
 kf
-oE
-oE
-ir
-Ru
-BK
-AS
-AB
-ir
+mF
+mF
+in
+hp
+qY
+zy
+iE
+in
 Dv
 "}
 (6,1,1) = {"
 Dv
-cf
-Ni
-is
-Yx
-Om
-Za
-oE
+ak
+xX
+BH
+mz
+Hg
+VL
+mF
 Mg
 gf
 lC
-oE
-YR
-CK
-ZD
-Eo
-uS
-ir
+mF
+Bm
+fL
+ef
+Kh
+bg
+in
 Dv
 "}
 (7,1,1) = {"
 Dv
-cf
-PC
-II
-Wa
-MB
-im
-oE
-Zv
+ak
+IA
+ZY
+xR
+VO
+wy
+mF
+sM
 ma
-hN
-oE
-ir
-KL
-XQ
-XQ
-ir
-ir
+XC
+mF
+in
+DF
+ky
+ky
+in
+in
 Dv
 "}
 (8,1,1) = {"
 Dv
-cf
-cf
-rs
-iG
-MB
-kV
-cf
-oE
-hQ
-oE
-ir
-fU
-iH
-dN
-vZ
-ir
-ir
+ak
+ak
+LF
+QQ
+VO
+PM
+ak
+mF
+Hx
+mF
+in
+zs
+Ic
+mw
+KJ
+in
+in
 Dv
 "}
 (9,1,1) = {"
 Dv
-Ao
-LL
-Ui
-JX
-Gs
-hR
-gS
-MJ
-bj
-Va
-Xn
-Iy
-Lz
-Oa
-xg
-Vm
-wn
+RN
+hQ
+Nh
+bc
+oz
+PO
+HW
+ld
+kL
+OT
+qA
+JD
+NG
+gk
+HJ
+oY
+CI
 Dv
 "}
 (10,1,1) = {"
 Dv
-cf
-cf
-cf
-cf
-cf
-cf
-cf
-bs
-VO
-Ka
-ir
-ir
-yb
-FM
-pl
-ir
-ir
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+Zt
+NS
+GU
+in
+in
+na
+tw
+SR
+in
+in
 Dv
 "}
 (11,1,1) = {"
 Dv
-CE
-Lq
+Ww
+AB
 uq
-IF
-vy
+YH
+JH
 MG
-Pl
+Hm
 Jy
-Eb
-na
+JT
+hT
 Ny
 OV
 OV
 OV
 OV
 OV
-aW
+WL
 Dv
 "}
 (12,1,1) = {"
 Dv
 Dv
-Lq
-RJ
-WN
-FR
+AB
+QI
+Ka
+gz
 gs
-Pl
-uJ
-UX
-GL
+Hm
+MB
+Hh
+qN
 eH
 OV
-Sh
-GQ
-JS
+kx
+px
+XP
 OV
 Dv
 Dv
@@ -5194,20 +5239,20 @@ Dv
 (13,1,1) = {"
 Dv
 Dv
-Lq
-QI
-Nz
-FR
-WF
-Lq
-Zj
+AB
+hF
+Oh
+gz
+Ak
+AB
+Cw
 VH
-kg
+Zj
 OV
 OV
-tl
-dI
-Hh
+fp
+kk
+Uq
 OV
 Dv
 Dv
@@ -5215,117 +5260,117 @@ Dv
 (14,1,1) = {"
 Dv
 Dv
-Lq
-px
-YM
-HW
-wW
-SG
+AB
+cf
+Dq
+lg
+pl
+UN
 aI
 AD
 Gx
-ZK
-Xx
-wC
-XA
-Xc
+dP
+nZ
+Pl
+gl
+bj
 OV
 Dv
 Dv
 "}
 (15,1,1) = {"
 Dv
-jX
+my
 jS
 jS
-mF
-mF
+bR
+bR
 jS
 jS
 LN
-qQ
+GJ
 mA
-XC
-XC
-bR
-bR
-XC
-XC
-LC
+fr
+fr
+oE
+oE
+fr
+fr
+Ai
 Dv
 "}
 (16,1,1) = {"
 Dv
 jS
-It
-GO
-aM
-Qc
-Bd
+nB
+Xa
+hx
+Mr
+ku
 jS
-my
+wW
 lv
 sg
-XC
+fr
 Pw
 UV
 uK
 uh
 Ee
-XC
+fr
 Dv
 "}
 (17,1,1) = {"
 Dv
-nX
-nr
+US
+ea
 th
 EV
 TO
-tu
+RJ
 jS
 or
-cI
+UX
 sD
-XC
-hh
-xS
+fr
+OZ
+Fc
 Fz
 NQ
-kj
-sM
+vm
+cV
 Dv
 "}
 (18,1,1) = {"
 Dv
 HI
-nB
-YH
-YH
+HL
+kV
+kV
 TO
-ku
+qk
 sb
 IZ
 WE
 dK
 yZ
-vL
+Wa
 RE
 YD
 YD
-vm
+UQ
 wm
 Dv
 "}
 (19,1,1) = {"
 wh
 HI
-ea
+Zp
 Ip
 Ip
 cn
 LM
-fp
+xT
 EE
 zi
 tj
@@ -5334,71 +5379,71 @@ DS
 Oy
 rE
 zA
-XD
+PF
 wm
 Jq
 "}
 (20,1,1) = {"
 Dv
 HI
-nB
-YH
-YH
+HL
+kV
+kV
 TO
 rQ
-Ed
+Cl
 fz
-UX
+Hh
 Fd
 yZ
 Tw
 RE
 YD
 YD
-vm
+UQ
 wm
 Dv
 "}
 (21,1,1) = {"
 Dv
-jz
+en
 GG
-uw
-hx
+VX
+an
 TO
 dO
 jS
 kb
 FH
 pt
-XC
+fr
 Rm
 RE
-ZL
+Zy
 bE
 Is
-rG
+Ci
 Dv
 "}
 (22,1,1) = {"
 Dv
 jS
-dY
-UP
-EI
-ei
-Uu
+Da
+LB
+Gs
+Dy
+Hv
 jS
-my
+wW
 DR
 sg
-XC
-LB
-BB
-te
-wE
-Vg
-XC
+fr
+yQ
+CF
+Yl
+GQ
+aM
+fr
 Dv
 "}
 (23,1,1) = {"
@@ -5413,24 +5458,24 @@ jS
 DJ
 oR
 dy
-XC
-XC
-XC
-XC
-XC
-XC
-XC
+fr
+fr
+fr
+fr
+fr
+fr
+fr
 Dv
 "}
 (24,1,1) = {"
 Dv
-in
+Xy
 OJ
 xr
 tI
 xo
 dh
-Xa
+LL
 vQ
 VH
 yJ
@@ -5440,60 +5485,60 @@ kO
 TT
 iZ
 Mt
-ec
+ir
 Dv
 "}
 (25,1,1) = {"
 Dv
-Xa
+LL
 Ex
 tQ
 xh
 xo
-FJ
-ME
+AQ
+QB
 sk
-SV
+Ze
 Xo
-Bg
+iO
 ms
-ll
-ij
-tA
+My
+Fw
+uD
 Wg
 bx
 Dv
 "}
 (26,1,1) = {"
 Dv
-in
-do
+Xy
+HD
 tX
 iY
 ck
 qg
-Xa
+LL
 Xl
 VH
 OP
 bx
-qr
+XQ
 aY
 SA
-cV
-ye
-ec
+Cy
+Zv
+ir
 Dv
 "}
 (27,1,1) = {"
 Dv
-CX
-Xa
+Cr
+LL
 AG
 hC
 Zk
-mP
-pu
+wq
+GL
 Se
 VH
 Jy
@@ -5503,24 +5548,24 @@ Ds
 TR
 bx
 bx
-vH
+Fa
 Dv
 "}
 (28,1,1) = {"
 Dv
 Dv
-Xa
+LL
 nY
 LZ
 VZ
-KJ
-pu
+ll
+GL
 Ov
 zC
 Gr
 Ia
 iq
-mu
+pz
 Jk
 OW
 Ia
@@ -5530,20 +5575,20 @@ Dv
 (29,1,1) = {"
 Dv
 Dv
-Xa
-fl
+LL
+vP
 LZ
 Rb
 vw
-Xa
+LL
 FN
 Mz
 Jy
-Xk
-PS
+PY
+bO
 Xw
-gp
-TQ
+qK
+Fi
 Ia
 Dv
 Dv
@@ -5551,20 +5596,20 @@ Dv
 (30,1,1) = {"
 Dv
 Dv
-Xa
-Xa
+LL
+LL
 tg
 nV
 yq
-vx
+EX
 hB
 Jx
 BX
-jh
-jh
+jz
+jz
 AC
-jh
-jh
+jz
+jz
 xl
 Dv
 Dv
@@ -5572,21 +5617,21 @@ Dv
 (31,1,1) = {"
 Dv
 Dv
-bW
-hS
+Id
+Fq
 vB
 UH
 Yd
-Xa
+LL
 Wh
 Lt
-ak
-dx
+fG
+ZK
 qJ
 Zq
 bv
-sp
-DM
+Cf
+bW
 Dv
 Dv
 "}
@@ -5594,18 +5639,18 @@ Dv
 Dv
 Dv
 pS
-rP
-ql
+rW
+jh
 Op
-Ix
-Xa
+hy
+LL
 aX
 RV
-Fi
-jh
-Ug
-mf
-Co
+IF
+jz
+zX
+iU
+ql
 oF
 pS
 Dv
@@ -5614,21 +5659,21 @@ Dv
 (33,1,1) = {"
 Dv
 Dv
-AQ
-Np
+ET
+Qp
 TP
 yN
-Xa
-Fi
-yw
+LL
+IF
+FM
 Bx
-zz
-Fi
-jh
+Vr
+IF
+jz
 SB
 mv
 ig
-AQ
+ET
 Dv
 Dv
 "}
@@ -5636,19 +5681,19 @@ Dv
 Dv
 Dv
 Dv
-Xj
+YV
 oa
 qO
-Fq
+vL
 Qg
 eL
-Ak
+zz
 aR
 IJ
 vi
 eu
 Vb
-st
+Ib
 Dv
 Dv
 Dv
@@ -5658,17 +5703,17 @@ Dv
 Dv
 Dv
 Dv
-Xj
-cO
-Fq
-EC
+YV
+yt
+vL
+Td
 mR
 cw
 oB
-Jh
+Hq
 vi
-Uk
-Hv
+An
+yW
 Dv
 Dv
 Dv
@@ -5681,13 +5726,13 @@ Dv
 Dv
 Dv
 Dv
-Nm
-Fi
-FU
+Vs
+IF
+PD
 zl
-jI
-Fi
-Nm
+TW
+IF
+Vs
 Dv
 Dv
 Dv
@@ -5703,11 +5748,11 @@ Dv
 Dv
 Dv
 Dv
-Nm
-gq
-gq
-gq
-Nm
+Vs
+am
+am
+am
+Vs
 Dv
 Dv
 Dv

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -354,6 +354,12 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
+"ec" = (
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "eg" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/can/food/beans,
@@ -680,7 +686,7 @@
 "hQ" = (
 /obj/machinery/button/door{
 	id = "dwayne_port";
-	name = "Port Blast Doors";
+	name = "Port Blast Door Control";
 	pixel_x = -8;
 	pixel_y = 20
 	},
@@ -1934,19 +1940,6 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
-"rX" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/caution/red,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/yellow,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
-/area/ship/cargo/port)
 "sb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
@@ -2968,7 +2961,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/freezer{
-	name = "Bathroom";
+	name = "Captain's-Bathroom";
 	dir = 4;
 	req_access_txt = "20";
 	id_tag = "dwayne_bathroom"
@@ -3158,7 +3151,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/freezer{
-	name = "Bathroom";
+	name = "Dorms-Bathroom";
 	dir = 4;
 	id_tag = "dwayne_bathroom"
 	},
@@ -3204,22 +3197,26 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/border{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/megaphone/cargo,
 /obj/structure/railing{
 	dir = 2
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/item/bodycamera,
-/obj/item/bodycamera,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light_switch{
 	pixel_x = -12;
 	pixel_y = 22
 	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/folder/yellow,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/obj/item/megaphone/cargo,
 /obj/item/gps,
+/obj/item/bodycamera,
+/obj/item/bodycamera,
+/obj/item/pen,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "DP" = (
@@ -3695,7 +3692,7 @@
 	dir = 2;
 	pixel_y = 20;
 	id = "dwayne_engines_starboard";
-	name = "Starboard Engine Blast Doors"
+	name = "Starboard Engine Window Control"
 	},
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
@@ -4119,7 +4116,7 @@
 	dir = 1;
 	pixel_y = -21;
 	id = "dwayne_engines_port";
-	name = "Port Engine Blast Doors"
+	name = "Port Engine Window Control"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid/dark,
@@ -4783,6 +4780,19 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
+"Qu" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "QG" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 2;
@@ -4963,12 +4973,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"Sd" = (
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "Se" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -5772,7 +5776,7 @@
 "ZX" = (
 /obj/machinery/button/door{
 	id = "dwayne_starboard";
-	name = "Starboard Blast Doors";
+	name = "Starboard Blast Door Control";
 	pixel_x = -8;
 	pixel_y = -20;
 	dir = 1
@@ -6158,7 +6162,7 @@ Dv
 (18,1,1) = {"
 Dv
 AB
-rX
+Qu
 kV
 kV
 TR
@@ -6460,7 +6464,7 @@ eq
 Pl
 aX
 RV
-Sd
+ec
 vi
 HB
 Op

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -298,6 +298,7 @@
 /obj/effect/turf_decal/borderfloor/corner{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dK" = (
@@ -836,6 +837,10 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = -3;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
@@ -2723,7 +2728,6 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "yJ" = (
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -3469,6 +3473,10 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/item/flashlight/seclite{
+	pixel_x = -3;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Fj" = (
@@ -3838,11 +3846,6 @@
 /obj/structure/closet/crate/engineering/electrical{
 	name = "fuel crate"
 	},
-/obj/item/stack/sheet/mineral/plasma/twenty{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/effect/mapping_helpers/crate_shelve,
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
@@ -3853,6 +3856,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/warning,
+/obj/item/stack/sheet/mineral/plasma/ten,
+/obj/effect/mapping_helpers/crate_shelve,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/starboard)
 "IF" = (
@@ -3864,7 +3869,7 @@
 /obj/machinery/fax/indie{
 	pixel_y = 7
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "IW" = (
@@ -4077,6 +4082,18 @@
 	pixel_x = -8;
 	pixel_y = -2
 	},
+/obj/item/storage/backpack/satchel{
+	pixel_x = -11;
+	pixel_y = -10
+	},
+/obj/item/storage/backpack{
+	pixel_x = 0;
+	pixel_y = -11
+	},
+/obj/item/storage/backpack/duffelbag{
+	pixel_x = 7;
+	pixel_y = -7
+	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "KJ" = (
@@ -4257,6 +4274,7 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "LZ" = (
@@ -4762,7 +4780,6 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/west,
 /obj/structure/table/emptycomputer{
 	icon_state = "emptycomputer-left"
 	},
@@ -4778,6 +4795,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "Qp" = (

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -5188,6 +5188,14 @@
 	pixel_x = 10;
 	pixel_y = 21
 	},
+/obj/machinery/button/door{
+	id = "dwayne_bridge";
+	name = "Privacy Shutter Control";
+	pixel_x = 21;
+	pixel_y = -3;
+	dir = 8;
+	req_one_access = list(20,41)
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Wy" = (

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -54,11 +54,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -274,6 +274,10 @@
 	pixel_x = 11;
 	pixel_y = -19
 	},
+/obj/structure/closet/crate/bin{
+	pixel_x = -7;
+	pixel_y = 0
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "dx" = (
@@ -284,9 +288,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/structure/sign/poster/official/get_your_legs{
-	pixel_x = -30
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "dy" = (
@@ -310,15 +311,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 4
-	},
 /obj/structure/chair/handrail{
 	dir = 2
 	},
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
@@ -484,6 +485,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "fJ" = (
@@ -853,8 +855,8 @@
 	},
 /obj/structure/sink/kitchen{
 	dir = 1;
-	pixel_x = 16;
-	pixel_y = 11
+	pixel_x = 7;
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -1017,7 +1019,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
+	name = "Atmospherics";
+	req_one_access = list(20,41,10)
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
@@ -1382,6 +1385,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "nr" = (
@@ -1397,16 +1401,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "nu" = (
@@ -1484,12 +1488,12 @@
 	pixel_y = 6;
 	pixel_x = 13
 	},
+/obj/machinery/light/directional/north,
 /obj/structure/reagent_dispensers/water_cooler{
 	density = 0;
 	pixel_y = 6;
 	pixel_x = -5
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/canteen)
 "oa" = (
@@ -1559,15 +1563,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/borderfloor/corner,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
 /obj/effect/turf_decal/trimline/opaque/yellow/filled/warning{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/opaque/red/filled/corner{
 	dir = 8
-	},
-/obj/effect/turf_decal/borderfloor/corner,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 9
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
@@ -1621,19 +1625,35 @@
 /obj/effect/turf_decal/box/corners,
 /obj/structure/closet/crate/wooden,
 /obj/item/storage/box/glowsticks{
-	pixel_x = -4;
+	pixel_x = -6;
 	pixel_y = 0
 	},
 /obj/item/storage/box/glowsticks{
-	pixel_x = -4;
+	pixel_x = 5;
 	pixel_y = 0
 	},
 /obj/item/storage/box/glowsticks{
-	pixel_x = -4;
+	pixel_x = -6;
 	pixel_y = 0
 	},
 /obj/item/storage/box/glowsticks{
-	pixel_x = -4;
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/storage/box/glowsticks{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/storage/box/glowsticks{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/pickaxe{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/pickaxe{
+	pixel_x = 6;
 	pixel_y = 0
 	},
 /obj/item/shovel{
@@ -1642,14 +1662,6 @@
 	},
 /obj/item/shovel{
 	pixel_x = -2;
-	pixel_y = 0
-	},
-/obj/item/pickaxe{
-	pixel_x = 6;
-	pixel_y = 0
-	},
-/obj/item/pickaxe{
-	pixel_x = 6;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
@@ -1922,6 +1934,19 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
+"rX" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/caution/red,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ship/cargo/port)
 "sb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
@@ -2098,16 +2123,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/coffeemaker{
-	pixel_y = 12;
-	pixel_x = 0
+	pixel_y = 9
 	},
 /obj/item/coffee_cartridge/bootleg{
 	pixel_x = 6;
-	pixel_y = 2
+	pixel_y = -2
 	},
 /obj/item/coffee_cartridge/bootleg{
 	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
@@ -2498,6 +2522,11 @@
 /obj/effect/turf_decal/corner/opaque/white/diagonal{
 	dir = 4
 	},
+/obj/structure/sink/kitchen{
+	dir = 1;
+	pixel_x = -8;
+	pixel_y = 16
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "xl" = (
@@ -2632,11 +2661,11 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor,
 /obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -2786,10 +2815,6 @@
 	dir = 8
 	},
 /obj/machinery/blackbox_recorder,
-/obj/structure/sign/poster/contraband/cardinal_port_starboard{
-	pixel_y = 0;
-	pixel_x = -30
-	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "zA" = (
@@ -3102,6 +3127,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Dm" = (
@@ -3513,6 +3539,7 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "FM" = (
@@ -3667,7 +3694,8 @@
 /obj/machinery/button/door{
 	dir = 2;
 	pixel_y = 20;
-	id = "dwayne_engines_starboard"
+	id = "dwayne_engines_starboard";
+	name = "Starboard Engine Blast Doors"
 	},
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/engineering)
@@ -3771,14 +3799,14 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/borderfloor{
 	layer = 2.030;
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Ip" = (
@@ -4090,7 +4118,8 @@
 /obj/machinery/button/door{
 	dir = 1;
 	pixel_y = -21;
-	id = "dwayne_engines_port"
+	id = "dwayne_engines_port";
+	name = "Port Engine Blast Doors"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid/dark,
@@ -4207,14 +4236,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
@@ -4325,13 +4354,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
@@ -4934,6 +4963,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"Sd" = (
+/obj/structure/sign/poster/contraband/cardinal_port_starboard{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "Se" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -5048,6 +5083,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/structure/sign/poster/official/get_your_legs{
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
@@ -5324,10 +5362,6 @@
 	pixel_x = 20;
 	pixel_y = -12
 	},
-/obj/item/kirbyplants/fullysynthetic{
-	pixel_x = 10;
-	pixel_y = 21
-	},
 /obj/machinery/button/door{
 	id = "dwayne_bridge";
 	name = "Privacy Shutter Control";
@@ -5346,6 +5380,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/opaque/ntbluelight/filled/corner,
+/obj/structure/closet/crate/bin{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Wy" = (
@@ -5641,7 +5679,8 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	name = "Engineering"
+	name = "Engineering";
+	req_one_access = list(20,41,10)
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
@@ -6119,7 +6158,7 @@ Dv
 (18,1,1) = {"
 Dv
 AB
-ea
+rX
 kV
 kV
 TR
@@ -6421,7 +6460,7 @@ eq
 Pl
 aX
 RV
-IF
+Sd
 vi
 HB
 Op

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -239,24 +239,21 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)
 "cV" = (
-/obj/item/clothing/head/helmet/space/syndicate/generic{
-	pixel_y = 0
-	},
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/structure/railing/thin{
 	dir = 4
 	},
-/obj/item/clothing/suit/space/syndicate/generic/grey,
-/obj/item/clothing/mask/gas,
 /obj/structure/railing/thin{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/item/tank/internals/oxygen/yellow{
-	pixel_x = -3;
-	pixel_y = -7
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/syndicate/generic/grey,
+/obj/item/clothing/head/helmet/space/syndicate/generic{
+	pixel_y = 0
 	},
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "dh" = (
@@ -625,16 +622,18 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/toilet)
 "ht" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window{
-	pixel_y = 0
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "dwayne_equipment";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/port)
 "hB" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -1910,13 +1909,14 @@
 /area/ship/bridge)
 "ro" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/light/engineer,
-/obj/item/clothing/mask/gas,
 /obj/structure/sign/warning/enginesafety{
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/head/helmet/space/light/engineer,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "rw" = (
@@ -2048,10 +2048,10 @@
 	layer = 2.030;
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/white{
+/obj/effect/turf_decal/trimline/opaque/yellow/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/yellow/warning{
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -2283,8 +2283,8 @@
 /obj/effect/turf_decal/trimline/opaque/yellow/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/trimline/opaque/yellow/warning,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "uq" = (
@@ -3055,9 +3055,9 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/fragile,
-/obj/item/clothing/head/helmet/space/fragile,
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/central)
@@ -4111,18 +4111,15 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo/port)
 "Ln" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/structure/railing/thin{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/item/tank/internals/oxygen/yellow{
-	pixel_x = -3;
-	pixel_y = -7
-	},
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "Lo" = (
@@ -4823,8 +4820,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "QI" = (
-/obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/item/clothing/mask/gas/explorer,
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/corner/opaque/yellow/mono,
 /obj/machinery/light/directional/north,
@@ -4834,10 +4829,9 @@
 /obj/structure/railing/thin{
 	dir = 4
 	},
-/obj/item/tank/internals/oxygen/yellow{
-	pixel_x = -3;
-	pixel_y = -7
-	},
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/mining/independent,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/storage/equip)
 "QK" = (
@@ -5318,6 +5312,13 @@
 	layer = 2.038
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/button/door{
+	pixel_y = 10;
+	dir = 4;
+	id = "dwayne_equipment";
+	name = "Equipment Room Shutter Control";
+	pixel_x = -21
+	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
 "VZ" = (

--- a/_maps/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/shuttles/independent/independent_dwayne.dmm
@@ -263,6 +263,17 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = 6
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_y = -6
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -19
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "dx" = (
@@ -1634,11 +1645,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -19
-	},
 /obj/item/radio/intercom/directional/south{
 	pixel_y = -31;
 	pixel_x = 1
@@ -2286,18 +2292,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -9;
-	pixel_y = -32
-	},
-/obj/structure/extinguisher_cabinet/directional/south{
-	pixel_x = 3
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = -19
-	},
+/obj/machinery/computer/helm/viewscreen/directional/south,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "vA" = (
@@ -5388,14 +5383,19 @@
 	dir = 1;
 	id = "dwayne_lounge";
 	name = "Canteen Window Control";
-	pixel_x = 6
+	pixel_x = 10
 	},
 /obj/machinery/button/door{
 	pixel_y = -20;
 	dir = 1;
 	id = "dwayne_canteen";
 	name = "Canteen Shutter Control";
-	pixel_x = -6
+	pixel_x = -2
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -19
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remaps the Dwayne-class Long Range Mining Transport.
<img width="1184" height="608" alt="image" src="https://github.com/user-attachments/assets/c9fb88bb-ed4c-4f36-9bef-7c607738d605" />
<img width="1184" height="608" alt="image" src="https://github.com/user-attachments/assets/7b7a8b35-eb6c-489b-b832-ee58a8c3622b" />
<img width="1184" height="608" alt="image" src="https://github.com/user-attachments/assets/f25d3862-dcea-43a6-9888-9bc0966aecdb" />

The armory is shifting from a bajillion flaming arrows to a Volt carbine, Conflagration shotgun, Ohm pistol, and a Candor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simultaneously brings the Dwayne in line with other NT vessels while making it enjoyable to play on. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: remaps the Dwayne
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
