### PR TITLE
Adjusts Cargo MK III Hypospray Contents

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -300,8 +300,8 @@
 /obj/item/storage/box/hypospray/mkiii/PopulateContents()
 	new /obj/item/hypospray/mkii/mkiii(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/silfrine(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/gjalrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/ysiltane(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancraizne(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
 
 /obj/item/storage/box/hypospray/mkiii/cargo
@@ -309,9 +309,9 @@
 
 /obj/item/storage/box/hypospray/mkiii/PopulateContents()
 	new /obj/item/hypospray/mkii/mkiii(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/cureall(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salglu(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/morphine(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/indomix(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/quadratane(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/gjalrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
 
 /obj/item/storage/box/medigels

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -311,7 +311,7 @@
 	new /obj/item/hypospray/mkii/mkiii(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/hadramide(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/quadratane(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/gjalrazine(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
 
 /obj/item/storage/box/medigels

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -300,8 +300,8 @@
 /obj/item/storage/box/hypospray/mkiii/PopulateContents()
 	new /obj/item/hypospray/mkii/mkiii(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/silfrine(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/gjalrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/ysiltane(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
 
 /obj/item/storage/box/hypospray/mkiii/cargo
@@ -309,7 +309,7 @@
 
 /obj/item/storage/box/hypospray/mkiii/PopulateContents()
 	new /obj/item/hypospray/mkii/mkiii(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/indomix(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/hadramide(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/quadratane(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/gjalrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -313,6 +313,7 @@
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/quadratane(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/morphine(src)
 
 /obj/item/storage/box/medigels
 	name = "box of medical gels"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -301,7 +301,7 @@
 	new /obj/item/hypospray/mkii/mkiii(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/silfrine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/ysiltane(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancraizne(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancrazine(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salbutamol(src)
 
 /obj/item/storage/box/hypospray/mkiii/cargo

--- a/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/code/modules/reagents/reagent_containers/hypovial.dm
@@ -278,25 +278,25 @@
 	icon_state = "hypoviallarge-t"
 	comes_with = list(/datum/reagent/medicine/charcoal = 120)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/cureall
-	name = "large hypovial (cureall)"
-	icon_state = "hypoviallarge"
-	comes_with = list(/datum/reagent/medicine/cureall = 120)
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/hadramide
+	name = "large hypovial (hadra-mide)"
+	icon_state = "hypoviallarge-b"
+	comes_with = list(/datum/reagent/medicine/indomide = 40, /datum/reagent/medicine/cureall = 40, /datum/reagent/medicine/hadrakine = 40)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salglu
-	name = "large green hypovial (salglu)"
-	icon_state = "hypoviallarge-a"
-	comes_with = list(/datum/reagent/medicine/salglu_solution = 120)
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/quadratane
+	name = "large green hypovial (quadra-tane)"
+	icon_state = "hypoviallarge-k"
+	comes_with = list(/datum/reagent/medicine/quardexane = 40, /datum/reagent/medicine/alvitane = 40, /datum/reagent/medicine/cureall = 40)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/synthflesh
 	name = "large orange hypovial (synthflesh)"
 	icon_state = "hypoviallarge-k"
 	comes_with = list(/datum/reagent/medicine/synthflesh = 120)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/morphine
-	name = "large hypovial (morphine)"
-	icon_state = "hypoviallarge-t"
-	comes_with = list(/datum/reagent/medicine/morphine = 120)
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/pancrazine
+	name = "large hypovial (pancrazine)"
+	icon_state = "hypoviallarge-a"
+	comes_with = list(/datum/reagent/medicine/pancrazine = 120)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/combat
 	name = "combat hypovial"

--- a/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/code/modules/reagents/reagent_containers/hypovial.dm
@@ -278,6 +278,21 @@
 	icon_state = "hypoviallarge-t"
 	comes_with = list(/datum/reagent/medicine/charcoal = 120)
 
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/cureall
+	name = "large hypovial (cureall)"
+	icon_state = "hypoviallarge"
+	comes_with = list(/datum/reagent/medicine/cureall = 120)
+
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/salglu
+	name = "large green hypovial (salglu)"
+	icon_state = "hypoviallarge-a"
+	comes_with = list(/datum/reagent/medicine/salglu_solution = 120)
+
+/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/morphine
+	name = "large hypovial (morphine)"
+	icon_state = "hypoviallarge-t"
+	comes_with = list(/datum/reagent/medicine/morphine = 120)
+
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/hadramide
 	name = "large hypovial (hadra-mide)"
 	icon_state = "hypoviallarge-b"


### PR DESCRIPTION
## About The Pull Request

Hadra-mide: 40u Indomide 40u Hadrakine 40u Cureall
Quadra-tane: 40u Quadraxene 40u Alvitane 40u Cureall
Pancrazine: 120u Pancrazine
Salbutamol: 120u Salbutamol

## Why It's Good For The Game

Slightly adjusts the MK III hypo contents to be passably performant mixes. The MK III is a good bit more expensive than the base hypo for things like 120u morphine or 120u saline glucose.

I recognize that it may be intended to fill the large canisters with some other chemical by your own hand, though I believe this may make the MK III a more desirable purchase while not giving it the large volume of highly performant chems it had before 

## Changelog

:cl:
balance: Adjusted MK III Hypospray Cargo Vials to be slightly more performant
/:cl:
