### PR TITLE
Buffs Longarm Sharplites + Rush (plus nerfs the taipan)

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -57,7 +57,7 @@
 /obj/item/ammo_casing/energy/lasergun/sharplite/dmr
 	projectile_type = /obj/projectile/beam/laser/sharplite/dmr
 	e_cost = 1000 // 10 per regular cell  20 per upgraded cell
-	delay = 0.5 SECONDS
+	delay = 0.4 SECONDS
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/sharplite/sniper

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -57,12 +57,13 @@
 /obj/item/ammo_casing/energy/lasergun/sharplite/dmr
 	projectile_type = /obj/projectile/beam/laser/sharplite/dmr
 	e_cost = 1000 // 10 per regular cell  20 per upgraded cell
+	delay = 0.5 SECONDS
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/sharplite/sniper
 	projectile_type = /obj/projectile/beam/laser/sharplite/sniper
 	fire_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'
-	delay = 1.3 SECONDS
+	delay = 1 SECONDS
 	e_cost = 2000 // 5 per regular cell 10 per upgraded cell
 	select_name = "kill"
 
@@ -132,6 +133,7 @@
 
 /obj/item/ammo_casing/energy/laser/shotgun/sharplite
 	projectile_type = /obj/projectile/beam/weak/shotgun/sharplite
+	delay = 0.4 SECONDS
 
 /obj/item/ammo_casing/energy/laser/heavy
 	projectile_type = /obj/projectile/beam/laser/heavylaser

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -714,6 +714,7 @@ NO_MAG_GUN_HELPER(automatic/marksman/boomslang/indie)
 	recoil_unwielded = 50
 
 	wield_delay = 1.3 SECONDS
+	fire_delay = 1.5 SECONDS
 
 	valid_attachments = list()
 	slot_available = list()

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -166,6 +166,7 @@
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	zoom_amt = DMR_ZOOM
 	wield_delay = 1 SECONDS
+	fire_delay = 0.8 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
@@ -291,7 +292,7 @@
 	)
 
 	w_class = WEIGHT_CLASS_BULKY
-	fire_delay = 0.6 SECONDS
+	fire_delay = 0.4 SECONDS
 	shaded_charge = TRUE
 
 	wield_slowdown = SHOTGUN_SLOWDOWN
@@ -435,6 +436,7 @@
 
 	wield_slowdown = SNIPER_SLOWDOWN
 	wield_delay = 1.3 SECONDS
+	fire_delay = 1 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -166,7 +166,7 @@
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	zoom_amt = DMR_ZOOM
 	wield_delay = 1 SECONDS
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.4 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
@@ -436,6 +436,7 @@
 
 	wield_slowdown = SNIPER_SLOWDOWN
 	wield_delay = 1.3 SECONDS
+	fire_delay = 1 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -166,7 +166,7 @@
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	zoom_amt = DMR_ZOOM
 	wield_delay = 1 SECONDS
-	fire_delay = 0.8 SECONDS
+	fire_delay = 0.5 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -436,7 +436,6 @@
 
 	wield_slowdown = SNIPER_SLOWDOWN
 	wield_delay = 1.3 SECONDS
-	fire_delay = 1 SECONDS
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -58,7 +58,7 @@
 
 /obj/projectile/beam/weak/sharplite
 	icon_state = "sharplite_laser_light"
-	damage = 15
+	damage = 20
 	speed = 0.3
 	light_color = COLOR_BLUE_LIGHT
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -67,8 +67,8 @@
 
 /obj/projectile/beam/laser/sharplite/dmr
 	icon_state = "sharplite_laser_stronger"
-	damage = 30
-	armour_penetration = 20
+	damage = 35
+	armour_penetration = 30
 
 /obj/projectile/beam/laser/assault/sharplite
 	icon_state = "sharplite_laser_heavy"
@@ -84,8 +84,8 @@
 
 /obj/projectile/beam/laser/sharplite/sniper
 	icon_state = "sharplite_laser_sniper"
-	damage = 35
-	armour_penetration = 30
+	damage = 40
+	armour_penetration = 40
 	speed = 0.2
 	wound_bonus = 0
 	bare_wound_bonus = 20


### PR DESCRIPTION
## About The Pull Request

Buffs the Surge and Sarissa to be of similar strength to their ballistic counterpart. Slightly more AP. Straight buffed the Rush. Decreased fire_delay on most of these guns to be roughly comparable, along with decreasing fire delay on the Amperage

Nerfed the taipan by not giving it a fire delay of 0.4 seconds

## Why It's Good For The Game

These guns aren't super performant and they could stand to be better

## Changelog

:cl:
balance: Buffs Surge / Sarissa / Rush damage and AP across the board, decreased fire delay on Surge, Sarissa, and Amperage
balance: Nerfed Taipan from 0.4 second fire delay to 1.5 seconds
/:cl:
