### PR TITLE
End of round bluespace jump no longer prevents docking

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -342,9 +342,6 @@
 			cloaking_system.set_cloak(!cloaking_system.cloak_active)
 			return TRUE
 		if("act_overmap")
-			if(SSshuttle.jump_mode > BS_JUMP_CALLED)
-				to_chat(usr, "<span class='warning'>Cannot interact due to bluespace jump preperations!</span>")
-				return
 			var/datum/overmap/to_act = locate(params["ship_to_act"]) in current_ship.get_nearby_overmap_objects(include_docked = TRUE, empty_if_src_docked = FALSE)
 			var/feedback_text = current_ship.show_interaction_menu(usr, to_act)
 			if(feedback_text)
@@ -358,9 +355,6 @@
 	if(!current_ship.docked_to && !current_ship.docking)
 		switch(action)
 			if("quick_dock")
-				if(SSshuttle.jump_mode > BS_JUMP_CALLED)
-					to_chat(usr, span_warning("Cannot dock due to bluespace jump preperations!"))
-					return
 				var/datum/overmap/to_act = locate(params["ship_to_act"]) in current_ship.get_nearby_overmap_objects(include_docked = TRUE)
 				say(current_ship.Dock(to_act))
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Dock prevention is more or less a holdover from when the end of round jump actually jumped the ships. It's nice to be able to get that last dock to the outpost for a sense of completion.

## Changelog

:cl:
add: End of round bluespace jump no longer prevents docking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
