### PR TITLE
Ice Lodge Touch Ups and mine initialization changes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_ice_lodge.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_ice_lodge.dmm
@@ -745,7 +745,7 @@
 /obj/machinery/door/airlock/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/wood/mahogany,
 /area/ruin/powered/icemoon/lodge/cellar)
 "mc" = (
@@ -875,7 +875,6 @@
 /area/ruin/powered/icemoon/lodge/residential)
 "no" = (
 /obj/structure/table/wood,
-/obj/machinery/fax/ruin,
 /turf/open/floor/carpet/red_gold,
 /area/ruin/powered/icemoon/lodge/montagne_office)
 "nD" = (
@@ -2855,7 +2854,7 @@
 /obj/machinery/door/airlock/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/wood/mahogany,
 /area/ruin/powered/icemoon/lodge/cellar)
 "RM" = (
@@ -2906,6 +2905,10 @@
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/item/extinguisher/mini{
+	pixel_x = -10;
+	pixel_y = 13
 	},
 /turf/open/floor/wood/maple,
 /area/ruin/powered/icemoon/lodge/residential)
@@ -3280,7 +3283,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/proximity/explosive/live{
 	range_heavy = 1;
-	range_light = 5
+	range_light = 5;
+	spawn_arm_delay = 100
 	},
 /obj/effect/mob_spawn/human/corpse/srm/montagne,
 /turf/open/floor/wood/maple,

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -23,12 +23,22 @@
 	/// Use to set a delay after activation to trigger the explosion.
 	var/blast_delay = 1 DECISECONDS
 
+	/// Should our start live?
+	var/spawn_armed = FALSE
+	/// Sets a delay for mines for mines that start live
+	var/spawn_arm_delay
+
 	var/manufacturer = MANUFACTURER_NONE
 
 /obj/item/mine/Initialize(mapload)
 	. = ..()
-	if(armed)
-		now_armed()
+	if(spawn_armed)
+		if(spawn_arm_delay)
+			armed = FALSE
+			update_appearance(UPDATE_ICON_STATE)
+			addtimer(CALLBACK(src, PROC_REF(now_armed)), spawn_arm_delay)
+		else
+			now_armed()
 
 /obj/item/mine/examine(mob/user)
 	. = ..()
@@ -817,7 +827,7 @@
 #define LIVE_MINE_HELPER(mine_type)		\
 	/obj/item/mine/##mine_type/live {		\
 		anchored = TRUE;					\
-		armed = TRUE;						\
+		spawn_armed = TRUE;						\
 	}
 
 LIVE_MINE_HELPER(pressure/explosive)

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -36,7 +36,7 @@
 		if(spawn_arm_delay)
 			armed = FALSE
 			update_appearance(UPDATE_ICON_STATE)
-			addtimer(CALLBACK(src, PROC_REF(now_armed)), spawn_arm_delay)
+			addtimer(CALLBACK(src, PROC_REF(now_armed),FALSE), spawn_arm_delay)
 		else
 			now_armed()
 
@@ -104,12 +104,13 @@
 	return TRUE
 
 /// let them know the mine's done cooking
-/obj/item/mine/proc/now_armed()
+/obj/item/mine/proc/now_armed(silent = FALSE)
 	armed = TRUE
 	update_appearance(UPDATE_ICON_STATE)
 	light_power = 1
 	light_range = 1
-	playsound(src, 'sound/machines/nuke/angry_beep.ogg', 55, FALSE, 1)
+	if(!silent)
+		playsound(src, 'sound/machines/nuke/angry_beep.ogg', 55, FALSE, 1)
 	visible_message("<span class='danger'>\The [src] beeps softly, indicating it is now active.<span>", vision_distance = COMBAT_MESSAGE_RANGE)
 
 /// Can this mine trigger on the passed movable?

--- a/code/modules/ruins/icemoonruin_code/ice_lodge.dm
+++ b/code/modules/ruins/icemoonruin_code/ice_lodge.dm
@@ -26,5 +26,5 @@
 	mask = /obj/item/clothing/mask/gas/sechailer
 	suit = /obj/item/clothing/suit/armor/vest/marine/frontier
 	back = /obj/item/storage/backpack
-	backpack_contents = list(/obj/item/ammo_box/magazine/ammo_stack/prefilled/shotgun/pulseslug = 2)
+	backpack_contents = list(/obj/item/storage/box/ammo/pulseslug = 2)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adjusts mine initialization so armed mines can have a delay on spawn. Fixes the issue of the montagnue instantly exploding on mapload.

Removes the fax from Tiyak's office so he's less likely to hit and set his own room on fire.

Tiyak drops pulse slug boxes as intended rather than handfuls.

Adds a fire extinguisher to the dorms for fire safety reasons.
<img width="579" height="509" alt="image" src="https://github.com/user-attachments/assets/69f2decb-5533-4eab-82d8-e27658d7eca6" />


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes are good, and the adjusments should help the ruin run a bit more smoothly.

## Changelog

:cl:
add: Ice Lodge Touch ups
add: Arm on spawn mines can have a delay set.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
