### PR TITLE
Fix Shrike fuel line

### DIFF
--- a/_maps/shuttles/nanotrasen/nanotrasen_shrike.dmm
+++ b/_maps/shuttles/nanotrasen/nanotrasen_shrike.dmm
@@ -541,19 +541,16 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/hallway/port)
 "gs" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/siding/white,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "gt" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "gu" = (
@@ -2143,9 +2140,7 @@
 "zj" = (
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
 "zm" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The main large fuel tank does not connect to the pipes, as it faces downward and seemingly can't be rotated. It also just made a bit more sense to have it connected to the fuel lines instead of a canister, similar to the magpie. Also gives them a scrubber and (blue thingy I can't remember the name of), since they tend to be in modernized ships.
<details>
<img width="1040" height="796" alt="image" src="https://github.com/user-attachments/assets/fbe78a8b-ef84-45a6-b2b1-887758f6acb8" />
</details>

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This has been messed up for a while and this should hopefully finally fix it

## Changelog

:cl:
fix: shrike fuel lines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
