### PR TITLE
Right click wig restyling

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -185,6 +185,11 @@
 		add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 	update_appearance()
 
+/obj/item/clothing/head/wig/attack_hand_secondary(mob/living/carbon/human/user, modifiers)
+	attack_self(user)
+	user.regenerate_icons()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/clothing/head/wig/afterattack(mob/living/carbon/human/target, mob/user)
 	. = ..()
 	if (istype(target) && (HAIR in target.dna.species.species_traits) && target.hairstyle != "Bald")

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -187,7 +187,8 @@
 
 /obj/item/clothing/head/wig/attack_hand_secondary(mob/living/carbon/human/user, modifiers)
 	attack_self(user)
-	user.regenerate_icons()
+	user.update_inv_head()
+	user.update_inv_neck()
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/head/wig/afterattack(mob/living/carbon/human/target, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR allows a user to restyle a wig via right-click. It also updates a user's icon, so if a user is wearing a wig and restyles it, they can, for instance, "put their hair up into a bun" or "let it down".

## Why It's Good For The Game

This is another minor thing, but I feel like it would be nice to have, as someone using a wig would no longer have to take it off first in order to restyle it for roleplay purposes.

## Changelog

:cl:
add: Added right click interaction on wigs, allows for them to be restyled on a mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
