### PR TITLE
Updates chlorine and hydrogen chloride canister descriptions.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -182,14 +182,14 @@
 
 /obj/machinery/portable_atmospherics/canister/chlorine
 	name = "chlorine canister"
-	desc = "chlorine"
+	desc = "Chlorine gas. Highly toxic."
 	icon_state = "greenys"
 	gas_type = GAS_CHLORINE
 	filled = 1
 
 /obj/machinery/portable_atmospherics/canister/hydrogen_chloride
 	name = "hydrogen chloride canister"
-	desc = "awful"
+	desc = "Hydrogen chloride gas. Don't breathe this."
 	icon_state = "greenyshaz"
 	gas_type = GAS_HYDROGEN_CHLORIDE
 	filled = 1


### PR DESCRIPTION
## About The Pull Request

Changes the description of the chlorine and hydrogen chloride canisters

## Why It's Good For The Game

chlorine

awful

## Changelog

:cl: Bumtickley00
spellcheck: Improved description of chlorine and hydrogen chloride canisters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
