### PR TITLE
gives the karst an NGR headset and adds a missing lightswitch to the kali

### DIFF
--- a/_maps/shuttles/subshuttles/ngr_karst.dmm
+++ b/_maps/shuttles/subshuttles/ngr_karst.dmm
@@ -219,7 +219,6 @@
 	},
 /obj/item/clothing/under/syndicate/ngr/fatigues,
 /obj/item/clothing/head/helmet/ngr/swat,
-/obj/item/radio/headset/syndicate/alt,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/gloves/fingerless{
 	desc = "These make you feel like a better pilot than you are.";
@@ -229,6 +228,7 @@
 	name = "Pilot's Locker";
 	req_access = list(1)
 	},
+/obj/item/radio/headset/syndicate/alt/ngr,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "q" = (

--- a/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
+++ b/_maps/shuttles/syndicate/syndicate_ngr_kaliandhi.dmm
@@ -7927,6 +7927,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -14;
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/maintenance/starboard)
 "PM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

replaces the karst's headset and adds a lightswitch to the canteen airlock that i forgot

## Why It's Good For The Game

fix good
## Changelog

:cl:
fix: After a several-hour fax exchange, Hardline have replaced the headsets provided to Karst-class dropships and started installing light switches in the canteen airlocks of Kali Andhi-class destroyers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
