### PR TITLE
Syndicate Headset Fixes

### DIFF
--- a/_maps/RandomRuins/MoonRuins/moon_hideout.dmm
+++ b/_maps/RandomRuins/MoonRuins/moon_hideout.dmm
@@ -2407,7 +2407,6 @@
 	pixel_x = 0;
 	pixel_y = -10
 	},
-/obj/item/radio/headset/syndicate/alt/captain,
 /obj/item/clothing/under/syndicate/ramzi/officer,
 /obj/item/clothing/neck/shemagh/ramzi,
 /obj/item/clothing/head/ramzi/beret,
@@ -2421,6 +2420,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/item/radio/headset/alt,
 /turf/open/floor/wood/walnut,
 /area/ruin/moon/hideout/dorms/officer/bedroom)
 "yL" = (

--- a/_maps/shuttles/cybersun/cybersun_cirrus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_cirrus.dmm
@@ -920,6 +920,7 @@
 	dir = 9
 	},
 /obj/item/radio/headset/syndicate/alt/captain/cybersun,
+/obj/item/radio/headset/syndicate/captain/cybersun,
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/dorm/commad)
 "eI" = (
@@ -2762,6 +2763,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/radio/headset/syndicate/cybersun,
 /turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/dorm/commad)
 "sC" = (

--- a/_maps/shuttles/cybersun/cybersun_nimbus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_nimbus.dmm
@@ -2183,6 +2183,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/headset/syndicate/alt/captain/cybersun,
+/obj/item/radio/headset/syndicate/captain/cybersun,
 /turf/open/floor/suns/dark/plain,
 /area/ship/bridge)
 "KN" = (

--- a/_maps/shuttles/ngr/ngr_derecho.dmm
+++ b/_maps/shuttles/ngr/ngr_derecho.dmm
@@ -2490,6 +2490,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /obj/item/radio/headset/syndicate/alt/ngr,
+/obj/item/radio/headset/syndicate/ngr,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm)
 "vs" = (
@@ -5870,6 +5871,7 @@
 /obj/item/storage/belt/military/assault,
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /obj/item/radio/headset/syndicate/alt/captain/ngr,
+/obj/item/radio/headset/syndicate/captain/ngr,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "Yq" = (

--- a/_maps/shuttles/ngr/ngr_kaliandhi.dmm
+++ b/_maps/shuttles/ngr/ngr_kaliandhi.dmm
@@ -1297,6 +1297,7 @@
 /obj/item/storage/backpack/messenger/sec,
 /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch,
 /obj/item/radio/headset/syndicate/alt/captain/ngr,
+/obj/item/radio/headset/syndicate/captain/ngr,
 /turf/open/floor/carpet/red_gold,
 /area/ship/crew/dorm/captain)
 "gS" = (
@@ -6192,6 +6193,7 @@
 /obj/item/clothing/glasses/hud/security/sunglasses/ngr,
 /obj/item/storage/backpack/messenger/sec,
 /obj/item/radio/headset/syndicate/alt/ngr,
+/obj/item/radio/headset/syndicate/ngr,
 /turf/open/floor/carpet/black,
 /area/ship/crew/dorm/commad)
 "Gh" = (

--- a/_maps/shuttles/suns/suns_mercury.dmm
+++ b/_maps/shuttles/suns/suns_mercury.dmm
@@ -2156,6 +2156,7 @@
 	dir = 10
 	},
 /obj/item/radio/headset/syndicate/alt/suns,
+/obj/item/radio/headset/syndicate/suns,
 /turf/open/floor/suns/hatch/ebony,
 /area/ship/bridge)
 "Iy" = (
@@ -2788,6 +2789,7 @@
 /obj/item/clothing/suit/armor/vest/suns/captain,
 /obj/item/clothing/head/suns/captain,
 /obj/item/radio/headset/syndicate/alt/suns/command,
+/obj/item/radio/headset/syndicate/suns/command,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm/captain)
 "Qw" = (

--- a/code/modules/clothing/outfits/factions/cybersun.dm
+++ b/code/modules/clothing/outfits/factions/cybersun.dm
@@ -96,7 +96,7 @@
 	jobtype = /datum/job/captain
 	job_icon = "headofsecurity"
 
-	ears = /obj/item/radio/headset/syndicate/alt/captain
+	ears = /obj/item/radio/headset/syndicate/captain/cybersun
 	uniform = /obj/item/clothing/under/cybersun/officer
 	suit = /obj/item/clothing/suit/armor/cybersun
 
@@ -128,7 +128,7 @@
 	uniform = /obj/item/clothing/under/cybersun/doctor
 	alt_uniform = /obj/item/clothing/under/cybersun/medic
 
-	ears = /obj/item/radio/headset/syndicate/alt/captain
+	ears = /obj/item/radio/headset/syndicate/alt/cybersun
 	id = /obj/item/card/id/syndicate_command/captain_id
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/cybersun/cmo

--- a/code/modules/clothing/outfits/factions/syndicate.dm
+++ b/code/modules/clothing/outfits/factions/syndicate.dm
@@ -373,7 +373,7 @@
 	faction = FACTION_NGR
 
 	head = /obj/item/clothing/head/hardhat/ngr/foreman
-	ears = /obj/item/radio/headset/syndicate/alt
+	ears = /obj/item/radio/headset/syndicate/alt/ngr
 	uniform = /obj/item/clothing/under/syndicate/ngr/officer
 	alt_uniform = null
 	suit = /obj/item/clothing/suit/ngr
@@ -389,7 +389,7 @@
 	id_assignment = "Medical Instructor"
 
 	uniform = /obj/item/clothing/under/syndicate/suns/doctorscrubs
-	ears = /obj/item/radio/headset/syndicate/alt/captain
+	ears = /obj/item/radio/headset/syndicate/alt/suns
 	id = /obj/item/card/id/syndicate_command/captain_id
 	shoes = /obj/item/clothing/shoes/combat/suns
 	l_pocket = /obj/item/pinpointer/crew
@@ -431,7 +431,7 @@
 	faction = FACTION_NGR
 	id_assignment = "Ensign"
 
-	ears = /obj/item/radio/headset/syndicate
+	ears = /obj/item/radio/headset/syndicate/ngr
 	uniform = /obj/item/clothing/under/syndicate/ngr/officer
 	head = /obj/item/clothing/head/ngr
 	suit = /obj/item/clothing/suit/armor/ngr/lieutenant

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -192,7 +192,7 @@
 	suit = /obj/item/clothing/suit/cybersun
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil
-	ears = /obj/item/radio/headset/syndicate
+	ears = /obj/item/radio/headset/syndicate/cybersun
 	belt = /obj/item/gun/ballistic/automatic/pistol/challenger
 	head = /obj/item/clothing/head/soft/cybersun/medical
 	id = /obj/item/card/id
@@ -210,7 +210,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/raincoat
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil
-	ears = /obj/item/radio/headset/syndicate
+	ears = /obj/item/radio/headset/syndicate/cybersun
 	belt = /obj/item/storage/belt/medical/paramedic
 	head = /obj/item/clothing/head/soft/cybersun/medical
 	back = /obj/item/storage/backpack/messenger


### PR DESCRIPTION
## About The Pull Request

Removes a few mapped in syndicate headsets I missed. Also fixes it on certain outfits (namely Cybersun and a few NGR)

Adds the non-bowman version of a few headsets to command to lockers in case you don't want the bigass microphone in your face

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
fix: Removed a few token syndicate headsets replaced with their faction variants
add: Added non-bowman headsets to command lockers for former Syndicate ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
