### PR TITLE
Allows the firerate or energy type of weapons to be toggled with the secondary unique action key

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1170,6 +1170,13 @@
 	else
 		..()
 
+//If a gun does not already have a secondary_action set, and has more than one firemode, the firemode can be toggled with the secondary action: default being shift+space
+/obj/item/gun/secondary_action(user)
+	if(gun_firemodes.len > 1)
+		fire_select(user)
+	else
+		..()
+
 /obj/item/gun/proc/fire_select(mob/living/carbon/human/user)
 
 	//gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST, FIREMODE_FULLAUTO, FIREMODE_OTHER)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -219,6 +219,15 @@
 			update_appearance()
 	return
 
+//If an energy gun has both a variable firerate and a variable ammotype, prioritize switching the firerate. Otherwise, swap the ammotype.
+/obj/item/gun/energy/secondary_action(user)
+	if(gun_firemodes.len > 1)
+		fire_select(user)
+	else if (ammo_type.len > 1)
+		select_fire(user)
+	else
+		..()
+
 /obj/item/gun/energy/can_shoot(visuals)
 	if(safety && !visuals)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that if a gun has more than one firemode, it's possible to swap the firemode with the secondary unique action keybinding -- the default being shift + space.

If an energy gun has only one firemode but more than one energy type, the secondary action bind swaps the energy type instead. If a gun has both, only the firemode is swapped.

Some weapons, like the Negotiator, already have a secondary unique action, and because of that, their implementation overrides this one -- meaning that there should be no conflicts.

Underbarrels also override this behavior, so they should also still work.

The goal of this PR was to add some extra QOL while not compromising on base function.

## Why It's Good For The Game

After some testing, I found that it can be really nice to be able to swap the firemode of weapons, or the energy type of weapons without having to move your mouse all the way to the top of the screen in order to do so. Examples being with the E-40, the Rattlesnake, and the Cadejo, where being able to swap modes quickly can be beneficial.

Ultimately not super important, but I felt it could be a nice little quality of life change.

## Changelog

:cl:
add: Added secondary unique action key interaction to toggle firerates or energy modes for guns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
