### PR TITLE
Very small Shrike change

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_shrike.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_shrike.dmm
@@ -2639,7 +2639,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/safe/floor,
+/obj/structure/safe/floor{
+	number_of_tumblers = 4;
+	tumblers = list(17,42,86, 63)
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "FD" = (
@@ -4763,6 +4766,9 @@
 	},
 /obj/effect/turf_decal/corner/opaque/vired/half{
 	dir = 1
+	},
+/obj/item/paper/crumpled{
+	default_raw_text = "17, 42, 89, 63"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)


### PR DESCRIPTION
## About The Pull Request

Gives the Shrike a set tumbler in-round now instead of a random set one

## Why It's Good For The Game

Whilst I doubt that most people would care about having to guess what the new tumbler set is each round, for the few that did and just so happened to not have a stethoscope will now be able to open their safe with the code being located within the captains locker for ease of access.

## Changelog

:cl:
add: The Shrikes bridge safe now has a set code on spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
