### PR TITLE
SAW-80 can no longer mount laser sights or suppressor

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -846,6 +846,7 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/indie)
 	wield_delay = 0.9 SECONDS //ditto
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
+	refused_attachments = /obj/item/attachment/silencer, /obj/item/attachment/laser_sight
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -846,7 +846,9 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/indie)
 	wield_delay = 0.9 SECONDS //ditto
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
-	refused_attachments = /obj/item/attachment/silencer, /obj/item/attachment/laser_sight
+	refused_attachments = list(/obj/item/attachment/silencer,
+								/obj/item/attachment/laser_sight
+								)
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -846,9 +846,10 @@ NO_MAG_GUN_HELPER(automatic/assault/hydra/indie)
 	wield_delay = 0.9 SECONDS //ditto
 
 	valid_attachments = SCARBOROUGH_ATTACHMENTS
-	refused_attachments = list(/obj/item/attachment/silencer,
-								/obj/item/attachment/laser_sight
-								)
+	refused_attachments = list(
+		/obj/item/attachment/silencer,
+		/obj/item/attachment/laser_sight
+		)
 	slot_available = SCARBOROUGH_ATTACH_SLOTS
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(


### PR DESCRIPTION
## Why It's Good For The Game

No negating the one downside of this weapon

## Changelog

:cl:
balance: Hydra SAW can no longer mount laser sight or suppressor
/:cl: