### PR TITLE
Reflavors the Resistor to a midline rifle

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_corpo_resort.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_corpo_resort.dmm
@@ -11953,7 +11953,6 @@
 "XJ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/stock_parts/cell/gun/sharplite/plus/empty,
-/obj/item/gun/energy/sharplite/l201/l204/empty_cell,
 /obj/item/stack/ore/salvage/scrapmetal/ten,
 /obj/item/stack/ore/salvage/scraptitanium/five,
 /obj/item/circuitboard/machine/recharger,
@@ -11963,6 +11962,7 @@
 /obj/item/melee/classic_baton/telescopic,
 /obj/item/restraints/handcuffs,
 /obj/item/gun/energy/disabler,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
 /turf/open/floor/plating/asteroid/dirt/beach,
 /area/overmap_encounter/planetoid/beachplanet/explored)
 "XM" = (

--- a/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
@@ -518,7 +518,7 @@
 "cY" = (
 /obj/effect/mob_spawn/human/corpse/ruin/ns_mine_miner/armored,
 /obj/effect/gibspawner/human/bodypartless,
-/obj/item/gun/energy/sharplite/l201/l204/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
 /turf/open/floor/mineral/titanium/tiled/rockplanet/lit,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "da" = (
@@ -1784,7 +1784,7 @@
 "jP" = (
 /obj/structure/guncloset,
 /obj/effect/turf_decal/box,
-/obj/item/gun/energy/sharplite/l201/l204/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/rockplanet/mining_base/armory)
 "jS" = (
@@ -8854,7 +8854,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light/directional/east,
-/obj/item/gun/energy/sharplite/l201/l204/empty_cell,
+/obj/item/gun/energy/sharplite/x12/empty_cell,
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/rockplanet/mining_base/armory)
 "XV" = (

--- a/_maps/RandomRuins/SpaceRuins/singularity_lab.dmm
+++ b/_maps/RandomRuins/SpaceRuins/singularity_lab.dmm
@@ -11883,7 +11883,7 @@
 	name = "Prototype Storage"
 	},
 /obj/item/gun/energy/sharplite/l201/l204,
-/obj/item/gun/energy/sharplite/l201/l204,
+/obj/item/gun/energy/sharplite/x12,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/singularitylab/lab)
 "UM" = (

--- a/_maps/RandomRuins/SpaceRuins/vi_deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vi_deepstorage.dmm
@@ -984,8 +984,8 @@
 /obj/effect/turf_decal/trimline/opaque/vired/warning{
 	dir = 5
 	},
-/obj/item/gun/energy/sharplite/l201/l204,
 /obj/item/gun/energy/sharplite/l201,
+/obj/item/gun/energy/sharplite/x12,
 /turf/open/floor/plasteel/tech,
 /area/ruin/space/has_grav/deepstorage/security)
 "gI" = (

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -801,9 +801,9 @@
 	dir = 10
 	},
 /obj/structure/guncloset,
-/obj/item/gun/energy/sharplite/l201/l204,
 /obj/item/gun/energy/laser/e10,
 /obj/item/gun/energy/laser/e10,
+/obj/item/gun/energy/sharplite/x12,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance)
 "pY" = (

--- a/_maps/shuttles/warra/warra_kiwi.dmm
+++ b/_maps/shuttles/warra/warra_kiwi.dmm
@@ -625,10 +625,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/energy/sharplite/x26,
-/obj/item/gun/energy/sharplite/l201/l204,
-/obj/item/gun/energy/sharplite/l201/l204,
-/obj/item/gun/energy/sharplite/l201/l204,
 /obj/item/gun/energy/sharplite/x46,
+/obj/item/gun/energy/sharplite/x12,
+/obj/item/gun/energy/sharplite/x12,
+/obj/item/gun/energy/sharplite/x12,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo/office)
 "eu" = (

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -230,8 +230,8 @@
 
 /datum/supply_pack/gun/l204
 	name = "L204 'Resistor' Plasma Rifle Crate"
-	desc = "Contains a lethal, high-energy laser gun."
-	cost = 1000
+	desc = "Contains a lethal, high-energy electroplasma gun with a higher power consumption. Rated for moderatedly armored opponents."
+	cost = 2500
 	contains = list(/obj/item/storage/guncase/energy/laser)
 	crate_name = "laser crate"
 	faction = /datum/faction/warra

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -38,9 +38,6 @@
 	fire_sound = 'sound/weapons/gun/laser/e40_las.ogg'
 	delay = 2
 
-/obj/item/ammo_casing/energy/laser/assault/sharplite/resistor
-	e_cost = 800  // 24 shots upgraded cell, 12 shots normal
-
 /obj/item/ammo_casing/energy/laser/eoehoma/e50
 	projectile_type = /obj/projectile/beam/emitter/hitscan
 	fire_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -38,6 +38,9 @@
 	fire_sound = 'sound/weapons/gun/laser/e40_las.ogg'
 	delay = 2
 
+/obj/item/ammo_casing/energy/laser/assault/sharplite/resistor
+	e_cost = 800  // 24 shots upgraded cell, 12 shots normal
+
 /obj/item/ammo_casing/energy/laser/eoehoma/e50
 	projectile_type = /obj/projectile/beam/emitter/hitscan
 	fire_sound = 'sound/weapons/gun/laser/heavy_laser.ogg'

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -192,7 +192,7 @@
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/assault/sharplite/resistor)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/assault/sharplite)
 
 	zoom_amt = RIFLE_ZOOM
 	wield_slowdown = SMG_SLOWDOWN

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -186,16 +186,15 @@
 
 /obj/item/gun/energy/sharplite/l201/l204
 	name = "SL L204 “Resistor” Plasma Rifle"
-	desc = "A rifle-sized, semi-automatic electroplasma gun known for its low price and surprisingly low energy usage."
+	desc = "A rifle-sized, semi-automatic electroplasma gun. It's high powered capacitor gives the Resistor a significant punch compared to it's peers, but consumes much more power."
 	icon_state = "l204"
 	item_state = "l204"
 
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
-	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/sharplite)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/assault/sharplite/resistor)
 
-	zoomable = FALSE
-	zoom_amt = PISTOL_ZOOM
+	zoom_amt = RIFLE_ZOOM
 	wield_slowdown = SMG_SLOWDOWN
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	wield_delay = 0.4 SECONDS

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/lasers.dm
@@ -198,6 +198,7 @@
 	wield_slowdown = SMG_SLOWDOWN
 	aimed_wield_slowdown = LONG_RIFLE_AIM_SLOWDOWN
 	wield_delay = 0.4 SECONDS
+	fire_delay = 0.5 SECONDS
 
 	spread = 2
 	spread_unwielded = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changes the Resistor to a midline rifle niche similar to the Super Sporter and Indie Hydra.

It has 15 shots on a standard cell, and deals 25 damage with 20 AP. It costs 2500 credits from the Outpost.

Replaces Resistors on some maps with Volts

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The Resistor doesn't stand particularly stand out from the Volt as it currently stands, basically being 250 credits cheaper version without a disable mode.

This should hopefully make it feel more distinct, and better to use.

## Changelog

:cl:
balance: Resistor is now a midline rifle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
