### PR TITLE
Devastating explosions no longer gib

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -470,8 +470,6 @@
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			brute_loss = 500
-			var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-			throw_at(throw_target, 200, 4)
 			damage_clothes(400 - bomb_armor, BRUTE, "bomb")
 
 		if (EXPLODE_HEAVY)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -469,24 +469,10 @@
 
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
-			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
-				for(var/I in contents)
-					var/atom/A = I
-					if(!QDELETED(A))
-						switch(severity)
-							if(EXPLODE_DEVASTATE)
-								SSexplosions.highobj += A
-							if(EXPLODE_HEAVY)
-								SSexplosions.medobj += A
-							if(EXPLODE_LIGHT)
-								SSexplosions.lowobj += A
-				gib()
-				return
-			else
-				brute_loss = 500
-				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-				throw_at(throw_target, 200, 4)
-				damage_clothes(400 - bomb_armor, BRUTE, "bomb")
+			brute_loss = 500
+			var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+			throw_at(throw_target, 200, 4)
+			damage_clothes(400 - bomb_armor, BRUTE, "bomb")
 
 		if (EXPLODE_HEAVY)
 			brute_loss = 35


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Explosions were modified slightly so that someone caught in a devastating explosion is no longer gibbed.

## Why It's Good For The Game

Gibbing in general tends to require admin intervention to fix, and this tends to be the most common cause of it

## Changelog

:cl:
balance: removed gibbing from devastating explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
