### PR TITLE
Armored Grey Spacesuit reskin no longer makes you naked

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -33,7 +33,7 @@
 	icon_state = "syndicate-generic"
 	item_state = "syndicate-generic"
 	unique_reskin = list("armored olive space suit" = "syndicate-generic",
-						"armored grey space suit" = "syndicate-grey"
+						"armored grey space suit" = "syndicate-generic-grey"
 						)
 	unique_reskin_changes_base_icon_state = TRUE
 	unique_reskin_changes_name = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an incorrect icon/item state that would cause the grey spacesuit reskin to make the suit dissapear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix, no more space strippers. (sad I know)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: fixed the armored grey spacesuit reskin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
