### PR TITLE
Abandoned Crate Fix

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -224,7 +224,7 @@
 		if(92)
 			new /obj/item/storage/firstaid/advanced(src)
 		if(93)
-			//new /obj/item/attachment/gun/energy/e50(src)
+			new /obj/item/gun/energy/laser/e10(src)
 		if(94)
 			new /mob/living/simple_animal/hostile/mimic/crate(src)
 			qdel_on_open = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces buggy E-50 attachment inside the Abandoned Crate with an E-10, also allowing that number to actually give you an item if you roll it.

## Why It's Good For The Game

If you gamble you should probably get at least pennies for your time.

## Changelog

:cl: Cloudbreak
balance: 1% Chance for an E-10 in abandoned crates 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
