### PR TITLE
Fixes certain surgeries appearing when they shouldn't, fixes boneless smite

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1206,11 +1206,11 @@
 				if(!squish_part)
 					continue
 				var/severity = pick(list(
-					"[WOUND_SEVERITY_MODERATE]",
-					"[WOUND_SEVERITY_SEVERE]",
-					"[WOUND_SEVERITY_SEVERE]",
-					"[WOUND_SEVERITY_CRITICAL]",
-					"[WOUND_SEVERITY_CRITICAL]",
+					WOUND_SEVERITY_MODERATE,
+					WOUND_SEVERITY_SEVERE,
+					WOUND_SEVERITY_SEVERE,
+					WOUND_SEVERITY_CRITICAL,
+					WOUND_SEVERITY_CRITICAL,
 				))
 				C.cause_wound_of_type_and_severity(WOUND_BLUNT, squish_part, severity)
 

--- a/code/modules/surgery/bone_fractures.dm
+++ b/code/modules/surgery/bone_fractures.dm
@@ -23,7 +23,7 @@
 	requires_real_bodypart = TRUE
 	targetable_wound = /datum/wound/blunt/bone/critical
 
-/datum/surgery/reset_compound_fracture/can_start(mob/living/user, mob/living/carbon/target)
+/datum/surgery/repair_bone_compound/can_start(mob/living/user, mob/living/carbon/target)
 	if(..())
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
 		return(targeted_bodypart.get_wound_type(targetable_wound))

--- a/code/modules/surgery/heatwarp_repair.dm
+++ b/code/modules/surgery/heatwarp_repair.dm
@@ -13,7 +13,7 @@
 	self_operable = TRUE
 	targetable_wound = /datum/wound/burn/heat_warping/critical
 
-/datum/surgery/repair_sheared_frame/can_start(mob/user, mob/living/patient)
+/datum/surgery/repair_heat_warp/can_start(mob/user, mob/living/patient)
 	if(!..())
 		return FALSE
 	var/obj/item/bodypart/targeted_bodypart = patient.get_bodypart(user.zone_selected)


### PR DESCRIPTION
## About The Pull Request

Fixes compound fracture and heat warp repair showing up on the surgery list when they shouldn't be.
Also fixes the admin boneless smite.

## Why It's Good For The Game

Bugs bad.

## Changelog

:cl: Bumtickley00
fix: Compound fracture and heat warp repair surgeries no longer show as available without a corresponding wound
fix: Admin bone destruction smite now works again
/:cl:
