### PR TITLE
Reduces interference when landed on planetoids

### DIFF
--- a/code/modules/overmap/planets/planet_types.dm
+++ b/code/modules/overmap/planets/planet_types.dm
@@ -30,7 +30,7 @@
 	///Do we 'selfloop' like the overmap? Probably should only enable this on space levels
 	var/selfloop = FALSE
 	///How much of a radio message we mess up on nearby or on landed/orbitting ships
-	var/interference_power = 0
+	var/interference_power = -15
 
 
 /datum/planet_type/lava
@@ -44,7 +44,6 @@
 	gravity = STANDARD_GRAVITY
 	weather_controller_type = /datum/weather_controller/lavaland
 	ruin_type = RUINTYPE_LAVA
-	interference_power = 0
 
 	primary_ores = list(
 		/obj/item/stack/ore/iron,
@@ -211,7 +210,6 @@
 	gravity = STANDARD_GRAVITY
 	weather_controller_type = /datum/weather_controller/chlorine
 	ruin_type = RUINTYPE_WASTE
-	interference_power = 0
 	primary_ores = list(\
 		/obj/item/stack/ore/iron,
 		/obj/item/stack/ore/plasma,
@@ -311,6 +309,7 @@
 	icon_state = "moon"
 	color = "#d1c3c3"
 	weight = 20
+	interference_power = -5
 
 	mapgen = /datum/map_generator/planet_generator/moon
 	ruin_type = RUINTYPE_MOON


### PR DESCRIPTION
## About The Pull Request

Reduces interference by 15 points when landed on planetoids, excluding shrouded worlds/reebe.
Moons are reduced by only 5 points.

## Why It's Good For The Game

Interference is a PITA when landed on planets, and not in a good way. Also, all of them (outside of moons) probably have magnetic fields or else they'd be inhospitable.

## Changelog

:cl:
balance: Planetary interference reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
