### PR TITLE
Removes R&D server board from autolathe

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -243,7 +243,7 @@
 	name = "Machine Design (R&D Server Board)"
 	desc = "The circuit board for an R&D Server."
 	id = "rdserver"
-	build_type = AUTOLATHE | IMPRINTER
+	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/rdserver
 	category = list("Research Machinery", "initial", "Equipment")
 


### PR DESCRIPTION
## About The Pull Request

Removes the R&D server board recipe from the autolathe

## Why It's Good For The Game

Cruft

## Changelog

:cl: Bumtickley00
del: Removed R&D server board recipe from autolathe
/:cl:
