### PR TITLE
Stops from reviving corpses without a key

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -308,7 +308,6 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=12)
 
-
 /obj/item/shockpaddles/Destroy()
 	defib = null
 	return ..()
@@ -322,7 +321,6 @@
 /obj/item/shockpaddles/Moved()
 	. = ..()
 	check_range()
-
 
 /obj/item/shockpaddles/fire_act(exposed_temperature, exposed_volume)
 	. = ..()
@@ -391,6 +389,9 @@
 
 /obj/item/shockpaddles/attack(mob/M, mob/user)
 	if(busy)
+		return
+	if(!M.key) //Stops from reviving DNR player corpses. Maybe expand this to still defib, but have a body thump and fail message then for drama or whatever
+		to_chat(user, span_warning("It's too late for [M.p_them()]. Revival is impossible."))
 		return
 	if(req_defib && !defib.powered)
 		user.visible_message(span_notice("[defib] beeps: Unit is unpowered."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pretty much what it says

## Changelog

:cl:
balance: You can no longer revive corpses without a ckey (npc bodies, DNR players)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
