### PR TITLE
Adds polyglot quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,7 +29,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Alcohol Tolerance","Light Drinker"),
 		list("Bad Touch", "Friendly"),
 		list("Self-Aware", "Congenital Analgesia"),
-		list("Trilingual", "Monolingual"),
+		list("Trilingual", "Monolingual", "Polyglot"),
 	)
 
 	species_blacklist = list(

--- a/code/datums/traits/positive/polyglot.dm
+++ b/code/datums/traits/positive/polyglot.dm
@@ -1,4 +1,4 @@
 /datum/quirk/polyglot
 	name = "Polyglot"
-	desc = "You're fluent in four languages! (+4 language points)"
+	desc = "You're fluent in four languages! (+5 language points)"
 	value = 2

--- a/code/datums/traits/positive/polyglot.dm
+++ b/code/datums/traits/positive/polyglot.dm
@@ -1,0 +1,4 @@
+/datum/quirk/polyglot
+	name = "Polyglot"
+	desc = "You're fluent in four languages! (+4 language points)"
+	value = 2

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1586,6 +1586,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		checked_langs += lang_type
 	if("Trilingual" in all_quirks)
 		points_balance += 2
+	if("Polyglot" in all_quirks)
+		points_balance += 5
 	if("Monolingual" in all_quirks)
 		points_balance -= 2
 	return points_balance

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -981,6 +981,7 @@
 #include "code\datums\traits\positive\robust_metabolism.dm"
 #include "code\datums\traits\positive\self_aware.dm"
 #include "code\datums\traits\positive\trilingual.dm"
+#include "code\datums\traits\positive\polyglot.dm"
 #include "code\datums\votes\_vote_datum.dm"
 #include "code\datums\votes\custom_vote.dm"
 #include "code\datums\votes\restart_vote.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a polyglot quirk, giving you 5 language points. Incompatible with monolingual and trilingual. Requires two trait points.

This might be a flawed idea, but I think more languages isn't really that powerful of a quirk? Please give feedback if you have suggestions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Several players expressed interest in having such a quirk. Would be interesting for RP imo given a player doesn't mind having a couple more negative quirks. Also, I love yapping.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added polyglot quirk for maximum yapping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
