### PR TITLE
Makes the Himehabu tiny

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -336,7 +336,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake/inteq)
 /obj/item/ammo_box/magazine/m10mm_cottonmouth/empty
 	start_empty = TRUE
 
-	/obj/item/gun/ballistic/automatic/pistol/himehabu
+/obj/item/gun/ballistic/automatic/pistol/himehabu
 	name = "PC-81 \"Himehabu\""
 	desc = "An astonishingly compact machine pistol firing ultra-light projectiles, designed to be as small and concealable as possible while remaining a credible threat at very close range. Armor penetration is practically non-existent. Chambered in .22."
 

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -336,7 +336,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake/inteq)
 /obj/item/ammo_box/magazine/m10mm_cottonmouth/empty
 	start_empty = TRUE
 
-/obj/item/gun/ballistic/automatic/pistol/himehabu
+	/obj/item/gun/ballistic/automatic/pistol/himehabu
 	name = "PC-81 \"Himehabu\""
 	desc = "An astonishingly compact machine pistol firing ultra-light projectiles, designed to be as small and concealable as possible while remaining a credible threat at very close range. Armor penetration is practically non-existent. Chambered in .22."
 
@@ -349,7 +349,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake/inteq)
 	mob_overlay_icon = 'icons/obj/guns/manufacturer/scarborough/onmob.dmi'
 
 
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	default_ammo_type = /obj/item/ammo_box/magazine/m22lr_himehabu
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m22lr_himehabu,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the Himehabu tiny how it was before.

## Why It's Good For The Game
I've been  thinking about it alot, while people really liked to show off themselves stashing like 120 himehabus in a bag back then... this rarely if ever happened during actual rounds.

While I understood the change when it happened a few years ago, the landscape has changed a lot more. 22lr is worse by how much better and more common every other weapon has gotten. This thing's meant to be an ultracompact spy pistol... it may as well be able to be stored in very concealable places as a gimmick.

## Changelog

:cl:
add: Himehabu is now tiny sized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
