### PR TITLE
Typhon Mech Nerf

### DIFF
--- a/_maps/shuttles/minutemen/minutemen_typhon.dmm
+++ b/_maps/shuttles/minutemen/minutemen_typhon.dmm
@@ -378,11 +378,6 @@
 /obj/structure/crate_shelf{
 	capacity = 2
 	},
-/obj/structure/closet/crate/secure/weapon{
-	req_access_txt = "3"
-	},
-/obj/item/mecha_parts/weapon_bay,
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
 /turf/open/floor/pod/dark,
 /area/ship/hangar)
 "fc" = (
@@ -2063,6 +2058,8 @@
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
 /obj/effect/mapping_helpers/crate_shelve,
 /obj/effect/turf_decal/industrial/warning,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/mecha_equipment/salvage_saw,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/hangar)
 "zk" = (


### PR DESCRIPTION
## About The Pull Request

Removes the mech weapons from the typhon. Adds a drill and a mech angle grinder in place of it. Alternative to #5869

## Why It's Good For The Game

The murder death kills you gun is not fun for people to fight against. However, the ship itself is not inherently super flawed, and without weapons the mech can simply be a noncombat tool until later changes are made.

## Changelog

:cl:
balance: Typhon has had it's mech weapons stripped.
/:cl:
