### PR TITLE
Verbose Cargo Manifests

### DIFF
--- a/code/modules/cargo/market/market.dm
+++ b/code/modules/cargo/market/market.dm
@@ -70,18 +70,15 @@ GLOBAL_LIST_EMPTY(cargo_landing_zones)
 		unprocessed_packs -= combo_packs
 
 /datum/cargo_market/proc/send_order(mob/user, list/packs, atom/landing_zone)
-	var/name = "*None Provided*"
 	var/rank = "*None Provided*"
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		name = H.get_authentification_name()
 		rank = H.get_assignment(hand_first = TRUE)
 	else if(issilicon(user))
-		name = user.real_name
 		rank = "Silicon"
 	//Including the ship bank account means you cant open the crate lol
 	//var/datum/supply_order/SO = new(packs, name, rank, user.ckey, charge_account, market = current_market)
-	var/datum/supply_order/order = new(packs, name, rank, user.ckey, market = src, landing_zone = landing_zone)
+	var/datum/supply_order/order = new(packs, user, rank, user.ckey, market = src, landing_zone = landing_zone)
 	SScargo.queue_item(order)
 	return TRUE
 

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -55,20 +55,48 @@
 	requisition_paper.update_appearance()
 	return requisition_paper
 
-/datum/supply_order/proc/generateManifest(obj/structure/closet/crate/container, owner) //generates-the-manifests.
-	var/manifest_text = "<h2>[market.name] Shipping Manifest</h2>"
+/datum/supply_order/proc/generateManifest(obj/structure/closet/crate/container, owner, ordering_ship_name)
+	var/manifest_text = "<h2><font face = 'Adobe Pi Std'>[market.name] Shipping Manifest</h2>"
 	manifest_text += "<hr/>"
-	if(owner && !(owner == "Unknown"))
-		manifest_text += "Direct purchase from [owner]<br/>"
-	manifest_text += "Destination: [market.name]<br/>"
+	if(ordering_ship_name)
+		manifest_text += "Destination: [ordering_ship_name]<br/>"
+	manifest_text += "Order #[id]<br/>"
+	manifest_text += "Time of Order: [station_time_timestamp("hh:mm")]<br/>"
+	manifest_text += "<br/>"
+	manifest_text += "Supply Packs Purchased:<br/>"
+	var/previous_pack
+	var/pack_counter
+	var/list/datum/supply_pack/sorted_packs = sortNames(supply_packs)
+	for(var/datum/supply_pack/pack in sorted_packs)
+		if(!previous_pack || (previous_pack != pack.name))
+			if ((previous_pack != pack.name) && !!previous_pack)
+				manifest_text += "<li>[previous_pack] x [pack_counter]</li>"
+			previous_pack = pack.name
+			pack_counter = 1
+		else
+			pack_counter += 1
+	manifest_text += "<li>[previous_pack] x [pack_counter]</li>"
+	manifest_text += "<br/>"
 	manifest_text += "Contents: <br/>"
-	manifest_text += "<ul>"
+	manifest_text += "<table border>"
+	manifest_text += "<tr>"
+	manifest_text += "<td><div align = 'center'>QTY</td>"
+	manifest_text += "<td><div align = 'center'>ITEM</td>"
+	manifest_text += "</tr>"
 	var/container_contents = list() // Associative list with the format (item_name = nº of occurrences, ...)
 	for(var/atom/movable/AM in container.contents)
-		container_contents[AM.name]++
+		if(istype(AM, /obj/item/storage/guncase))
+			var/obj/item/storage/guncase/purchased_guncase = AM
+			for(var/obj/guncase_contents in purchased_guncase.contents)
+				container_contents[guncase_contents.name]++
+		else
+			container_contents[AM.name]++
 	for(var/item in container_contents)
-		manifest_text += "<li> [container_contents[item]] [item][container_contents[item] == 1 ? "" : "s"]</li>"
-	manifest_text += "</ul>"
+		manifest_text += "<td><div align = 'center'>[container_contents[item]]</td>"
+		manifest_text += "<td><div align = 'center'>[item]</td>"
+		manifest_text += "</tr>"
+	manifest_text += "</table>"
+	manifest_text += "<br/>"
 	manifest_text += "<h4>Stamp below to confirm receipt of goods:</h4>"
 
 	container.manifest_id = id
@@ -78,6 +106,7 @@
 /datum/supply_order/proc/generate(atom/location)
 	var/account_holder
 	var/datum/supply_pack/initial_pack = supply_packs[1]
+	var/ordering_ship_name
 
 	var/obj/structure/closet/crate/order_crate
 	if(paying_account)
@@ -88,7 +117,12 @@
 		account_holder = "Unknown"
 		order_crate = new initial_pack.crate_type(location)
 
+	//really really awful, but I'm not seeing a nicer way to get the ship name
+	var/area/ship/current_ship_area = get_area(src.orderer)
+	if(istype(current_ship_area) && current_ship_area.mobile_port)
+		ordering_ship_name = current_ship_area.mobile_port.current_ship.name
+
 	for(var/datum/supply_pack/filling_pack in supply_packs)
 		filling_pack.fill(order_crate)
-	generateManifest(order_crate, account_holder)
+	generateManifest(order_crate, account_holder, ordering_ship_name)
 	return order_crate

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -61,7 +61,7 @@
 	if(ordering_ship_name)
 		manifest_text += "Destination: [ordering_ship_name]<br/>"
 	manifest_text += "Order #[id]<br/>"
-	manifest_text += "Time of Order: [station_time_timestamp("hh:mm")]<br/>"
+	manifest_text += "Time of Order: [station_time_timestamp("hh:mm")] [sector_datestamp()]<br/>"
 	manifest_text += "<br/>"
 	manifest_text += "Supply Packs Purchased:<br/>"
 	var/previous_pack


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a few more details to cargo manifests. Namely it:
- lists the ship that purchased an order
- the order number
- the time an order was made
- the supply packs purchased
- encapsulates purchased pack contents into a table, and
- lists the contents of guncases (as previously manifests did not do this)

Old manifests:
<img width="401" height="199" alt="image" src="https://github.com/user-attachments/assets/705990a7-78aa-4bc5-b666-7ca577b04c5b" />

Modified manifests:
<img width="420" height="500" alt="image" src="https://github.com/user-attachments/assets/10cc9898-81c3-49ba-84fd-987da8129809" />
<img width="420" height="500" alt="image" src="https://github.com/user-attachments/assets/4904e393-60c7-414b-83cf-da67d6369695" />


## Why It's Good For The Game
I think it would be nice fluff to have a bit more details in manifests -- if one were actually keeping track of their orders, these changes would provide one with much better details to do so.

## Changelog

:cl:
refactor: refactored cargo manifest formatting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
