### PR TITLE
Fixes cloak discount

### DIFF
--- a/code/modules/cargo/packs/ship_hardware.dm
+++ b/code/modules/cargo/packs/ship_hardware.dm
@@ -76,7 +76,7 @@
 	crate_name = "cloaking system crate"
 	crate_type = /obj/structure/closet/crate/engineering
 	faction = /datum/faction/syndicate/hardliners
-	faction_discount = 0.3
+	faction_discount = 30
 
 /datum/supply_pack/ship_hardware/advanced_cloaking_device
 	name = "BFRD-3A Advanced Cloaking System"


### PR DESCRIPTION
`0.3` -> `30`

:cl:
fix: Fixed Gorlex Hardliners receiving a 0.3% discount on cloaking devices instead of 30%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
