### PR TITLE
Cocktail recipe adjustments, pure ethanol is now stronger

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -57,11 +57,11 @@
 
 /datum/chemical_reaction/gin_tonic
 	results = list(/datum/reagent/consumable/ethanol/gintonic = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 2, /datum/reagent/consumable/tonic = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 1, /datum/reagent/consumable/tonic = 2)
 
 /datum/chemical_reaction/rum_coke
 	results = list(/datum/reagent/consumable/ethanol/rum_coke = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 2, /datum/reagent/consumable/space_cola = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/space_cola = 2)
 
 /datum/chemical_reaction/cuba_libre
 	results = list(/datum/reagent/consumable/ethanol/cuba_libre = 4)
@@ -81,11 +81,11 @@
 
 /datum/chemical_reaction/whiskey_cola
 	results = list(/datum/reagent/consumable/ethanol/whiskey_cola = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/space_cola = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/space_cola = 2)
 
 /datum/chemical_reaction/screwdriver
 	results = list(/datum/reagent/consumable/ethanol/screwdrivercocktail = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/orangejuice = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/orangejuice = 2)
 
 /datum/chemical_reaction/bloody_mary
 	results = list(/datum/reagent/consumable/ethanol/bloody_mary = 4)
@@ -162,7 +162,7 @@
 
 /datum/chemical_reaction/whiskeysoda
 	results = list(/datum/reagent/consumable/ethanol/whiskeysoda = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/sodawater = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/sodawater = 2)
 
 /datum/chemical_reaction/black_russian
 	results = list(/datum/reagent/consumable/ethanol/black_russian = 5)
@@ -178,7 +178,7 @@
 
 /datum/chemical_reaction/vodka_tonic
 	results = list(/datum/reagent/consumable/ethanol/vodkatonic = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/tonic = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/tonic = 2)
 
 /datum/chemical_reaction/gin_fizz
 	results = list(/datum/reagent/consumable/ethanol/ginfizz = 4)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents/ethanol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents/ethanol.dm
@@ -9,7 +9,7 @@
 	nutriment_factor = 0
 	taste_description = "alcohol"
 	metabolization_rate = ETHANOL_METABOLISM
-	var/boozepwr = 65 //Higher numbers equal higher hardness, higher hardness equals more intense alcohol poisoning
+	var/boozepwr = 150 //Higher numbers equal higher hardness, higher hardness equals more intense alcohol poisoning
 	accelerant_quality = 5
 
 /datum/reagent/consumable/ethanol/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)


### PR DESCRIPTION
## About The Pull Request

Changes a few cocktail recipes to be more sensible / closer to their real counterparts.
Drastically increases the `boozepwr` of pure ethanol from 65 (only as strong as ale) to 150 (will fuck you up).

## Why It's Good For The Game

Nobody makes a gin and tonic with 2/3 gin. Drinking pure ethanol should fuck you up. Realism. Immersion. Third thing.

## Changelog

:cl: Bumtickley00
balance: Changed the following cocktail recipes to be more accurate: gin and tonic, rum and coke, whiskey cola, screwdriver, whiskey soda, vodka tonic.
balance: Pure ethanol is now an extremely strong drink instead of being only as strong as ale.
/:cl:
