### PR TITLE
Weapon Cell Price Revisit

### DIFF
--- a/code/modules/cargo/blackmarket/packs/ammo.dm
+++ b/code/modules/cargo/blackmarket/packs/ammo.dm
@@ -176,6 +176,17 @@
 	stock_max = 4
 	availability_prob = 40
 
+/datum/blackmarket_item/ammo/sharplite_plus_cell
+	name = "Sharplite Plus Cell"
+	desc = "A sharplite plus energy weapon cell. The plus in the name means bigger, if that wasn't obvious."
+	item = /obj/item/stock_parts/cell/gun/sharplite/plus
+
+	cost_min = 800
+	cost_max = 1200
+	stock_min = 2
+	stock_max = 4
+	availability_prob = 40
+
 /datum/blackmarket_item/ammo/gauss_cell
 	name = "SolCon Weapon Cell"
 	desc = "A Solarian weapon cell, for powering their gauss weaponry."
@@ -213,8 +224,8 @@
 	desc = "These upgraded weapon powercells come with twice the capacity of the standard cells, and quality checked to make sure they won't explode!"
 	item = /obj/item/stock_parts/cell/gun/upgraded
 
-	cost_min = 1000
-	cost_max = 1750
+	cost_min = 800
+	cost_max = 1200
 	stock_min = 2
 	stock_max = 4
 	availability_prob = 25

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -402,22 +402,22 @@
 	desc = "Contains a proprietary weapon cell, compatible with most Sharplite energy weapons."
 	contains = list(/obj/item/stock_parts/cell/gun/sharplite)
 	faction = /datum/faction/warra
-	faction_discount = 30
-	cost = 700
+	faction_discount = 25 /*300 credits*/
+	cost = 400
 
 /datum/supply_pack/magazine/tinyguncell
 	name = "Sharplite Mini Power Cell"
 	desc = "Contains a proprietary weapon cell, compatible with the Ohm self-defence pistol."
 	contains = list(/obj/item/stock_parts/cell/gun/sharplite/mini)
 	faction = /datum/faction/warra
-	faction_discount = 30
-	cost = 300
+	faction_discount = 20 /*200 credits*/
+	cost = 250
 
 /datum/supply_pack/magazine/upgradedguncell
 	name = "Sharplite Plus Proprietary Weapon Cell"
 	desc = "Contains an upgraded weapon cell, compatible with most Sharplite models. For MW use only."
 	contains = list(/obj/item/stock_parts/cell/gun/sharplite/plus)
-	cost = 1000
+	cost = 750
 	faction = /datum/faction/warra
 	faction_discount = 0
 	faction_locked = TRUE
@@ -426,7 +426,7 @@
 	name = "Sharplite Plus Proprietary Weapon Cell"
 	desc = "Contains an upgraded weapon cell, compatible with most Sharplite models."
 	contains = list(/obj/item/stock_parts/cell/gun/sharplite/plus)
-	cost = 1000
+	cost = 750
 	faction = /datum/faction/inteq
 	faction_discount = 0
 	faction_locked = TRUE
@@ -437,14 +437,14 @@
 	name = "Etherbor Cell Crate"
 	desc = "Contains an Etherbor weapon cell, compatible with Etherbor armaments with a slightly higher capacity."
 	contains = list(/obj/item/stock_parts/cell/gun/kalix)
-	cost = 600
+	cost = 500
 	faction = /datum/faction/pgf
 
 /datum/supply_pack/magazine/pgfcell
 	name = "Military-Grade Etherbor Cell Crate"
 	desc = "Contains a military-grade Etherbor weapon cell produced for the PGFMC, compatible with Etherbor armaments with a significantly higher capacity."
 	contains = list(/obj/item/stock_parts/cell/gun/pgf)
-	cost = 1000
+	cost = 750
 	faction = /datum/faction/pgf
 	faction_discount = 0
 	faction_locked = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts the prices of the energy weapon cells on the cargo market.

**SHARPLITE:**

Sharplite fills the niche of the mass produced, working man's guns, and while the weapons fit that status in price, their cells were even more expensive than Etherbor, which didn't feel right.

Standard Sharplite cells were dropped in price to 400 credits

Sharplite mini cells (Ohm cells) were dropped in price to 250 credits


**ETHERBOR:**

A premium option in the world of energy weapons, and for good reason. Their cells are more expensive than their competition from sharplite due to their marginally greater capacity and production cost

Civilian Etherbor cells were set in price to 500 credits


**EXTENDED CAPACITY:**

Akin to the drop in price for extended magazines for the SKM/CM-82/Hydra

Extended capacity weapon cells across the board have been dropped in price to 750 credits.

It's important to note that Extended capacity energy weapon cells are comparable in shot count to standard magazines in equivalent ballistic options.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Energy weapons have the notable advantage of not requiring the purchase of ammunition, and for this reason their cells must be more expensive than a ballistic weapon magazine.

However, they also suffer the disadvantage of being unable to be topped off or refilled away from charging infrastructure.

To balance, this change keeps energy cells fairly priced, but makes the aquisition of further cells more reasonable.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added sharplite plus cells to the black market
balance: rebalanced energy cell prices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->