### PR TITLE
Swaps the glove type for the Derecho Foreman

### DIFF
--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -392,7 +392,7 @@
 	suit = /obj/item/clothing/suit/ngr
 	alt_suit = null
 	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/color/red/insulated
+	gloves = /obj/item/clothing/gloves/color/yellow
 
 
 //Chief Medical Officer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR swaps the type of glove that Derecho Foremen wake up with from the red insulated variant to the yellow variant.

Comparison:
| Original (Red) | New (Yellow) |
|----------------|--------------|
|<img width="72" height="67" alt="image" src="https://github.com/user-attachments/assets/719ffb67-73a0-4837-9930-59ad19c58e7c" />|<img width="72" height="68" alt="image" src="https://github.com/user-attachments/assets/a0d105c0-481c-4835-a3eb-31f1e1591c08" />|

Special Dependencies: None

## Why It's Good For The Game

Super duper minor thing, but I just think that the newer yellow glove sprites look a bit better than the red ones. Ultimately not really even a big deal because the yellow gloves are easily accessible enough to be swapped out in-game.

## Changelog

:cl:
code: swapped the type of insulated glove that derecho foremen wake up with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
