### PR TITLE
Walking on ice no longer slips you

### DIFF
--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -83,10 +83,10 @@
 			lube_flags |= SLIDE | GALOSHES_DONT_HELP
 		if(TURF_WET_ICE)
 			intensity = 120
-			lube_flags |= SLIDE | GALOSHES_DONT_HELP
+			lube_flags |= SLIDE | NO_SLIP_WHEN_WALKING
 		if(TURF_WET_PERMAFROST)
 			intensity = 120
-			lube_flags |= SLIDE_ICE | GALOSHES_DONT_HELP
+			lube_flags |= SLIDE_ICE | NO_SLIP_WHEN_WALKING
 		if(TURF_WET_SUPERLUBE)
 			intensity = 120
 			lube_flags |= SLIDE | GALOSHES_DONT_HELP | SLIP_WHEN_CRAWLING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that you can tentatively walk on ice and avoid slipping -- magboots and the spiked/cleated ice boots still allow you to run on them at fullspeed.

## Why It's Good For The Game

I think that it could be nice to not be required to crawl over ice in order to transit any ice patches, but it should still be a hazard. This change makes it so that one has to be careful with their steps in order to walk across ice without falling.

## Changelog

:cl:
balance: makes it possible to walk on ice without slipping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
