### PR TITLE
Fix T4 Drill not drilling

### DIFF
--- a/code/modules/mining/drill.dm
+++ b/code/modules/mining/drill.dm
@@ -290,6 +290,7 @@
 	if(destructive)
 		our_vein.Destroy()
 		our_vein = null
+		anchored = FALSE
 	playsound(src, 'sound/machines/switch2.ogg', 50, TRUE)
 	update_icon_state()
 	update_overlays()

--- a/code/modules/missions/outpost/industrial_drill.dm
+++ b/code/modules/missions/outpost/industrial_drill.dm
@@ -63,8 +63,8 @@
 		return
 	return ..()
 
-/obj/machinery/drill/sampler_mission/mission/mine_success()
-	//add thumping noise? Dune thumper...
+/obj/machinery/drill/sampler_mission/mine_success()
+	playsound(src, 'sound/effects/podwoosh.ogg', 50)
 	num_current++
 
 	if(num_current == samples_required)


### PR DESCRIPTION
resolves #5828 
## Changelog

:cl:
fix: T4 drill missions will now progress properly
fix: T4 drills now have a sound associated with their mining.
fix: drills will now properly unanchor themselves from veins they destroy.
/:cl: