### PR TITLE
APC Control Console Removal (From Ships & Ruins)

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
@@ -4342,7 +4342,7 @@
 /turf/open/floor/plating,
 /area/ruin/icemoon/training_facility/classroom)
 "vC" = (
-/obj/machinery/computer/apc_control{
+/obj/machinery/computer/monitor{
 	dir = 1
 	},
 /obj/effect/spawner/random/trash/crushed_can{
@@ -5369,11 +5369,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/training_facility/classroom)
-"Ay" = (
-/obj/structure/table/greyscale,
-/obj/item/attachment/gun/flamethrower,
-/turf/open/floor/plating/asteroid/icerock/cracked,
-/area/ruin/icemoon/training_facility)
 "AA" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 5
@@ -7673,7 +7668,6 @@
 /area/ruin/icemoon/training_facility/dorms)
 "Lz" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/human/ramzi/melee/sawbones,
 /turf/open/floor/plasteel/mono/white,
 /area/ruin/icemoon/training_facility/medbay)
 "LA" = (
@@ -9244,7 +9238,6 @@
 	pixel_x = 0;
 	pixel_y = 12
 	},
-/obj/item/reagent_containers/food/drinks/mead,
 /turf/open/floor/wood,
 /area/ruin/icemoon/training_facility/office_2)
 "SW" = (
@@ -14822,7 +14815,7 @@ kk
 wN
 Bv
 kk
-Ay
+do
 xj
 xj
 tB

--- a/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
@@ -2150,6 +2150,7 @@
 	pixel_x = 0;
 	pixel_y = -5
 	},
+/obj/item/reagent_containers/food/drinks/mead,
 /turf/open/floor/wood,
 /area/ruin/icemoon/training_facility/office_2)
 "kA" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
@@ -6366,6 +6366,10 @@
 "Ff" = (
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/training_facility/dorms)
+"Fi" = (
+/mob/living/simple_animal/hostile/human/ramzi/melee/sawbones,
+/turf/open/floor/plating/rust,
+/area/ruin/icemoon/training_facility/medbay)
 "Fj" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -8510,6 +8514,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ruin/icemoon/training_facility/classroom)
+"PO" = (
+/obj/structure/table/greyscale,
+/obj/item/attachment/gun/flamethrower,
+/turf/open/floor/plating/asteroid/icerock/cracked,
+/area/ruin/icemoon/training_facility)
 "PP" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -13936,7 +13945,7 @@ qr
 tx
 Cd
 wr
-ZU
+Fi
 ZU
 rW
 qP
@@ -14815,7 +14824,7 @@ kk
 wN
 Bv
 kk
-do
+PO
 xj
 xj
 tB

--- a/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
@@ -3607,7 +3607,7 @@
 /turf/open/floor/plating/rust,
 /area/ruin/jungle/interceptor/forehall)
 "Fs" = (
-/obj/machinery/computer/apc_control{
+/obj/machinery/computer/monitor{
 	dir = 4
 	},
 /turf/open/floor/plating/rust,

--- a/_maps/RandomRuins/SpaceRuins/spacemall.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacemall.dmm
@@ -10039,7 +10039,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/spacemall/dorms)
 "Me" = (
-/obj/machinery/computer/apc_control,
+/obj/machinery/computer/monitor,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/spacemall/maint)

--- a/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -1746,7 +1746,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "lD" = (
-/obj/machinery/computer/apc_control{
+/obj/machinery/computer/monitor{
 	dir = 4;
 	icon_state = "computer-left"
 	},

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -3117,7 +3117,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "qy" = (
-/obj/machinery/computer/apc_control{
+/obj/machinery/computer/monitor{
 	icon_state = "computer-right"
 	},
 /obj/effect/turf_decal/techfloor{


### PR DESCRIPTION
## About The Pull Request

Removes the power flow control console from ships and ruins. For context, you can remotely disable APCs no matter if they are ruin or ship-attached, including other ships.

## Why It's Good For The Game

It's cruft, also I encouraged someone to use it to delam a supermatter last round so this is my community service to Shiptest.

## Changelog

:cl:
balance: APC Control Console removed from all player-facing environments.
/:cl: