### PR TITLE
Shotgun Dart Capacity Reduction

### DIFF
--- a/code/modules/cargo/blackmarket/packs/ammo.dm
+++ b/code/modules/cargo/blackmarket/packs/ammo.dm
@@ -5,7 +5,7 @@
 	name = "Shotgun Dart"
 	desc = "These handy darts can be filled up with any chemical and be shot with a shotgun! \
 	Prank your friends by shooting them with laughter! \
-	Not recommended for comercial use."
+	Not recommended for commercial use."
 	item = /obj/item/ammo_casing/shotgun/dart
 
 	cost_min = 10

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -88,7 +88,7 @@
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
-	desc = "A dart for use in shotguns. Can be injected with up to thirty units of any chemical."
+	desc = "A dart for use in shotguns. Can be injected with up to ten units of any chemical."
 	icon_state = "dart"
 	projectile_type = /obj/projectile/bullet/dart
 	var/reagent_amount = 10

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -91,7 +91,7 @@
 	desc = "A dart for use in shotguns. Can be injected with up to thirty units of any chemical."
 	icon_state = "dart"
 	projectile_type = /obj/projectile/bullet/dart
-	var/reagent_amount = 30
+	var/reagent_amount = 10
 
 /obj/item/ammo_casing/shotgun/dart/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the capacity of shotgun darts from 30u to 10u.

## Why It's Good For The Game

Dangerous amount of chemicals to include in a shotgun dart, especially given balance concerns around certain chemicals that can in testing instantly kill a target if the shell connects. 

## Changelog

:cl:
balance: Shotgun darts now only hold 10u of chems.
/:cl: