### PR TITLE
Reduces the layer of a subset of atmospherics machines so that they layer below catwalks

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
@@ -4,7 +4,7 @@
 	initialize_directions = SOUTH|NORTH
 	use_power = IDLE_POWER_USE
 	device_type = BINARY
-	layer = GAS_PUMP_LAYER
+	layer = UNDER_CATWALK
 	var/uid
 	var/static/gl_uid = 1
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
@@ -4,7 +4,7 @@
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = IDLE_POWER_USE
 	device_type = TRINARY
-	layer = GAS_FILTER_LAYER
+	layer = UNDER_CATWALK
 	pipe_flags = PIPING_ONE_PER_TURF
 
 	var/flipped = FALSE

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -7,6 +7,7 @@
 	initialize_directions = NORTH|SOUTH
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE
 	piping_layer = PIPING_LAYER_DEFAULT
+	layer = UNDER_CATWALK
 	device_type = 0
 	volume = 260
 	construction_type = /obj/item/pipe/binary
@@ -41,9 +42,6 @@
 
 /obj/machinery/atmospherics/pipe/layer_manifold/proc/get_all_connected_nodes()
 	return front_nodes + back_nodes + nodes
-
-/obj/machinery/atmospherics/pipe/layer_manifold/update_layer()
-	layer = initial(layer) + (PIPING_LAYER_MAX * PIPING_LAYER_LCHANGE)	//This is above everything else.
 
 /obj/machinery/atmospherics/pipe/layer_manifold/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the layer of binary, trinary, and layer adapter atmospherics machines so that they layer below catwalks instead of jutting above them.

| Before |<img width="741" height="934" alt="image" src="https://github.com/user-attachments/assets/3f6e7e7c-d5dc-493d-8c50-53b45cb3db16" />|
|--------|---|
| After  |<img width="790" height="975" alt="image" src="https://github.com/user-attachments/assets/5b1f791c-9895-4b5a-8101-ecdaf6a963a8" />|

Below is an example with the layer changes implemented, to show that they don't appear to layer incorrectly in a different context.

<img width="617" height="378" alt="image" src="https://github.com/user-attachments/assets/7feadbd4-625c-4ca4-86c3-62af4353369a" />

## Why It's Good For The Game

Having certain atmospherics machines pop out of a catwalk and layer above them can look bad in certain maps. This should help make them look nicer when used alongside catwalks.

## Changelog

:cl:
del: Removed layer adapter layer update proc
code: changed the layer of atmospherics machines so they layer below catwalks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
