### PR TITLE
Camera network refactor

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -19,7 +19,7 @@
 	integrity_failure = 0.5
 	var/default_camera_icon = "camera" //the camera's base icon used by update_appearance - icon_state is primarily used for mapping display purposes.
 	var/list/network = list("ship")
-	var/mapload_network
+	var/mapload_network = "ship"
 	var/c_tag = null
 	var/status = TRUE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -19,6 +19,7 @@
 	integrity_failure = 0.5
 	var/default_camera_icon = "camera" //the camera's base icon used by update_appearance - icon_state is primarily used for mapping display purposes.
 	var/list/network = list("ship")
+	var/mapload_network
 	var/c_tag = null
 	var/status = TRUE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start
@@ -61,6 +62,7 @@
 
 /obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
+	network[1] = mapload_network
 	for(var/i in network)
 		network -= i
 		network += lowertext(i)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -18,7 +18,7 @@
 	max_integrity = 100
 	integrity_failure = 0.5
 	var/default_camera_icon = "camera" //the camera's base icon used by update_appearance - icon_state is primarily used for mapping display purposes.
-	var/list/network = list("ss13")
+	var/list/network = list("ship")
 	var/c_tag = null
 	var/status = TRUE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -6,7 +6,8 @@
 	circuit = /obj/item/circuitboard/computer/security
 	light_color = COLOR_SOFT_RED
 
-	var/list/network = list("ss13")
+	var/network = list("ship")
+	var/mapload_network = "ship"
 	var/temp_network = list("")
 	var/obj/machinery/camera/active_camera
 	/// The turf where the camera was last updated.
@@ -33,6 +34,8 @@
 
 /obj/machinery/computer/security/Initialize()
 	. = ..()
+	// Sets the console on mapload to the default network. Allows for resyncing back to the default.
+	network[1] = mapload_network
 	// Map name has to start and end with an A-Z character,
 	// and definitely NOT with a square bracket or even a number.
 	// I wasted 6 hours on this. :agony:
@@ -69,11 +72,19 @@
 		network -= i
 		network += "[REF(port)][i]"
 
+/obj/machinery/computer/security/proc/link_to_shuttle_network()
+	network[1] = mapload_network
+	var/area/ship/current_ship_area = get_area(src)
+	if(istype(current_ship_area) && current_ship_area.mobile_port)
+		var/obj/docking_port/mobile/port = current_ship_area.mobile_port
+		var/net_tag = network[1]
+		network[1] = "[REF(port)][net_tag]"
+
 /obj/machinery/computer/security/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
 	var/obj/item/multitool/M = I
 	if(M.buffer != null)
-		network = M.buffer
+		network[1] = M.buffer
 		to_chat(user, span_notice("You input network '[M.buffer]' from the multitool's buffer into [src]."))
 	return
 
@@ -106,7 +117,7 @@
 
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()
-	data["network"] = network
+	data["network"] = network[1]
 	data["activeCamera"] = null
 	if(active_camera)
 		if(istype(active_camera, /obj/machinery/camera))
@@ -163,8 +174,11 @@
 		return
 
 	if(action == "set_network")
-		network = temp_network
+		network[1] = temp_network
 		update_static_data_for_all_viewers()
+
+	if(action == "sync")
+		link_to_shuttle_network()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -179,6 +179,7 @@
 
 	if(action == "sync")
 		link_to_shuttle_network()
+		update_static_data_for_all_viewers()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -97,11 +97,11 @@
 /obj/item/bodycamera/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
 	var/obj/item/multitool/M = I
-	var/list/choice_list = list("Modify the camera tag", "Change the camera network", "Sync the network to the ship", "Save the network to the multitool buffer", "Transfer the buffered network to the camera")
+	var/list/choice_list = list("Modify the camera nametag", "Change the camera network", "Sync the network to the ship", "Save the network to the multitool buffer", "Transfer the buffered network to the camera")
 	var/choice = tgui_input_list(user, "Select an option", "Advanced Camera Configuration", choice_list)
 
 	switch(choice)
-		if("Modify the camera tag")
+		if("Modify the camera nametag")
 			c_tag_addition = stripped_input(user, "Set a nametag for this camera. Ensure that it is no bigger than 32 characters long.", "Nametag Setup", max_length = 32)
 			set_name(c_tag_addition)
 			to_chat(user, span_notice("You set [src] nametag to '[c_tag]'."))
@@ -133,11 +133,11 @@
 	if(broadcast_camera)
 		return
 
-	var/list/choice_list = list("Modify the camera tag", "Sync the network to the ship", "Change the camera network directly")
+	var/list/choice_list = list("Modify the camera nametag", "Sync the network to the ship", "Change the camera network directly")
 	var/choice = tgui_input_list(user, "Select an option", "Camera Configuration", choice_list)
 
 	switch(choice)
-		if("Modify the camera tag")
+		if("Modify the camera nametag")
 			c_tag_addition = stripped_input(user, "Set a nametag for this camera. Ensure that it is no bigger than 32 characters long.", "Nametag Setup", max_length = 32)
 			set_name(c_tag_addition)
 			to_chat(user, span_notice("You set [src] nametag to '[c_tag]'."))

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -37,13 +37,16 @@
 	GLOB.cameranet.addCamera(src)
 
 	if(!broadcast_camera)
-		// If the c_tag is changed in a map before initialization, the camera will gain that c_tag instead of a random string
 		if(c_tag == "")
 			c_tag = random_string(4, list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"))
 
-		// If the name of the camera is changed directly, it'll keep that name, instead
+		// If the c_tag is changed in a map before initialization, the camera will gain that c_tag instead of a random string
 		if(name == "body camera")
 			name = "body camera - (" + c_tag + ")"
+
+		// If the name of the camera is changed directly, it'll keep that name, instead, and it'll set the c_tag as the name. Be careful to avoid c_tag collisions!
+		else
+			c_tag = name
 
 	update_appearance()
 

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -12,7 +12,6 @@
 	var/c_tag_addition = ""
 	var/status = FALSE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start
-	var/sync_on_init = FALSE
 	var/area/myarea = null
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK
@@ -32,7 +31,7 @@
 		network[1] = mapload_network
 
 	// If the first network in the list isn't "default", or if the sync_on_init variable is set to TRUE, it'll autolink to a ship's camera network
-	if((network[1] != "default") || sync_on_init)
+	if(network[1] != "default")
 		link_to_shuttle_network()
 	else
 		for(var/i in network)

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -7,10 +7,12 @@
 	icon_state = "bodycamera-off"
 	resistance_flags = FIRE_PROOF //double check that this flag works for fireproof objects
 	var/list/network = list("default")
-	var/c_tag = "Body Camera"
+	var/mapload_network = "ship"
+	var/c_tag = ""
 	var/c_tag_addition = ""
 	var/status = FALSE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start
+	var/sync_on_init = FALSE
 	var/area/myarea = null
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK
@@ -24,15 +26,32 @@
 
 /obj/item/bodycamera/Initialize()
 	. = ..()
-	for(var/i in network)
-		network -= i
-		network += lowertext(i)
+
+	// If a mapload_network is specified, this sets the network to the mapload default
+	if(mapload_network != network[1])
+		network[1] = mapload_network
+
+	// If the first network in the list isn't "default", or if the sync_on_init variable is set to TRUE, it'll autolink to a ship's camera network
+	if((network[1] != "default") || sync_on_init)
+		link_to_shuttle_network()
+	else
+		for(var/i in network)
+			network -= i
+			network += lowertext(i)
 
 	tracker = new /datum/movement_detector(src, CALLBACK(src, PROC_REF(obj_move)))
 	GLOB.cameranet.cameras += src
 	GLOB.cameranet.addCamera(src)
-	c_tag = random_string(4, list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"))
-	name = "body camera - (" + c_tag + ")"
+
+	if(!broadcast_camera)
+		// If the c_tag is changed in a map before initialization, the camera will gain that c_tag instead of a random string
+		if(c_tag == "")
+			c_tag = random_string(4, list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"))
+
+		// If the name of the camera is changed directly, it'll keep that name, instead
+		if(name == "body camera")
+			name = "body camera - (" + c_tag + ")"
+
 	update_appearance()
 
 /obj/item/bodycamera/Destroy()
@@ -41,6 +60,16 @@
 	GLOB.cameranet.cameras -= src
 	qdel(tracker)
 	return ..()
+
+/obj/item/bodycamera/proc/link_to_shuttle_network()
+	var/area/ship/current_ship_area = get_area(src)
+	if(istype(current_ship_area) && current_ship_area.mobile_port)
+		var/obj/docking_port/mobile/port = current_ship_area.mobile_port
+		if(network[1] == "default")
+			network[1] = "[REF(port)][mapload_network]"
+			return TRUE
+	else
+		return FALSE
 
 /obj/item/bodycamera/examine(mob/user)
 	. += ..()
@@ -74,7 +103,7 @@
 /obj/item/bodycamera/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
 	var/obj/item/multitool/M = I
-	var/list/choice_list = list("Modify the camera tag", "Change the camera network", "Save the network to the multitool buffer", "Transfer the buffered network to the camera")
+	var/list/choice_list = list("Modify the camera tag", "Change the camera network", "Sync the network to the ship", "Save the network to the multitool buffer", "Transfer the buffered network to the camera")
 	var/choice = tgui_input_list(user, "Select an option", "Advanced Camera Configuration", choice_list)
 
 	switch(choice)
@@ -86,6 +115,12 @@
 		if("Change the camera network")
 			network[1] = stripped_input(user, "Tune [src] to a specific network. Enter the network name and ensure that it is no bigger than 32 characters long. Network names are case sensitive.", "Network Tuning", max_length = 32)
 			to_chat(user, span_notice("You set [src] to transmit across the '[network[1]]' network."))
+
+		if("Sync the network to the ship")
+			if(link_to_shuttle_network())
+				to_chat(user, span_notice("You sync the camera to the ship's network."))
+			else
+				to_chat(user, span_notice("ERROR: You must be within a ship to link to its network."))
 
 		if("Save the network to the multitool buffer")
 			M.buffer = network[1]
@@ -104,7 +139,7 @@
 	if(broadcast_camera)
 		return
 
-	var/list/choice_list = list("Modify the camera tag", "Change the camera network")
+	var/list/choice_list = list("Modify the camera tag", "Sync the network to the ship", "Change the camera network directly")
 	var/choice = tgui_input_list(user, "Select an option", "Camera Configuration", choice_list)
 
 	switch(choice)
@@ -113,7 +148,13 @@
 			set_name(c_tag_addition)
 			to_chat(user, span_notice("You set [src] nametag to '[c_tag]'."))
 
-		if("Change the camera network")
+		if("Sync the network to the ship")
+			if(link_to_shuttle_network())
+				to_chat(user, span_notice("You sync the camera to the ship's network."))
+			else
+				to_chat(user, span_notice("ERROR: You must be within a ship to link to its network."))
+
+		if("Change the camera network directly")
 			network[1] = stripped_input(user, "Tune [src] to a specific network. Enter the network name and ensure that it is no bigger than 32 characters long. Network names are case sensitive.", "Network Tuning", max_length = 32)
 			to_chat(user, span_notice("You set [src] to transmit across the '[network[1]]' network."))
 
@@ -249,8 +290,10 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
 	RegisterSignal(radio, COMSIG_RADIO_NEW_FREQUENCY, PROC_REF(adjust_name))
-	c_tag = "Broadcast Camera - " + random_string(6, list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"))
-	name = c_tag
+	if(c_tag == "")
+		c_tag = "Broadcast Camera - " + random_string(6, list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"))
+	if(name != "broadcast camera")
+		name = c_tag
 	update_appearance()
 
 /obj/item/bodycamera/broadcast_camera/Destroy()

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -26,8 +26,7 @@
 /obj/item/bodycamera/Initialize()
 	. = ..()
 	// If a mapload_network is specified, this sets the network to the mapload default
-	if(link_to_shuttle_network())
-	else
+	if(!link_to_shuttle_network())
 		for(var/i in network)
 			network -= i
 			network += lowertext(i)

--- a/code/game/objects/items/bodycamera.dm
+++ b/code/game/objects/items/bodycamera.dm
@@ -25,14 +25,8 @@
 
 /obj/item/bodycamera/Initialize()
 	. = ..()
-
 	// If a mapload_network is specified, this sets the network to the mapload default
-	if(mapload_network != network[1])
-		network[1] = mapload_network
-
-	// If the first network in the list isn't "default", or if the sync_on_init variable is set to TRUE, it'll autolink to a ship's camera network
-	if(network[1] != "default")
-		link_to_shuttle_network()
+	if(link_to_shuttle_network())
 	else
 		for(var/i in network)
 			network -= i
@@ -64,9 +58,8 @@
 	var/area/ship/current_ship_area = get_area(src)
 	if(istype(current_ship_area) && current_ship_area.mobile_port)
 		var/obj/docking_port/mobile/port = current_ship_area.mobile_port
-		if(network[1] == "default")
-			network[1] = "[REF(port)][mapload_network]"
-			return TRUE
+		network[1] = "[REF(port)][mapload_network]"
+		return TRUE
 	else
 		return FALSE
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -31,7 +31,7 @@
 	radio = /obj/item/radio/headset/silicon/ai
 	native_fov = null
 	var/battery = 200 //emergency power if the AI's APC is off
-	var/list/network = list("ss13")
+	var/list/network = list("ship")
 	var/obj/machinery/camera/current
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = POWER_RESTORATION_OFF

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -126,6 +126,7 @@
 
 	if(action == "sync")
 		link_to_shuttle_network()
+		update_static_data_for_all_viewers()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -12,7 +12,7 @@
 	tgui_id = "NtosSecurEye"
 	program_icon = "eye"
 
-	var/list/network = list("ss13")
+	var/list/network = list("ship")
 	var/temp_network = list("")
 	var/obj/machinery/camera/active_camera
 	/// The turf where the camera was last updated.
@@ -57,6 +57,12 @@
 	QDEL_LIST(cam_plane_masters)
 	qdel(cam_background)
 	return ..()
+
+/datum/computer_file/program/secureye/proc/link_to_shuttle_network()
+	var/area/ship/current_ship_area = get_area(src)
+	if(istype(current_ship_area) && current_ship_area.mobile_port)
+		var/obj/docking_port/mobile/port = current_ship_area.mobile_port
+		network[1] = "[REF(port)]ship"
 
 /datum/computer_file/program/secureye/ui_interact(mob/user, datum/tgui/ui)
 	// Update UI
@@ -117,6 +123,9 @@
 	if(action == "set_network")
 		network = temp_network
 		update_static_data_for_all_viewers()
+
+	if(action == "sync")
+		link_to_shuttle_network()
 
 	if(action == "set_temp_network")
 		temp_network = sanitize_filename(params["name"])

--- a/tgui/packages/tgui/interfaces/CameraConsole.js
+++ b/tgui/packages/tgui/interfaces/CameraConsole.js
@@ -113,6 +113,7 @@ export const CameraConsoleContent = (props, context) => {
         />
         <Button icon="add" ml={1} onClick={() => act('set_network')} />
         <Button icon="refresh" onClick={() => act('refresh')} />
+        <Button icon="signal" onClick={() => act('sync')} />
       </Flex.Item>
       <Flex.Item>
         <Input


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR refactors cameras and camera consoles slightly. The "ss13" camera network is gone, and is now replaced with the "ship" camera network. 

Mapped in camera consoles, and structural cameras will default to this ship network, prefixed with a pointer to the ship. 
Example: 
<img width="188" height="24" alt="image" src="https://github.com/user-attachments/assets/42b77012-bcea-4249-8f34-b3a26ab5a9da" />
Mapped in body cameras are also supposed to default to the ship's network on init, but they don't do this, it seems. I can't quite figure out how to resolve this right now, but it looks like the mobile port is null during mapload, which causes the issue.

If a mapper wishes to change the network for a camera console, structural camera, or body camera, they can set the `mapload_network` variable as they wish. For instance, an input of "banana" for the mapload_network variable will set the network as `[ship_pointer]banana`.

Body camera initialization was changed slightly such that changing the name variable in a map will set the c_tag to this name. If one wishes to change the c_tag only, the name of the resulting body camera will be in the format "body camera - (`c_tag`)".

In addition, camera consoles and bodycameras can resync to a ship's camera network via their respective menus.

## Why It's Good For The Game

I hadn't considered how mappers might use these devices in their maps, and I only recently realized that they're coded in such a way that they prevent certain usecases. This PR should hopefully address this and provide a bit more power for mappers to create the vision they want for their maps. If I miss anything with this refactor, feel free to let me know.

## Changelog

:cl:
add: ability to sync with ship's camera network, bodycam init on mapload
refactor: refactored camera backend to allow for mappers to set multiple custom networks for isolated camera networks within the same ship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
