### PR TITLE
Fixes the Wideband interaction say key

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -34,8 +34,8 @@
 #define RADIO_TOKEN_SOLGOV ":s"
 
 #define RADIO_CHANNEL_WARRA "Makosso-Warra"
-#define RADIO_KEY_WARRA "w"
-#define RADIO_TOKEN_WARRA ":w"
+#define RADIO_KEY_WARRA "mw"
+#define RADIO_TOKEN_WARRA ":mw"
 
 #define RADIO_CHANNEL_MINUTEMEN "Minutemen"
 #define RADIO_KEY_MINUTEMEN "m"

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -165,9 +165,9 @@
 		else if(key == ";" && !mods[MODE_HEADSET])
 			mods[MODE_HEADSET] = TRUE
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
-			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
+			mods[RADIO_KEY] = trimtext(lowertext(message[1 + length(key)] + message[2 + length(key)])) // Allows for two character radio keys
 			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]
-			chop_to = length(key) + 2
+			chop_to = length(mods[RADIO_KEY]) + 2
 		else if(key == "," && !mods[LANGUAGE_EXTENSION])
 			for(var/ld in GLOB.all_languages)
 				var/datum/language/LD = ld


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the say key for widebands -- you can now continue to use the .w key to interact with them. The Makosso-Warra channel was given the .mw key. Some minor refactoring was also done to allow for two character radio keys.

## Why It's Good For The Game

This fixes a minor bug, and it also introduces the framework for more radio keys. This expands the possible radio keys by a considerable amount.

## Changelog

:cl:
fix: fixed wideband radio keys
refactor: refactored say.dm, allowing for two-character radio keys
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
