### PR TITLE
Removes Black Market and Ruin AI Core

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_interceptor.dmm
@@ -293,7 +293,6 @@
 	},
 /obj/effect/decal/cleanable/robot_debris/gib,
 /obj/effect/decal/cleanable/oil,
-/obj/structure/AIcore/deactivated,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ruin/jungle/interceptor/starhall)

--- a/code/modules/cargo/blackmarket/packs/tech.dm
+++ b/code/modules/cargo/blackmarket/packs/tech.dm
@@ -41,49 +41,6 @@
 	stock = 1
 	availability_prob = 30
 
-/datum/blackmarket_item/tech/ai_core
-	name = "AI Core Board"
-	desc = "The future is now! Become one with your ship with this AI core board! (Some assembly required.)"
-	item = /obj/item/circuitboard/aicore
-	pair_item = list(/datum/blackmarket_item/tech/boris, /datum/blackmarket_item/tech/mmi, /datum/blackmarket_item/tech/borg)
-
-	cost_min = 5000
-	cost_max = 7000
-	stock = 1
-	availability_prob = 10
-	spawn_weighting = FALSE
-
-/datum/blackmarket_item/tech/boris
-	name = "B.O.R.I.S Module"
-	desc = "A Bluespace Optimi-blah blah blah, I'm bored already. This module will convert a cyborg frame into an AI compatible shell."
-	item = /obj/item/borg/upgrade/ai
-
-	cost_min = 100
-	cost_max = 250
-	stock = 3
-	availability_prob = 0
-
-/datum/blackmarket_item/tech/mmi
-	name = "Man Machine Interface"
-	desc = "Transcend the weakness of your flesh with this man machine interface, compatible with AIs, Cyborgs and Mechs!"
-	item = /obj/item/mmi
-
-	cost_min = 250
-	cost_max = 750
-	stock = 3
-	availability_prob = 0
-
-/datum/blackmarket_item/tech/borg
-	name = "Cyborg Construction Kit"
-	desc = "This durable and verastile cyborg frame is capable of fufilling a number of roles and survive situations that would kill the average person. Brain sold seperately."
-	item = /obj/structure/closet/crate/cyborg
-	pair_item = list(/datum/blackmarket_item/tech/boris, /datum/blackmarket_item/tech/mmi)
-
-	cost_min = 1000
-	cost_max = 2000
-	stock = 3
-	availability_prob = 40
-
 /datum/blackmarket_item/tech/t4_capacitor
 	name = "Quadratic Capacitor"
 	desc = "A top grade quadractic capacitor. These highly effiecent capacitors are capable of storing massive amounts of electricity. Keep away from open plugs."


### PR DESCRIPTION

## About The Pull Request

Removes the AI Core + associated packs from the Black Market, and also removes a loose AI core from a ruin.

## Why It's Good For The Game

AIs are unmaintained, highly buggy, and their place within Shiptest has become increasingly and increasingly debated. Until they're further developed (and bugs regarding having infinite vision/borgs being comically unbalanced in the current environment/AI remote control potentially being equally as unbalanced) they should probably not be used. Cleared with thgvr before the PR was posted.

## Changelog

:cl:
balance: AI cores, shells, and BORIS/MMIs removed from the Black Market and a ruin.
/:cl: