### PR TITLE
Extends vote timer to three minutes

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -116,7 +116,7 @@
 	min_val = 0
 
 /datum/config_entry/number/vote_period  // length of voting period (deciseconds, default 1 minute)
-	config_entry_value = 600
+	config_entry_value = 3 MINUTES
 	integer = FALSE
 	min_val = 0
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -189,7 +189,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 VOTE_DELAY 6000
 
 ## time period (deciseconds) which voting session will last (default 1 minute)
-VOTE_PERIOD 600
+VOTE_PERIOD 1800
 
 ## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
 VOTE_AUTOTRANSFER_INITIAL 72000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Extends the voting period for votes from one minute to three minutes

## Why It's Good For The Game

There've been instances where people have missed that a vote is currently ongoing or cannot interact with the vote due to a firefight that they're participating in. Or, someone might lag out and miss their opportunity to vote -- this PR extends the voting window so these people can get the time they may need in order to participate.

## Changelog

:cl:
balance: extends voting window from one minute to three minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
