### PR TITLE
Pouches fit in Vests

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -30,6 +30,13 @@
 	quickdraw = FALSE
 	silent = FALSE
 
+/datum/component/storage/concrete/pockets/exo/Initialize()
+	. = ..()
+	var/static/list/exception_cache = typecacheof(list(
+		/obj/item/storage/pouch
+		))
+	exception_hold = exception_cache
+
 /datum/component/storage/concrete/pockets/exo/large
 	max_items = 3
 

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -640,7 +640,7 @@
 	if(isitem(host))
 		var/obj/item/IP = host
 		var/datum/component/storage/STR_I = I.GetComponent(/datum/component/storage)
-		if((I.w_class >= IP.w_class) && STR_I && !allow_big_nesting)
+		if((I.w_class >= IP.w_class) && STR_I && !allow_big_nesting && !is_type_in_list(I, exception_hold))
 			if(!stop_messages)
 				to_chat(M, span_warning("[IP] cannot hold [I] as it's a storage item of the same size!"))
 			return FALSE //To prevent the stacking of same sized storage items.


### PR DESCRIPTION

## About The Pull Request

Pouches now fit in vests, allowing for more flexibility. Adjusts nesting code to account for exception lists as well.

## Why It's Good For The Game

Turns out, even trying to make pouches work for pockets - that space is valuable enough that people tend to stick the same few items in there, with oxygen tanks taking up a mandatory slot.

This should add flexibility to people's loadouts and make them consider a bit more what they do with their vests - and allow for customization. And snack pouches. Everyone needs one of those.

## Changelog

:cl:
balance: Pouches fit in vests now.
code: Storage nesting code now accounts for exception lists, in the specific cases this would be relevant.
/:cl:
