### PR TITLE
Removes Hunter's Pride engraving from the improvised shotgun

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -155,6 +155,7 @@ NO_MAG_GUN_HELPER(shotgun/automatic/bulldog/inteq)
 	)
 	sawn_desc = "I'm just here for the gasoline."
 	unique_reskin = null
+	manufacturer = MANUFACTURER_NONE
 	var/slung = FALSE
 
 	gun_firemodes = list(FIREMODE_SEMIAUTO)


### PR DESCRIPTION
## About The Pull Request

Removes the HP engraving from the pipe shotgun.

## Why It's Good For The Game

They did not make this gun. You, or some other bum, did.

## Changelog

:cl: Bumtickley00
spellcheck: Improvised shotgun no longer has a Hunter's Pride engraving.
/:cl: