### PR TITLE
Etherbor Weapon Amends

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -306,7 +306,7 @@
 
 /datum/supply_pack/gun/laser/bg16
 	name = "Etherbor BG-16 Beam Gun Crate"
-	desc = "Contains a single BG-16 Beam Gun, a military-grade automatic developed in the PGF and manufactured by Etherbor Industries for use within the Marine Corps."
+	desc = "Contains a single BG-16 Beam Gun, a light military-grade automatic developed in the PGF and manufactured by Etherbor Industries for use within the Marine Corps."
 	cost = 3000
 	contains = list(/obj/item/storage/guncase/energy/bg16)
 	crate_name = "beam gun crate"
@@ -320,6 +320,16 @@
 	cost = 5000
 	contains = list(/obj/item/storage/guncase/energy/bgc10)
 	crate_name = "beam carbine crate"
+	faction = /datum/faction/pgf
+	faction_discount = 0
+	faction_locked = TRUE
+
+/datum/supply_pack/gun/laser/hbg7
+	name = "Etherbor HBG-7 Beam Rifle Crate"
+	desc = "Contains a single HBG-7 Beam Rifle, a high power military-grade automatic developed in the PGF and manufactured by Etherbor Industries for use within the Marine Corps."
+	cost = 6000
+	contains = list(/obj/item/storage/guncase/energy/hbg7)
+	crate_name = "beam rifle crate"
 	faction = /datum/faction/pgf
 	faction_discount = 0
 	faction_locked = TRUE

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -211,7 +211,7 @@
 
 /obj/item/ammo_casing/energy/disabler/hitscan
 	projectile_type = /obj/projectile/beam/hitscan/disabler
-	e_cost = 666
+	e_cost = 500
 
 /obj/projectile/beam/hitscan/disabler
 	name = "disabler beam"
@@ -244,7 +244,7 @@
 
 /obj/item/ammo_casing/energy/disabler/hitscan/heavy
 	projectile_type = /obj/projectile/beam/hitscan/disabler/heavy
-	e_cost = 1000
+	e_cost = 666
 
 /obj/projectile/beam/hitscan/disabler/heavy
 	range = 15

--- a/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
+++ b/code/modules/projectiles/guns/manufacturer/etherbor/energy_gunsword.dm
@@ -32,7 +32,7 @@
 /obj/item/ammo_casing/energy/kalix
 	projectile_type = /obj/projectile/beam/hitscan/kalix
 	fire_sound = 'sound/weapons/gun/energy/kalixsmg.ogg'
-	e_cost = 666 //30 shots per cell
+	e_cost = 500 //25 shots per cell
 	delay = 1
 
 /obj/projectile/beam/hitscan/kalix
@@ -66,13 +66,13 @@
 /obj/item/ammo_casing/energy/kalix/nock
 	projectile_type = /obj/projectile/beam/hitscan/kalix/nock
 	fire_sound = 'sound/weapons/gun/energy/kalixsmg.ogg'
-	e_cost = 312
+	e_cost = 312 //10 bursts per cell
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/disabler/hitscan/kalix/nock
 	projectile_type = /obj/projectile/beam/hitscan/disabler
 	fire_sound = 'sound/weapons/gun/energy/kalixsmg.ogg'
-	e_cost = 312
+	e_cost = 312 //10 bursts per cell
 	select_name = "disable"
 
 /obj/item/gun/energy/kalix/nock
@@ -129,13 +129,13 @@
 /obj/item/ammo_casing/energy/kalix/pgf/nock
 	projectile_type = /obj/projectile/beam/hitscan/kalix/pgf/nock
 	fire_sound = 'sound/weapons/gun/energy/kalixrifle.ogg'
-	e_cost = 250
+	e_cost = 250 //16 bursts per cell
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/disabler/hitscan/kalix/pgf/nock
 	projectile_type = /obj/projectile/beam/hitscan/disabler
 	fire_sound = 'sound/weapons/gun/energy/kalixrifle.ogg'
-	e_cost = 250
+	e_cost = 250 //16 bursts per cell
 	select_name = "disable"
 
 /obj/item/gun/energy/kalix/pgf/nock
@@ -225,7 +225,7 @@
 /obj/item/ammo_casing/energy/kalix/pgf
 	projectile_type = /obj/projectile/beam/hitscan/kalix/pgf
 	fire_sound = 'sound/weapons/gun/energy/kalixsmg.ogg'
-	e_cost = 666 //30 shots per cell
+	e_cost = 500 //40 shots per cell
 	delay = 1
 
 /obj/item/gun/energy/kalix/pistol //blue
@@ -260,7 +260,7 @@
 
 /obj/item/ammo_casing/energy/kalix/pistol
 	fire_sound = 'sound/weapons/gun/energy/kalixpistol.ogg'
-	e_cost = 1250 //10 shots per cell
+	e_cost = 1000 //12 shots per cell
 	delay = 0
 
 /obj/item/gun/energy/kalix/pistol/empty_cell
@@ -338,7 +338,7 @@
 	select_name  = "AR"
 	projectile_type = /obj/projectile/beam/hitscan/kalix/pgf/assault
 	fire_sound = 'sound/weapons/gun/energy/kalixrifle.ogg'
-	e_cost = 1000 //20 shots per cell
+	e_cost = 666 //30 shots per cell
 	delay = 1
 
 /obj/projectile/beam/hitscan/kalix/pgf/assault
@@ -354,7 +354,7 @@
 	select_name  = "DMR"
 	projectile_type = /obj/projectile/beam/hitscan/kalix/pgf/sniper
 	fire_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'
-	e_cost = 2000 //20 shots per cell
+	e_cost = 2000 //10 shots per cell
 	delay = 6
 
 /obj/projectile/beam/hitscan/kalix/pgf/sniper


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the HBG-7 Beam Rifle to PGF factional cargo. Increases ammo efficiency on etherbor beam and assault beam variants. DMR mode untouched.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Following some discussion between Cloudbreak, Jay, Thrax, and myself, where we came to notice a certain mismatch in the potential of the available Etherbor armory when compared with it's peers. 

Finding a way to tactfully remedy this while accounting for the inherent strength of hitscan weapons puts any dropoff or range/damage changes off the table. Instead, increasing the energy efficiency/ammo economy of the laser weapons helps to offset some of their limitations as well as helping to justify the civilian beamguns premium price tags.

Likewise, the absence of an "LMG" style etherbor weapon options is a symptom of the difficulty that would go into balancing a hitscan LMG. Instead, the unscoped HBG-7 has been added to factional cargo for purchase at standard LMG price.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: added the HBG-7 (unscoped) to factional cargo
balance: adjusted ammo economy on etherbor beam weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
