### PR TITLE
Gives Facemask Concealing Ability

### DIFF
--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -54,3 +54,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/mask.dmi'
 	supports_variations = SNOUTED_VARIATION | SNOUTED_SMALL_VARIATION | KEPORI_VARIATION
 	alternate_worn_layer = BELT_LAYER
+	flags_cover = MASKCOVERSMOUTH
+	visor_flags_cover = MASKCOVERSMOUTH
+	flags_inv = HIDEFACE | HIDEFACIALHAIR
+	visor_flags_inv = HIDEFACE | HIDEFACIALHAIR


### PR DESCRIPTION
## About The Pull Request

Facemask now conceals identity of the wearer like the sechailer

## Why It's Good For The Game

They're relatively similar, they should hide the ability to be identified. Facemask retains the ability to not filter gas well.

## Changelog

:cl:
balance: Facemasks now conceal identity
/:cl:
