### PR TITLE
Adds grilles to the Cybersun Outpost windows.

### DIFF
--- a/_maps/outpost/cybersun_gas_giant.dmm
+++ b/_maps/outpost/cybersun_gas_giant.dmm
@@ -2695,11 +2695,6 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/outpost/crew/bar/cybersun_outpost)
-"gw" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/outpost/vacant_rooms/shop)
 "gx" = (
 /obj/machinery/light/floor,
 /obj/structure/showcase/cyborg/assault{
@@ -2817,11 +2812,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/lounge)
-"gH" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/outpost/crew/garden)
 "gI" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -5642,6 +5632,11 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/promenade)
+"no" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/outpost/crew/court)
 "np" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
@@ -6951,6 +6946,11 @@
 "qy" = (
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/bar/cybersun_outpost)
+"qz" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/crew/garden)
 "qB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Teceti Garden";
@@ -12046,6 +12046,11 @@
 	},
 /turf/open/floor/suns/dark/plain,
 /area/outpost/operations)
+"CY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/outpost/crew/library)
 "CZ" = (
 /obj/effect/turf_decal/industrial/hatch,
 /turf/open/floor/plasteel/tech,
@@ -15717,7 +15722,6 @@
 "LB" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/grille,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/library)
 "LC" = (
@@ -17423,6 +17427,11 @@
 	},
 /turf/open/floor/suns/dark/plain,
 /area/outpost/vacant_rooms/shop)
+"Po" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/vacant_rooms/shop)
 "Pp" = (
 /obj/machinery/door/airlock{
 	id_tag = "cs_b_2";
@@ -18065,12 +18074,6 @@
 /obj/structure/platform/ship_three/indestructible,
 /turf/open/cybersun_outpost_exterior,
 /area/outpost/external)
-"QF" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/outpost/crew/court)
 "QG" = (
 /obj/structure/platform/ship_three/corner/indestructible{
 	dir = 1
@@ -19714,11 +19717,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo/smeltery)
-"Us" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/outpost/crew/library)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 4
@@ -29368,7 +29366,7 @@ RL
 kE
 Rl
 GL
-LB
+CY
 kc
 OI
 OI
@@ -29493,8 +29491,8 @@ iA
 RL
 DL
 yT
-Us
-Us
+LB
+LB
 kc
 OI
 OI
@@ -29618,8 +29616,8 @@ zY
 iA
 rv
 rv
-Us
-Us
+LB
+LB
 nY
 kA
 OI
@@ -30097,7 +30095,7 @@ ZT
 tN
 tN
 tN
-gw
+Po
 kc
 jh
 Os
@@ -30223,7 +30221,7 @@ tN
 tN
 tN
 tN
-gw
+Po
 kc
 jh
 Os
@@ -30344,12 +30342,12 @@ Mc
 Bb
 Rk
 kI
-gw
+Po
 lM
 dE
 tN
 fk
-gw
+Po
 kc
 QG
 jj
@@ -30470,12 +30468,12 @@ rx
 uD
 Yx
 ll
-gw
+Po
 ri
 pn
 tN
 SR
-gw
+Po
 Fo
 dI
 dI
@@ -30598,9 +30596,9 @@ Rk
 kI
 BO
 BO
-gw
-gw
-gw
+Po
+Po
+Po
 BO
 Sv
 Sv
@@ -31341,10 +31339,10 @@ Oy
 Oy
 bQ
 XU
-gH
-gH
+qz
+qz
 yo
-gH
+qz
 XU
 XU
 ZR
@@ -31466,7 +31464,7 @@ OI
 OI
 OI
 jh
-gH
+qz
 NT
 nN
 Cb
@@ -31592,7 +31590,7 @@ OI
 OI
 OI
 jh
-gH
+qz
 Sr
 SX
 SX
@@ -31718,7 +31716,7 @@ dI
 Bx
 OI
 jh
-gH
+qz
 rG
 lh
 pt
@@ -31837,14 +31835,14 @@ ck
 ja
 gz
 BO
-gw
-gw
-gw
+Po
+Po
+Po
 BO
 Fo
 Bx
 jh
-gH
+qz
 rG
 uQ
 SX
@@ -31970,8 +31968,8 @@ BO
 BO
 kc
 jh
-gH
-gH
+qz
+qz
 Hu
 Ek
 Hu
@@ -32079,7 +32077,7 @@ CH
 kc
 OI
 jh
-gH
+qz
 Do
 Zo
 kS
@@ -32093,13 +32091,13 @@ NS
 tN
 tN
 VG
-gw
+Po
 kc
 QG
 iL
-gH
-gH
-gH
+qz
+qz
+qz
 XU
 XU
 oh
@@ -32205,7 +32203,7 @@ CH
 kc
 OI
 jh
-gH
+qz
 Wv
 kS
 kS
@@ -32219,7 +32217,7 @@ pG
 pG
 AY
 Fa
-gw
+Po
 kc
 OI
 QG
@@ -32331,7 +32329,7 @@ CH
 kc
 OI
 jh
-gH
+qz
 Do
 kS
 Ft
@@ -32457,7 +32455,7 @@ OB
 kc
 OI
 jh
-gH
+qz
 va
 Do
 kS
@@ -32614,7 +32612,7 @@ qR
 LV
 UR
 Yy
-QF
+no
 UR
 Si
 PV
@@ -32848,7 +32846,7 @@ BO
 gV
 yq
 px
-gw
+Po
 kc
 OI
 OI
@@ -32974,7 +32972,7 @@ ME
 NI
 KE
 Mt
-gw
+Po
 kc
 OI
 OI
@@ -33100,7 +33098,7 @@ BO
 cM
 TC
 vp
-gw
+Po
 kc
 OI
 OI
@@ -33226,7 +33224,7 @@ qG
 ot
 kn
 qE
-gw
+Po
 kc
 OI
 OI
@@ -33352,7 +33350,7 @@ BO
 DT
 MY
 te
-gw
+Po
 kc
 OI
 OI

--- a/_maps/outpost/cybersun_gas_giant.dmm
+++ b/_maps/outpost/cybersun_gas_giant.dmm
@@ -257,6 +257,7 @@
 	id = "admin_pressure";
 	dir = 1
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/security/checkpoint)
 "aF" = (
@@ -489,6 +490,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "admin_pressure"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/operations)
 "bo" = (
@@ -1429,6 +1431,7 @@
 /area/outpost/cargo/smeltery)
 "dH" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/engineering/atmospherics)
 "dI" = (
@@ -2452,6 +2455,7 @@
 /area/outpost/crew/promenade)
 "fS" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/operations)
 "fT" = (
@@ -2691,6 +2695,11 @@
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/outpost/crew/bar/cybersun_outpost)
+"gw" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/vacant_rooms/shop)
 "gx" = (
 /obj/machinery/light/floor,
 /obj/structure/showcase/cyborg/assault{
@@ -2780,6 +2789,7 @@
 	id = "admin_pressure";
 	dir = 1
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/operations)
 "gG" = (
@@ -2807,6 +2817,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/lounge)
+"gH" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/crew/garden)
 "gI" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -4816,6 +4831,7 @@
 /area/outpost/crew/promenade)
 "lv" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/lounge)
 "lx" = (
@@ -5020,6 +5036,7 @@
 /area/outpost/crew/sauna)
 "lY" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/dorm)
 "lZ" = (
@@ -6905,6 +6922,7 @@
 	id = "outpost_refinery_external";
 	dir = 4
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/cargo/office)
 "qu" = (
@@ -7229,6 +7247,7 @@
 /area/outpost/crew/bar/cybersun_outpost)
 "rh" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/medical)
 "ri" = (
@@ -8234,6 +8253,7 @@
 	id = "admin_pressure";
 	dir = 4
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/security/checkpoint)
 "tN" = (
@@ -10424,6 +10444,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "outpost_refinery_external"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/cargo/office)
 "zg" = (
@@ -10622,6 +10643,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cs_shut_1"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/promenade)
 "zC" = (
@@ -13256,6 +13278,7 @@
 /area/outpost/hallway/fore)
 "FL" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/vacant_rooms/office)
 "FM" = (
@@ -13501,6 +13524,7 @@
 /obj/item/newspaper{
 	pixel_x = -1
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/dorm)
 "Gv" = (
@@ -14184,6 +14208,7 @@
 /area/outpost/operations)
 "Id" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/sauna)
 "Ie" = (
@@ -15691,6 +15716,8 @@
 /area/outpost/exterior/csoutpost)
 "LB" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/library)
 "LC" = (
@@ -15911,6 +15938,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "admin_pressure"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/security/checkpoint)
 "Ml" = (
@@ -16464,6 +16492,7 @@
 "Ni" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/engineering/atmospherics)
 "Nk" = (
@@ -17346,6 +17375,7 @@
 /area/outpost/crew/bar/cybersun_outpost)
 "Pj" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/promenade)
 "Pl" = (
@@ -17440,6 +17470,7 @@
 /area/outpost/operations)
 "Pw" = (
 /obj/structure/window/reinforced/fulltile/shuttle/indestructible,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/medical)
 "Px" = (
@@ -18034,6 +18065,12 @@
 /obj/structure/platform/ship_three/indestructible,
 /turf/open/cybersun_outpost_exterior,
 /area/outpost/external)
+"QF" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/crew/court)
 "QG" = (
 /obj/structure/platform/ship_three/corner/indestructible{
 	dir = 1
@@ -18469,6 +18506,7 @@
 /area/outpost/engineering)
 "RD" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
 "RE" = (
@@ -19676,6 +19714,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo/smeltery)
+"Us" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/outpost/crew/library)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 4
@@ -19919,6 +19962,7 @@
 	id = "admin_pressure";
 	dir = 4
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/operations)
 "UY" = (
@@ -21464,6 +21508,7 @@
 /area/outpost/operations)
 "Yu" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/bar/cybersun_outpost)
 "Yv" = (
@@ -21518,6 +21563,7 @@
 /area/outpost/crew/promenade)
 "Yy" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/outpost/crew/court)
 "Yz" = (
@@ -29447,8 +29493,8 @@ iA
 RL
 DL
 yT
-LB
-LB
+Us
+Us
 kc
 OI
 OI
@@ -29572,8 +29618,8 @@ zY
 iA
 rv
 rv
-LB
-LB
+Us
+Us
 nY
 kA
 OI
@@ -30051,7 +30097,7 @@ ZT
 tN
 tN
 tN
-KY
+gw
 kc
 jh
 Os
@@ -30177,7 +30223,7 @@ tN
 tN
 tN
 tN
-KY
+gw
 kc
 jh
 Os
@@ -30298,12 +30344,12 @@ Mc
 Bb
 Rk
 kI
-KY
+gw
 lM
 dE
 tN
 fk
-KY
+gw
 kc
 QG
 jj
@@ -30424,12 +30470,12 @@ rx
 uD
 Yx
 ll
-KY
+gw
 ri
 pn
 tN
 SR
-KY
+gw
 Fo
 dI
 dI
@@ -30552,9 +30598,9 @@ Rk
 kI
 BO
 BO
-KY
-KY
-KY
+gw
+gw
+gw
 BO
 Sv
 Sv
@@ -31295,10 +31341,10 @@ Oy
 Oy
 bQ
 XU
-IN
-IN
+gH
+gH
 yo
-IN
+gH
 XU
 XU
 ZR
@@ -31420,7 +31466,7 @@ OI
 OI
 OI
 jh
-IN
+gH
 NT
 nN
 Cb
@@ -31546,7 +31592,7 @@ OI
 OI
 OI
 jh
-IN
+gH
 Sr
 SX
 SX
@@ -31672,7 +31718,7 @@ dI
 Bx
 OI
 jh
-IN
+gH
 rG
 lh
 pt
@@ -31791,14 +31837,14 @@ ck
 ja
 gz
 BO
-KY
-KY
-KY
+gw
+gw
+gw
 BO
 Fo
 Bx
 jh
-IN
+gH
 rG
 uQ
 SX
@@ -31924,8 +31970,8 @@ BO
 BO
 kc
 jh
-IN
-IN
+gH
+gH
 Hu
 Ek
 Hu
@@ -32033,7 +32079,7 @@ CH
 kc
 OI
 jh
-IN
+gH
 Do
 Zo
 kS
@@ -32047,13 +32093,13 @@ NS
 tN
 tN
 VG
-KY
+gw
 kc
 QG
 iL
-IN
-IN
-IN
+gH
+gH
+gH
 XU
 XU
 oh
@@ -32159,7 +32205,7 @@ CH
 kc
 OI
 jh
-IN
+gH
 Wv
 kS
 kS
@@ -32173,7 +32219,7 @@ pG
 pG
 AY
 Fa
-KY
+gw
 kc
 OI
 QG
@@ -32285,7 +32331,7 @@ CH
 kc
 OI
 jh
-IN
+gH
 Do
 kS
 Ft
@@ -32411,7 +32457,7 @@ OB
 kc
 OI
 jh
-IN
+gH
 va
 Do
 kS
@@ -32568,7 +32614,7 @@ qR
 LV
 UR
 Yy
-Yy
+QF
 UR
 Si
 PV
@@ -32802,7 +32848,7 @@ BO
 gV
 yq
 px
-KY
+gw
 kc
 OI
 OI
@@ -32928,7 +32974,7 @@ ME
 NI
 KE
 Mt
-KY
+gw
 kc
 OI
 OI
@@ -33054,7 +33100,7 @@ BO
 cM
 TC
 vp
-KY
+gw
 kc
 OI
 OI
@@ -33180,7 +33226,7 @@ qG
 ot
 kn
 qE
-KY
+gw
 kc
 OI
 OI
@@ -33306,7 +33352,7 @@ BO
 DT
 MY
 te
-KY
+gw
 kc
 OI
 OI

--- a/_maps/outpost/hangar/cybersun_gas_giant_20x20.dmm
+++ b/_maps/outpost/hangar/cybersun_gas_giant_20x20.dmm
@@ -389,6 +389,7 @@
 /area/hangar)
 "Af" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/hangar)
 "Ai" = (

--- a/_maps/outpost/hangar/cybersun_gas_giant_40x20.dmm
+++ b/_maps/outpost/hangar/cybersun_gas_giant_40x20.dmm
@@ -776,6 +776,7 @@
 /area/hangar)
 "NS" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/hangar)
 "Ox" = (

--- a/_maps/outpost/hangar/cybersun_gas_giant_40x40.dmm
+++ b/_maps/outpost/hangar/cybersun_gas_giant_40x40.dmm
@@ -1029,6 +1029,7 @@
 /area/hangar)
 "Zk" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/hangar)
 "ZD" = (

--- a/_maps/outpost/hangar/cybersun_gas_giant_56x20.dmm
+++ b/_maps/outpost/hangar/cybersun_gas_giant_56x20.dmm
@@ -531,6 +531,7 @@
 /area/hangar)
 "ya" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/hangar)
 "yf" = (

--- a/_maps/outpost/hangar/cybersun_gas_giant_56x40.dmm
+++ b/_maps/outpost/hangar/cybersun_gas_giant_56x40.dmm
@@ -218,6 +218,7 @@
 /area/hangar)
 "lL" = (
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/hangar)
 "mz" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
During local testing, I noticed most of the windows on the Cybersun outpost didn't have grilles under them. This adds them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Title T
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added grilles to Cybersun outpost windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
