### PR TITLE
replaces roach syndicate headsets with pirate headsets

### DIFF
--- a/_maps/shuttles/pirate/pirate_roach.dmm
+++ b/_maps/shuttles/pirate/pirate_roach.dmm
@@ -278,7 +278,6 @@
 	pixel_x = 0;
 	pixel_y = -10
 	},
-/obj/item/radio/headset/syndicate/alt/captain,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
@@ -295,6 +294,7 @@
 /obj/item/clothing/head/ramzi/peaked,
 /obj/item/clothing/suit/armor/ramzi/officer,
 /obj/item/clothing/suit/armor/ramzi/captain,
+/obj/item/radio/headset/pirate/alt/captain,
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "dR" = (

--- a/_maps/shuttles/pirate/pirate_roach.dmm
+++ b/_maps/shuttles/pirate/pirate_roach.dmm
@@ -1201,10 +1201,10 @@
 	pixel_x = 9;
 	pixel_y = 12
 	},
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/radio/headset/syndicate/alt,
+/obj/item/radio/headset/pirate/alt,
+/obj/item/radio/headset/pirate/alt,
+/obj/item/radio/headset/pirate/alt,
+/obj/item/radio/headset/pirate/alt,
 /obj/item/storage/belt/security/webbing/ramzi/alt,
 /obj/item/storage/belt/security/webbing/ramzi/alt,
 /obj/item/storage/belt/security/webbing/ramzi/alt,
@@ -2042,7 +2042,7 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/belt/utility,
-/obj/item/radio/headset/syndicate/alt,
+/obj/item/radio/headset/pirate/alt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},


### PR DESCRIPTION
## Why It's Good For The Game

this probably wont ever come into play but in the event it does prevents some stupid things from happening

## Changelog

:cl:
fix: roach now has pirate headsets instead of syndicate ones
/:cl: