### PR TITLE
modernizes Vaq medkit selection

### DIFF
--- a/_maps/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/shuttles/inteq/inteq_vaquero.dmm
@@ -1307,22 +1307,6 @@
 	pixel_y = 4;
 	pixel_x = 2
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -9;
-	pixel_y = 15
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_y = 15;
-	pixel_x = 9
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -9;
-	pixel_y = 9
-	},
-/obj/item/storage/firstaid/advanced{
-	pixel_x = 9;
-	pixel_y = 9
-	},
 /obj/item/storage/box/bodybags{
 	pixel_x = -9;
 	pixel_y = 4
@@ -1354,6 +1338,14 @@
 /obj/item/reagent_containers/blood/synthetic,
 /obj/item/sensor_device,
 /obj/item/pinpointer/crew,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "jI" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the current medkit selection in the Vaq, which is broadly lacking in the actual medical supplies you'd need for a mercenary ship regularly getting shot at, with one that is far more appropriate - and more up to recently updated ship standards.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vaq corpsman slot is less suffering now because you actually start with the necessary supplies
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Medical Kit & Bruise Kit to Vaq Medbay
del: Old Medkit Selection from the Vaquero
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
