### PR TITLE
Directional Attacks will refrain from self-targetting

### DIFF
--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -60,6 +60,8 @@
 
 	var/mob/living/target_mob
 	for(target_mob in turf_to_check)
+		if(target_mob == source)
+			continue
 		if(!target_mob || target_mob.stat == DEAD)
 			continue
 		return target_mob

--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -54,7 +54,7 @@
 	if(QDELETED(clicked_atom))
 		return FALSE
 
-	var/turf/turf_to_check = get_step(source, angle_to_dir(Get_Angle(source, clicked_atom)))
+	var/turf/turf_to_check = get_step(source, angle_to_dir(Get_Angle(source,parse_caught_click_modifiers(modifiers, get_turf(source), source?.client))))
 	if(!turf_to_check || !source.Adjacent(turf_to_check))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request
directional attacks will no longer select your own mob as a valid target

## Changelog

:cl:
fix: you can no longer randomly melee yourself with directional melee
/:cl:


