### PR TITLE
Removes Nanotrasen from the Crying Sun

### DIFF
--- a/_maps/shuttles/pgf/pgf_crying_sun.dmm
+++ b/_maps/shuttles/pgf/pgf_crying_sun.dmm
@@ -367,7 +367,7 @@
 /area/ship/hallway/central)
 "bB" = (
 /obj/structure/punching_bag{
-	desc = "A punching bag. The Nanotrasen symbol has been cheekily hand-painted on.";
+	desc = "A punching bag. The Makosso-Warra symbol has been cheekily hand-painted on.";
 	dir = 1
 	},
 /obj/machinery/light/directional/west,


### PR DESCRIPTION
## About The Pull Request

Removes Nanotrasen

## Why It's Good For The Game

Get out of here

## Changelog

:cl: Bumtickley00
spellcheck: Removed Nanotrasen reference from the Crying Sun.
/:cl: