### PR TITLE
Removes "Goebbles" from the list of random last names

### DIFF
--- a/strings/names/last.txt
+++ b/strings/names/last.txt
@@ -173,7 +173,6 @@ Garrison
 Gettemy
 Gibson
 Glover
-Goebbles
 Goodman
 Graham
 Gray


### PR DESCRIPTION
I shouldn't have to explain this one

:cl:
del: Removed "Goebbles" from the list of random last names
/:cl:
