### PR TITLE
Fixes Kali Subshuttle Docking Port

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -1718,13 +1718,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
-"iV" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	name = "Karst Docking Gantry"
-	},
-/turf/open/floor/plating,
-/area/ship/external/dark)
 "iZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11485,7 +11478,7 @@ CN
 pi
 pi
 pi
-iV
+pi
 pi
 pi
 pi


### PR DESCRIPTION
## About The Pull Request

by removing it

## Why It's Good For The Game

subshuttle spawner already makes a docking port you dont need double

## Changelog

:cl:
fix: Kali Subshuttle Port is no longer double and works
/:cl: