### PR TITLE
minor ruin loot audit

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_treasure_cove.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_treasure_cove.dmm
@@ -977,10 +977,6 @@
 	pixel_x = -6;
 	pixel_y = 10
 	},
-/obj/item/melee/energy/sword/saber/pirate/red{
-	pixel_y = 8;
-	pixel_x = 10
-	},
 /obj/item/radio/old{
 	pixel_x = -3
 	},

--- a/_maps/RandomRuins/BeachRuins/beach_treasure_cove.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_treasure_cove.dmm
@@ -980,6 +980,10 @@
 /obj/item/radio/old{
 	pixel_x = -3
 	},
+/obj/item/melee/boarding_axe{
+	pixel_x = 9;
+	pixel_y = 12
+	},
 /turf/open/floor/plating/asteroid/dirt/beach,
 /area/ruin/beach/treasure_cove)
 "Mg" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
@@ -5270,7 +5270,6 @@
 	},
 /obj/item/ammo_box/magazine/m556_42_hydra/empty,
 /obj/item/ammo_box/magazine/m556_42_hydra/empty,
-/obj/item/gun/ballistic/automatic/assault/hydra/no_mag,
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},

--- a/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_training_center.dmm
@@ -259,6 +259,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/item/storage/box/ammo/a12g_buckshot,
 /turf/open/floor/plasteel/tech,
 /area/ruin/icemoon/training_facility/armory)
 "bj" = (
@@ -5268,12 +5269,11 @@
 /obj/structure/closet/secure_closet/armorycage{
 	req_access = list(0)
 	},
-/obj/item/ammo_box/magazine/m556_42_hydra/empty,
-/obj/item/ammo_box/magazine/m556_42_hydra/empty,
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/item/gun/ballistic/shotgun/gaboon/empty,
 /turf/open/floor/plasteel/tech,
 /area/ruin/icemoon/training_facility/armory)
 "zR" = (

--- a/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
@@ -373,7 +373,6 @@
 /obj/item/clothing/suit/armor/ramzi/captain,
 /obj/item/clothing/under/syndicate/ramzi/officer,
 /obj/item/clothing/head/ramzi/beret,
-/obj/item/storage/guncase/pistol/a357,
 /turf/open/floor/carpet/red,
 /area/ruin/rockplanet/rust_base/dorms)
 "cq" = (
@@ -6265,6 +6264,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/item/gun/ballistic/shotgun/gaboon/empty,
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/rockplanet/rust_base/armory)
 "RV" = (

--- a/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_rustbase.dmm
@@ -4069,8 +4069,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/shotgun{
-	name = "'Armored' O. Ray";
-	weapon_drop_chance = 100
+	name = "'Armored' O. Ray"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ruin/rockplanet/rust_base/armory)

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_recyclebay.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_recyclebay.dmm
@@ -1493,7 +1493,10 @@
 /area/overmap_encounter/planetoid/wasteplanet/explored)
 "kD" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/tactical,
+/obj/item/storage/firstaid/advanced{
+	pixel_x = 3;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/mono/white,
 /area/ruin/wasteplanet/recycle_bay/eva)
 "kG" = (
@@ -5779,7 +5782,6 @@
 /obj/structure/closet/wall/med/directional/south,
 /obj/item/reagent_containers/syringe/contraband/morphine,
 /obj/item/reagent_containers/syringe/contraband/morphine,
-/obj/item/storage/firstaid/tactical,
 /obj/item/storage/firstaid/regular,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/mono/white,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cuts the hydra on training center (replaced with a gaboon), cuts the 100% bockadam on rustbase along with the viper in turn for a gaboon, and kills some energy cutlass because they suck ass. Removes the combat medkits on recyclebay because holy shit those things are busted. If theres any other suggestions I'm up for discussion on em.

## Why It's Good For The Game

Two assault rifles in one ruin is crazy. Rustbase already has an e40. energy cutlass sucks.

## Changelog

:cl:
balance: ruin loot audit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
