### PR TITLE
Allows Rachnids to speak Solarian and Tecetian

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -262,6 +262,8 @@
 		/datum/language/gezena_kalixcian,
 		/datum/language/zohil_kalixcian,
 		/datum/language/league_kalixcian,
+		/datum/language/teceti_unified,
+		/datum/language/solarian_international,
 		/datum/language/codespeak,
 		/datum/language/monkey,
 		/datum/language/aphasia,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows rachnids to speak solarian and tecetian in addition to the languages they can already speak

## Why It's Good For The Game

I figured that having the option available for rachnids could allow for more varied and interesting roleplay, as without the ability to speak in these languages, it forces rachnids to be unable to respond if they're, say, on a solarian ship, for instance. I don't see too much reason why they'd be unable to speak solarian or tecetian if they can speak common or league kalician

## Changelog

:cl:
add: Added ability for rachnids to speak in solarian and tecetian 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
