### PR TITLE
Firefly sofa fix + Chair buckle dir

### DIFF
--- a/_maps/shuttles/independent/independent_firefly.dmm
+++ b/_maps/shuttles/independent/independent_firefly.dmm
@@ -4082,7 +4082,8 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/red/old/right{
-	dir = 8
+	dir = 8;
+	buckle_dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -82,7 +82,13 @@
 
 	M.buckling = null
 	M.set_buckled(src)
-	M.setDir(dir)
+
+	var/obj/structure/chair/buckle_chair = null
+	if(istype(src, /obj/structure/chair))
+		buckle_chair = src
+
+	M.setDir(buckle_chair.buckle_dir || dir)
+
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/restrained/buckled)
 	M.set_glide_size(glide_size)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -82,12 +82,7 @@
 
 	M.buckling = null
 	M.set_buckled(src)
-
-	var/obj/structure/chair/buckle_chair = null
-	if(istype(src, /obj/structure/chair))
-		buckle_chair = src
-
-	M.setDir(buckle_chair.buckle_dir || dir)
+	M.setDir(dir)
 
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/restrained/buckled)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -83,7 +83,6 @@
 	M.buckling = null
 	M.set_buckled(src)
 	M.setDir(dir)
-
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/restrained/buckled)
 	M.set_glide_size(glide_size)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -108,6 +108,11 @@
 	else
 		layer = OBJ_LAYER
 
+/obj/structure/chair/buckle_mob(mob/living/M, force, check_loc)
+	. = ..()
+	if(buckle_dir)
+		M.setDir(buckle_dir)
+
 /obj/structure/chair/post_buckle_mob(mob/living/M)
 	. = ..()
 	handle_layer()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -14,6 +14,7 @@
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up
 	layer = OBJ_LAYER
+	var/buckle_dir = null // force a buckled mob to face in this direction
 
 /obj/structure/chair/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Chairs now have a var to force the buckled mob to force a given dir
- That one sofa on the Firefly bridge uses this so you are no longer backwards
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
That sofa was bothering me. Could come in handy if there's a similar issue elsewhere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: the sofa in the firefly no longer makes you face backwards
add: chairs now have a var to force the buckled mob to face a dir
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
