### PR TITLE
More right-click QoL stuff

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -473,8 +473,10 @@
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proxiumity_flag, click_parameters)
 #define COMSIG_MOB_ITEM_ATTACK_QDELETED "mob_item_attack_qdeleted"
-///from base of mob/RangedAttack(): (atom/A, params)
+///from base of mob/RangedAttack(): (atom/A, modifiers)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"
+///from base of mob/RangedAttack(): (atom/target, modifiers)
+#define COMSIG_MOB_ATTACK_RANGED_SECONDARY "mob_attack_ranged_secondary"
 ///From base of mob/update_movespeed():area
 #define COMSIG_MOB_MOVESPEED_UPDATED "mob_update_movespeed"
 ///from base of /mob/throw_item(): (atom/target)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -302,7 +302,15 @@
  * Useful for mobs that have their abilities mapped to right click.
  */
 /mob/proc/ranged_secondary_attack(atom/target, modifiers)
+	var/signal_result = SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED_SECONDARY, target, modifiers)
 
+	if(signal_result & COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(signal_result & COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /**
  * Middle click

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -34,7 +34,7 @@
 	A.attack_hand(src, modifiers)
 
 /// Return TRUE to cancel other attack hand effects that respect it.
-/atom/proc/attack_hand(mob/user)
+/atom/proc/attack_hand(mob/user, list/modifiers)
 	. = FALSE
 	if(!(interaction_flags_atom & INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND))
 		add_fingerprint(user)

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -2,6 +2,7 @@
 	max_items = 2
 	max_w_class = WEIGHT_CLASS_SMALL
 	max_combined_w_class = 50
+	alt_click_open = FALSE // alt-click has special interactions on a lot of clothing items and shouldn't be canceled by opening storage instead
 	use_sound = null
 
 /datum/component/storage/concrete/pockets/handle_item_insertion(obj/item/I, prevent_warning, mob/user)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -62,8 +62,12 @@
 
 	var/allow_big_nesting = FALSE					//allow storage objects of the same or greater size.
 
-	var/attack_hand_interact = TRUE					//interact on attack hand.
-	var/quickdraw = FALSE							//altclick interact
+	/// Should left-click open this storage item while equipped?
+	var/attack_hand_interact = TRUE
+	/// Should alt-click open this storage item?
+	var/alt_click_open = TRUE
+	/// Should alt or right click quickly draw the first available item?
+	var/quickdraw = FALSE
 	///can we quickopen storage when it's in a pocket
 	var/pocket_openable = FALSE
 
@@ -122,10 +126,12 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_POST_THROW, PROC_REF(close_all))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
-	RegisterSignals(parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_ITEM_ATTACK_SELF_SECONDARY), PROC_REF(on_open_storage_click))
+	RegisterSignals(parent, list(COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_ITEM_ATTACK_SELF_SECONDARY), PROC_REF(on_open_storage_click))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY_SECONDARY, PROC_REF(on_open_storage_attackby))
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, PROC_REF(mousedrop_onto))
 	RegisterSignal(parent, COMSIG_MOUSEDROPPED_ONTO, PROC_REF(mousedrop_receive))
+	if(alt_click_open)
+		RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_open_storage_click))
 
 	update_actions()
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -8,7 +8,7 @@
 	var/buckle_prevents_pull = FALSE
 
 //Interaction
-/atom/movable/attack_hand(mob/living/user)
+/atom/movable/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(.)
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -444,7 +444,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	// Right-click is now the standard for opening storage items, and shouldn't try to pickup/unequip items without storage.
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		to_chat(user, span_warning("[src] has no room to store anything!"))
 		return
 
 	//check if the item is inside another item's storage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -433,7 +433,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	add_fingerprint(usr)
 	return ..()
 
-/obj/item/attack_hand(mob/user)
+/obj/item/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)
 		return
@@ -442,11 +442,16 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	if(anchored)
 		return
 
+	// Right-click is now the standard for opening storage items, and shouldn't try to pickup/unequip items without storage.
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		to_chat(user, span_warning("[src] has no room to store anything!"))
+		return
+
 	//check if the item is inside another item's storage
-	if(istype(loc, /obj/item/storage))
+	if(isitem(loc))
 		//if so, can we actually access it?
 		var/datum/component/storage/ourstorage = loc.GetComponent(/datum/component/storage)
-		if(!ourstorage.access_check())
+		if(ourstorage && !ourstorage.access_check())
 			SEND_SIGNAL(loc, COMSIG_TRY_STORAGE_HIDE_FROM, user)//you're not supposed to be in here right now, punk!
 			return
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -693,15 +693,18 @@
 	if(O.loc != src.loc)
 		step(O, get_dir(O, src))
 
-/obj/structure/rack/attackby(obj/item/W, mob/user, params)
-	var/list/modifiers = params2list(params)
-	if (W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1) && user.a_intent != INTENT_HELP)
-		W.play_tool_sound(src)
-		deconstruct(TRUE)
+/obj/structure/rack/wrench_act(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(. & COMPONENT_BLOCK_TOOL_ATTACK)
 		return
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	if(user.transferItemToLoc(W, drop_location(), silent = FALSE))
+	if(!(flags_1 & NODECONSTRUCT_1) && LAZYACCESS(modifiers, RIGHT_CLICK))
+		tool.play_tool_sound(src)
+		deconstruct(TRUE)
+		return COMPONENT_BLOCK_TOOL_ATTACK
+
+/obj/structure/rack/attackby(obj/item/W, mob/user, params)
+	if(user.a_intent != INTENT_HARM && user.transferItemToLoc(W, drop_location(), silent = FALSE))
+		var/list/modifiers = params2list(params)
 		//Center the icon where the user clicked.
 		if(!LAZYACCESS(modifiers, ICON_X) || !LAZYACCESS(modifiers, ICON_Y))
 			return
@@ -709,6 +712,7 @@
 		W.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size/2), world.icon_size/2)
 		W.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
 		return TRUE
+	return ..()
 
 /obj/structure/rack/attack_paw(mob/living/user)
 	attack_hand(user)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -559,23 +559,24 @@
 	else
 		return span_notice("The top cover is firmly <b>welded</b> on.")
 
-/obj/structure/table/reinforced/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HELP)
-		if(!W.tool_start_check(user, src, amount=0))
-			return
-
+/obj/structure/table/reinforced/welder_act(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(. & COMPONENT_BLOCK_TOOL_ATTACK)
+		return
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		if(!tool.tool_start_check(user, src, amount = 0))
+			return COMPONENT_BLOCK_TOOL_ATTACK
 		if(deconstruction_ready)
 			to_chat(user, span_notice("You start strengthening the reinforced table..."))
-			if (W.use_tool(src, user, 50, volume=50))
+			if(tool.use_tool(src, user, 5 SECONDS, volume = 50))
 				to_chat(user, span_notice("You strengthen the table."))
 				deconstruction_ready = 0
 		else
 			to_chat(user, span_notice("You start weakening the reinforced table..."))
-			if (W.use_tool(src, user, 50, volume=50))
+			if(tool.use_tool(src, user, 5 SECONDS, volume = 50))
 				to_chat(user, span_notice("You weaken the table."))
 				deconstruction_ready = 1
-	else
-		. = ..()
+		return COMPONENT_BLOCK_TOOL_ATTACK
 
 /obj/structure/table/bronze
 	name = "bronze table"

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -138,22 +138,18 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
-/obj/item/clothing/suit/toggle/attack_hand_secondary(mob/user, list/modifiers)
-	suit_toggle(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		return FALSE
-
-	. = SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
-	if(. & COMPONENT_CANCEL_CLICK_ALT)
-		return
 
 	if(unique_reskin && !current_skin)
 		reskin_obj(user)
 		return TRUE
 
+	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT, user) & COMPONENT_CANCEL_CLICK_ALT)
+		return TRUE
+
+	suit_toggle(user)
 	return TRUE
 
 /obj/item/clothing/suit/toggle/ui_action_click()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -758,20 +758,27 @@
 	if(isliving(user) && in_range(src, user))
 		toggle_safety(user)
 
-// /obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
-// 	if(toggle_safety(user))
-// 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-// 	return ..()
+// This is overridden when interacting with attached underbarrel guns.
+/obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-// /obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
-// 	if(toggle_safety(user))
-// 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-// 	return ..()
+/obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-// /obj/item/gun/attack_self_secondary(mob/user, modifiers)
-// 	if(toggle_safety(user))
-// 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-// 	return ..()
+/obj/item/gun/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/proc/toggle_safety(mob/user, silent=FALSE, override_check = FALSE)
 	if(!has_safety)


### PR DESCRIPTION
## About The Pull Request

- Gun safeties can be toggled with right click
- Racks and reinforced tables are deconstructed with right click instead of disarm/grab intent
- Moved suit toggling back to alt-click, which no longer opens storage on clothing items to avoid conflicts
- Right click doesn't try to pick up or unequip items
- Fixed `RangedAttack` never being called when right-clicking
- Fixed clothing items with storage components not checking if the user should be able to access their contents

## Why It's Good For The Game

Right click has become the primary way storage items are accessed, and other special interactions like toggling or reskinning clothing items should avoid conflicting with it when possible.

## Changelog

:cl:
add: Right click can now toggle gun safeties, deconstruct racks, and weld reinforced tables
add: Moved suit toggling back to alt-click to avoid conflicts with opening their storage
del: Alt-click no longer tries to open the storage on clothing items
del: Right click no longer tries to pick up or unequip items without storage
fix: Fixed right-clicking at range not defaulting to the left-click interaction
fix: Fixed clothing items with storage components not checking if the user should be able to access them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
