### PR TITLE
Give crystals a range limit.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -428,6 +428,7 @@
 	damage = 25
 	damage_type = BRUTE
 	speed = 3
+	range = 14
 
 /obj/projectile/goliath/on_hit(atom/target, blocked)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crystal mobs fire crystals in a pentagon kinda ship. However the crystals have no range limit and are spammed, leading to crystal mobs trashing massive areas they're not even near and damaging ships. Also forces people nine miles away to play a bullethell, this adds a range limit to crystal mob crystals so none of this happens.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Puts a range limit on crystal mob crystals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
