### PR TITLE
Drops Scatterlaser + Pulse slug wear down to 2 from 4

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -166,7 +166,7 @@
 	pellets = 6
 	variance = 25
 
-	wear_modifier = 4
+	wear_modifier = 2
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -176,7 +176,7 @@
 	icon_state = "pulse"
 	projectile_type = /obj/projectile/beam/pulse/shotgun
 
-	wear_modifier = 4
+	wear_modifier = 2
 
 /obj/item/ammo_casing/shotgun/buckshot/twobore
 	name = "two-bore shell"


### PR DESCRIPTION
## Why It's Good For The Game

Would have been good when they were best-in-class but I don't think the current pulse slug / scatter laser is performant enough to justify 4x wear

Other specialist shells remain 4x wear

## Changelog

:cl:
balance: Scatter laser + pulse slugs are now 2x wear instead of 4x wear
/:cl: