### PR TITLE
Prevents ghosts and dead bodies from unflipping tables

### DIFF
--- a/code/game/objects/structures/table_flipped.dm
+++ b/code/game/objects/structures/table_flipped.dm
@@ -65,7 +65,7 @@
 		return COMPONENT_ATOM_BLOCK_EXIT
 	return
 
-/obj/structure/flippedtable/CtrlShiftClick(mob/user)
+/obj/structure/flippedtable/CtrlShiftClick(mob/living/user)
 	. = ..()
 	if(!istype(user) || !user.can_interact_with(src))
 		return FALSE


### PR DESCRIPTION
## Why It's Good For The Game

frontiers haunted

## Changelog

:cl:
fix: ghosts and dead bodies can no longer unflip tables
/:cl: