### PR TITLE
Breaching hammer force increase + makes it better at its namesake.

### DIFF
--- a/code/game/objects/items/melee/blunt.dm
+++ b/code/game/objects/items/melee/blunt.dm
@@ -9,7 +9,7 @@
 	force = 5
 	throwforce = 15
 	armour_penetration = 40
-	demolition_mod = 2
+	demolition_mod = 2.5
 	sharpness = SHARP_NONE
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
@@ -24,7 +24,7 @@
 
 /obj/item/melee/sledgehammer/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = force, force_wielded = 30, icon_wielded="[base_icon_state]_w")
+	AddComponent(/datum/component/two_handed, force_unwielded = force, force_wielded = 40, icon_wielded="[base_icon_state]_w")
 
 /obj/item/melee/sledgehammer/update_icon_state()
 	icon_state = "[base_icon_state]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the hammer's force to 40 and it's demolition mod to 2.5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Over the variety of melee changes the breaching hammer has become somewhat of a miserable melee weapon. Outclassed in breaching ability by the boarding axe and dps by about 65% in both aspects. This raises it to be slightly worse than the boarding axe in terms of dps, and better in terms of demolition force. These numbers may be a bit too high so they may be tweaked after a testmerge. ✨
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Breaching hammer now has 40 force and 2.5 demo mod. Lovers of improvised cover everywhere weep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
