### PR TITLE
Removes trickwine effect text and effect examine text

### DIFF
--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -45,7 +45,6 @@
 
 
 /datum/status_effect/trickwine/on_apply()
-	owner.visible_message(span_notice("[owner] " + message_apply_others), span_notice(message_apply_self))
 	if(trait)
 		ADD_TRAIT(owner, trait, id)
 	if(!particle_generator)
@@ -54,14 +53,12 @@
 	return ..()
 
 /datum/status_effect/trickwine/on_remove()
-	owner.visible_message(span_notice("[owner] " + message_remove_others), span_notice(message_remove_self))
 	if(trait)
 		REMOVE_TRAIT(owner, trait, id)
 	if(particle_generator)
 		QDEL_NULL(particle_generator)
 
 /datum/status_effect/trickwine/get_examine_text()
-		return span_notice("[owner.p_they(TRUE)] seem[owner.p_s()] to be affected by [src].")
 
 //////////
 // BUFF //


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the "You are affected by a trickwine!" chat text and the "seems to be affected by /datum/status_effect/trickwine/buff/ice" examine text.

## Why It's Good For The Game

I thought it was a little strange for trickwines in particular to have a special examine text like this, no less that it just says the datum typepath

Similarly, the game telling you that you're affected by the trickwine in the chat might be a little strange

<img width="308" height="57" alt="image" src="https://github.com/user-attachments/assets/8839d671-ab16-4e61-98ce-b1cda0f9fdbb" />

## Changelog

:cl:
del: Removed trickwine effect text and examine text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
