### PR TITLE
Proper outpost baseturfs

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost_types.dm
+++ b/code/modules/overmap/objects/outpost/outpost_types.dm
@@ -225,6 +225,19 @@
 	)
 	faction = /datum/faction/nt
 
+	main_level_ztraits = list(
+		ZTRAIT_STATION = TRUE,
+		ZTRAIT_SUN_TYPE = AZIMUTH,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/icerock/temperate/lit
+	)
+	hangar_ztraits =  list(
+		ZTRAIT_GAS_GIANT = TRUE,
+		ZTRAIT_SUN_TYPE = STATIC_EXPOSED,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/icerock/temperate/lit
+	)
+
 /datum/overmap/outpost/ngr_rock
 	token_icon_state = "station_asteroid"
 	main_template = /datum/map_template/outpost/ngr_rock
@@ -238,6 +251,19 @@
 		/datum/map_template/outpost/hangar/ngr_rock_56x40
 	)
 
+	main_level_ztraits = list(
+		ZTRAIT_STATION = TRUE,
+		ZTRAIT_SUN_TYPE = AZIMUTH,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/rockplanet/safe/lit
+	)
+	hangar_ztraits =  list(
+		ZTRAIT_GAS_GIANT = TRUE,
+		ZTRAIT_SUN_TYPE = STATIC_EXPOSED,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/rockplanet/safe/lit
+	)
+
 /datum/overmap/outpost/clip_ocean
 	token_icon_state = "station_planet"
 	main_template = /datum/map_template/outpost/clip_ocean
@@ -249,6 +275,19 @@
 		/datum/map_template/outpost/hangar/clip_ocean_40x40,
 		/datum/map_template/outpost/hangar/clip_ocean_56x20,
 		/datum/map_template/outpost/hangar/clip_ocean_56x40
+	)
+
+	main_level_ztraits = list(
+		ZTRAIT_STATION = TRUE,
+		ZTRAIT_SUN_TYPE = AZIMUTH,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/water/beach/deep/outpost
+	)
+	hangar_ztraits =  list(
+		ZTRAIT_GAS_GIANT = TRUE,
+		ZTRAIT_SUN_TYPE = STATIC_EXPOSED,
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/water/beach/deep/outpost
 	)
 
 /datum/overmap/outpost/cybersun_gas_giant
@@ -268,12 +307,14 @@
 		ZTRAIT_GAS_GIANT = TRUE,
 		ZTRAIT_STATION = TRUE,
 		ZTRAIT_SUN_TYPE = AZIMUTH,
-		ZTRAIT_GRAVITY = STANDARD_GRAVITY
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/cybersun_outpost_exterior
 	)
 	hangar_ztraits =  list(
 		ZTRAIT_GAS_GIANT = TRUE,
 		ZTRAIT_SUN_TYPE = STATIC_EXPOSED,
-		ZTRAIT_GRAVITY = STANDARD_GRAVITY
+		ZTRAIT_GRAVITY = STANDARD_GRAVITY,
+		ZTRAIT_BASETURF = /turf/open/cybersun_outpost_exterior
 	)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

outposts now have proper baseturfs minus Trifuge, since that would require actual map changes and i just want to ping someone and have this merged

resolves #2526 

## Why It's Good For The Game

Any kind of situation where a turf on an outpost gets destroyed for any reasons reveals that every outpost doesn't have a proper baseturf set up

## Changelog

:cl:
fix: Outposts now have proper baseturfs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
