### PR TITLE
Adjusts Overmap Icons for Fractus, and Gauze

### DIFF
--- a/_maps/configs/cybersun_fractus.json
+++ b/_maps/configs/cybersun_fractus.json
@@ -15,7 +15,7 @@
 	"map_path": "_maps/shuttles/cybersun/cybersun_fractus.dmm",
 	"tranist_x_offset": -19,
 	"tranist_y_offset": -10,
-	"token_icon_state": "ship_small_generic",
+	"token_icon_state": "ship_small_long_generic",
 	"namelists": [
 		"SPACE",
 		"BEASTS",

--- a/_maps/configs/independent_mkii_dwayne.json
+++ b/_maps/configs/independent_mkii_dwayne.json
@@ -14,7 +14,7 @@
 	"tranist_x_offset": -5,
 	"tranist_y_offset": -10,
 	"map_path": "_maps/shuttles/independent/independent_dwayne.dmm",
-	"token_icon_state": "ship_small_long_generic",
+	"token_icon_state": "ship_generic",
 	"description": "The Dwayne is one of the older classes of ships commonly seen on the Frontier, and one of the few such classes that doesn’t also carry a reputation for nightmarish conditions or high accident rates. Originally conceived of as a “mothership” for mining shuttles that could enable long-duration mining missions at minimal cost, severe budget overruns and issues with the mining shuttle docking system left Makosso-Warra with a massive number of mostly-completed hulls upon the project’s cancellation. These hulls were then quickly refurbished and sold on the civilian market, where they proved an immediate success on the Frontier. Contemporary Dwaynes can typically be found carrying a variety of mining equipment and extensive modifications unique to their captains.",
 	"tags": [
 		"Mining",

--- a/_maps/configs/independent_mkii_dwayne.json
+++ b/_maps/configs/independent_mkii_dwayne.json
@@ -14,7 +14,7 @@
 	"tranist_x_offset": -5,
 	"tranist_y_offset": -10,
 	"map_path": "_maps/shuttles/independent/independent_dwayne.dmm",
-	"token_icon_state": "ship_generic",
+	"token_icon_state": "ship_small_long_generic",
 	"description": "The Dwayne is one of the older classes of ships commonly seen on the Frontier, and one of the few such classes that doesn’t also carry a reputation for nightmarish conditions or high accident rates. Originally conceived of as a “mothership” for mining shuttles that could enable long-duration mining missions at minimal cost, severe budget overruns and issues with the mining shuttle docking system left Makosso-Warra with a massive number of mostly-completed hulls upon the project’s cancellation. These hulls were then quickly refurbished and sold on the civilian market, where they proved an immediate success on the Frontier. Contemporary Dwaynes can typically be found carrying a variety of mining equipment and extensive modifications unique to their captains.",
 	"tags": [
 		"Mining",

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -476,6 +476,7 @@
 	file_name = "cybersun_bambulance"
 	name = "Gauze-class Ambulance Pod"
 	faction = /datum/faction/syndicate/cybersun
+	token_icon_state = "ship_tiny_generic"
 	prefix = "CSSV"
 
 /datum/map_template/shuttle/subshuttles/thunder


### PR DESCRIPTION
## About The Pull Request

Fractus goes from Ship_Small to Ship_Small_Long
Gauze goes from Ship_Generic to Ship_Tiny

## Why It's Good For The Game

Fractus is quite a bit larger than other ships that have ship_small, and the Gauze did not have a token set at all so it was always a medium-sized looking ship when it deployed

## Changelog

:cl:
fix: Fractus and Gauze subshuttle now have fitting overmap icons
/:cl:
