### PR TITLE
Reduces prices of jetpacks

### DIFF
--- a/code/modules/cargo/packs/tools.dm
+++ b/code/modules/cargo/packs/tools.dm
@@ -126,7 +126,7 @@
 /datum/supply_pack/tools/jetpack
 	name = "Jetpack Crate"
 	desc = "For when you need to go fast in space."
-	cost = 750
+	cost = 500
 	contains = list(/obj/item/tank/jetpack/carbondioxide)
 	crate_name = "jetpack crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
@@ -134,13 +134,13 @@
 /datum/supply_pack/tools/jetpack/harness
 	name = "Jetpack Harness Crate"
 	desc = "A compact jetpack harness for those who don't wish to be weighed down by larger traditional jetpacks."
-	cost = 1500
+	cost = 750
 	contains = list(/obj/item/tank/jetpack/oxygen/harness)
 
 /datum/supply_pack/tools/jetpack/suit
 	name = "Hardsuit Jetpack Upgrade Crate"
 	desc = "A standardized jetpack attachment designed for direct integration with hardsuits. For when every gram matters."
-	cost = 2000
+	cost = 1250
 	contains = list(/obj/item/tank/jetpack/suit)
 
 /datum/supply_pack/tools/anglegrinder


### PR DESCRIPTION
## About The Pull Request

Reduces the prices of jetpacks to be much more reasonable given their usecases and limitations.

Standard: 500
Harness: 750
Upgrade: 1250 (only compatible with hardsuits so you still have a buy-in)

Given that jetpacks are used for effectively only two or three environments (being space, asteroids, and debris in the future), them being so highly priced while still taking up your back slot is rough. Mobility in space without a jetpack usually boils down to people conga-lining on the one jetpack person, or throwing cigarettes and whatnot to propel yourself.

## Why It's Good For The Game

Given the importance of space, and how expensive stocking a full crew with jetpacks at their original prices would be, it's simply unfair to have them be this expensive. By making them cheaper, this should mean people get to use tools fitting for the job while they work in space - for the times they do actually land at a space signal or asteroid field to work.

## Changelog

:cl:
balance: Jetpack prices reduced.
/:cl