### PR TITLE
Fixes Kunai areas & relocates external/dark

### DIFF
--- a/_maps/shuttles/subshuttles/independent_kunai.dmm
+++ b/_maps/shuttles/subshuttles/independent_kunai.dmm
@@ -223,7 +223,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/area/ship/external/dark)
 "gA" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
@@ -239,7 +239,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/area/ship/external/dark)
 "hJ" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
@@ -298,7 +298,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/area/ship/external/dark)
 "kM" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -338,7 +338,7 @@
 	},
 /obj/structure/grille,
 /turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/area/ship/external/dark)
 "pk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -540,7 +540,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/area/ship/external/dark)
 
 (1,1,1) = {"
 Pq

--- a/code/game/MapData/shuttles/srm_elder.dm
+++ b/code/game/MapData/shuttles/srm_elder.dm
@@ -58,11 +58,6 @@
 	desc = "The closet of mining equipment."
 	icon_state = "mining"
 
-/area/ship/external/dark
-	name = "Dark External"
-	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
-	icon_state = "space_near"
-
 /area/ship/roumain
 	name = "Hunter's Glade"
 	icon_state = "Sleep"

--- a/code/game/area/ship_areas.dm
+++ b/code/game/area/ship_areas.dm
@@ -577,3 +577,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambience_index = AMBIENCE_SPACE
 	sound_environment = SOUND_AREA_SPACE
 	lightswitch = TRUE
+
+/area/ship/external/dark
+	name = "Dark External"
+	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+	icon_state = "space_near"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I initially made this PR to make the Kunai's external areas dark, but then I realized /external/dark was in the Elder's mapdata file and I couldn't leave it like that. 

## Why It's Good For The Game

organisation good

## Changelog

:cl:
fix: The Kunai's external areas have been darkened.
code: The /ship/external/dark area has been moved out of the Elder's mapdata file.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
