### PR TITLE
Tweaks tank alerts -- should stop proccing every atmos tick

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -339,7 +339,7 @@
 			if(!critical_warning_alert)
 				critical_warning_alert = TRUE
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
-				say("Tank pressure low -- Estimated time until depletion: 5 minutes.")
+				say("Tank pressure low -- Estimated time until depletion: [(src.volume/2) * 5] minutes.")
 		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
 			if(!empty_alert)
 				empty_alert = TRUE

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -339,7 +339,7 @@
 			if(!critical_warning_alert)
 				critical_warning_alert = TRUE
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
-				say("Tank pressure low! Estimated time until depletion: 6 minutes!")
+				say("Tank pressure low! Estimated time until depletion: 5 minutes!")
 		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
 			if(!empty_alert)
 				empty_alert = TRUE

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -328,7 +328,7 @@
 	// Checks the pressure of the tank while it's in use and sends an alert out when the pressure reaches a specific range.
 	// Binary variables are used here to prevent an alert from repeating more than once
 	switch(pressure)
-		if((5 * ONE_ATMOSPHERE) to (20 * ONE_ATMOSPHERE))
+		if((5 * ONE_ATMOSPHERE) to (29 * ONE_ATMOSPHERE))
 			warning_alert = FALSE
 			critical_warning_alert = FALSE
 			empty_alert = FALSE

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -78,6 +78,8 @@
 
 	START_PROCESSING(SSobj, src)
 
+	addtimer(CALLBACK(src, PROC_REF(pressure_alerts)), 1 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
+
 /obj/item/tank/proc/populate_gas()
 	return
 
@@ -226,7 +228,6 @@
 	//Allow for reactions
 	air_contents.react()
 	check_status()
-	pressure_alerts()
 
 /obj/item/tank/update_overlays()
 	. = ..()

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -339,7 +339,7 @@
 			if(!critical_warning_alert)
 				critical_warning_alert = TRUE
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
-				say("Tank pressure low! Estimated time until depletion: 5 minutes!")
+				say("Tank pressure low -- Estimated time until depletion: 5 minutes.")
 		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
 			if(!empty_alert)
 				empty_alert = TRUE

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -78,7 +78,7 @@
 
 	START_PROCESSING(SSobj, src)
 
-	addtimer(CALLBACK(src, PROC_REF(pressure_alerts)), 1 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
+	addtimer(CALLBACK(src, PROC_REF(pressure_alerts)), 5 SECONDS, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
 
 /obj/item/tank/proc/populate_gas()
 	return

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -339,12 +339,12 @@
 			if(!critical_warning_alert)
 				critical_warning_alert = TRUE
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
-				say("Tank is at [pressure] kPa! Pressure critically low!")
+				say("Tank pressure low! Estimated time until depletion: 6 minutes!")
 		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
 			if(!empty_alert)
 				empty_alert = TRUE
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
 				playsound(src, 'sound/machines/beep.ogg', 30, FALSE)
-				say("Tank is empty! Replacement recommended!")
+				say("Tank is nearly empty! Replacement recommended!")
 
 	update_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks tank pressure alerts slightly so that they are hopefully a little better

This presents a few fixes as well, like ensuring that an overlay is generated for tanks below rupture pressure, and it also stops it from lagging the server so much.

## Why It's Good For The Game

Having the tank state its pressure might be a bit meaningless to people, so having it instead give an estimated time until depletion might be more meaningful -- the fixes are also kind of important sorry about the lag

## Changelog

:cl:
fix: modified tank pressure alerts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
