### PR TITLE
Frontie Sarathi helmet no longer invisible

### DIFF
--- a/code/modules/clothing/factions/frontiersmen.dm
+++ b/code/modules/clothing/factions/frontiersmen.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/obj/clothing/faction/frontiersmen/head.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/frontiersmen/head.dmi'
 	hardsuit_type = "frontier"
+	supports_variations = null
 
 /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 	name = "\improper Frontiersmen hardsuit"


### PR DESCRIPTION
## About The Pull Request

Snout support without having snout sprite

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
fix: Sarathi with frontiersmen suits should no longer have invisible helmets
/:cl:
