### PR TITLE
Adds Separate Market for CLIP Civilian Vessels

### DIFF
--- a/_maps/configs/minutemen_atlas.json
+++ b/_maps/configs/minutemen_atlas.json
@@ -10,7 +10,7 @@
 		"Generalist"
 	],
 	"map_short_name": "Atlas-class",
-	"faction": "/datum/faction/clip",
+	"faction": "/datum/faction/clip/cmm",
 	"starting_funds": 1000,
 	"map_path": "_maps/shuttles/minutemen/minutemen_atlas.dmm",
 	"limit": 1,

--- a/_maps/configs/minutemen_cetus.json
+++ b/_maps/configs/minutemen_cetus.json
@@ -11,7 +11,7 @@
 	],
 	"map_short_name": "Cetus-class",
 	"tranist_x_offset": -5,
-	"faction": "/datum/faction/clip",
+	"faction": "/datum/faction/clip/cmm",
 	"starting_funds": 3000,
 	"map_path": "_maps/shuttles/minutemen/minutemen_cetus.dmm",
 	"limit": 1,

--- a/_maps/configs/minutemen_puppis.json
+++ b/_maps/configs/minutemen_puppis.json
@@ -11,7 +11,7 @@
 		"Response"
 	],
 	"map_short_name": "Puppis-class",
-	"faction": "/datum/faction/clip",
+	"faction": "/datum/faction/clip/cmm",
 	"starting_funds": 2000,
 	"map_path": "_maps/shuttles/minutemen/minutemen_puppis.dmm",
 	"limit": 1,

--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -7,6 +7,7 @@
 #define FACTION_SRM "Saint-Roumain Militia"
 #define FACTION_INTEQ "Inteq Risk Management Group"
 #define FACTION_CLIP "Confederated League of Independent Planets"
+	#define FACTION_MINUTEMEN "CLIP Minutemen"
 #define FACTION_WARRA "Makosso-Warra Corporation"
 	#define FACTION_NS_LOGI "N+S Logistics"
 	#define FACTION_VIGILITAS "Vigilitas Interstellar"
@@ -25,7 +26,8 @@
 #define PREFIX_SOLCON list("SCSV")
 #define PREFIX_SRM list("SRSV")
 #define PREFIX_INTEQ list("IRMV")
-#define PREFIX_CLIP list("CMSV", "CMGSV", "CLSV")
+#define PREFIX_CLIP list("CLSV")
+	#define PREFIX_MINUTEMEN list("CMSV", "CMGSV")
 #define PREFIX_WARRA list("MWSV")
 	#define PREFIX_NS_LOGI list("NSSV")
 	#define PREFIX_VIGILITAS list("VISV")

--- a/code/game/objects/items/storage/filled_guncases.dm
+++ b/code/game/objects/items/storage/filled_guncases.dm
@@ -337,6 +337,10 @@
 	gun_type = /obj/item/gun/ballistic/automatic/smg/cm5
 	mag_type = /obj/item/ammo_box/magazine/cm5_9mm
 
+/obj/item/storage/guncase/cm5c
+	gun_type = /obj/item/gun/ballistic/automatic/smg/cm5/compact
+	mag_type = /obj/item/ammo_box/magazine/cm5_9mm
+
 /obj/item/storage/guncase/cm82
 	gun_type = /obj/item/gun/ballistic/automatic/assault/cm82
 	mag_type = /obj/item/ammo_box/magazine/p16

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -210,7 +210,7 @@
 	desc = "Contains a magazine-fed .357 handgun, produced for the CLIP-BARD division and available for requisition in small numbers to the Minutemen."
 	cost = 1750
 	contains = list(/obj/item/storage/guncase/pistol/cm357)
-	faction = /datum/faction/clip
+	faction = /datum/faction/clip/cmm
 	faction_discount = 0
 	faction_locked = TRUE
 
@@ -603,6 +603,16 @@
 	faction_discount = 0
 	faction_locked = TRUE
 
+/datum/supply_pack/gun/cm5
+	name = "CM-5c SMG Crate"
+	desc = "Contains a CM-5c compact automatic SMG, produced proudly within Lanchester City. Confederated Minutemen issue only."
+	cost = 2000
+	contains = list(/obj/item/storage/guncase/cm5c)
+	crate_name = "SMG crate"
+	faction = /datum/faction/clip/cmm
+	faction_discount = 0
+	faction_locked = TRUE
+
 /datum/supply_pack/gun/sidewinder
 	name = "Sidewinder SMG Crate"
 	desc = "Contains a Sidewinder PDW produced by Scarborough Arms and chambered in 5.7mm for armor-piercing capabilities."
@@ -744,7 +754,7 @@
 	cost = 5000
 	contains = list(/obj/item/storage/guncase/cm82)
 	crate_name = "rifle crate"
-	faction = /datum/faction/clip
+	faction = /datum/faction/clip/cmm
 	faction_discount = 0
 	faction_locked = TRUE
 
@@ -766,7 +776,7 @@
 	cost = 6000
 	contains = list(/obj/item/storage/guncase/cm40)
 	crate_name = "LMG crate"
-	faction = /datum/faction/clip
+	faction = /datum/faction/clip/cmm
 	faction_discount = 0
 	faction_locked = TRUE
 
@@ -896,7 +906,7 @@
 	cost = 4000
 	contains = list(/obj/item/storage/guncase/cmf90)
 	crate_name = "marksman rifle crate"
-	faction = /datum/faction/clip
+	faction = /datum/faction/clip/cmm
 	faction_discount = 0
 	faction_locked = TRUE
 

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -604,12 +604,12 @@
 	faction_locked = TRUE
 
 /datum/supply_pack/gun/cm5
-	name = "CM-5c SMG Crate"
+	name = "CM-5c Compact SMG Crate"
 	desc = "Contains a CM-5c compact automatic SMG, produced proudly within Lanchester City. Confederated Minutemen issue only."
 	cost = 2000
 	contains = list(/obj/item/storage/guncase/cm5c)
 	crate_name = "SMG crate"
-	faction = /datum/faction/clip/cmm
+	faction = /datum/faction/clip
 	faction_discount = 0
 	faction_locked = TRUE
 

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -112,10 +112,10 @@
 	color = "#3F90DF"
 
 /datum/faction/clip/cmm
-	name = FACTION_CLIP
+	name = FACTION_MINUTEMEN
 	short_name = "CLIP Minutemen"
 	parent_faction = /datum/faction/clip
-	prefixes = PREFIX_CLIP
+	prefixes = PREFIX_MINUTEMEN
 	allowed_factions = list(/datum/faction/clip)
 
 /datum/faction/warra

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -107,13 +107,15 @@
 /datum/faction/clip
 	name = FACTION_CLIP
 	short_name = "CLIP"
-	parent_faction = /datum/faction/clip
 	official_language = /datum/language/league_kalixcian
 	prefixes = PREFIX_CLIP
 	color = "#3F90DF"
 
 /datum/faction/clip/cmm
+	name = FACTION_CLIP
 	short_name = "CLIP Minutemen"
+	parent_faction = /datum/faction/clip
+	prefixes = PREFIX_CLIP
 	allowed_factions = list(/datum/faction/clip)
 
 /datum/faction/warra

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -107,6 +107,7 @@
 /datum/faction/clip
 	name = FACTION_CLIP
 	short_name = "CLIP"
+	parent_faction = /datum/faction/clip
 	official_language = /datum/language/league_kalixcian
 	prefixes = PREFIX_CLIP
 	color = "#3F90DF"
@@ -114,9 +115,8 @@
 /datum/faction/clip/cmm
 	name = FACTION_MINUTEMEN
 	short_name = "CLIP Minutemen"
-	parent_faction = /datum/faction/clip
 	prefixes = PREFIX_MINUTEMEN
-	allowed_factions = list(/datum/faction/clip)
+
 
 /datum/faction/warra
 	name = FACTION_WARRA

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -112,6 +112,10 @@
 	prefixes = PREFIX_CLIP
 	color = "#3F90DF"
 
+/datum/faction/clip/cmm
+	short_name = "CLIP Minutemen"
+	allowed_factions = list(/datum/faction/clip)
+
 /datum/faction/warra
 	name = FACTION_WARRA
 	short_name = "MAKOSSO-WARRA"

--- a/code/modules/faction/faction_datum.dm
+++ b/code/modules/faction/faction_datum.dm
@@ -117,7 +117,6 @@
 	short_name = "CLIP Minutemen"
 	prefixes = PREFIX_MINUTEMEN
 
-
 /datum/faction/warra
 	name = FACTION_WARRA
 	short_name = "MAKOSSO-WARRA"


### PR DESCRIPTION
## About The Pull Request

Adds a separate market for civilian CLIP vessels, reducing their access to explicit military firepower - and emphasizing their civilian role in turn. Does not totally remove weapons from their arsenal, it just makes them rely on CLIP weapons that might be more commonly seen in civilian (and lower-priority minuteman) hands.

Adds the CM5c to the market - to help add some extra flavor.

Now locked as military-only, are the:
- CM-F90
- CM-82
- CM-40
- CM-357
  
## Why It's Good For The Game

Makes a more mechanical divide between Military and Civilian CLIP vessels, seeing that _both_ are present on the frontier and serve their own purposes, while still ensuring that they have access to weapons to engage with the gameplay loop and still feel CLIP.

## Changelog

:cl:
balance: Explicitly civilian CLIP vessels now have a slightly reduced market of military firepower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
