### PR TITLE
Shield bash now works for any melee weapon

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -93,7 +93,7 @@
 	material_flags = MATERIAL_NO_EFFECTS
 
 /obj/item/shield/riot/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/melee/baton))
+	if(istype(W, /obj/item/melee))
 		if(COOLDOWN_FINISHED(src, baton_bash))
 			user.visible_message(span_warning("[user] bashes [src] with [W]!"))
 			playsound(src, shield_bash_sound, 50, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shield bash now works for anything classified as a melee weapon
Batons aren't real and cannot hurt you. This sword, however...

## Why It's Good For The Game

half life 1 crowbar sound effect

## Changelog

:cl:
add: bashing your shield is no longer restricted to batons and now works for all melee weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
