### PR TITLE
rhode QOL

### DIFF
--- a/_maps/shuttles/independent/independent_rhode.dmm
+++ b/_maps/shuttles/independent/independent_rhode.dmm
@@ -382,6 +382,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
+"ip" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -448,9 +452,6 @@
 "ln" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/food/flour,
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plasteel,
@@ -461,9 +462,6 @@
 	},
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "lu" = (
@@ -570,10 +568,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
-"nY" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/ship/crew/dorm)
 "oc" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1470,9 +1464,6 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
-/obj/effect/turf_decal/borderfloor/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -1814,9 +1805,6 @@
 "Mm" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/button/door{
 	pixel_x = -21;
@@ -2203,9 +2191,6 @@
 "TN" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
-/obj/effect/turf_decal/borderfloor{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -2624,7 +2609,7 @@ UH
 DP
 eS
 Wg
-nY
+ip
 gr
 FO
 Ao
@@ -2677,7 +2662,7 @@ vq
 dg
 Ar
 tm
-nY
+ip
 Ar
 Ar
 MH

--- a/_maps/shuttles/independent/independent_rhode.dmm
+++ b/_maps/shuttles/independent/independent_rhode.dmm
@@ -10,7 +10,6 @@
 /area/ship/engineering/engines)
 "aq" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
@@ -135,6 +134,7 @@
 	dir = 4
 	},
 /obj/item/gun/ballistic/shotgun/flamingarrow/pyre/empty,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "cH" = (
@@ -557,7 +557,6 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "nl" = (
@@ -1385,6 +1384,7 @@
 "CK" = (
 /obj/machinery/computer/mech_bay_power_console/retro,
 /obj/effect/turf_decal/box,
+/obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "CT" = (
@@ -1400,6 +1400,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
+"De" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
 "Dn" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/structure/cable{
@@ -1698,7 +1702,6 @@
 /obj/structure/cable{
 	icon_state = "6-10"
 	},
-/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -1927,7 +1930,6 @@
 /turf/open/floor/plating/rust,
 /area/ship/engineering/engines)
 "Ok" = (
-/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -2123,10 +2125,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ship/engineering/engines)
-"Tc" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/ship/crew/dorm)
 "Ti" = (
 /obj/machinery/washing_machine{
 	pixel_x = 4;
@@ -2608,7 +2606,7 @@ UH
 DP
 eS
 Wg
-Tc
+De
 gr
 FO
 Ao
@@ -2661,7 +2659,7 @@ vq
 dg
 Ar
 tm
-Tc
+De
 Ar
 Ar
 MH

--- a/_maps/shuttles/independent/independent_rhode.dmm
+++ b/_maps/shuttles/independent/independent_rhode.dmm
@@ -161,9 +161,21 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "cX" = (
-/obj/structure/ore_box,
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/storage/bag/ore{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/pickaxe/drill{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/mineral/wood/twentyfive{
+	pixel_x = -9;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "dc" = (
@@ -184,6 +196,10 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/shoes/workboots,
 /obj/item/storage/belt/utility/full/engi,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -7;
+	pixel_y = 0
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
 "dg" = (
@@ -382,10 +398,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
-"ip" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/ship/crew/dorm)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1325,6 +1337,10 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/shoes/workboots,
 /obj/item/storage/belt/utility/full/engi,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -8;
+	pixel_y = -5
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
 "Cq" = (
@@ -1475,6 +1491,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
 "EW" = (
@@ -1638,20 +1655,7 @@
 /turf/closed/wall/rust,
 /area/ship/cargo)
 "Il" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore{
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/pickaxe/drill{
-	pixel_x = 10;
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/box,
-/obj/item/stack/sheet/mineral/wood/fifty{
-	pixel_x = -9;
-	pixel_y = 0
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Ir" = (
@@ -1923,7 +1927,6 @@
 /turf/open/floor/plating/rust,
 /area/ship/engineering/engines)
 "Ok" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/patterned,
@@ -1983,10 +1986,9 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Qq" = (
-/obj/structure/rack,
 /obj/item/gear_pack/anglegrinder{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 0;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable{
@@ -1996,14 +1998,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/item/clothing/gloves/color/yellow{
-	pixel_x = -7;
-	pixel_y = 0
-	},
-/obj/item/clothing/gloves/color/yellow{
-	pixel_x = -8;
-	pixel_y = -5
-	},
+/obj/structure/table,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Qw" = (
@@ -2128,6 +2123,10 @@
 	},
 /turf/open/floor/plating/rust,
 /area/ship/engineering/engines)
+"Tc" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
 "Ti" = (
 /obj/machinery/washing_machine{
 	pixel_x = 4;
@@ -2609,7 +2608,7 @@ UH
 DP
 eS
 Wg
-ip
+Tc
 gr
 FO
 Ao
@@ -2662,7 +2661,7 @@ vq
 dg
 Ar
 tm
-ip
+Tc
 Ar
 Ar
 MH

--- a/_maps/shuttles/independent/independent_rhode.dmm
+++ b/_maps/shuttles/independent/independent_rhode.dmm
@@ -131,19 +131,21 @@
 /obj/structure/guncloset,
 /obj/effect/turf_decal/box,
 /obj/item/gun/ballistic/automatic/m12_sporter/mod,
-/obj/item/gun/ballistic/shotgun/doublebarrel/beacon,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/item/gun/ballistic/shotgun/flamingarrow/pyre/empty,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "cH" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner_techfloor_grid/full,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/transparent/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "cQ" = (
@@ -191,20 +193,15 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "dK" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 6
-	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = 5;
-	pixel_y = 4
-	},
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken2"
+	},
 /area/ship/crew/dorm)
 "eb" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -224,11 +221,10 @@
 /obj/machinery/computer/cargo/retro{
 	dir = 8
 	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "eS" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -302,7 +298,6 @@
 /obj/effect/spawner/bunk_bed{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -388,33 +383,16 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engines)
 "jh" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/structure/closet/wall/directional/east,
-/obj/item/clothing/under/shorts/explorer,
-/obj/item/clothing/under/shorts/explorer,
-/obj/item/clothing/under/shorts/dolphin,
-/obj/item/clothing/under/shorts/dolphin,
-/obj/item/clothing/under/shorts/jorts,
-/obj/item/clothing/under/shorts/jorts,
-/obj/item/clothing/under/pants/jeans,
-/obj/item/clothing/under/pants/jeans,
-/obj/item/clothing/under/pants/blackjeans,
-/obj/item/clothing/under/pants/blackjeans,
-/obj/item/clothing/head/soft/utility_olive,
-/obj/item/clothing/head/soft/utility_olive,
-/obj/item/clothing/head/soft/utility_olive,
-/obj/item/clothing/head/soft/utility_olive,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/workboots,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
 "jv" = (
 /turf/closed/wall/rust,
@@ -490,21 +468,28 @@
 /area/ship/cargo)
 "lu" = (
 /obj/structure/chair/sofa/olive/old/right/directional,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "lv" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken3"
+	},
 /area/ship/crew/dorm)
 "lE" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4{
@@ -536,7 +521,13 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "mU" = (
 /obj/machinery/shower{
@@ -579,6 +570,10 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"nY" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/ship/crew/dorm)
 "oc" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -626,10 +621,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/borderfloorblack{
-	dir = 8
+	dir = 4;
+	layer = 2.030
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/effect/turf_decal/corner/transparent/green/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ph" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -645,7 +643,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/brown,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "pv" = (
 /obj/structure/chair/plastic{
@@ -654,7 +659,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "px" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -670,14 +681,18 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "pQ" = (
-/obj/effect/turf_decal/borderfloorblack{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/corner/transparent/green/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "pW" = (
 /obj/effect/turf_decal/corner_techfloor_grid{
@@ -690,9 +705,6 @@
 /area/ship/cargo)
 "qc" = (
 /obj/effect/turf_decal/box,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	pixel_x = 21;
 	pixel_y = 1;
@@ -718,7 +730,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/fax/indie,
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "qf" = (
 /obj/effect/turf_decal/corner_techfloor_grid{
@@ -789,16 +804,26 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "rj" = (
+/obj/structure/chair/sofa/olive/old/right/directional,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "rl" = (
-/obj/effect/turf_decal/box/corners,
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/wrapping,
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 10
+	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "rr" = (
 /obj/structure/closet/crate/trashcart,
@@ -867,7 +892,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "sF" = (
 /turf/open/floor/engine/hull,
@@ -895,9 +926,6 @@
 /area/ship/cargo)
 "un" = (
 /obj/item/clothing/suit/space/hardsuit/mining/independent,
-/obj/effect/turf_decal/corner_techfloor_grid/full{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/item/clothing/mask/breath,
 /obj/structure/cable{
@@ -911,6 +939,9 @@
 	},
 /obj/item/tank/jetpack/oxygen,
 /obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/trimline/transparent/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "uJ" = (
@@ -989,6 +1020,9 @@
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "vX" = (
@@ -1114,9 +1148,18 @@
 	icon_state = "8-9"
 	},
 /obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "zc" = (
 /turf/closed/wall/r_wall/rust,
@@ -1157,14 +1200,14 @@
 	pixel_x = 0;
 	pixel_y = 8
 	},
-/obj/item/attachment/long_scope{
-	pixel_x = -2;
-	pixel_y = -5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/item/attachment/scope/old{
+	pixel_x = -4;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ai" = (
@@ -1195,8 +1238,31 @@
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "Ao" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 4
+/obj/structure/dresser/wall/directional/south,
+/obj/structure/closet/wall/directional/west,
+/obj/item/clothing/head/hardhat/weldhat/orange{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/hardhat/weldhat/orange{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = -10;
+	pixel_y = -7
+	},
+/obj/item/clothing/suit/hazardvest{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/obj/item/clothing/suit/toggle/hazard{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/item/clothing/suit/toggle/hazard{
+	pixel_x = -1;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -1312,10 +1378,17 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "CT" = (
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/beige,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Dn" = (
 /obj/effect/turf_decal/industrial/warning/fulltile,
@@ -1383,7 +1456,13 @@
 	pixel_y = 12
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Eu" = (
 /obj/machinery/griddle,
@@ -1411,9 +1490,6 @@
 /obj/structure/closet/wall/blue/directional/north{
 	name = "Captain's locker"
 	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
-	},
 /obj/item/gun/energy/laser/e10,
 /obj/item/stock_parts/cell/gun/upgraded,
 /obj/item/storage/backpack/duffelbag,
@@ -1437,13 +1513,19 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "FB" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
 /obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#543C30"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 17;
+	pixel_y = 2
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken2"
+	},
 /area/ship/crew/dorm)
 "FE" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1454,11 +1536,21 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "FO" = (
-/obj/structure/dresser{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 0
-	},
+/obj/structure/closet/wall/directional/west,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/head/soft/utility_olive,
+/obj/item/clothing/head/soft/utility_olive,
+/obj/item/clothing/under/pants/blackjeans,
+/obj/item/clothing/under/pants/blackjeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/shorts/dolphin,
+/obj/item/clothing/under/shorts/dolphin,
+/obj/item/clothing/under/shorts/jorts,
+/obj/item/clothing/under/shorts/jorts,
+/obj/item/clothing/under/shorts/explorer,
+/obj/item/clothing/under/shorts/explorer,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "Gb" = (
@@ -1466,7 +1558,16 @@
 /mob/living/simple_animal/pet/cat/original{
 	name = "Scav"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Gh" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -1572,13 +1673,10 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
+/obj/item/storage/box/ammo/a4570,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "IT" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/structure/chair/office,
 /obj/machinery/button/door{
 	pixel_x = 22;
 	pixel_y = 3;
@@ -1589,7 +1687,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/structure/chair/sofa/olive/old/left,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken6"
+	},
 /area/ship/crew/dorm)
 "Jc" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -1670,7 +1775,6 @@
 	dir = 1
 	},
 /obj/machinery/holopad/emergency,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "LQ" = (
@@ -1681,9 +1785,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Md" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1693,7 +1794,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Mf" = (
@@ -1770,7 +1873,14 @@
 	pixel_x = 11;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.030
+	},
+/obj/effect/turf_decal/corner/transparent/green/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "MV" = (
 /obj/machinery/vending/cigarette,
@@ -1923,7 +2033,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
 /obj/machinery/light_switch{
 	pixel_x = 9;
 	pixel_y = 22
@@ -2053,14 +2162,14 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
+/obj/machinery/light/small/directional/north{
+	pixel_x = 10;
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Tm" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
 /obj/item/radio/intercom/wideband/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -2246,11 +2355,10 @@
 /obj/machinery/computer/helm/retro{
 	dir = 8
 	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/turf/open/floor/plasteel/telecomms_floor,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "Yo" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -2266,13 +2374,19 @@
 /area/ship/crew/toilet)
 "Yv" = (
 /obj/structure/chair/sofa/olive/old/corner/directional/south,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Yw" = (
 /obj/item/plunger,
@@ -2336,13 +2450,23 @@
 	pixel_x = -8;
 	pixel_y = 2
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Zq" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/beige{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Zu" = (
 /obj/machinery/power/terminal{
@@ -2500,7 +2624,7 @@ UH
 DP
 eS
 Wg
-tm
+nY
 gr
 FO
 Ao
@@ -2553,7 +2677,7 @@ vq
 dg
 Ar
 tm
-tm
+nY
 Ar
 Ar
 MH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="928" height="480" alt="image" src="https://github.com/user-attachments/assets/be3c5f76-9642-4546-8bee-0f72ef47f012" />

## Why It's Good For The Game
Mostly decal adjustments.
Major changes include swapping the beacon with a pyre and giving it an extra ammo box. The rhode genuinely had the most dogshit arsenal in the game and i cant bear to see people get owned by a coughing goliath due to the beacon being unable to kill anything in reasonable timeframe

## Changelog

:cl:
add: Rhode QOL, swaps beacon for pyre and room redo/redecal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
