### PR TITLE
Balances the Yari

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -115,6 +115,7 @@
 		/obj/item/gun/energy/laser,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/energy/sharplite/x26,
+		/obj/item/gun/energy/sharplite/x01,
 		/obj/item/gun/energy/kalix/pistol,
 		/obj/item/stock_parts/cell/gun,
 		/obj/item/ammo_box)) // this doesnt let you put hades into holsters trust me

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -487,6 +487,7 @@
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/gun/energy/laser,
 		/obj/item/gun/energy/sharplite/x26,
+		/obj/item/gun/energy/sharplite/x01,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/energy/kalix/pistol,
 		/obj/item/bodycamera,

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -104,7 +104,7 @@
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/sharplite/hos
-	e_cost = 500
+	e_cost = 1000
 
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/projectile/beam/practice

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -14,7 +14,7 @@
 
 /obj/item/ammo_casing/energy/ion/hos
 	projectile_type = /obj/projectile/ion/weak
-	e_cost = 2000
+	e_cost = 5000
 
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/projectile/energy/declone

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -36,8 +36,8 @@
 	e_cost = 625
 
 /obj/item/ammo_casing/energy/disabler/sharplite/hos
-	e_cost = 500
-
+	e_cost = 1000
+g
 /obj/item/ammo_casing/energy/disabler/scatter	//WS edit, scatter repathing
 	pellets = 3
 	variance = 15

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -37,7 +37,6 @@
 
 /obj/item/ammo_casing/energy/disabler/sharplite/hos
 	e_cost = 1000
-g
 /obj/item/ammo_casing/energy/disabler/scatter	//WS edit, scatter repathing
 	pellets = 3
 	variance = 15


### PR DESCRIPTION
## About The Pull Request

Doubles the energy cost of disabler + laser so it has 10 shots on a normal cell 20 shots on an upgraded shell (its base)

Also increased the energy cost of its ion so you can only do it twice on a normal four times on an upgraded

Also adds it to Holster

## Why It's Good For The Game

Gun is too good to map onto roundstart ships

## Changelog

:cl:
balance: Nerfed energy cost of Yari projectiles
fix: Yari can now fit in either belt or shoulder holster
/:cl:
