### PR TITLE
Fixes wading bug

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -131,8 +131,6 @@ GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
 	if(isliving(movable))
 		var/mob/living/living_mob = movable
 		living_mob.remove_movespeed_modifier(/datum/movespeed_modifier/wading)
-	if(buckled)
-		return
 	UnregisterSignal(movable, list(
 		COMSIG_MOVETYPE_FLAG_ENABLED,
 		COMSIG_MOVETYPE_FLAG_DISABLED,

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -128,11 +128,11 @@ GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
 	var/atom/movable/to_check = buckled || movable
 	if(!(to_check.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && !movable.throwing)
 		remove_immerse_overlay(movable)
-	if(buckled)
-		return
 	if(isliving(movable))
 		var/mob/living/living_mob = movable
 		living_mob.remove_movespeed_modifier(/datum/movespeed_modifier/wading)
+	if(buckled)
+		return
 	UnregisterSignal(movable, list(
 		COMSIG_MOVETYPE_FLAG_ENABLED,
 		COMSIG_MOVETYPE_FLAG_DISABLED,


### PR DESCRIPTION
## About The Pull Request

Fixes the bug where you get slowed forever when landing on water while buckled, which did not previously clear your movespeed modifier.

## Why It's Good For The Game

Nobody likes being slow forever.

## Changelog

:cl: Bumtickley00
fix: You are no longer permanently slowed when landing on water.
/:cl:
