### PR TITLE
Adds advanced first aid kit to cargo

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -56,6 +56,12 @@
 	faction = /datum/faction/srm
 	faction_discount = 10
 
+/datum/supply_pack/medical/advancedfirstaid
+	name = "Advanced First Aid Kit Single-Pack"
+	desc = "Contains one advanced first aid kit, with treatment options for advanced and severe injuries."
+	cost = 600
+	contains = list(/obj/item/storage/firstaid/advanced)
+
 /datum/supply_pack/medical/salbutamol_canister
 	name = "Salbutamol Inhaler Canister Single-Pack"
 	desc = "Contains one inhaler canister filled with aerosolized salbutamol, a potent bronchodilator."


### PR DESCRIPTION
## About The Pull Request

Adds an advanced first aid kit (not combat first aid kit) cargo option, finishing up the last of the specialty kit availabilities. It's 600 credits for the kit.

## Why It's Good For The Game

It's the last non-overpowered specialty first aid kit to be added to cargo, thus fulfilling the group - and serves as a good more valuable generalist first aid kit with a better option spread, though not replacing the other options. This should give ship medical players better options and variety with medication too.

## Changelog

:cl:
balance: Advanced first aid kit in cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
