### PR TITLE
Significantly decreases the time needed to flip a table

### DIFF
--- a/code/game/objects/structures/table_flipped.dm
+++ b/code/game/objects/structures/table_flipped.dm
@@ -70,7 +70,7 @@
 	if(!istype(user) || !user.can_interact_with(src))
 		return FALSE
 	user.visible_message(span_danger("[user] starts flipping [src]!"), span_notice("You start flipping over the [src]!"))
-	if(do_after(user, max_integrity/4))
+	if(do_after(user, max_integrity/12))
 		var/obj/structure/table/table_unflip = new table_type(src.loc)
 		table_unflip.update_integrity(atom_integrity)
 		user.visible_message(span_danger("[user] flips over the [src]!"), span_notice("You flip over the [src]!"))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -257,7 +257,7 @@
 		return
 	if(can_flip)
 		user.visible_message(span_danger("[user] starts flipping [src]!"), span_notice("You start flipping over the [src]!"))
-		if(do_after(user, max_integrity/4))
+		if(do_after(user, max_integrity/12))
 			var/obj/structure/flippedtable/flipped = new flipped_table_type(src.loc)
 			flipped.name = "flipped [src.name]"
 			flipped.desc = "[src.desc] It is flipped!"


### PR DESCRIPTION
## About The Pull Request

Triples the speed at which you can flip a table

## Why It's Good For The Game

I feel like it should be feasible to flip a table at the start or the middle of combat for cover but its reaaaally slow

## Changelog

:cl:
balance: Triples the speed of flipping tables
/:cl: