### PR TITLE
Scatter Laser Nerf

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -145,7 +145,7 @@
 	icon_state = "frag12"
 	projectile_type = /obj/projectile/bullet/slug/frag12
 
-	wear_modifier = 1
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
@@ -156,17 +156,17 @@
 	pellets = 8
 	variance = 25
 
-	wear_modifier = 1
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/laserscatter
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "laser"
-	projectile_type = /obj/projectile/beam/weak
-	pellets = 8
+	projectile_type = /obj/projectile/beam/weak/shotgun/sharplite
+	pellets = 6
 	variance = 25
 
-	wear_modifier = 1
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -175,6 +175,8 @@
 	would have difficulty with."
 	icon_state = "pulse"
 	projectile_type = /obj/projectile/beam/pulse/shotgun
+
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/buckshot/twobore
 	name = "two-bore shell"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -129,7 +129,7 @@
 	pellets = 8
 	variance = 45
 
-	wear_modifier = 1
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteorslug shell"
@@ -137,7 +137,7 @@
 	icon_state = "meteor"
 	projectile_type = /obj/projectile/bullet/slug/meteor
 
-	wear_modifier = 1
+	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
@@ -159,8 +159,8 @@
 	wear_modifier = 4
 
 /obj/item/ammo_casing/shotgun/laserscatter
-	name = "scatter laser shell"
-	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
+	name = "scatter plasma shell"
+	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of an EP weapon in a ballistic package."
 	icon_state = "laser"
 	projectile_type = /obj/projectile/beam/weak/shotgun/sharplite
 	pellets = 6


### PR DESCRIPTION
## About The Pull Request

Scatter Laser shotgun shells now fire 6 sharplite shotgun projectiles rather than 8 lasers.

## Changelog

:cl:
balance: scatter laser shells now shoot scatter plasma that has actual shotgun ranging
balance: techshells now have 4x shotgun wear
/:cl: