### PR TITLE
Dogtag stipend mission QOL

### DIFF
--- a/code/modules/missions/outpost/dogtag_stipend.dm
+++ b/code/modules/missions/outpost/dogtag_stipend.dm
@@ -20,6 +20,10 @@
 		Retrieve their dogtags, put them in the provided case, and return it to us to complete the bounty."
 	value += (num_wanted*200)
 
+/datum/mission/acquire/dogtags/accept(datum/overmap/ship/controlled/acceptor, turf/accept_loc, obj/hangar_crate_spawner/cargo_belt)
+	. = ..()
+	container.name = "dogtag case ([num_wanted] [pirate_type] dogtags)"
+
 /datum/mission/acquire/dogtags/ramzi
 	name = "Ramzi Clique Bounty"
 	desc = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR modifies the name of mission dogtag cases such that the number of dogtags is displayed alongside the type.
<img width="389" height="70" alt="image" src="https://github.com/user-attachments/assets/8845a601-a9e9-4f27-9e12-a78827b501e0" />

## Why It's Good For The Game

This makes it a lot easier to differentiate different dogtag cases. Putting a dogtag in while checking the bounty console works too, but this makes it so that the console is no longer required -- allowing for your poorly paid deckhands to do the work while you sit in decadence in your titanium throne (shuttle seat).

## Changelog

:cl:
add: Added the number of dogtags required for a particular dogtag case to be filled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
