### PR TITLE
Mobs are effected by armor + Seedling Nerf

### DIFF
--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -480,7 +480,6 @@ GLOBAL_LIST_EMPTY(ore_veins)
 		/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands/nest = 60,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/nest = 20,
 		/mob/living/simple_animal/hostile/asteroid/basilisk/whitesands = 30,
-		/mob/living/simple_animal/hostile/asteroid/basilisk/whitesands/heat = 10,
 		)
 
 	ore_list = list(

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -124,15 +124,6 @@
 		combatant_state = SEEDLING_STATE_WARMUP
 		walk(src,0)
 		update_icons()
-		var/target_dist = get_dist(src,target)
-		var/living_target_check = isliving(target)
-		if(living_target_check)
-			if(target_dist > 7)//Offscreen check
-				SolarBeamStartup(target)
-				return
-			if(get_dist(src,target) >= 4 && prob(40))
-				SolarBeamStartup(target)
-				return
 		addtimer(CALLBACK(src, PROC_REF(Volley)), 5)
 
 /mob/living/simple_animal/hostile/jungle/seedling/proc/SolarBeamStartup(mob/living/living_target)//It's more like requiem than final spark

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -61,7 +61,7 @@
 	damage = 40
 	damage_type = BRUTE
 	nodamage = FALSE
-	flag = "energy"
+	flag = ENERGY
 	temperature = 0
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)
@@ -195,10 +195,6 @@
 			icon_state = "basilisk_whitesands_shell0"
 	else
 		icon_state = "basilisk_whitesands_dead"
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/whitesands/heat
-	name = "glowing basilisk"
-	projectiletype = /obj/projectile/temp/basilisk/heated
 
 //Watcher
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -61,6 +61,7 @@
 	damage = 40
 	damage_type = BRUTE
 	nodamage = FALSE
+	flag = "energy"
 	temperature = 0
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -217,8 +217,10 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message(span_danger("[src] grabs hold of [L]!"))
-		L.Stun(10)
-		L.adjustBruteLoss(rand(30,35))
+		//I don't think there's any situation where only one leg will be armored and I don't care to make it figure out which leg was dierolled so we just assume the right leg has the same armor as the left and go off that
+		var/obj/item/bodypart/affecting = L.get_bodypart(BODY_ZONE_L_LEG)
+		var/armor_block = L.run_armor_check(affecting, "melee")
+		L.apply_damage(rand(10,20), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), armor_block, TRUE, wound_bonus = CANT_WOUND)
 		latched = TRUE
 	if(!latched)
 		retract()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -217,11 +217,22 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message(span_danger("[src] grabs hold of [L]!"))
-		//I don't think there's any situation where only one leg will be armored and I don't care to make it figure out which leg was dierolled so we just assume the right leg has the same armor as the left and go off that
-		var/obj/item/bodypart/affecting = L.get_bodypart(BODY_ZONE_L_LEG)
-		var/armor_block = L.run_armor_check(affecting, MELEE)
-		L.apply_damage(rand(10,20), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), armor_block, TRUE, wound_bonus = CANT_WOUND)
-		latched = TRUE
+		var/mob/living/target = L
+		var/obj/item/bodypart/affecting
+		if(ishuman(target))
+			if(prob(50))
+				affecting = target.get_bodypart(BODY_ZONE_R_LEG)
+			else
+				affecting = target.get_bodypart(BODY_ZONE_L_LEG)
+			//if(affecting != "l_leg" && affecting != "r_leg")
+				//affecting = "chest"
+			var/armor_block
+			armor_block = target.run_armor_check(affecting, MELEE)
+			target.Knockdown(1 DECISECONDS)
+			target.apply_damage(rand(30,35), BRUTE, affecting, armor_block, FALSE, wound_bonus = CANT_WOUND)
+			latched = TRUE
+		else
+			target.apply_damage(rand(30,35), BRUTE, wound_bonus = CANT_WOUND)
 	if(!latched)
 		retract()
 	else

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -219,7 +219,7 @@
 		visible_message(span_danger("[src] grabs hold of [L]!"))
 		//I don't think there's any situation where only one leg will be armored and I don't care to make it figure out which leg was dierolled so we just assume the right leg has the same armor as the left and go off that
 		var/obj/item/bodypart/affecting = L.get_bodypart(BODY_ZONE_L_LEG)
-		var/armor_block = L.run_armor_check(affecting, "melee")
+		var/armor_block = L.run_armor_check(affecting, MELEE)
 		L.apply_damage(rand(10,20), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), armor_block, TRUE, wound_bonus = CANT_WOUND)
 		latched = TRUE
 	if(!latched)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -224,8 +224,8 @@
 				affecting = target.get_bodypart(BODY_ZONE_R_LEG)
 			else
 				affecting = target.get_bodypart(BODY_ZONE_L_LEG)
-			//if(affecting != "l_leg" && affecting != "r_leg")
-				//affecting = "chest"
+			if(!affecting)
+				affecting = target.get_bodypart(BODY_ZONE_CHEST)
 			var/armor_block
 			armor_block = target.run_armor_check(affecting, MELEE)
 			target.Knockdown(1 DECISECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -345,8 +345,8 @@
 			affecting = target.get_bodypart(BODY_ZONE_R_LEG)
 		else
 			affecting = target.get_bodypart(BODY_ZONE_L_LEG)
-		//if(affecting != "l_leg" && affecting != "r_leg")
-			//affecting = "chest"
+		if(!affecting) //(!target.get_bodypart(BODY_ZONE_R_LEG) && !target.get_bodypart(BODY_ZONE_L_LEG))
+			affecting = target.get_bodypart(BODY_ZONE_CHEST)
 		var/armor_block
 		armor_block = target.run_armor_check(affecting, MELEE)
 		target.apply_damage(rand(20,25), BRUTE, affecting, armor_block, FALSE, wound_bonus = CANT_WOUND)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -339,13 +339,22 @@
 		timerid = addtimer(CALLBACK(src, PROC_REF(retract)), 10, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/goliath_tentacle/proc/on_hit(mob/living/target)
-	var/obj/item/bodypart/affecting = target.get_bodypart(BODY_ZONE_L_LEG)
-	var/armor_block = target.run_armor_check(affecting, "melee")
-	target.apply_damage(rand(15,25), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), armor_block, TRUE, wound_bonus = CANT_WOUND) //already dangerous, don't break legs too
+	var/obj/item/bodypart/affecting
+	if(ishuman(target))
+		if(prob(50))
+			affecting = target.get_bodypart(BODY_ZONE_R_LEG)
+		else
+			affecting = target.get_bodypart(BODY_ZONE_L_LEG)
+		//if(affecting != "l_leg" && affecting != "r_leg")
+			//affecting = "chest"
+		var/armor_block
+		armor_block = target.run_armor_check(affecting, MELEE)
+		target.apply_damage(rand(20,25), BRUTE, affecting, armor_block, FALSE, wound_bonus = CANT_WOUND)
+	else
+		target.apply_damage(rand(20,25), BRUTE, wound_bonus = CANT_WOUND)
 	if(iscarbon(target))
 		var/obj/item/restraints/legcuffs/beartrap/goliath/B = new /obj/item/restraints/legcuffs/beartrap/goliath(get_turf(target))
 		B.on_entered(src, target)
-
 /obj/effect/temp_visual/goliath_tentacle/proc/retract()
 	icon_state = "marker"
 	flick(retract,src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -339,8 +339,9 @@
 		timerid = addtimer(CALLBACK(src, PROC_REF(retract)), 10, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/goliath_tentacle/proc/on_hit(mob/living/target)
-	target.apply_damage(rand(10,20), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), wound_bonus = CANT_WOUND) //already dangerous, don't break legs too
-
+	var/obj/item/bodypart/affecting = target.get_bodypart(BODY_ZONE_L_LEG)
+	var/armor_block = target.run_armor_check(affecting, "melee")
+	target.apply_damage(rand(15,25), BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), armor_block, TRUE, wound_bonus = CANT_WOUND) //already dangerous, don't break legs too
 	if(iscarbon(target))
 		var/obj/item/restraints/legcuffs/beartrap/goliath/B = new /obj/item/restraints/legcuffs/beartrap/goliath(get_turf(target))
 		B.on_entered(src, target)


### PR DESCRIPTION
Goliath Tentacles and Basilisk Bolts are now effected by armor values. Additionally baby grubboids no longer stun and the Seedling orbital laser has been removed, because these sucked.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies Goliath/Gruboid tentacle behavior to account for leg armor. 
Removes the Seedling's ability to fire orbital lasers.
Makes Glowing Basilisk bolts affected by armor.
Removes Baby Gruboid tentacle stun and makes their tentacles do damage more in line with adult goliaths. (slightly less instead of massively more damage)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


## Why It's Good For The Game
Armor generally should do something, if you're wearing leg armor it should reduce the damage from goliath tentacles, It didn't before, it does now. Glowing basilisks don't need to be firing something with the same damage as the boomslang and even higher armor piercing. 
The Orbital laser effect on the Seedling is hard to understand (there's no indication its going to fire) and can hit players off screen and through cover. This sucks and also is conceptually baffling, because its a plant, a plant should not have an orbital deathray. Because of these reasons the orbital deathray has been removed.
Baby Grubboid tentacle stun has been removed because its not very fun to drop your gun because you got hit by an attack that is nearly impossible to see.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance:Goliath/Gruboid tentacles are now affected by armor.
del:Glowing Basilisks have been taken out behind the shed. Rejoice
balance:Seedlings have had their access to an orbital deathray revoked and will now only ever use their burst fire attack.
balance:Baby Gruboids no longer stun and instead knockdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
