### PR TITLE
fixes a test failure caused by a window in Reebe falling into the void

### DIFF
--- a/_maps/RandomRuins/ReebeRuins/reebe_arena.dmm
+++ b/_maps/RandomRuins/ReebeRuins/reebe_arena.dmm
@@ -140,11 +140,6 @@
 /obj/structure/grille,
 /turf/open/floor/bronze,
 /area/ruin/reebe)
-"HX" = (
-/obj/structure/grille,
-/obj/structure/window/bronze/fulltile,
-/turf/template_noop,
-/area/ruin/reebe)
 "Ib" = (
 /obj/structure/table/bronze,
 /obj/item/storage/firstaid/regular,
@@ -333,7 +328,7 @@ pm
 pm
 pm
 De
-HX
+De
 IC
 IC
 IC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah, we still have reebe ig

anyways a window in the arena ruin was constantly falling into the void and this was causing test failures, so i have taken the hole in the floor causing that problem out back
## Why It's Good For The Game

fix good test failure bad
## Changelog

:cl:
fix: A window in Reebe's arena no longer falls into the void every time it gets spawned, preventing random test failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
