### PR TITLE
Adds moth and rachnid fbp

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/body/prosthetic.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/body/prosthetic.dm
@@ -28,7 +28,29 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot/surplus/human,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot/surplus/human,
 	)
-	allowed_species = list(/datum/species/human, /datum/species/moth)
+	allowed_species = list(/datum/species/human)
+
+/datum/sprite_accessory/body/prosthetic/moth
+	name = "Prosthetic Moth"
+	replacement_bodyparts = list(
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot/human,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot/human,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/robot/surplus/human,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/robot/surplus/human,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot/surplus/human,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot/surplus/human,
+	)
+	replacement_organs = list(
+		ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic,
+		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/compound/robotic,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears/cybernetic,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/robot,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/cybernetic,
+		ORGAN_SLOT_WINGS = /obj/item/organ/moth_wings/cybernetic,
+	)
+	allowed_species = list(/datum/species/moth)
 
 /datum/sprite_accessory/body/prosthetic/sarathi
 	name = "Prosthetic Sarathi"
@@ -85,3 +107,24 @@
 	)
 	allowed_species = list(/datum/species/vox)
 	bodytype = BODYTYPE_VOX
+
+/datum/sprite_accessory/body/prosthetic/spider
+	name = "Prosthetic Rachnid"
+	replacement_bodyparts = list(
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot/human,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot/human,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/robot/surplus/human,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/robot/surplus/human,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot/surplus/human,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot/surplus/human,
+	)
+	replacement_organs = list(
+		ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic,
+		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/night_vision/spider/robotic,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears/cybernetic,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/robot,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/cybernetic,
+	)
+	allowed_species = list(/datum/species/spider)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -42,7 +42,7 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/moth,
 	)
 
-	prosthetic_style = /datum/sprite_accessory/body/prosthetic/human
+	prosthetic_style = /datum/sprite_accessory/body/prosthetic/moth
 
 	min_temp_comfortable = HUMAN_BODYTEMP_NORMAL - 5
 	bodytemp_cold_damage_limit = HUMAN_BODYTEMP_COLD_DAMAGE_LIMIT - 5

--- a/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -4,6 +4,13 @@
 	see_in_dark = 4
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 
+/obj/item/organ/eyes/night_vision/spider/robotic
+	name = "robotic spider eyes"
+	icon_state = "robotic_eyes"
+	eye_icon_state = "eyes_synth"
+	status = ORGAN_ROBOTIC
+	organ_flags = ORGAN_SYNTHETIC
+
 /datum/species/spider
 	name = "Rachnid"
 	id = SPECIES_RACHNID
@@ -46,6 +53,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/rachnid,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/rachnid,
 	)
+	prosthetic_style = /datum/sprite_accessory/body/prosthetic/spider
 
 /datum/species/spider/random_name(gender,unique,lastname)
 	if(unique)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -516,3 +516,8 @@
 	flash_protect = FLASH_PROTECTION_SENSITIVE	//Obligatory flash sensitivity for balance
 	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT - 5	//This acts as *slightly* more powerful nightvision compared to the nightvision trait, if someone chooses NV as a trait it will be overwritten by this (highest wins).
 	//This reason these eyes do not inherit from /night_vision/ is because the fullbright the night_vision subtype provides is too overpowered for a roundstart selectable race.
+
+/obj/item/organ/eyes/compound/robotic
+	name = "robotic compound eyes"
+	status = ORGAN_ROBOTIC
+	organ_flags = ORGAN_SYNTHETIC

--- a/code/modules/surgery/organs/moth_wings.dm
+++ b/code/modules/surgery/organs/moth_wings.dm
@@ -28,3 +28,10 @@
 		H.dna.species.mutant_bodyparts -= "moth_wings"
 		wing_type = H.dna.features["moth_wings"]
 		H.update_body()
+
+/obj/item/organ/moth_wings/cybernetic
+	name = "cybernetic moth wings"
+
+/obj/item/organ/moth_wings/cybernetic/examine(mob/user)
+	. = ..()
+	. += "Their fluff is made of syntetic materials."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds moth and rachnid FBP.
The moths have robotic compound eyes and synthetic wings. Both looks identical to their bio counterpart as the coumpound eyes looks belivably robotic and the wings are made with false fluff.
The rachnid have robotic spider eyes, they look like generic human eyes since there is no spider eyes sprite.

## Why It's Good For The Game

Enchaced vision is a trait of both species and having it removed by playing a fbp sucks.

## Changelog

:cl:
add: moth and rachnid fbps now have the same vision as organics of their species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
