### PR TITLE
Adds Airlock Pneumatic Seals to Autolathe

### DIFF
--- a/code/game/objects/items/door_seal.dm
+++ b/code/game/objects/items/door_seal.dm
@@ -16,4 +16,4 @@
 	/// how long the seal takes to place on the door
 	var/seal_time = 3 SECONDS
 	/// how long it takes to remove the seal from a door
-	var/unseal_time = 2 SECONDS
+	var/unseal_time = 10 SECONDS

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -821,6 +821,14 @@
 	build_path = /obj/item/restraints/handcuffs
 	category = list("initial", "Security")
 
+/datum/designs/doorseal
+	name = "Pneumatic Seal"
+	id = "doorseal"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 5000)
+	build_path = /obj/item/door_seal
+	category = list("initial", "Security")
+
 /datum/design/evidencebag
 	name = "Evidence Bag"
 	id = "evidencebag"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -821,7 +821,7 @@
 	build_path = /obj/item/restraints/handcuffs
 	category = list("initial", "Security")
 
-/datum/designs/doorseal
+/datum/design/doorseal
 	name = "Pneumatic Seal"
 	id = "doorseal"
 	build_type = AUTOLATHE


### PR DESCRIPTION
## About The Pull Request

Adds to autolathe for base 5000 iron units (8000 units on base parts)

Makes it so removing the seal takes 10 seconds

## Why It's Good For The Game

Combat utility to close off an area in a sturdier method than simply welding it

## Changelog

:cl:
add: Added Airlock Pneumatic Seal to cargo
balance: Pneumatic Seal now takes 10 seconds to remove
/:cl:
