### PR TITLE
emergency tank optimizations

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -78,7 +78,7 @@
 
 	START_PROCESSING(SSobj, src)
 
-	addtimer(CALLBACK(src, PROC_REF(pressure_alerts)), 5 SECONDS, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
+	addtimer(CALLBACK(src, PROC_REF(pressure_alerts)), 1 SECONDS, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
 
 /obj/item/tank/proc/populate_gas()
 	return
@@ -235,15 +235,20 @@
 	var/pressure = air_contents.return_pressure()
 
 	// Switches the pressure status overlay depending on which range the tank pressure lies in
+	// The extra icon state check prevents the icon state from being changed if it's already set to it
 	switch(pressure)
 		if((5 * ONE_ATMOSPHERE) to (20 * ONE_ATMOSPHERE))
-			status_overlay_icon_state = "status_nominal"
+			if(status_overlay_icon_state != "status_nominal")
+				status_overlay_icon_state = "status_nominal"
 		if((2 * ONE_ATMOSPHERE) to (5 * ONE_ATMOSPHERE))
-			status_overlay_icon_state = "status_warning"
+			if(status_overlay_icon_state != "status_warning")
+				status_overlay_icon_state = "status_warning"
 		if((0.75 * ONE_ATMOSPHERE) to (2 * ONE_ATMOSPHERE))
-			status_overlay_icon_state = "status_alert"
+			if(status_overlay_icon_state != "status_alert")
+				status_overlay_icon_state = "status_alert"
 		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
-			status_overlay_icon_state = "status_critical"
+			if(status_overlay_icon_state != "status_critical")
+				status_overlay_icon_state = "status_critical"
 
 	// Actually sets the overlay. As of now, this has only been done for smaller emergency tanks
 	// The if statement is set as follows due to the coarse search type that the istype proc conducts, as subtypes count as valid types

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -237,7 +237,7 @@
 	// Switches the pressure status overlay depending on which range the tank pressure lies in
 	// The extra icon state check prevents the icon state from being changed if it's already set to it
 	switch(pressure)
-		if((5 * ONE_ATMOSPHERE) to (20 * ONE_ATMOSPHERE))
+		if((5 * ONE_ATMOSPHERE) to (29 * ONE_ATMOSPHERE))
 			if(status_overlay_icon_state != "status_nominal")
 				status_overlay_icon_state = "status_nominal"
 		if((2 * ONE_ATMOSPHERE) to (5 * ONE_ATMOSPHERE))

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -19,13 +19,7 @@
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 3
 	var/volume = 70
-
-	//Alert variables
-	var/nominal_alert = FALSE
-	var/warning_alert = FALSE
-	var/critical_warning_alert = FALSE
-	var/empty_alert = FALSE
-
+	var/alert_level = 0 //1 = nominal, 2 = warning, 3 = critical warning, 4 = empty
 	supports_variations = VOX_VARIATION
 
 /obj/item/tank/ui_action_click(mob/user)
@@ -321,36 +315,25 @@
 	if(istype(src, /obj/item/tank/jetpack))
 		return 0
 
-	// Prevents newly printed tanks from beeping out an alert
-	if(!air_contents || pressure == 0)
-		warning_alert = TRUE
-		critical_warning_alert = TRUE
-		empty_alert = TRUE
-		return 0
-
 	// Checks the pressure of the tank while it's in use and sends an alert out when the pressure reaches a specific range.
-	// Binary variables are used here to prevent an alert from repeating more than once
 	switch(pressure)
 		if((5 * ONE_ATMOSPHERE) to (29 * ONE_ATMOSPHERE))
-			if(!nominal_alert)
-				nominal_alert = TRUE
+			if(alert_level != 1)
+				alert_level = 1
 				update_overlays()
-				warning_alert = FALSE
-				critical_warning_alert = FALSE
-				empty_alert = FALSE
 		if((2 * ONE_ATMOSPHERE) to (5 * ONE_ATMOSPHERE))
-			if(!warning_alert)
-				warning_alert = TRUE
+			if(alert_level != 2)
+				alert_level = 2
 				update_overlays()
 		if((0.75 * ONE_ATMOSPHERE) to (2 * ONE_ATMOSPHERE))
-			if(!critical_warning_alert)
-				critical_warning_alert = TRUE
+			if(alert_level != 3)
+				alert_level = 3
 				update_overlays()
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
 				say("Tank pressure low -- Estimated time until depletion: [(src.volume/2) * 5] minutes.")
-		if((0 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
-			if(!empty_alert)
-				empty_alert = TRUE
+		if((0.01 * ONE_ATMOSPHERE) to (0.75 * ONE_ATMOSPHERE))
+			if(alert_level != 4)
+				alert_level = 4
 				update_overlays()
 				playsound(src, 'sound/machines/twobeep_high.ogg', 30, FALSE)
 				playsound(src, 'sound/machines/beep.ogg', 30, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a status overlay check to prevent tanks from changing their overlay state over and over to the same exact state they're already in -- which seems to be a performance sink. 

I figured that since this may solve the issue, the timer that updates their alert status can be brought down from 5 seconds to 1 second, but please let me know if that's a little too often.

I also fixed a pressure range visual bug that I forgot to put in the previous patch.

## Why It's Good For The Game

This should help reduce lag a little further by removing pointless operations, and it should help the tanks update a little more quickly, which might be a little nicer (as it might be confusing for tanks to stay on the same icon for five seconds even after the pressure is updated)

## Changelog

:cl:
refactor: tank alert code modified to reduce pointless operations, updates more rapidly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
