### PR TITLE
Replaces a single eoehoma cell on Mining installation with a sharplite one (normal)

### DIFF
--- a/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
@@ -6777,12 +6777,12 @@
 	},
 /obj/effect/turf_decal/borderfloor/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/item/stock_parts/cell/gun/empty,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/stock_parts/cell/gun/sharplite,
 /turf/open/floor/plasteel/patterned/rockplanet/lit,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "Lw" = (


### PR DESCRIPTION
## Why It's Good For The Game

right cell

## Changelog

:cl:
fix: Added right cell to Mining Facility
/:cl: