### PR TITLE
Adds pouring reagents down the sink

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -401,7 +401,8 @@
 /obj/structure/sink/attackby_secondary(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/reagent_containers))
 		try_dump_container(user, O)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/structure/sink/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -312,6 +312,15 @@
 	user.visible_message(span_notice("[user] washes [user.p_their()] [washing_face ? "face" : "hands"] using [src]."), \
 						span_notice("You wash your [washing_face ? "face" : "hands"] using [src]."))
 
+/obj/structure/sink/proc/try_dump_container(mob/living/user, obj/item/reagent_containers/dump_target)
+	if(dump_target.reagents.total_volume > 0)
+		var/dump_amount = min(dump_target.reagents.total_volume, dump_target.amount_per_transfer_from_this)
+		dump_target.reagents.remove_all(dump_amount)
+		to_chat(user, span_notice("You pour [dump_amount] units of [dump_target] down the drain."))
+		return TRUE
+	to_chat(user, span_notice("\The [dump_target] is already empty!"))
+	return FALSE
+
 /obj/structure/sink/attackby(obj/item/O, mob/living/user, params)
 	if(busy)
 		to_chat(user, span_warning("Someone's already washing here!"))
@@ -320,13 +329,7 @@
 	if(istype(O, /obj/item/reagent_containers))
 		var/obj/item/reagent_containers/RG = O
 		if(user.a_intent == INTENT_HARM && RG.is_drainable())
-			if(RG.reagents.total_volume > 0)
-				var/dump_amount = min(RG.reagents.total_volume, RG.amount_per_transfer_from_this)
-				RG.reagents.remove_all(dump_amount)
-				to_chat(user, span_notice("You pour [dump_amount] units of [RG] down the drain."))
-				return TRUE
-			to_chat(user, span_notice("\The [RG] is already empty!"))
-			return FALSE
+			return try_dump_container(user, RG)
 		if(RG.is_refillable())
 			if(!RG.reagents.holder_full())
 				var/fill_amount = min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this)
@@ -394,6 +397,11 @@
 		return 1
 	else
 		return ..()
+
+/obj/structure/sink/attackby_secondary(obj/item/O, mob/user, params)
+	if(istype(O, /obj/item/reagent_containers))
+		try_dump_container(user, O)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/sink/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -319,10 +319,19 @@
 
 	if(istype(O, /obj/item/reagent_containers))
 		var/obj/item/reagent_containers/RG = O
+		if(user.a_intent == INTENT_HARM && RG.is_drainable())
+			if(RG.reagents.total_volume > 0)
+				var/dump_amount = min(RG.reagents.total_volume, RG.amount_per_transfer_from_this)
+				RG.reagents.remove_all(dump_amount)
+				to_chat(user, span_notice("You pour [dump_amount] units of [RG] down the drain."))
+				return TRUE
+			to_chat(user, span_notice("\The [RG] is already empty!"))
+			return FALSE
 		if(RG.is_refillable())
 			if(!RG.reagents.holder_full())
-				RG.reagents.add_reagent(dispensedreagent, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-				to_chat(user, span_notice("You fill [RG] from [src]."))
+				var/fill_amount = min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this)
+				RG.reagents.add_reagent(dispensedreagent, fill_amount)
+				to_chat(user, span_notice("You fill [RG] with [fill_amount] units from [src]."))
 				return TRUE
 			to_chat(user, span_notice("\The [RG] is full."))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

Sinks now have functioning drains. Clicking on one with harm intent will pour reagents from your beaker into the sink, safely disposing of them. Also makes filling from the sink tell you how many reagents you got.

## Why It's Good For The Game

Lets you destroy reagents without throwing beakers all over the floor or drinking toxic goop. Improved feedback from sink filling.

## Changelog

:cl: Bumtickley00
add: You can now pour reagents down the sink by clicking on one with harm intent.
spellcheck: Filling from a sink now tells you how many reagents you took.
/:cl:

