### PR TITLE
Replaces Missing Welders on Spacemall with Electric Welders

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacemall.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacemall.dmm
@@ -3200,6 +3200,14 @@
 /obj/effect/turf_decal/siding/wideplating/dark/end{
 	dir = 8
 	},
+/obj/item/weldingtool/electric{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/weldingtool/electric{
+	pixel_x = -5;
+	pixel_y = 0
+	},
 /turf/open/floor/light,
 /area/ruin/space/has_grav/spacemall/shop)
 "mA" = (


### PR DESCRIPTION
## About The Pull Request

Ruin originally had some of the welders that the electric welders replaced and theyve been absent ever since

## Why It's Good For The Game

Conspicuously empty space

## Changelog

:cl:
add: Spacemall now has 2 electric welders
/:cl: