### PR TITLE
Orbit menu fix

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -77,7 +77,10 @@
 			continue
 
 		serialized["ref"] = REF(mob_poi)
-		serialized["full_name"] = mob_poi.real_name
+		if(!mob_poi.real_name)
+			serialized["full_name"] = mob_poi.name
+		else
+			serialized["full_name"] = mob_poi.real_name
 		serialized["name"] = mob_poi.name
 		serialized["job"] = mob_poi.job
 		if(number_of_orbiters)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the orbit window breaking when carbons are spawned with no "real name". 
<img width="248" height="216" alt="image" src="https://github.com/user-attachments/assets/157c74d7-b9cc-4c02-a0e4-86b54dce779b" />

## Why It's Good For The Game

This should fix a minor bug that has popped up a few times and broken the orbit menu

## Changelog

:cl:
fix: adds null check for mob pois in the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
