### PR TITLE
FIX: REMOVED NULL SPACE MY GUN - CTF CM-82

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -468,11 +468,11 @@
 /obj/item/gun/ballistic/automatic/assault/cm82/ctf
 	desc = "CLIP's standard assault rifle, a relatively new service weapon. This rifle will disintegrate if dropped."
 
-/obj/item/gun/ballistic/automatic/assault/cm82/dropped()
+/obj/item/gun/ballistic/automatic/assault/cm82/ctf/dropped()
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(floor_vanish)), 30)
 
-/obj/item/gun/ballistic/automatic/assault/cm82/proc/floor_vanish()
+/obj/item/gun/ballistic/automatic/assault/cm82/ctf/proc/floor_vanish()
 	if(isturf(loc))
 		qdel(src)
 


### PR DESCRIPTION
## About The Pull Request
Fixes code missed in PR #5628 where non-CTF guns were incorrectly being deleted.

## Why It's Good For The Game
Fix CTF guns code missed `/cm82/ctf/` code.
Prevents non-CTF guns from being improperly deleted when thrown or drop.

## Changelog

:cl:
fix: Non-CTF CM-82 guns no longer get deleted when thrown or drop
/:cl: