### PR TITLE
CM-40 ammo box 7.62x40mm ammo variant fix

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -637,6 +637,7 @@ NO_MAG_GUN_HELPER(automatic/assault/skm/cm24)
 	base_icon_state = "cm40_mag"
 	icon_state = "cm40_mag-1"
 	ammo_type = /obj/item/ammo_casing/a762_40
+	caliber = "7.62x40mm"
 	max_ammo = 80
 	w_class = WEIGHT_CLASS_NORMAL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This should fix a bug with CM-40 box magazines where they would be unable to take specialty 7.62x40mm ammo types.

## Why It's Good For The Game

Minor bugfix

## Changelog

:cl:
fix: fixes CM-40 box magazines so they can hold specialty ammunition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
