### PR TITLE
Retools the Banshee into a Combat Ship

### DIFF
--- a/_maps/configs/hardliners_banshee.json
+++ b/_maps/configs/hardliners_banshee.json
@@ -3,7 +3,7 @@
 	"faction": "/datum/faction/syndicate/hardliners",
 	"prefix": "ISV",
 	"manufacturer": "ISF Spacecraft",
-	"map_name": "Y450-H Banshee-class Salvage Clipper",
+	"map_name": "Y450-H Banshee-class Security Clipper",
 	"namelists": [
 		"GORLEX",
 		"NATURAL_AGGRESSIVE",
@@ -11,12 +11,9 @@
 		"WEAPONS"
 	],
 	"map_short_name": "Banshee-class",
-	"description": "A drastic refit of an ICW-era Cybersun yacht into a salvage vessel. While the Banshee retains most of the original exterior, its interior houses an exosuit-based Hardliner salvage team and all the facilities they could need. Though somewhat dated, it functions well as a sleeper ship that could easily be mistaken for any other civilian vessel.",
+	"description": "A drastic refit of an ICW-era Cybersun yacht into a combat-capable vessel. While the Banshee retains most of the original exterior, its interior houses a small hardliner combat team and all the facilities they could need. Though somewhat dated, it functions well as a sleeper ship that could easily be mistaken for any other civilian vessel.",
 	"tags": [
-		"Salvage",
-		"Combat",
-		"Engineering",
-		"Generalist"
+		"Combat"
 	],
 	"map_path": "_maps/shuttles/hardliner/hardliners_banshee.dmm",
 	"tranist_x_offset": -30,
@@ -33,11 +30,11 @@
 			"outfit": "/datum/outfit/job/syndicate/engineer/gorlex",
 			"slots": 1
 		},
-		"Wrecker": {
-			"outfit": "/datum/outfit/job/syndicate/miner/gorlex",
+		"Trooper": {
+			"outfit": "/datum/outfit/job/syndicate/security/gorlex",
 			"slots": 2
 		},
-		"Junior Wrecker": {
+		"Junior Agent": {
 			"outfit": "/datum/outfit/job/syndicate/assistant/gorlex",
 			"slots": 1
 		}

--- a/_maps/shuttles/hardliner/hardliners_banshee.dmm
+++ b/_maps/shuttles/hardliner/hardliners_banshee.dmm
@@ -395,18 +395,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "gT" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/machinery/recharger{
-	pixel_x = 8;
-	pixel_y = 5
-	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "hL" = (
@@ -538,27 +530,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "iW" = (
-/obj/item/clothing/suit/hazardvest/hardliners,
-/obj/item/clothing/head/hardhat/hardliners,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/explorer,
-/obj/item/radio/headset/alt,
-/obj/item/clothing/under/syndicate/hardliners/jumpsuit,
-/obj/item/melee/sledgehammer/gorlex,
-/obj/item/melee/knife/survival,
-/obj/item/storage/toolbox/syndicate,
-/obj/structure/closet/secure_closet/wall/directional/west{
-	icon_state = "cargo_wall";
-	name = "Wreckers closet";
-	req_access_txt = "48";
-	pixel_x = -28;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/obj/item/clothing/glasses/hud/security/sunglasses/hardliners,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "jf" = (
@@ -580,13 +554,13 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/hallway/central)
 "jt" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 10
-	},
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/obj/structure/rack,
+/obj/item/gun_maint_kit{
+	pixel_x = -1;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "jE" = (
@@ -852,8 +826,24 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/glass/twenty{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/metal/twenty{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -9;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "ng" = (
@@ -952,19 +942,11 @@
 /turf/open/floor/engine/hull,
 /area/ship/engineering)
 "oo" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/item/stack/sheet/metal/twenty{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/glass/twenty{
-	pixel_x = 8;
-	pixel_y = 7
-	},
 /obj/item/radio/intercom/directional/east,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "op" = (
@@ -1051,6 +1033,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "pE" = (
@@ -1064,23 +1047,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "qi" = (
-/obj/item/clothing/suit/hazardvest/hardliners,
-/obj/item/clothing/head/hardhat/hardliners,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/explorer,
-/obj/item/radio/headset/alt,
-/obj/item/clothing/under/syndicate/hardliners/jumpsuit,
-/obj/item/melee/sledgehammer/gorlex,
-/obj/item/melee/knife/survival,
-/obj/item/storage/toolbox/syndicate,
-/obj/structure/closet/secure_closet/wall/directional/west{
-	icon_state = "cargo_wall";
-	name = "Wreckers closet";
-	req_access_txt = "48";
-	pixel_x = -28;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
@@ -1089,7 +1055,6 @@
 	pixel_x = -20;
 	pixel_y = -11
 	},
-/obj/item/clothing/glasses/hud/security/sunglasses/hardliners,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/cargo)
 "ra" = (
@@ -1621,9 +1586,25 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "ye" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/techfloor{
 	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/gun_maint_kit{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/weldingtool/mini{
+	pixel_x = 0;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -1941,52 +1922,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Df" = (
-/obj/structure/closet/crate/large{
-	name = "APLU construction kit"
+/obj/structure/closet/secure_closet/security{
+	name = "operative's locker"
 	},
-/obj/item/circuitboard/mecha/ripley/peripherals,
-/obj/item/circuitboard/mecha/ripley/main,
-/obj/item/mecha_parts/chassis/ripley,
-/obj/item/mecha_parts/part/ripley_torso,
-/obj/item/mecha_parts/part/ripley_right_leg{
-	pixel_y = -9;
-	pixel_x = 8
-	},
-/obj/item/mecha_parts/part/ripley_left_leg{
-	pixel_y = -9;
-	pixel_x = -8
-	},
-/obj/item/mecha_parts/part/ripley_left_arm{
-	pixel_x = -12
-	},
-/obj/item/mecha_parts/part/ripley_right_arm{
-	pixel_x = 12
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp{
-	pixel_x = -8;
-	pixel_y = 16
-	},
-/obj/item/mecha_parts/mecha_equipment/salvage_saw{
-	pixel_x = -13;
-	pixel_y = -11
-	},
-/obj/item/mecha_parts/mecha_equipment/thrusters/ion{
-	pixel_x = 17;
-	pixel_y = 14
-	},
-/obj/item/mecha_parts/mecha_equipment/drill{
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/item/stock_parts/cell/super{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/obj/item/storage/belt/security/webbing/hardliners,
+/obj/item/storage/belt/security/webbing/hardliners/alt,
+/obj/item/clothing/glasses/hud/security/sunglasses/hardliners,
+/obj/item/melee/knife/survival,
+/obj/item/clothing/under/syndicate/hardliners/jumpsuit,
+/obj/item/radio/headset/alt,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/head/helmet/hardliners,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2501,14 +2449,24 @@
 /area/ship/crew/canteen)
 "Kx" = (
 /obj/structure/guncloset,
-/obj/item/gun/ballistic/automatic/pistol/asp/no_mag,
-/obj/item/gun/ballistic/shotgun/automatic/bulldog/no_mag,
+/obj/item/gun/ballistic/automatic/pistol/asp/no_mag{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/no_mag{
+	pixel_x = 1;
+	pixel_y = -8
+	},
 /obj/effect/turf_decal/industrial/warning/cee{
 	color = "#FFFFFF";
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 4
+	},
+/obj/item/gun/ballistic/automatic/smg/sidewinder/no_mag{
+	pixel_x = -3;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -2810,12 +2768,6 @@
 /obj/item/ammo_box/magazine/m57_39_asp,
 /obj/item/ammo_box/magazine/m12g_bulldog,
 /obj/item/ammo_box/magazine/m12g_bulldog,
-/obj/item/clothing/suit/armor/hardliners,
-/obj/item/clothing/suit/armor/hardliners,
-/obj/item/storage/belt/security/webbing/hardliners,
-/obj/item/storage/belt/security/webbing/hardliners,
-/obj/item/clothing/head/helmet/hardliners,
-/obj/item/clothing/head/helmet/hardliners,
 /obj/effect/turf_decal/industrial/warning/cee{
 	color = "#FFFFFF";
 	dir = 8
@@ -2833,8 +2785,9 @@
 	pixel_y = -5
 	},
 /obj/item/gun_maint_kit,
-/obj/item/storage/belt/security/webbing/hardliners/alt,
-/obj/item/storage/belt/security/webbing/hardliners/alt,
+/obj/item/ammo_box/magazine/m57_39_sidewinder,
+/obj/item/ammo_box/magazine/m57_39_sidewinder,
+/obj/item/ammo_box/magazine/m57_39_sidewinder,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Qe" = (
@@ -3013,12 +2966,20 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "St" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
+/obj/structure/closet/secure_closet/security{
+	name = "operative's locker"
 	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 6
-	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/obj/item/clothing/glasses/hud/security/sunglasses/hardliners,
+/obj/item/melee/knife/survival,
+/obj/item/clothing/under/syndicate/hardliners/jumpsuit,
+/obj/item/radio/headset/alt,
+/obj/item/clothing/under/syndicate/hardliners,
+/obj/item/clothing/suit/armor/hardliners,
+/obj/item/storage/belt/security/webbing/hardliners,
+/obj/item/storage/belt/security/webbing/hardliners/alt,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/head/helmet/hardliners,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "SB" = (

--- a/_maps/shuttles/hardliner/hardliners_banshee.dmm
+++ b/_maps/shuttles/hardliner/hardliners_banshee.dmm
@@ -514,6 +514,7 @@
 /obj/item/storage/box/flares,
 /obj/item/storage/box/flares,
 /obj/item/pickaxe/drill,
+/obj/item/melee/sledgehammer/gorlex,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "iV" = (

--- a/_maps/shuttles/hardliner/hardliners_banshee.dmm
+++ b/_maps/shuttles/hardliner/hardliners_banshee.dmm
@@ -1922,9 +1922,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Df" = (
-/obj/structure/closet/secure_closet/security{
-	name = "operative's locker"
-	},
 /obj/effect/turf_decal/corner/opaque/syndiered/border,
 /obj/item/storage/belt/security/webbing/hardliners,
 /obj/item/storage/belt/security/webbing/hardliners/alt,
@@ -1934,6 +1931,12 @@
 /obj/item/radio/headset/alt,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/head/helmet/hardliners,
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon_state = "syndicate";
+	name = "trooper's locker";
+	req_access = list(1)
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dt" = (
@@ -2966,9 +2969,6 @@
 /turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "St" = (
-/obj/structure/closet/secure_closet/security{
-	name = "operative's locker"
-	},
 /obj/effect/turf_decal/corner/opaque/syndiered/border,
 /obj/item/clothing/glasses/hud/security/sunglasses/hardliners,
 /obj/item/melee/knife/survival,
@@ -2980,6 +2980,12 @@
 /obj/item/storage/belt/security/webbing/hardliners/alt,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/head/helmet/hardliners,
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon_state = "syndicate";
+	name = "trooper's locker";
+	req_access = list(1)
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "SB" = (

--- a/_maps/shuttles/hardliner/hardliners_banshee.dmm
+++ b/_maps/shuttles/hardliner/hardliners_banshee.dmm
@@ -1937,6 +1937,8 @@
 	name = "trooper's locker";
 	req_access = list(1)
 	},
+/obj/item/clothing/under/syndicate/hardliners,
+/obj/item/clothing/suit/armor/hardliners,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dt" = (


### PR DESCRIPTION
## About The Pull Request

Lot of style discussion in deadchat so I went and did it

<img width="423" height="735" alt="image" src="https://github.com/user-attachments/assets/5d2fc627-4e2f-42ae-a3e2-f3cd94e46c65" />

Additionally added a Sidewinder to the ship armoury to make up for losing a hammer and the Salvage Ripley

## Why It's Good For The Game

Stylistically not purpose-built for salvage like a number of other salvage ships. Simply has them more set for shooting and killing and so forth

## Changelog

:cl:
balance: Banshee retooled into a combat ship. Removed salvage ripley, one hammer, and added a Sidewinder and replaced wreckers with Troopers
/:cl:
