### PR TITLE
Further increases loadout item slots from 20 to 30

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -131,7 +131,7 @@
 	value_mode = VALUE_MODE_FLAG
 
 /datum/config_entry/number/max_loadout_items	//maximum number of items that can be in a player's loadout
-	config_entry_value = 20
+	config_entry_value = 30
 	min_val = 0
 
 /datum/config_entry/flag/no_summon_guns	//No

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -421,7 +421,7 @@ ROUNDSTART_RACES elzuose
 #ROUNDSTART_NO_HARD_CHECK felinid
 
 ## The amount of loadout items players are allowed to spawn with. Default 10
-MAX_LOADOUT_ITEMS 20
+MAX_LOADOUT_ITEMS 30
 
 ## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
 OVERFLOW_CAP -1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the number of loadout item slots that you can take from 20 to 30.

## Why It's Good For The Game

Having more loadout slots can allow a player to have greater diversity in clothing and fluff for more character expression. Personally, many of my characters have a wide diversity of outfits, but I've noticed that 20 slots wasn't enough to portray more than two or three of them at a time. 30 slots should round it out comfortably.
 
## Changelog

:cl:
balance: increases loadout item slots from 20 to 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
