### PR TITLE
Makes simplemobs not get stuck on railings

### DIFF
--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -183,7 +183,7 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
-/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)
 	if (!(to_dir & dir))
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -183,6 +183,12 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
+/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if (to_dir & dir)
+		return caller.movement_type & (FLYING | FLOATING)
+	return ..()
+
+
 /obj/structure/platform/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -184,8 +184,8 @@
 	return TRUE
 
 /obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
-	if (to_dir & dir)
-		return caller.movement_type & (FLYING | FLOATING)
+	if (!(to_dir & dir))
+		return TRUE
 	return ..()
 
 

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -105,7 +105,7 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
-/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)
+/obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)
 	if (!(to_dir & dir))
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -105,9 +105,9 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
-/obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
-	if (to_dir & dir)
-		return caller.movement_type & (FLYING | FLOATING)
+/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if (!(to_dir & dir))
+		return TRUE
 	return ..()
 
 /obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, direction)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -105,7 +105,7 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
-/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+/obj/structure/platform/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/requester)
 	if (!(to_dir & dir))
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -105,6 +105,11 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
+/obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if (to_dir & dir)
+		return caller.movement_type & (FLYING | FLOATING)
+	return ..()
+
 /obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 


### PR DESCRIPTION
## About The Pull Request
Simplemobs will no longer get stuck bashing platforms and railings they can get over
## Changelog

:cl:
fix: simplemobs will no longer get stuck on railings when they're trying to kill you
/:cl: