### PR TITLE
Adds .45-70 Hollow Point to cargo

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -250,7 +250,7 @@
 	name = ".45-70 Hollow Point Ammo Box Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 hollow point caliber ammunition."
 	contains = list(/obj/item/storage/box/ammo/a4570_hp)
-	cost = 400
+	cost = 300
 
 /* 7.62 */
 

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -250,7 +250,7 @@
 	name = ".45-70 Hollow Point Ammo Box Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 hollow point caliber ammunition."
 	contains = list(/obj/item/storage/box/ammo/a4570_hp)
-	cost = 300
+	cost = 260
 
 /* 7.62 */
 

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -246,6 +246,12 @@
 	contains = list(/obj/item/storage/box/ammo/a4570_match)
 	cost = 235
 
+/obj/item/storage/box/ammo/a4570_hp
+	name = ".45-70 Hollow Point Ammo Box Crate"
+	desc = "Contains a 24-round box containing devastatingly powerful .45-70 hollow point caliber ammunition."
+	contains = list(/obj/item/storage/box/ammo/a4570_hp)
+	cost = 400
+
 /* 7.62 */
 
 /datum/supply_pack/ammo/a762_ammo_box

--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -240,13 +240,13 @@
 	contains = list(/obj/item/storage/box/ammo/a4570)
 	cost = 190 //5.6 ammo efficiency at 45 damage
 
-/datum/supply_pack/ammo/a4570_box/match
+/datum/supply_pack/ammo/a4570_match
 	name = ".45-70 Match Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 caliber ammunition, that travels faster, pierces armour better, and ricochets off targets."
 	contains = list(/obj/item/storage/box/ammo/a4570_match)
 	cost = 235
 
-/obj/item/storage/box/ammo/a4570_hp
+/datum/supply_pack/ammo/a4570_hp
 	name = ".45-70 Hollow Point Ammo Box Crate"
 	desc = "Contains a 24-round box containing devastatingly powerful .45-70 hollow point caliber ammunition."
 	contains = list(/obj/item/storage/box/ammo/a4570_hp)

--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
@@ -334,7 +334,7 @@
 	ammo_type = /obj/item/ammo_casing/a4570/match
 
 /obj/item/storage/box/ammo/a4570_match
-	name = "box of HP match .45-70 ammo"
+	name = "box of match .45-70 ammo"
 	desc = "A 12-round ammo box for .45-70 revolvers. These match rounds travel faster, perform better against armor, and can ricochet off targets."
 	icon_state = "4570-match"
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -143,7 +143,7 @@
 
 /obj/projectile/bullet/a4570
 	name = ".45-70 bullet"
-	damage = 50 //crits in 2-3 taps depending on armor
+	damage = 45 //crits in 3-4 taps depending on armor
 	speed = BULLET_SPEED_REVOLVER
 	bullet_identifier = "large bullet"
 
@@ -160,7 +160,7 @@
 
 /obj/projectile/bullet/a4570/hp
 	name = ".45-70 hollow point bullet"
-	damage = 65
+	damage = 55
 	armour_penetration = -10
 	speed_mod = BULLET_SPEED_HP_MOD
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -143,7 +143,7 @@
 
 /obj/projectile/bullet/a4570
 	name = ".45-70 bullet"
-	damage = 45 //crits in 3-4 taps depending on armor
+	damage = 50 //crits in 2-3 taps depending on armor
 	speed = BULLET_SPEED_REVOLVER
 	bullet_identifier = "large bullet"
 
@@ -160,7 +160,7 @@
 
 /obj/projectile/bullet/a4570/hp
 	name = ".45-70 hollow point bullet"
-	damage = 55
+	damage = 65
 	armour_penetration = -10
 	speed_mod = BULLET_SPEED_HP_MOD
 


### PR DESCRIPTION
## Why It's Good For The Game

Initially I was going to increase the base damage of .45-70 but I think the simpler solution is just adding the hollow point package for open use since both .45-70 guns are extremely unwieldy and it'd unlikely be a guaranteed one-two on carbons because of the limb hit chance

## Changelog

:cl:
add: .45-70 hollowpoint added to cargo
/:cl: