### PR TITLE
Underbarrel Safety sanity and obliterates the remains of underbarrel firemode

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
@@ -49,6 +49,8 @@
 #define COMSIG_GUN_TRY_FIRE "gun_try_fire"
 	#define COMPONENT_CANCEL_GUN_FIRE (1<<0) /// Also returned to cancel COMSIG_MOB_TRYING_TO_FIRE_GUN
 
+#define COMSIG_GUN_TOGGLE_SAFETY "gun_try_safety"
+
 ///from base of item/sharpener/attackby(): (amount, max)
 #define COMSIG_ITEM_SHARPEN_ACT "sharpen_act"
 	#define COMPONENT_BLOCK_SHARPEN_APPLIED 1

--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -226,7 +226,6 @@
 #define FIREMODE_FULLAUTO "auto"
 #define FIREMODE_OTHER "other"
 #define FIREMODE_OTHER_TWO "other2"
-#define FIREMODE_UNDERBARREL "underbarrel"
 
 #define GUN_LEFTHAND_ICON 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 #define GUN_RIGHTHAND_ICON 'icons/mob/inhands/weapons/guns_righthand.dmi'

--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -140,6 +140,7 @@
 #define COMSIG_ATTACHMENT_CTRL_CLICK "attach-ctrl-click"
 #define COMSIG_ATTACHMENT_ALT_CLICK "attach-alt-click"
 #define COMSIG_ATTACHMENT_ATTACK_HAND "attach-attack-hand"
+#define COMSIG_ATTACHMENT_TOGGLE_SAFETY "attach-safety"
 
 #define COMSIG_ATTACHMENT_TOGGLE "attach-toggle"
 #define COMSIG_ATTACHMENT_TOGGLE_AMMO "attach-ammo"

--- a/code/datums/components/attachment.dm
+++ b/code/datums/components/attachment.dm
@@ -15,6 +15,7 @@
 	var/datum/callback/on_alt_click
 	var/datum/callback/on_examine
 	var/datum/callback/on_attack_hand
+	var/datum/callback/on_safety
 	///Called on the parent's fire_gun
 	var/datum/callback/on_fire_gun
 	///Called on the parents preattack
@@ -48,6 +49,7 @@
 		datum/callback/on_examine = null,
 		datum/callback/on_alt_click = null,
 		datum/callback/on_attack_hand = null,
+		datum/callback/on_safety = null,
 		list/signals = null
 	)
 
@@ -71,6 +73,7 @@
 	src.on_examine = on_examine
 	src.on_alt_click = on_alt_click
 	src.on_attack_hand = on_attack_hand
+	src.on_safety = on_safety
 
 	ADD_TRAIT(parent, TRAIT_ATTACHABLE, "attachable")
 	RegisterSignal(parent, COMSIG_ATTACHMENT_ATTACH, PROC_REF(try_attach))
@@ -95,6 +98,7 @@
 	RegisterSignal(parent, COMSIG_ATTACHMENT_CTRL_CLICK, PROC_REF(relay_ctrl_click))
 	RegisterSignal(parent, COMSIG_ATTACHMENT_ALT_CLICK, PROC_REF(relay_alt_click))
 	RegisterSignal(parent, COMSIG_ATTACHMENT_ATTACK_HAND, PROC_REF(relay_attack_hand))
+	RegisterSignal(parent, COMSIG_ATTACHMENT_TOGGLE_SAFETY, PROC_REF(relay_safety))
 
 	for(var/signal in signals)
 		RegisterSignal(parent, signal, signals[signal])
@@ -258,6 +262,12 @@
 
 	if(on_attack_hand)
 		return on_attack_hand.Invoke(gun, user, params)
+
+/datum/component/attachment/proc/relay_safety(obj/item/parent, obj/item/gun, mob/user, params)
+	SIGNAL_HANDLER_DOES_SLEEP
+
+	if(on_safety)
+		return on_safety.Invoke(gun, user, params)
 
 /datum/component/attachment/proc/send_slot(obj/item/parent)
 	SIGNAL_HANDLER

--- a/code/datums/components/attachment_holder.dm
+++ b/code/datums/components/attachment_holder.dm
@@ -39,6 +39,7 @@
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(handle_alt_click))
 	RegisterSignal(parent, COMSIG_CLICK_SECONDARY_ACTION, PROC_REF(handle_secondary_action))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(handle_overlays))
+	RegisterSignal(parent, COMSIG_GUN_TOGGLE_SAFETY, PROC_REF(handle_safety))
 
 	if(length(default_attachments))
 		for(var/attachment in default_attachments)
@@ -248,4 +249,11 @@
 
 	for(var/obj/item/attach as anything in attachments)
 		if(SEND_SIGNAL(attach, COMSIG_ATTACHMENT_SECONDARY_ACTION, parent, user, params))
+			return TRUE
+
+/datum/component/attachment_holder/proc/handle_safety(obj/item/gun/parent_gun, mob/user, atom/target, flag, params)
+	SIGNAL_HANDLER
+
+	for(var/obj/item/attach as anything in attachments)
+		if(SEND_SIGNAL(attach, COMSIG_ATTACHMENT_TOGGLE_SAFETY, parent_gun, user, target, flag, params))
 			return TRUE

--- a/code/game/objects/items/attachments/_attachment.dm
+++ b/code/game/objects/items/attachments/_attachment.dm
@@ -64,6 +64,7 @@
 		CALLBACK(src, PROC_REF(on_examine)), \
 		CALLBACK(src, PROC_REF(on_alt_click)), \
 		CALLBACK(src, PROC_REF(on_attack_hand)), \
+		CALLBACK(src, PROC_REF(on_safety)), \
 		signals)
 
 /obj/item/attachment/Destroy()
@@ -133,6 +134,9 @@
 	return
 
 /obj/item/attachment/proc/on_attack_hand(obj/item/gun/gun, mob/user, list/examine_list)
+	return FALSE
+
+/obj/item/attachment/proc/on_safety(obj/item/gun/gun, mob/user, list/examine_list)
 	return FALSE
 
 /obj/item/attachment/proc/on_alt_click(obj/item/gun/gun, mob/user, list/examine_list)

--- a/code/game/objects/items/attachments/_gun_attachment.dm
+++ b/code/game/objects/items/attachments/_gun_attachment.dm
@@ -72,7 +72,7 @@
 	attached_gun.unique_action(user)
 	return OVERRIDE_SECONDARY_ACTION
 
-/obj/item/attachment/gun/on_ctrl_click(obj/item/gun/gun, mob/user)
+/obj/item/attachment/gun/on_safety(obj/item/gun/gun, mob/user)
 	if(has_safety)
 		attached_gun.toggle_safety(user,TRUE, TRUE)
 

--- a/code/game/objects/items/attachments/_gun_attachment.dm
+++ b/code/game/objects/items/attachments/_gun_attachment.dm
@@ -27,26 +27,11 @@
 
 /obj/item/attachment/gun/apply_attachment(obj/item/gun/gun, mob/user)
 	. = ..()
-	// if(FIREMODE_UNDERBARREL in gun.gun_firemodes)
-	// 	to_chat(user,span_warning("The [gun] already has an underbarrel gun and can't take the [src]!"))
-	// 	return FALSE
-	// else
-	// 	gun.gun_firemodes += FIREMODE_UNDERBARREL
 	gun.underbarrel_prefix = underbarrel_prefix
 	if(attached_gun)
 		attached_gun.safety = gun.safety
-	//gun.build_firemodes()
 	if(user)
 		gun.equipped(user)
-
-/obj/item/attachment/gun/remove_attachment(obj/item/gun/gun, mob/user)
-	. = ..()
-	// var/firemode_to_remove = gun.gun_firemodes.Find(FIREMODE_UNDERBARREL)
-	// if(firemode_to_remove)
-	// 	gun.gun_firemodes -= gun.gun_firemodes[firemode_to_remove]
-	gun.underbarrel_prefix = ""
-	// gun.build_firemodes()
-	// gun.equipped(user)
 
 /obj/item/attachment/gun/on_wield(obj/item/gun/gun, mob/user, list/params)
 	if(attached_gun)
@@ -93,10 +78,5 @@
 
 /obj/item/attachment/gun/on_alt_click(obj/item/gun/gun, mob/user, list/examine_list)
 	return FALSE
-	// if(gun.gun_firemodes[gun.firemode_index] == FIREMODE_UNDERBARREL)
-	// 	AltClick(user)
-	// 	return TRUE
-	// else
-	// 	return FALSE
 
 

--- a/code/game/objects/items/attachments/gun_attachments/flamethrower.dm
+++ b/code/game/objects/items/attachments/gun_attachments/flamethrower.dm
@@ -45,7 +45,7 @@
 	examine_list += span_notice("-You can empty the [attached_flamethrower.beaker] by pressing the <b>secondary action</b> key. By default, this is <b>shift + space</b>")
 	return examine_list
 
-/obj/item/attachment/gun/flamethrower/on_ctrl_click(obj/item/gun/gun, mob/user)
+/obj/item/attachment/gun/flamethrower/on_safety(obj/item/gun/gun, mob/user)
 	. = ..()
 	attached_flamethrower.toggle_igniter(user)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -329,7 +329,7 @@
 	/// Our firemodes, subtract and add to this list as needed. NOTE that the autofire component is given on init when FIREMODE_FULLAUTO is here.
 	var/list/gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST, FIREMODE_FULLAUTO, FIREMODE_OTHER, FIREMODE_OTHER_TWO)
 	/// A acoc list that determines the names of firemodes. Use if you wanna be weird and set the name of say, FIREMODE_OTHER to "Underbarrel grenade launcher" for example.
-	var/list/gun_firenames = list(FIREMODE_SEMIAUTO = "single", FIREMODE_BURST = "burst fire", FIREMODE_FULLAUTO = "full auto", FIREMODE_OTHER = "misc. fire", FIREMODE_OTHER_TWO = "very misc. fire", FIREMODE_UNDERBARREL = "underbarrel weapon")
+	var/list/gun_firenames = list(FIREMODE_SEMIAUTO = "single", FIREMODE_BURST = "burst fire", FIREMODE_FULLAUTO = "full auto", FIREMODE_OTHER = "misc. fire", FIREMODE_OTHER_TWO = "very misc. fire")
 	///BASICALLY: the little button you select firing modes from? this is jsut the prefix of the icon state of that. For example, if we set it as "laser", the fire select will use "laser_single" and so on.
 	var/fire_select_icon_state_prefix = ""
 	///If true, we put "safety_" before fire_select_icon_state_prefix's prefix. ex. "safety_laser_single"
@@ -429,12 +429,7 @@
 /obj/item/gun/examine_more(mob/user)
 	. = ..()
 	if(has_safety)
-		. += "The safety is [safety ? span_green("ON") : span_red("OFF")]. Right-Click to toggle the safety."
-
-/obj/item/gun/attackby(obj/item/I, mob/living/user, params)
-	. = ..()
-	if(gun_firemodes[firemode_index] == FIREMODE_UNDERBARREL)
-		return TRUE
+		. += "The safety is [safety ? span_green("ON") : span_red("OFF")]. Ctrl-Click to toggle the safety."
 
 /obj/item/gun/equipped(mob/living/user, slot)
 	. = ..()
@@ -757,28 +752,6 @@
 	. = ..()
 	if(isliving(user) && in_range(src, user))
 		toggle_safety(user)
-
-// This is overridden when interacting with attached underbarrel guns.
-/obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
-	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
-		return
-	if(toggle_safety(user))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-/obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
-	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
-		return
-	if(toggle_safety(user))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-/obj/item/gun/attack_self_secondary(mob/user, modifiers)
-	. = ..()
-	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
-		return
-	if(toggle_safety(user))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/proc/toggle_safety(mob/user, silent=FALSE, override_check = FALSE)
 	if(!has_safety)
@@ -1203,10 +1176,6 @@
 	var/current_firemode = our_gun.gun_firemodes[our_gun.firemode_index]
 	//tldr; if we have adjust_fire_select_icon_state_on_safety as true, we append "safety_" to the prefix, otherwise nothing.
 	var/safety_prefix = "[our_gun.adjust_fire_select_icon_state_on_safety ? "[our_gun.safety ? "safety_" : ""]" : ""]"
-	if(current_firemode == FIREMODE_UNDERBARREL)
-		button_icon_state = "[safety_prefix][our_gun.underbarrel_prefix][current_firemode]"
-	else
-		button_icon_state = "[safety_prefix][our_gun.fire_select_icon_state_prefix][current_firemode]"
 	return ..()
 
 GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -753,6 +753,28 @@
 	if(isliving(user) && in_range(src, user))
 		toggle_safety(user)
 
+// This is overridden when interacting with attached underbarrel guns.
+/obj/item/gun/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/gun/attackby_secondary(obj/item/weapon, mob/user, params)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/gun/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(toggle_safety(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/gun/proc/toggle_safety(mob/user, silent=FALSE, override_check = FALSE)
 	if(!has_safety)
 		return FALSE
@@ -769,7 +791,7 @@
 			span_notice("[user] turns the [safety_wording] on [src] [safety ? span_green("ON") : span_red("OFF")]."),
 			span_notice("You turn the [safety_wording] on [src] [safety ? span_green("ON") : span_red("OFF")]."),
 		)
-
+	SEND_SIGNAL(src, COMSIG_GUN_TOGGLE_SAFETY, user)
 	update_appearance()
 	return TRUE
 
@@ -1176,6 +1198,7 @@
 	var/current_firemode = our_gun.gun_firemodes[our_gun.firemode_index]
 	//tldr; if we have adjust_fire_select_icon_state_on_safety as true, we append "safety_" to the prefix, otherwise nothing.
 	var/safety_prefix = "[our_gun.adjust_fire_select_icon_state_on_safety ? "[our_gun.safety ? "safety_" : ""]" : ""]"
+	button_icon_state = "[safety_prefix][our_gun.fire_select_icon_state_prefix][current_firemode]"
 	return ..()
 
 GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -337,7 +337,7 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/gun/ballistic/attack_hand(mob/user)
 	// the main calls it's own eject mag before the underbarrel. fix this
-	if(user.is_holding(src) && loc == user && !(gun_firemodes[firemode_index] == FIREMODE_UNDERBARREL))
+	if(user.is_holding(src) && loc == user)
 		if(sealed_magazine)
 			to_chat(user, span_warning("The [magazine_wording] on [src] is sealed and cannot be accessed!"))
 			return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -134,7 +134,7 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/gun/energy/attack_hand(mob/user)
-	if(!internal_magazine && loc == user && user.is_holding(src) && cell && tac_reloads && !(gun_firemodes[firemode_index] == FIREMODE_UNDERBARREL))
+	if(!internal_magazine && loc == user && user.is_holding(src) && cell && tac_reloads)
 		eject_cell(user)
 		return
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Underbarrel weapon safeties now listen for the main gun's safeties to be toggled.

Obliterates any unused code related to the old implementation of underbarrels.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

New safety implementation should fix the issues with main gun/underbarrels safety desyncing since it was made that safeties could be toggled with both ctrl-click and right click but underbarrels weren't updated for it.

Any old underbarrel code can go buh bye since it's not needed.

## Changelog

:cl:
del: Old underbarrel code
fix: Main/underbarrel guns safeties desyncing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
