### PR TITLE
Crates display their shipping manifest on examine

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -37,7 +37,7 @@
 		return
 
 	. += "crittercrate_door"
-	if(manifest)
+	if(GetComponent(/datum/component/writing))
 		. += "manifest"
 
 /obj/structure/closet/crate/critter/return_air()

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -14,15 +14,17 @@
 
 /obj/structure/closet/crate/large/attack_hand(mob/user)
 	add_fingerprint(user)
+	var/datum/component/writing/manifest = GetComponent(/datum/component/writing)
 	if(manifest)
-		tear_manifest(user)
+		tear_manifest(user, manifest)
 	else
 		to_chat(user, span_warning("You need a crowbar to pry this open!"))
 
 /obj/structure/closet/crate/large/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_CROWBAR)
+		var/datum/component/writing/manifest = GetComponent(/datum/component/writing)
 		if(manifest)
-			tear_manifest(user)
+			tear_manifest(user, manifest)
 
 		user.visible_message(
 			span_notice("[user] pries \the [src] open."), \

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -56,33 +56,24 @@
 	return requisition_paper
 
 /datum/supply_order/proc/generateManifest(obj/structure/closet/crate/container, owner) //generates-the-manifests.
-	var/obj/item/paper/manifest/manifest_paper = new(container, id, 0)
-
-	manifest_paper.name = "shipping manifest - #[id]"
-
 	var/manifest_text = "<h2>[market.name] Shipping Manifest</h2>"
 	manifest_text += "<hr/>"
 	if(owner && !(owner == "Unknown"))
 		manifest_text += "Direct purchase from [owner]<br/>"
-		manifest_paper.name += " - Purchased by [owner]"
 	manifest_text += "Destination: [market.name]<br/>"
 	manifest_text += "Contents: <br/>"
 	manifest_text += "<ul>"
 	var/container_contents = list() // Associative list with the format (item_name = nº of occurrences, ...)
-	for(var/atom/movable/AM in container.contents - manifest_paper)
+	for(var/atom/movable/AM in container.contents)
 		container_contents[AM.name]++
 	for(var/item in container_contents)
 		manifest_text += "<li> [container_contents[item]] [item][container_contents[item] == 1 ? "" : "s"]</li>"
 	manifest_text += "</ul>"
 	manifest_text += "<h4>Stamp below to confirm receipt of goods:</h4>"
 
-	manifest_paper.add_raw_text(manifest_text)
-	manifest_paper.update_appearance()
-	manifest_paper.forceMove(container)
-	container.manifest = manifest_paper
+	container.manifest_id = id
+	container.AddComponent(/datum/component/writing, raw_text = manifest_text)
 	container.update_appearance()
-
-	return manifest_paper
 
 /datum/supply_order/proc/generate(atom/location)
 	var/account_holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shipping manifests on crates can now be viewed without removing them by examining the crate.

<img width="464" height="533" alt="image" src="https://github.com/user-attachments/assets/5a9aadc1-8e26-49e5-9c6d-a9b60132e3a2" />


## Why It's Good For The Game

Yes.

## Changelog

:cl:
add: Crates now display their shipping manifest when examined.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
