### PR TITLE
Fix examine text pronouns for low blood

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -256,7 +256,7 @@
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	switch(apparent_blood_volume)
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
-			msg += "[t_He] [t_has] looks a little pale.\n"
+			msg += "[t_He] looks a little pale.\n"
 		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 			msg += "<b>[t_He] look[p_s()] like [t_he] is going to faint.</b>\n"
 		if(-INFINITY to BLOOD_VOLUME_BAD)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -258,7 +258,7 @@
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 			msg += "[t_He] looks a little pale.\n"
 		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
-			msg += "<b>[t_He] look[p_s()] like [t_he] is going to faint.</b>\n"
+			msg += "<b>[t_He] look[p_s()] like [t_he] [t_is] going to faint.</b>\n"
 		if(-INFINITY to BLOOD_VOLUME_BAD)
 			msg += span_deadsay("<b>[t_He] looks drained of blood...</b>\n")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds proper pronoun use for the following:
Changes "they has look a little pale" to "they look a little pale" in the examine text if blood level is slightly low.
Changes "they look like they is going to faint" to "they look like they are going to faint"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
SPaG good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: No longer will you "has look a little pale" in your examine text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
