### PR TITLE
Corrects autolathe button label for Illestren clips

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1207,7 +1207,7 @@
 	category = list("initial", "Machinery")
 
 /datum/design/illestren_a850rclip
-	name = "8x50 Stripper Clip"
+	name = "8x50mmR En Bloc Clip"
 	id = "IllestrenStripClip"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 1000)


### PR DESCRIPTION
## About The Pull Request
Autolathe button to print an 8x50mmR en bloc clip for the Illestren is mislabelled as a "stripper clip" despite an actual stripper clip for a different weapon also being printable, with nearly the same label. This fixes it.

<img width="532" height="600" alt="enblocfix" src="https://github.com/user-attachments/assets/5f07d407-b1a3-4151-8aee-7e62992a7470" />


## Why It's Good For The Game

En bloc clips are not stripper clips. Clears up confusion.

## Changelog

:cl:
fix: illestren en bloc clips in the autolathe are now correctly labelled
/:cl: