### PR TITLE
Removes "NOTELEPORT" from centcom z-level

### DIFF
--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -7,7 +7,7 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	area_flags = VALID_TERRITORY | UNIQUE_AREA | NOTELEPORT
+	area_flags = VALID_TERRITORY | UNIQUE_AREA
 	flags_1 = NONE
 
 /area/centcom/control


### PR DESCRIPTION

## About The Pull Request

Removes noteleport from the centcom z-level.

## Why It's Good For The Game

Debug zone that's only accessible if things have gone very wrong, or if admins are involved - you can't get here without even being spawned in it or winding up in the error room. It's a huge amount of space for admins to build event zones in if necessary but they can't set up teleports to get inside due to the noteleport flag. Removing it shouldn't cause any issues and allow further freedom with running events in-round.

## Changelog

:cl:
del: Noteleport from the centcom z-level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
