### PR TITLE
Returns Zohilan as a selectable language

### DIFF
--- a/code/modules/language/league_kalixcian.dm
+++ b/code/modules/language/league_kalixcian.dm
@@ -1,6 +1,6 @@
 /datum/language/league_kalixcian
-	name = "League Zohilian"
-	desc = "A variation of Zohilian spoken in the former colonies of the URFZ, primarily in the Maxin system, emerging after around a century of drift."
+	name = "League Zohilan"
+	desc = "A variation of Zohilan spoken in the former colonies of the URFZ, primarily in the Maxin system, emerging after around a century of drift."
 	speech_verb = "hisses"
 	ask_verb = "questions"
 	exclaim_verb = "bellows"

--- a/code/modules/language/zohilan.dm
+++ b/code/modules/language/zohilan.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "roars"
 	sing_verb = "sings"
 	key = "z"
-	flags = TONGUELESS_SPEECH | LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD | NO_HISS
+	flags = TONGUELESS_SPEECH | LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD | ROUNDSTART_LANGUAGE | NO_HISS
 	space_chance = 12
 	sentence_chance = 0
 	between_word_sentence_chance = 10


### PR DESCRIPTION
## About The Pull Request

Zohilan can be selected as a language in character settings once again.

## Why It's Good For The Game

Zohil still exists as a place that characters can be from, it didn't make sense to remove the language as an option in the first place.

## Changelog

:cl:
add: Returns Zohilan as a selectable language
spellcheck: Zohilan
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
