### PR TITLE
Adds White-beet, Redbeet, Eggplants, and Cherries to the market

### DIFF
--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -182,6 +182,39 @@
 					/obj/item/food/grown/cabbage,
 	)
 
+/datum/supply_pack/food/ingredients_basic/eggplant
+	name = "Eggplant Crate"
+	desc = "Crate containing five eggplants."
+	cost = 75
+	contains = list(/obj/item/food/grown/eggplant,
+					/obj/item/food/grown/eggplant,
+					/obj/item/food/grown/eggplant,
+					/obj/item/food/grown/eggplant,
+					/obj/item/food/grown/eggplant,
+	)
+
+/datum/supply_pack/food/ingredients_basic/whitebeet
+	name = "White-beet Crate"
+	desc = "Crate containing five white-beets."
+	cost = 75
+	contains = list(/obj/item/food/grown/whitebeet,
+					/obj/item/food/grown/whitebeet,
+					/obj/item/food/grown/whitebeet,
+					/obj/item/food/grown/whitebeet,
+					/obj/item/food/grown/whitebeet,
+	)
+
+/datum/supply_pack/food/ingredients_basic/redbeet
+	name = "Redbeet Crate"
+	desc = "Crate containing five redbeets."
+	cost = 75
+	contains = list(/obj/item/food/grown/redbeet,
+					/obj/item/food/grown/redbeet,
+					/obj/item/food/grown/redbeet,
+					/obj/item/food/grown/redbeet,
+					/obj/item/food/grown/redbeet,
+	)
+
 /datum/supply_pack/food/ingredients_basic/chanterelle
 	name = "Chanterelle Crate"
 	desc = "Crate containing five chanterelle mushrooms."

--- a/code/modules/cargo/packs/food.dm
+++ b/code/modules/cargo/packs/food.dm
@@ -281,6 +281,17 @@
 					/obj/item/food/grown/apple,
 	)
 
+/datum/supply_pack/food/ingredients_basic/cherry
+	name = "Cherry Crate"
+	desc = "Crate containing five cherries."
+	cost = 75
+	contains = list(/obj/item/food/grown/cherries,
+					/obj/item/food/grown/cherries,
+					/obj/item/food/grown/cherries,
+					/obj/item/food/grown/cherries,
+					/obj/item/food/grown/cherries,
+	)
+
 /datum/supply_pack/food/ingredients_basic/lime
 	name = "Lime Crate"
 	desc = "Crate containing five limes."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds three cargo packs for whitebeet, redbeet, and eggplants for better soup/stew fabrication
Also adds a cargo pack for cherries for cherry pastries

## Why It's Good For The Game

yummy
<img width="752" height="752" alt="image" src="https://github.com/user-attachments/assets/39544796-7c8a-4094-9110-0356c6bfc555" />

## Changelog

:cl:
add: Added eggplant cargo crate (5 per 75cr)
add: Added white-beet cargo crate (5 per 75cr)
add: Added redbeet cargo crate (5 per 75cr)
add: Added cherry cargo crate (5 per 75cr)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
