### PR TITLE
Changes the layer of drills so that people layer over it by default

### DIFF
--- a/code/modules/mining/drill.dm
+++ b/code/modules/mining/drill.dm
@@ -19,7 +19,7 @@
 	density = TRUE
 	anchored = FALSE
 	use_power = NO_POWER_USE
-	layer = ABOVE_ALL_MOB_LAYER
+	layer = LYING_MOB_LAYER
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 	component_parts = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR shifts the layer of drills down to LYING_MOB_LAYER, so that players now layer above drills by default. This layer was chosen because through the use of the layershift IC command, players will still be able to layer under drills now, if they so choose to do so.

## Why It's Good For The Game

It always felt a little silly to me to see people pixelshift near a drill and start disappearing under it -- this PR aims to correct that.

## Changelog

:cl:
fix: decreased the layer that drills render at
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
