### PR TITLE
Elaborates on IPC wound treatment in health analyzer wound scan

### DIFF
--- a/code/datums/wounds/robotic/buckling.dm
+++ b/code/datums/wounds/robotic/buckling.dm
@@ -23,8 +23,8 @@
 
 /datum/wound/blunt/buckling/moderate
 	name = "Bent Plating"
-	desc = "Patient's external plating is bent out of shape. Applying duct tape can temporarily secure the limb until proper repairs."
-	treat_text = "Recommend applying crowbar or wirecutters to bend plating back into place."
+	desc = "Patient's external plating is bent out of shape."
+	treat_text = "Recommend applying crowbar or wirecutters to bend plating back into place. Applying duct tape can temporarily secure the limb until proper repairs."
 	examine_desc = "is bent out of shape"
 	occur_text = "suddenly bends out of shape"
 	sound_effect = 'sound/effects/bin_open.ogg'
@@ -44,8 +44,8 @@
 
 /datum/wound/blunt/buckling/severe
 	name = "Buckled Chassis"
-	desc = "Patient's chassis is buckled inwards, causing disruption to mobility. Applying duct tape can temporarily secure the limb until proper repairs."
-	treat_text = "Recommend cutting plating off with a welding implement, adding new alloyed plating, and then welding until secure."
+	desc = "Patient's chassis is buckled inwards, causing disruption to mobility."
+	treat_text = "Recommend cutting plating off with a welding implement, adding new alloyed plating, and then welding until secure. Applying duct tape can temporarily secure the limb until proper repairs."
 	examine_desc = "is buckled inwards"
 	occur_text = "creaks and buckles inwards"
 	severity = WOUND_SEVERITY_SEVERE
@@ -65,8 +65,8 @@
 
 /datum/wound/blunt/buckling/critical
 	name = "Sheared Frame"
-	desc = "Patient's limb is sheared, rendering it inoperable. Applying duct tape can temporarily secure the limb until proper repairs."
-	treat_text = "Recommend cutting off external plating with a welding implement, disconnecting it with a wrench, then applying and securing rods with a wrench. Add and weld new alloyed plating."
+	desc = "Patient's limb is sheared, rendering it inoperable."
+	treat_text = "Recommend cutting off external plating with a welding implement, disconnecting it with a wrench, then applying and securing rods with a wrench. Add and weld new alloyed plating. Applying duct tape can temporarily secure the limb until proper repairs."
 	examine_desc = "is sheared off, barely hanging on by the wires"
 	occur_text = "violently snaps as its frame shears apart"
 	wound_flags = MANGLES_INTERIOR | PLATING_DAMAGE

--- a/code/datums/wounds/robotic/buckling.dm
+++ b/code/datums/wounds/robotic/buckling.dm
@@ -23,8 +23,8 @@
 
 /datum/wound/blunt/buckling/moderate
 	name = "Bent Plating"
-	desc = "Patient's external plating is bent out of shape."
-	treat_text = "Recommend prying the external plate back into place."
+	desc = "Patient's external plating is bent out of shape. Applying duct tape can temporarily secure the limb until proper repairs."
+	treat_text = "Recommend applying crowbar or wirecutters to bend plating back into place."
 	examine_desc = "is bent out of shape"
 	occur_text = "suddenly bends out of shape"
 	sound_effect = 'sound/effects/bin_open.ogg'
@@ -45,7 +45,7 @@
 /datum/wound/blunt/buckling/severe
 	name = "Buckled Chassis"
 	desc = "Patient's chassis is buckled inwards, causing disruption to mobility. Applying duct tape can temporarily secure the limb until proper repairs."
-	treat_text = "Recommend replacement of external plating."
+	treat_text = "Recommend cutting plating off with a welding implement, adding new alloyed plating, and then welding until secure."
 	examine_desc = "is buckled inwards"
 	occur_text = "creaks and buckles inwards"
 	severity = WOUND_SEVERITY_SEVERE
@@ -65,8 +65,8 @@
 
 /datum/wound/blunt/buckling/critical
 	name = "Sheared Frame"
-	desc = "Patient's limb is sheared, rendering it inoperable."
-	treat_text = "Recommend replacement of internal frame and external plating. Applying duct tape can temporarily secure the limb until proper repairs."
+	desc = "Patient's limb is sheared, rendering it inoperable. Applying duct tape can temporarily secure the limb until proper repairs."
+	treat_text = "Recommend cutting off external plating with a welding implement, disconnecting it with a wrench, then applying and securing rods with a wrench. Add and weld new alloyed plating."
 	examine_desc = "is sheared off, barely hanging on by the wires"
 	occur_text = "violently snaps as its frame shears apart"
 	wound_flags = MANGLES_INTERIOR | PLATING_DAMAGE

--- a/code/datums/wounds/robotic/electrical.dm
+++ b/code/datums/wounds/robotic/electrical.dm
@@ -25,7 +25,7 @@
 /datum/wound/electric/severe
 	name = "Damaged Electronics"
 	desc = "Patient's electronics are damaged, preventing movement and damaging internal components."
-	treat_text = "Recommend replacement of internal wiring."
+	treat_text = "Recommend unscrewing shell, opening servicing hatch, and replacing internal wiring. Re-heat solder or apply new solder. Close and ensure hatch is secured."
 	examine_desc = "occasionally sparks"
 	occur_text = "emits a shower of sparks"
 	threshold_penalty = 20
@@ -41,7 +41,7 @@
 /datum/wound/electric/critical
 	name = "Short Circuit"
 	desc = "Patient's internal circuitry is shorted, causing significant power drain and loss of function."
-	treat_text = "Recommend replacement of internal electronics and wiring."
+	treat_text = "Recommend unscrewing shell, opening servicing hatch, and preparing of electronics with a multitool. Proceed to replace the capacitor, internal wiring, and then either apply a welding implement or liquid solder. Ensure the hatch and shell are closed and secured."
 	examine_desc = "is twitching and emitting electrical arcs"
 	occur_text = "arcs as its electronics short out"
 	threshold_penalty = 40

--- a/code/datums/wounds/robotic/heat_warping.dm
+++ b/code/datums/wounds/robotic/heat_warping.dm
@@ -145,7 +145,7 @@
 /datum/wound/burn/heat_warping/severe
 	name = "Warped Plating"
 	desc = "Patient's external plating has been warped by thermal stress, threatening its structural integrity."
-	treat_text = "Recommend re-heating the external plating and bending it back into shape."
+	treat_text = "Recommend re-heating the external plating and bending it back into shape with a crowbar."
 	examine_desc = "is heat-warped and charred"
 	occur_text = "warps from the high temperature"
 	severity = WOUND_SEVERITY_SEVERE
@@ -162,7 +162,7 @@
 /datum/wound/burn/heat_warping/critical
 	name = "Deformed Chassis"
 	desc = "Patient's chassis has been severely deformed from temperatures close to its melting point and can no longer function."
-	treat_text = "Recommend replacement of the warped external plating."
+	treat_text = "Recommend cutting off external plating, and then disconnecting it with a wrench. Apply new rods and secure with a wrench. Apply and weld new alloyed plating."
 	examine_desc = "is a deformed mass of metal and slag"
 	occur_text = "glows red-hot and begins to deform"
 	severity = WOUND_SEVERITY_CRITICAL


### PR DESCRIPTION
## About The Pull Request

It was a little vague before. I don't think a player could learn how to fix these wounds without perusing the pr or the code or without a lot of trial and error.

Goes from this
<img width="595" height="147" alt="image" src="https://github.com/user-attachments/assets/889d1a38-1918-4e71-a186-edf3b7e2e03d" />

To this
<img width="472" height="148" alt="image" src="https://github.com/user-attachments/assets/bc2e927b-10c4-4e50-85d6-353950207812" />

May attempt to shorten them if necessary but I think knowing all your options is good for treatment

## Why It's Good For The Game

More intuitive way to find out how to treat new IPC wounds in game

## Changelog

:cl:
add: Added more in-depth explanations on how to treat new IPC wounds on health analyzer
/:cl:
