### PR TITLE
Himehabu is no longer less accurate when wielded

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -385,6 +385,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake/inteq)
 		)
 	)
 
+	spread = -2
 	recoil = -2
 	recoil_unwielded = -2
 	spread_unwielded = 0


### PR DESCRIPTION
## About The Pull Request

Used to suddenly become less accurate when you held it in two hands

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
fix: Himehabu is no longer less accurate when wielded
/:cl: