### PR TITLE
Make baked potatoes classify as their actual ingredients

### DIFF
--- a/code/game/objects/items/food/vegetables.dm
+++ b/code/game/objects/items/food/vegetables.dm
@@ -40,15 +40,14 @@
 // Potatoes
 /obj/item/food/loaded_baked_potato
 	name = "loaded baked potato"
-	desc = "A potato that's been cut and spread down the middle, then filled with toppings and baked."
+	desc = "A potato that's been cut and spread down the middle, then filled with cheese and baked."
 	icon_state = "loadedbakedpotato"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 10,
 		/datum/reagent/consumable/nutriment/vitamin = 6,
-		/datum/reagent/consumable/nutriment/protein = 4,
 	)
-	tastes = list("baked potato" = 1, "bacon" = 1, "cheese" = 1, "cabbage" = 1)
-	foodtypes = VEGETABLES | DAIRY | MEAT
+	tastes = list("baked potato" = 1, "cheese" = 1)
+	foodtypes = VEGETABLES | DAIRY
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/loaded_miras_potato


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the baked potato recipe item to only have potato and cheese, like its ingredients imply

## Why It's Good For The Game
Food suddenly manifesting random shit in it sucks. You should know what's in a dish before you serve someone and poison them without a clue why
