### PR TITLE
Ammo Pouch can now only fit small items

### DIFF
--- a/code/game/objects/items/storage/pouches.dm
+++ b/code/game/objects/items/storage/pouches.dm
@@ -73,7 +73,7 @@
 /obj/item/storage/pouch/ammo/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_items = 3
 	STR.max_combined_w_class = 24
 	STR.set_holdable(list(


### PR DESCRIPTION
## Why It's Good For The Game

<img width="142" height="87" alt="image" src="https://github.com/user-attachments/assets/a4da49ec-b173-43b4-90a8-3ed70f0aba1e" />

<img width="225" height="92" alt="image" src="https://github.com/user-attachments/assets/e536420f-d107-4f27-bb0e-d317272113b7" />

<img width="217" height="98" alt="image" src="https://github.com/user-attachments/assets/0209f63f-7f19-4530-a05e-5a99517cd96c" />

## Changelog

:cl:
balance: Ammo pouches can no longer hold medium sized items
/:cl: