### PR TITLE
Allows desk lamps (and flashlights) to be toggled via right-click

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -45,6 +45,18 @@
 		A.UpdateButtonIcon()
 	return 1
 
+/obj/item/flashlight/attack_hand(mob/user, list/modifiers)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		on = !on
+		playsound(user, on ? toggle_on_sound : toggle_off_sound, 40, TRUE)
+		update_brightness(user)
+		for(var/X in actions)
+			var/datum/action/A = X
+			A.UpdateButtonIcon()
+		return 1
+	else
+		. = ..()
+
 /obj/item/flashlight/attack(mob/living/carbon/M, mob/living/carbon/human/user)
 	add_fingerprint(user)
 	if(istype(M) && on && (user.zone_selected in list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -45,17 +45,9 @@
 		A.UpdateButtonIcon()
 	return 1
 
-/obj/item/flashlight/attack_hand(mob/user, list/modifiers)
-	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		on = !on
-		playsound(user, on ? toggle_on_sound : toggle_off_sound, 40, TRUE)
-		update_brightness(user)
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.UpdateButtonIcon()
-		return 1
-	else
-		. = ..()
+/obj/item/flashlight/attack_hand_secondary(mob/user, modifiers)
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/flashlight/attack(mob/living/carbon/M, mob/living/carbon/human/user)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR integrates a right-click action into flashlights so they can be toggled while in the world with a right click, without having to be held in one's hand.

![dreamseeker_bsBaPQGk9H](https://github.com/user-attachments/assets/3856159f-a4c2-4454-9f14-fb3678cb8d90)

## Why It's Good For The Game

It's a really minor thing -- it felt a little silly to have to hold a lamp in a hand in order to toggle its state, instead of being able to toggle it with a click.

## Changelog

:cl:
add: Added right click toggle interaction to flashlights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
