### PR TITLE
Reverts undocumented armor changes

### DIFF
--- a/code/modules/clothing/factions/cybersun.dm
+++ b/code/modules/clothing/factions/cybersun.dm
@@ -311,7 +311,7 @@
 	alt_desc = "Designed with fighting Nanotrasen weapons in mind, the Cybersun combat hardsuit trades ballistic and blunt protection for top grade laser protection. It is in travel mode. Produced by Cybersun Industries."
 	icon_state = "hardsuit1-cybersun"
 	hardsuit_type = "cybersun"
-	armor = list("melee" = 35, "bullet" = 45, "laser" = 70, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 60, "wound" = 30)
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 60, "wound" = 30)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/cybersun
 	supports_variations = VOX_VARIATION | KEPORI_VARIATION
 	icon = 'icons/obj/clothing/faction/cybersun/suits.dmi'
@@ -323,7 +323,7 @@
 	alt_desc = "Designed with fighting Nanotrasen weapons in mind, the Cybersun combat hardsuit trades ballistic and blunt protection for top grade laser protection. It is in travel mode. Produced by Cybersun Industries."
 	icon_state = "hardsuit1-cybersun"
 	hardsuit_type = "cybersun"
-	armor = list("melee" = 30, "bullet" = 40, "laser" = 70, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 60, "wound" = 30)
+	armor = list("melee" = 20, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 60, "wound" = 30)
 	icon = 'icons/obj/clothing/faction/cybersun/head.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/cybersun/head.dmi'
 


### PR DESCRIPTION
## About The Pull Request

Reverts undocumented armor changes to the Neutron Star hardsuit in #5937. I'm fairly certain these were pushed on accident as we have an unmerged balance PR that touches these numbers right now.

## Why It's Good For The Game

Reverts most likely accidental undocumented balance changes to the neutron star hardsuit.

## Changelog

:cl:
balance: Reverted undocumented changes to the Neutron Star hardsuit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
