### PR TITLE
Increases capacity of fridges

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -1,5 +1,7 @@
 /obj/structure/closet/secure_closet/freezer
 	icon_state = "freezer"
+	drag_slowdown = 3
+	storage_capacity = 50
 	var/jones = FALSE
 
 /obj/structure/closet/secure_closet/freezer/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR increases the amount of items that fridges can hold from 30 items, same as a standard closet, up to 50 items. It also doubles its dragging slowdown, up from the standard of 1.5 from closets, up to 3.

Special Dependencies: None

## Why It's Good For The Game

Food items and ingredients can end up piling up quite a bit, and oftentimes I've seen a fridge get filled to the brim. I think an increase to 50 items can end up being a nice QOL change. 

The slowdown increase is intended to make it so that fridges don't become an attractive option for moving around items other than food. It would be a little silly to do so, anyway.

## Changelog

:cl:
balance: increases the amount of items fridges can hold from 30 items to 50, and doubles their dragging slowdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
