### PR TITLE
Shields now only reflect from the direction the user's facing

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -67,6 +67,8 @@
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
+	if(!(REVERSE_DIR(hitby.dir) & owner.dir))
+		return FALSE
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		final_block_chance += 30
 	if(attack_type == LEAP_ATTACK)


### PR DESCRIPTION
## About The Pull Request
at least i'm fairly sure that's how this code works

## Why It's Good For The Game

shields are less oppressive when they're not omnidirectional armor slabs.
## Changelog

:cl:
balance: shields now need to be facing a target to absorb an impact.
/:cl:

