### PR TITLE
Makosso-Warraning the TGUI crash screen

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -615,19 +615,19 @@ blink {
 <!-- Fatal error container -->
 <div id="FatalError" class="FatalError">
 <div class="FatalError__logo">
-ooooo      ooo     .     .oooooo.    .oooooo..o
-`888b.     `8'   .o8    d8P'  `Y8b  d8P'    `Y8
- 8 `88b.    8  .o888oo 888      888 Y88bo.
- 8   `88b.  8    888   888      888  `"Y8888o.
- 8     `88b.8    888   888      888      `"Y88b
- 8       `888    888 . `88b    d88' oo     .d8P
-o8o        `8    "888"  `Y8bood8P'  8""88888P'
+ .88. .88.      .oooooo.    .oooooo..o
+d8  8 8  8b    d8P'  `Y8b  d8P'    `Y8
+8    8    8   888      888 Y88bo.
+-----------   888      888  `"Y8888o.
+8.  .8.  .8   888      888      `"Y88b
+Y8  8 8  8P   `88b    d88' oo     .d8P
+ '88   88'     `Y8bood8P'  8""88888P'
 </div>
 <marquee class="FatalError__header">
 A fatal exception has occurred at 002B:C562F1B7 in TGUI.
 The current application will be terminated.
 Send the copy of the following stack trace to an authorized
-Nanotrasen incident handler at https://github.com/tgstation/tgstation.
+Makosso-Warra software technician at https://github.com/shiptest-ss13/Shiptest.
 Thank you for your cooperation.
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="493" height="177" alt="image" src="https://github.com/user-attachments/assets/892992f5-716e-4391-b328-1859368cd576" />
i'm not exactly the best at pixel art but M-W's post-ICW logo is intentionally boring enough to be easy

if anyone knows how i can force tgui to crash let me know so i can see what it looks like

## Why It's Good For The Game

what is a nanotrasen?
also points it to our github in case its a shiptest-exclusive ui

## Changelog

:cl:
add: The tgui crash screen is now slightly more lore-accurate. Slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
