### PR TITLE
Update CentCom.dmm to fix fix floating wallmounts and door orientations

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10133,10 +10133,6 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "jdR" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Shuttle";
-	req_access_txt = "106"
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
@@ -10145,6 +10141,7 @@
 	req_access_txt = "106";
 	dir = 4
 	},
+/turf/open/space/basic,
 /area/centcom/supply)
 "jdX" = (
 /obj/structure/chair{
@@ -56919,7 +56916,7 @@ aaa
 aiX
 fhE
 vyn
-aiX
+aiF
 jdR
 fac
 aiX
@@ -57176,7 +57173,7 @@ aaa
 ajb
 eGQ
 hql
-aiX
+aiF
 hql
 hfh
 ajb
@@ -57433,7 +57430,7 @@ aiX
 aiX
 ncR
 vyn
-aiX
+aiF
 vyn
 ojp
 aiX
@@ -66711,9 +66708,9 @@ ayq
 heO
 dUw
 dUw
-mju
-eVQ
-nSC
+dUw
+dUw
+dUw
 dUw
 gwJ
 bsB
@@ -66968,9 +66965,9 @@ ayq
 heO
 dUw
 dUw
-pDu
-cEu
-cCA
+dUw
+dUw
+dUw
 dUw
 gwJ
 bsB
@@ -67225,9 +67222,9 @@ ayq
 heO
 dUw
 dUw
-axq
-fBo
-oLM
+mju
+eVQ
+nSC
 dUw
 gwJ
 bsB
@@ -67482,9 +67479,9 @@ ayq
 heO
 dUw
 dUw
-dUw
-dUw
-dUw
+pDu
+cEu
+cCA
 dUw
 gwJ
 bsB
@@ -67739,9 +67736,9 @@ ayq
 heO
 dUw
 dUw
-vcZ
-eaU
-lVd
+axq
+fBo
+oLM
 dUw
 gwJ
 bsB
@@ -67996,9 +67993,9 @@ ayq
 heO
 dUw
 dUw
-cmE
-xKw
-gJY
+dUw
+dUw
+dUw
 dUw
 gwJ
 bsB
@@ -68253,9 +68250,9 @@ ayq
 heO
 dUw
 dUw
-pxL
-jsM
-aVT
+vcZ
+eaU
+lVd
 dUw
 gwJ
 bsB
@@ -68510,9 +68507,9 @@ ayq
 heO
 dUw
 dUw
-dUw
-dUw
-dUw
+cmE
+xKw
+gJY
 dUw
 gwJ
 bsB
@@ -68767,9 +68764,9 @@ ayq
 heO
 dUw
 dUw
-mju
-eVQ
-nSC
+pxL
+jsM
+aVT
 dUw
 gwJ
 bsB
@@ -69024,9 +69021,9 @@ ayq
 heO
 dUw
 dUw
-pDu
-cEu
-cCA
+dUw
+dUw
+dUw
 dUw
 gwJ
 bsB
@@ -69281,9 +69278,9 @@ ayq
 heO
 dUw
 dUw
-axq
-fBo
-oLM
+dUw
+dUw
+dUw
 dUw
 gwJ
 bsB

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13123,16 +13123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
-"oGl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
 "oGF" = (
 /obj/structure/table/reinforced,
 /obj/item/cartridge/quartermaster{
@@ -63349,7 +63339,7 @@ aiu
 aiu
 aim
 aiu
-oGl
+uRk
 aiu
 aiu
 uqL
@@ -64377,7 +64367,7 @@ aiu
 aiu
 aim
 aiu
-oGl
+uRk
 aiu
 aiu
 uqL

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3,7 +3,7 @@
 /turf/open/space/basic,
 /area/space)
 "aab" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/space)
 "aad" = (
 /turf/open/space,
@@ -40,14 +40,16 @@
 "afC" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
-	name = "General Supply"
+	name = "General Supply";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena_source)
 "afD" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
-	name = "Thunderdome Blast Door"
+	name = "Thunderdome Blast Door";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
@@ -86,14 +88,14 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "afX" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/start)
 "afY" = (
 /obj/effect/landmark/start/new_player,
 /turf/open/floor/plating,
 /area/start)
 "afZ" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/ctf)
 "agb" = (
 /obj/structure/chair/comfy/grey/directional/east,
@@ -227,22 +229,22 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "ail" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/prison)
 "aim" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "ain" = (
 /obj/structure/sign/warra,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "aio" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "aip" = (
 /obj/machinery/status_display/ai,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "air" = (
 /turf/closed/indestructible/fakeglass,
@@ -253,11 +255,12 @@
 /area/centcom/control)
 "aiB" = (
 /turf/closed/indestructible/fakedoor{
-	name = "CentCom Cell"
+	name = "CentCom Cell";
+	dir = 4
 	},
 /area/centcom/prison)
 "aiF" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/supply)
 "aiG" = (
 /turf/closed/indestructible/fakedoor{
@@ -266,15 +269,15 @@
 /area/centcom/supply)
 "aiH" = (
 /obj/structure/sign/warra,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/prison)
 "aiI" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/prison)
 "aiN" = (
 /obj/machinery/status_display,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/supply)
 "aiS" = (
 /obj/effect/turf_decal/industrial/hatch/yellow,
@@ -305,7 +308,7 @@
 /area/space)
 "ajE" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/supply)
 "ajO" = (
 /obj/machinery/vending/cola,
@@ -313,7 +316,8 @@
 /area/centcom/supplypod)
 "ajR" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Backstage"
+	name = "Thunderdome Backstage";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -416,7 +420,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
 "akB" = (
-/obj/machinery/door/poddoor/shuttledock,
+/obj/machinery/door/poddoor/shuttledock{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
@@ -774,15 +780,15 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
 "amD" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "amE" = (
 /obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "amF" = (
 /obj/machinery/status_display/ai,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/supply)
 "amQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -833,7 +839,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "anj" = (
 /obj/structure/toilet{
@@ -879,7 +885,7 @@
 /area/syndicate_mothership/control)
 "anA" = (
 /obj/structure/sign/warning/nosmoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "anB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -913,11 +919,11 @@
 /area/centcom/ferry)
 "anT" = (
 /obj/machinery/status_display/ai,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "anU" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "aoe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1207,7 +1213,7 @@
 	},
 /area/centcom/control)
 "aqx" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/evac)
 "aqy" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -1290,7 +1296,7 @@
 /area/syndicate_mothership/control)
 "aqR" = (
 /obj/structure/sign/warra,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "aqU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -1366,7 +1372,7 @@
 /area/centcom/ferry)
 "arz" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "arF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -1427,7 +1433,7 @@
 /area/centcom/ferry)
 "arS" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/evac)
 "arT" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -1514,7 +1520,7 @@
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "asx" = (
@@ -1592,7 +1598,7 @@
 /area/centcom/ferry)
 "atd" = (
 /obj/structure/sign/departments/drop,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/ferry)
 "atg" = (
 /turf/closed/indestructible/rock/snow,
@@ -1634,7 +1640,7 @@
 /area/centcom/ferry)
 "atP" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "atQ" = (
 /obj/structure/sign/map/left{
@@ -1648,7 +1654,7 @@
 /area/syndicate_mothership/control)
 "atR" = (
 /obj/machinery/status_display/ai,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/evac)
 "atX" = (
 /obj/machinery/door/airlock{
@@ -1746,7 +1752,8 @@
 /area/centcom/evac)
 "auJ" = (
 /obj/machinery/door/airlock/external{
-	req_access_txt = "150"
+	req_access_txt = "150";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
@@ -1811,7 +1818,7 @@
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "avh" = (
@@ -1962,7 +1969,8 @@
 "awg" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
-	name = "General Supply"
+	name = "General Supply";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/loading{
 	dir = 8
@@ -2093,13 +2101,17 @@
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "axq" = (
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/top_right,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "axr" = (
@@ -2303,7 +2315,8 @@
 "ayS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom"
+	name = "CentCom";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -2536,7 +2549,8 @@
 "aAG" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
-	name = "Thunderdome Blast Door"
+	name = "Thunderdome Blast Door";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/loading{
 	dir = 8
@@ -2569,7 +2583,7 @@
 /area/centcom/ferry)
 "aAT" = (
 /obj/structure/sign/departments/medbay/alt,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/control)
 "aBe" = (
 /obj/machinery/computer/camera_advanced/abductor{
@@ -2653,7 +2667,9 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
 "aCb" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
@@ -2690,7 +2706,8 @@
 "aCW" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -2712,7 +2729,7 @@
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
 "aDi" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/ai_multicam_room)
 "aDl" = (
 /obj/structure/closet/syndicate/personal,
@@ -2723,7 +2740,8 @@
 /area/syndicate_mothership/control)
 "aDm" = (
 /obj/machinery/door/airlock/external{
-	name = "Ferry Airlock"
+	name = "Ferry Airlock";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -2759,7 +2777,8 @@
 "aDw" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -2877,7 +2896,7 @@
 /turf/open/floor/plasteel/white,
 /area/wizard_station)
 "aEp" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeobserve)
 "aEv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2920,7 +2939,7 @@
 /area/tdome/tdomeobserve)
 "aEK" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeobserve)
 "aET" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -3044,11 +3063,11 @@
 /area/tdome/tdomeobserve)
 "aGw" = (
 /obj/structure/sign/warning/nosmoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeobserve)
 "aGy" = (
 /obj/structure/sign/warra,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeobserve)
 "aGz" = (
 /obj/structure/shuttle/engine/heater{
@@ -3135,7 +3154,8 @@
 /area/centcom/ferry)
 "aHa" = (
 /obj/machinery/door/airlock/external{
-	name = "Ferry Airlock"
+	name = "Ferry Airlock";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -3167,7 +3187,8 @@
 "aHj" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
-	name = "General Supply"
+	name = "General Supply";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/loading{
 	dir = 4
@@ -3257,7 +3278,7 @@
 /turf/open/floor/plasteel,
 /area/tdome/arena)
 "aIv" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeadmin)
 "aIw" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -3445,7 +3466,8 @@
 /area/centcom/evac)
 "aKg" = (
 /turf/closed/indestructible/fakedoor{
-	name = "Thunderdome Admin"
+	name = "Thunderdome Admin";
+	dir = 4
 	},
 /area/tdome/tdomeadmin)
 "aKk" = (
@@ -3488,11 +3510,11 @@
 /area/tdome/tdomeadmin)
 "aKC" = (
 /obj/machinery/status_display/evac,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeadmin)
 "aKD" = (
 /obj/machinery/status_display/ai,
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/tdome/tdomeadmin)
 "aKE" = (
 /obj/machinery/sleeper{
@@ -3918,7 +3940,8 @@
 "aMH" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCsec1";
-	name = "XCC Checkpoint 1 Shutters"
+	name = "XCC Checkpoint 1 Shutters";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4014,7 +4037,8 @@
 "aNz" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Customs";
-	req_access_txt = "109"
+	req_access_txt = "109";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4185,7 +4209,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "aOC" = (
-/obj/machinery/door/poddoor/ert,
+/obj/machinery/door/poddoor/ert{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4360,7 +4386,8 @@
 "aPw" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4405,7 +4432,8 @@
 "aPJ" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
-	name = "Thunderdome Blast Door"
+	name = "Thunderdome Blast Door";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/loading{
 	dir = 4
@@ -4452,7 +4480,8 @@
 /area/centcom/holding)
 "aQa" = (
 /obj/machinery/door/airlock/external{
-	name = "Backup Emergency Escape Shuttle"
+	name = "Backup Emergency Escape Shuttle";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
@@ -4711,13 +4740,14 @@
 	pixel_x = -4
 	},
 /obj/effect/turf_decal/industrial/warning,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "aRB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4778,7 +4808,8 @@
 "aRY" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCcustoms1";
-	name = "XCC Customs 1 Shutters"
+	name = "XCC Customs 1 Shutters";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4829,7 +4860,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
-	req_access_txt = "102"
+	req_access_txt = "102";
+	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -4897,7 +4929,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "aTb" = (
@@ -5095,7 +5127,8 @@
 "aUy" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supply";
-	req_access_txt = "106"
+	req_access_txt = "106";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5177,7 +5210,8 @@
 "aUU" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5297,10 +5331,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"aVT" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/bottom_right,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "aVU" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCcustoms2";
-	name = "XCC Customs 2 Shutters"
+	name = "XCC Customs 2 Shutters";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5356,8 +5405,8 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 5
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/firealarm/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "aWy" = (
@@ -5413,7 +5462,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "aXa" = (
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "aXb" = (
@@ -5479,7 +5528,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5561,7 +5611,8 @@
 "aXX" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCFerry";
-	name = "XCC Ferry Hangar"
+	name = "XCC Ferry Hangar";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/loading{
 	dir = 4
@@ -5573,7 +5624,9 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "aYc" = (
-/obj/machinery/door/poddoor/ert,
+/obj/machinery/door/poddoor/ert{
+	dir = 4
+	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
@@ -5597,7 +5650,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "aYn" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/centcom/supplypod)
 "aYo" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -5622,7 +5675,8 @@
 "aYz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom"
+	name = "CentCom";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5744,7 +5798,8 @@
 "aZf" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Storage";
-	req_access_txt = "106"
+	req_access_txt = "106";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5772,7 +5827,8 @@
 "aZp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom"
+	name = "CentCom";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5821,7 +5877,8 @@
 "aZB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5848,7 +5905,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
@@ -5897,7 +5955,9 @@
 /obj/machinery/door/airlock/vault{
 	req_access_txt = "109"
 	},
-/obj/machinery/door/poddoor/shutters/indestructible,
+/obj/machinery/door/poddoor/shutters/indestructible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "aZU" = (
@@ -5917,7 +5977,8 @@
 "bad" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "nukeop_ready";
-	name = "Shuttle Dock"
+	name = "Shuttle Dock";
+	dir = 4
 	},
 /turf/closed/indestructible/plastitanium/nodiagnonal,
 /area/syndicate_mothership/control)
@@ -5987,7 +6048,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "beI" = (
@@ -6092,6 +6153,22 @@
 /obj/structure/speaking_tile,
 /turf/closed/mineral/random/waterplanet,
 /area/errorroom)
+"bsB" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half,
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/centcom/evac)
 "bsD" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -6136,19 +6213,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"bww" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"bxf" = (
-/obj/effect/turf_decal/corner/opaque/blue,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "byE" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/glass/fifty,
@@ -6384,6 +6448,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"bYo" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half,
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/centcom/evac)
 "cdq" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 6
@@ -6499,9 +6582,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/north{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -6514,6 +6595,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"cmE" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/top,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "cnW" = (
 /obj/effect/turf_decal/corner/opaque/green/diagonal{
 	dir = 4
@@ -6554,7 +6649,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "crJ" = (
@@ -6695,6 +6790,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom)
+"cCA" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/bottom,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "cCK" = (
 /obj/machinery/telecomms/relay/preset/syndicate{
 	autolinkers = list("relay")
@@ -6748,6 +6857,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"cEu" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/center,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "cEL" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -6818,7 +6941,8 @@
 "cUm" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Restroom";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	dir = 4
 	},
 /obj/effect/turf_decal/corner/transparent/bar,
 /obj/effect/turf_decal/corner/transparent/bar{
@@ -7068,15 +7192,9 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"duv" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "duw" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old";
@@ -7147,7 +7265,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "dGh" = (
@@ -7174,7 +7292,7 @@
 /obj/effect/turf_decal/corner/opaque/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
 "dJP" = (
@@ -7252,13 +7370,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"dPZ" = (
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "dQR" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
@@ -7349,6 +7460,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"eaU" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/center_left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "ebb" = (
 /obj/structure/chair/comfy/orange/directional/north{
 	color = "#66b266"
@@ -7471,9 +7596,7 @@
 /area/tdome/tdomeobserve)
 "eii" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/newscaster/directional/north{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -7619,7 +7742,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "eub" = (
@@ -7928,6 +8051,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"eVQ" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/center_left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "eWo" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -7989,10 +8126,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/ctf)
+"eZT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
 "fac" = (
 /obj/machinery/door/poddoor{
 	id = "XCCQMLoaddoor";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8009,6 +8158,24 @@
 	icon_state = "platingdmg1"
 	},
 /area/centcom)
+"fbP" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/centcom/evac)
 "fda" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -8037,7 +8204,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "ffT" = (
@@ -8050,7 +8217,8 @@
 "fhE" = (
 /obj/machinery/door/poddoor{
 	id = "XCCQMLoaddoor2";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning/cee{
 	dir = 8
@@ -8256,8 +8424,12 @@
 	},
 /obj/effect/turf_decal/corner/transparent/neutral,
 /obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/warra/ns/center_right,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "fCj" = (
@@ -8388,6 +8560,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"fRl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
 "fRH" = (
 /obj/effect/turf_decal/corner/opaque/red,
 /obj/effect/turf_decal/corner/opaque/red{
@@ -8670,6 +8856,21 @@
 /obj/machinery/fax/admin,
 /turf/open/floor/plasteel/white,
 /area/centcom)
+"gwJ" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/centcom/evac)
 "gza" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/corner/opaque/red{
@@ -8698,7 +8899,7 @@
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "gDP" = (
@@ -8758,16 +8959,17 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "gJY" = (
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/warra/modern_big/bottom_center,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "gLF" = (
@@ -8928,7 +9130,7 @@
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "hbh" = (
@@ -8977,6 +9179,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"heO" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "hfh" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -9082,9 +9300,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"hzJ" = (
-/turf/closed/indestructible/riveted,
-/area/centcom)
 "hzR" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -9343,7 +9558,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supply)
 "ibc" = (
@@ -9511,7 +9726,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "inF" = (
@@ -9893,9 +10108,7 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "jcR" = (
-/obj/machinery/newscaster/directional/north{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
@@ -9926,7 +10139,11 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/airlock/external{
+	name = "Supply Shuttle";
+	req_access_txt = "106";
+	dir = 4
+	},
 /area/centcom/supply)
 "jdX" = (
 /obj/structure/chair{
@@ -10093,6 +10310,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"jsM" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/center_right,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "jvy" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/corner/transparent/neutral{
@@ -10457,7 +10688,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "keq" = (
@@ -10555,7 +10786,7 @@
 /obj/effect/turf_decal/corner/opaque/blue{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
 "kjG" = (
@@ -10620,6 +10851,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"krZ" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "kuk" = (
 /obj/item/storage/briefcase{
 	pixel_x = -3;
@@ -10674,7 +10924,7 @@
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "kAx" = (
@@ -10693,6 +10943,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"kCJ" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supplypod Loading";
+	req_access_txt = "106";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/supplypod)
 "kDv" = (
 /obj/machinery/telecomms/relay/preset/pgf,
 /obj/effect/turf_decal/spline/fancy/opaque/lime{
@@ -10978,7 +11236,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "lkr" = (
@@ -11131,7 +11389,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "lwW" = (
@@ -11231,7 +11489,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
 "lEZ" = (
@@ -11295,7 +11553,8 @@
 "lIA" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	req_access_txt = "109"
+	req_access_txt = "109";
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11385,15 +11644,17 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "lVd" = (
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/warra/modern_big/bottom_left,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "lWJ" = (
@@ -11600,6 +11861,20 @@
 	},
 /turf/open/floor/circuit,
 /area/ctf)
+"mju" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/top_left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "mkN" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -11915,13 +12190,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"mKO" = (
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "mKS" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
@@ -11953,6 +12221,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
+"mNG" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "mPb" = (
 /obj/effect/turf_decal/corner/opaque/red{
 	dir = 8
@@ -12004,7 +12288,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "mVC" = (
@@ -12055,7 +12339,8 @@
 "ncR" = (
 /obj/machinery/door/poddoor{
 	id = "XCCQMLoaddoor2";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/machinery/conveyor{
@@ -12101,7 +12386,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "ngI" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/indestructible/reinforced,
 /area/errorroom)
 "ngV" = (
 /obj/structure/table/reinforced,
@@ -12258,22 +12543,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
-"nDB" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "nEw" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/lighter,
-/obj/machinery/newscaster/directional/north{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -12389,6 +12663,20 @@
 /obj/structure/sign/syndicate,
 /turf/closed/indestructible/plastitanium/nodiagnonal,
 /area/centcom)
+"nSC" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/bottom_left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "nTW" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -12613,7 +12901,8 @@
 "ojp" = (
 /obj/machinery/door/poddoor{
 	id = "XCCQMLoaddoor";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	dir = 8;
@@ -12796,7 +13085,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "oEZ" = (
@@ -12923,6 +13212,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"oLM" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/bottom_right,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "oOf" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -13005,7 +13308,8 @@
 "oSc" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCsecdepartment";
-	name = "XCC Security Checkpoint Shutters"
+	name = "XCC Security Checkpoint Shutters";
+	dir = 4
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
@@ -13114,16 +13418,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"piY" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "pjR" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13260,6 +13554,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"ptZ" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "pua" = (
 /obj/item/storage/box/ids{
 	pixel_x = 3;
@@ -13337,13 +13647,17 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "pxL" = (
-/obj/effect/turf_decal/corner/opaque/blue,
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/blue{
+/obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/warra/modern_big/corner_right,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "pxX" = (
@@ -13413,6 +13727,20 @@
 /obj/item/food/fishmeat/carp,
 /turf/open/floor/plasteel,
 /area/centcom/holding)
+"pDu" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/ns/top,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "pDx" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/drinks,
@@ -13521,7 +13849,7 @@
 /obj/item/clothing/gloves/fingerless,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/eyepatch,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "pIO" = (
@@ -13669,7 +13997,9 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "pTM" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -13705,7 +14035,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "pWB" = (
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -13788,7 +14118,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -13816,7 +14146,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "qnU" = (
@@ -13825,6 +14155,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"qot" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/centcom/evac)
 "qoL" = (
 /turf/open/floor/wood/mahogany,
 /area/centcom)
@@ -13919,6 +14267,25 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qID" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half,
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
 /area/centcom/evac)
 "qJX" = (
 /obj/effect/turf_decal/corner/transparent/bar,
@@ -14245,6 +14612,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"riW" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/warrablue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "rja" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/corner/transparent/neutral{
@@ -14291,7 +14677,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "rjV" = (
@@ -14633,7 +15019,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -14915,7 +15301,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "sFM" = (
@@ -14946,7 +15332,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "sJA" = (
@@ -15024,6 +15410,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"sNc" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office";
+	req_access_txt = "109";
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "sOR" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -15214,7 +15609,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "tgw" = (
@@ -15287,9 +15682,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/lighter,
-/obj/machinery/newscaster/directional/north{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -15397,6 +15790,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"tzE" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "tAe" = (
 /obj/structure/chair{
 	dir = 1
@@ -15534,12 +15933,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"tNs" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "tOf" = (
 /obj/effect/turf_decal/solgov/wood/center,
 /obj/machinery/light/floor,
@@ -15864,12 +16257,6 @@
 "uBd" = (
 /turf/closed/indestructible/plastitanium/nodiagnonal,
 /area/centcom)
-"uEa" = (
-/obj/effect/turf_decal/corner/opaque/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "uFk" = (
 /obj/effect/turf_decal/corner/opaque/green,
 /turf/open/floor/plasteel,
@@ -16004,6 +16391,17 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom)
+"uRk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
 "uRu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -16106,6 +16504,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"vcZ" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/corner_left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "veT" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/corner/transparent/bar,
@@ -16273,7 +16685,7 @@
 /area/tdome/tdomeobserve)
 "vqb" = (
 /obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -16284,7 +16696,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supply)
 "vtH" = (
@@ -16350,6 +16762,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"vyn" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Shuttle";
+	req_access_txt = "106";
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "vzF" = (
 /obj/effect/turf_decal/corner/opaque/green{
 	dir = 1
@@ -16529,16 +16952,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/centcom)
-"vZq" = (
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/transparent/neutral,
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "wad" = (
 /obj/effect/turf_decal/minutemen/corner,
 /obj/structure/chair/comfy{
@@ -16851,7 +17264,7 @@
 /area/centcom/control)
 "wJP" = (
 /obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
 	},
@@ -16862,7 +17275,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "wPO" = (
@@ -16994,9 +17407,6 @@
 /turf/open/floor/plasteel,
 /area/tdome/arena)
 "xjr" = (
-/obj/machinery/computer/auxillary_base{
-	pixel_y = 32
-	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/radio/headset/headset_cent,
@@ -17012,6 +17422,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"xoq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	req_access_txt = "102";
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
 "xox" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -17026,7 +17448,7 @@
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "xpf" = (
@@ -17141,6 +17563,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"xKw" = (
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/neutral,
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/warra/modern_big/center,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "xMY" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/corner/opaque/green{
@@ -26758,13 +27194,13 @@ aPu
 aPu
 aPu
 aaa
-hzJ
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
+aPu
 bbf
-hzJ
-hzJ
+aPu
+aPu
 aaa
 aaa
 aaa
@@ -27015,13 +27451,13 @@ njp
 psm
 aPu
 aaa
-hzJ
+aPu
 iMC
 moE
 qVq
 qVq
 wbr
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -27272,13 +27708,13 @@ jja
 eqM
 aPu
 aaa
-hzJ
+aPu
 dGh
 wad
 pTR
 gaU
 vFM
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -27529,13 +27965,13 @@ tOf
 unc
 iSo
 aaa
-hzJ
+aPu
 qap
 pvW
 iWI
 hBf
 rvC
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -27786,13 +28222,13 @@ xTt
 pLM
 aPu
 aaa
-hzJ
+aPu
 qVq
 tGR
 kiC
 bUH
 rIP
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -28043,13 +28479,13 @@ oaQ
 gsx
 aPu
 aaa
-hzJ
+aPu
 bpl
 qVq
 qVq
 aIF
 slo
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -28300,13 +28736,13 @@ aPu
 aPu
 aPu
 aaa
-hzJ
-hzJ
-hzJ
-hzJ
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
+aPu
+aPu
+aPu
+aPu
 aaa
 aaa
 aaa
@@ -28814,13 +29250,13 @@ uBd
 uBd
 uBd
 aaa
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
 mpi
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
 aaa
 aaa
 aaa
@@ -29071,13 +29507,13 @@ fKt
 iZr
 nNb
 aaa
-hzJ
+aPu
 mJP
 lmY
 tUy
 sMn
 kFX
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -29328,13 +29764,13 @@ kXn
 msQ
 uBd
 aaa
-hzJ
+aPu
 lHR
 rmj
 weV
 lXI
 tAe
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -29585,13 +30021,13 @@ uOa
 jFa
 uBd
 aaa
-hzJ
+aPu
 jDt
 ibc
 eWz
 lXQ
 duw
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -29842,13 +30278,13 @@ uuY
 jly
 uBd
 aaa
-hzJ
+aPu
 iRP
 fau
 gDV
 iti
 unP
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -30099,13 +30535,13 @@ bFc
 iZr
 nNb
 aaa
-hzJ
+aPu
 mDT
 ttK
 nos
 cZi
 pvN
-hzJ
+aPu
 aaa
 aaa
 aaa
@@ -30356,13 +30792,13 @@ uBd
 uBd
 uBd
 aaa
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
 eLy
-hzJ
-hzJ
-hzJ
+aPu
+aPu
+aPu
 aaa
 aaa
 aaa
@@ -42909,7 +43345,7 @@ aWO
 aWO
 aWO
 aWO
-aXL
+tzE
 aWO
 aWO
 apy
@@ -44192,7 +44628,7 @@ aaa
 aaa
 aWO
 aWO
-aXL
+tzE
 aWO
 aWO
 aWO
@@ -56491,7 +56927,7 @@ aaa
 aaa
 aiX
 fhE
-jdR
+vyn
 aiX
 jdR
 fac
@@ -57005,9 +57441,9 @@ aiN
 aiX
 aiX
 ncR
-jdR
+vyn
 aiX
-jdR
+vyn
 ojp
 aiX
 aiX
@@ -58317,9 +58753,9 @@ amD
 amD
 amD
 amD
-aXw
+fRl
 axh
-aXw
+fRl
 amD
 anT
 arz
@@ -58559,7 +58995,7 @@ aXz
 ajE
 aiF
 aiF
-lAs
+sNc
 aiF
 aiN
 mBc
@@ -62727,7 +63163,7 @@ aIv
 aIv
 aIv
 aIv
-aSA
+xoq
 aIv
 aIv
 aaa
@@ -62921,14 +63357,14 @@ aqg
 lMB
 aiu
 aiu
-oGl
+uRk
 aiu
 aim
 aiu
 aiu
 aio
 aiu
-oGl
+eZT
 aiu
 aiu
 aiu
@@ -63949,14 +64385,14 @@ aqg
 lMB
 aiu
 aiu
-oGl
+uRk
 aiu
 aim
 aiu
 aiu
 aio
 aiu
-oGl
+uRk
 aiu
 aiu
 aiu
@@ -64729,9 +65165,9 @@ ail
 ain
 aim
 aiu
-oGl
+uRk
 amk
-oGl
+uRk
 aiu
 aio
 aio
@@ -65528,7 +65964,7 @@ aqx
 aCW
 aqx
 aYn
-asZ
+kCJ
 aYn
 aEp
 aEp
@@ -66024,15 +66460,15 @@ aqy
 aqx
 aQm
 ayq
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
+riW
+mNG
+mNG
+mNG
+mNG
+mNG
+mNG
+qot
+qID
 avh
 aRt
 aqx
@@ -66262,18 +66698,18 @@ aaa
 aaa
 aio
 aio
-oGl
+uRk
 aio
 aio
 aio
-oGl
+uRk
 aio
 aio
 aio
 aio
 ain
-oGl
-oGl
+uRk
+uRk
 ain
 aio
 aqA
@@ -66281,15 +66717,15 @@ aqy
 aqV
 auI
 ayq
-dUw
-bxf
-fBo
+heO
 dUw
 dUw
+mju
+eVQ
+nSC
 dUw
-dUw
-dUw
-dUw
+gwJ
+bsB
 avh
 aYg
 aqV
@@ -66300,8 +66736,8 @@ cWZ
 aYn
 aYn
 aYn
-asZ
-asZ
+kCJ
+kCJ
 aYn
 aYn
 aYn
@@ -66538,15 +66974,15 @@ aqz
 arS
 xEx
 ayq
-dUw
-dPZ
-axq
-fBo
+heO
 dUw
 dUw
+pDu
+cEu
+cCA
 dUw
-dUw
-dUw
+gwJ
+bsB
 avh
 aKM
 arS
@@ -66795,15 +67231,15 @@ aqz
 aqx
 xEx
 ayq
+heO
 dUw
-dPZ
-gJY
+dUw
 axq
 fBo
+oLM
 dUw
-dUw
-dUw
-dUw
+gwJ
+bsB
 avh
 aKM
 aqx
@@ -67052,15 +67488,15 @@ aqV
 aqx
 wSS
 ayq
+heO
 dUw
-bxf
-mKO
-mKO
-mKO
-mKO
-mKO
-tNs
 dUw
+dUw
+dUw
+dUw
+dUw
+gwJ
+bsB
 avh
 aLU
 aqx
@@ -67309,15 +67745,15 @@ aqW
 arT
 aQm
 ayq
+heO
 dUw
-uEa
-gJY
-gJY
-gJY
+dUw
+vcZ
+eaU
 lVd
-nDB
-duv
 dUw
+gwJ
+bsB
 avh
 aRt
 auX
@@ -67566,15 +68002,15 @@ aqX
 arU
 aQm
 ayq
+heO
 dUw
-avh
-uEa
-gJY
-gJY
-gJY
-tNs
-avh
 dUw
+cmE
+xKw
+gJY
+dUw
+gwJ
+bsB
 avh
 aNd
 aWR
@@ -67823,15 +68259,15 @@ aqY
 arV
 aQm
 ayq
+heO
 dUw
-bxf
-mKO
+dUw
 pxL
-gJY
-gJY
-gJY
-tNs
+jsM
+aVT
 dUw
+gwJ
+bsB
 avh
 aRt
 aQK
@@ -68080,15 +68516,15 @@ aqV
 aqx
 wSS
 ayq
+heO
 dUw
-uEa
-nDB
-nDB
-nDB
-nDB
-nDB
-duv
 dUw
+dUw
+dUw
+dUw
+dUw
+gwJ
+bsB
 avh
 aLU
 aqx
@@ -68337,15 +68773,15 @@ aqy
 aqx
 xEx
 ayq
+heO
 dUw
 dUw
+mju
+eVQ
+nSC
 dUw
-dUw
-vZq
-piY
-gJY
-bww
-dUw
+gwJ
+bsB
 avh
 aKM
 aqx
@@ -68594,15 +69030,15 @@ aqz
 arS
 xEx
 ayq
+heO
 dUw
 dUw
+pDu
+cEu
+cCA
 dUw
-dUw
-dUw
-vZq
-piY
-bww
-dUw
+gwJ
+bsB
 avh
 aKM
 arS
@@ -68851,15 +69287,15 @@ aqy
 aqV
 uzX
 ayq
+heO
 dUw
 dUw
+axq
+fBo
+oLM
 dUw
-dUw
-dUw
-dUw
-vZq
-duv
-dUw
+gwJ
+bsB
 avh
 aMF
 aqV
@@ -69108,15 +69544,15 @@ aqy
 aqx
 aQm
 ayq
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
-dUw
+krZ
+ptZ
+ptZ
+ptZ
+ptZ
+ptZ
+ptZ
+fbP
+bYo
 avh
 aRt
 aqx

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1165,7 +1165,8 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -23;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
@@ -2464,7 +2465,8 @@
 "aAo" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -23;
+	dir = 1
 	},
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 1
@@ -5147,7 +5149,7 @@
 "aUJ" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch{
-	dir = 4;
+	dir = 8;
 	pixel_x = 23
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5603,7 +5605,7 @@
 /area/centcom/supplypod)
 "aXW" = (
 /obj/machinery/light_switch{
-	dir = 8;
+	dir = 4;
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5840,7 +5842,6 @@
 /area/centcom/control)
 "aZr" = (
 /obj/machinery/light_switch{
-	dir = 1;
 	pixel_y = 23
 	},
 /turf/open/floor/wood,


### PR DESCRIPTION
## About The Pull Request

Updates the Centcom Z-level to fix door and wallmount orientations. Every single time I saw them it really, really annoyed me even if CC is mostly antiquated. Also changes the walling to modern anywalls (indestructible still).

<img width="3008" height="2720" alt="image" src="https://github.com/user-attachments/assets/9b90ebf4-fc15-415d-a06a-7473f544d03d" />


## Why It's Good For The Game

It makes an outdated debug z-level look a little nicer and for anyone watching gives off a better impression. Even if it's later replaced, the misaligned doors and walls REALLY bother me and I doubt i'm the only one.

## Changelog

:cl:
fix: Orientations of doors and wallmounts on CentCom.
fix: Replaces outdated indestructible walls with Anywalls (they're still indestructible.)
/:cl: