### PR TITLE
Fixes admins not being able to view faxes from pop up and outpost fax QoL

### DIFF
--- a/_maps/outpost/cybersun_gas_giant.dmm
+++ b/_maps/outpost/cybersun_gas_giant.dmm
@@ -17578,7 +17578,9 @@
 /area/outpost/cargo/office)
 "PJ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/fax/admin/outpost,
+/obj/machinery/fax/admin/outpost{
+	low_priority = 1
+	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D2BC9D";
 	dir = 8
@@ -20716,7 +20718,9 @@
 /area/outpost/crew/court)
 "WT" = (
 /obj/structure/table/reinforced,
-/obj/machinery/fax/admin/outpost,
+/obj/machinery/fax/admin/outpost{
+	low_priority = 1
+	},
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line,
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
 	dir = 1

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2158,7 +2158,8 @@
 		var/obj/item/paper/paper_to_show = locate(href_list["show_paper"])
 		if(!istype(paper_to_show))
 			return
-		paper_to_show.ui_interact(usr)
+		var/datum/component/writing/text_to_show = paper_to_show.GetComponent(/datum/component/writing)
+		text_to_show.ui_interact(usr)
 
 	else if(href_list["show_photo"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -23,6 +23,8 @@
 	var/frontier_network = FALSE
 	/// True if the fax machine should be visible to other fax machines in general.
 	var/visible_to_network = TRUE
+	/// Mainly for if there's multiple admin faxes with the same ID and you want mail to go a specific fax first. The paper will be sent to a non-low priority fax first.
+	var/low_priority = FALSE
 	/// If true we will eject faxes at speed rather than sedately place them into a tray.
 	var/hurl_contents = FALSE
 	/// If true you can fax things which strictly speaking are not paper.
@@ -342,11 +344,21 @@
 			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> <span class='linkify'>sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])][to_show]"))
 			log_fax(thing_to_send, params["id"], params["name"])
 			loaded_item_ref = null
-
+			var/list/low_priority_faxes = list()
+			var/fax_found = FALSE
 			for(var/obj/machinery/fax/fax as anything in GLOB.fax_machines)
 				if(fax.admin_fax_id == params["id"])
+					if(fax.low_priority)
+						low_priority_faxes += fax
+						continue
 					fax.receive(thing_to_send, fax_name)
+					fax_found = TRUE
 					break
+			if(!fax_found)
+				for(var/obj/machinery/fax/fax as anything in low_priority_faxes)
+					if(fax.admin_fax_id == params["id"])
+						fax.receive(thing_to_send, fax_name)
+						break
 			update_appearance()
 
 		if("history_clear")

--- a/code/modules/requests/requests_manager.dm
+++ b/code/modules/requests/requests_manager.dm
@@ -226,7 +226,8 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 				to_chat(usr, "Request is not a paper! Check the office it was sent to")
 				return TRUE
 			var/obj/item/paper/request_message = request.additional_information
-			request_message.ui_interact(usr)
+			var/datum/component/writing/text_to_show = request_message.GetComponent(/datum/component/writing)
+			text_to_show.ui_interact(usr)
 			return TRUE
 
 /datum/request_manager/ui_data(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the SHOW_FAX pop up button when a fax is sent.

Also adds a low priority fax var to faxes. Non-low priority faxes will prioritized over low-priority faxes.

Sets the outpost faxes not in the Thousand Eyes command area to low priority.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes are good. 

Low priority faxes should help with the issue of faxes getting sent off somewhere unexpected if multiple faxes with the same ID get mapped.

## Changelog

:cl:
add: Low priority fax var
fix: Admin show fax button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
