### PR TITLE
Fixes wounds causing ruin checks to fail

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -135,6 +135,7 @@
 
 	if(status_effect_type)
 		linked_status_effect = victim.apply_status_effect(status_effect_type, src)
+		RegisterSignal(linked_status_effect, COMSIG_QDELETING, PROC_REF(on_status_effect_remove))
 	SEND_SIGNAL(victim, COMSIG_CARBON_GAIN_WOUND, src, limb)
 
 	if(!victim.alerts["wound"]) // only one alert is shared between all of the wounds
@@ -245,6 +246,12 @@
 			victim.reagents.add_reagent(/datum/reagent/determination, WOUND_DETERMINATION_CRITICAL)
 		if(WOUND_SEVERITY_LOSS)
 			victim.reagents.add_reagent(/datum/reagent/determination, WOUND_DETERMINATION_LOSS)
+
+/// Handles unlinking the linked status effect on deletion.
+/datum/wound/proc/on_status_effect_remove()
+	SIGNAL_HANDLER
+	UnregisterSignal(linked_status_effect, COMSIG_QDELETING)
+	linked_status_effect = null
 
 /**
  * try_treating() is an intercept run from [/mob/living/carbon/proc/attackby] right after surgeries but before anything else. Return TRUE here if the item is something that is relevant to treatment to take over the interaction.


### PR DESCRIPTION
Wounds correctly unlink their linked status effect when the effect is deleted, and no longer cause ruin checks to fail.

:cl:
code: Fixed wounds causing ruin checks to fail
/:cl:
