### PR TITLE
makes the equipment dummy look like your character

### DIFF
--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -65,6 +65,8 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 			copycat.add_quirk(applied_quirk.type, target.client, FALSE)
 
 		copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
+
+		target?.client?.prefs?.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
 	else
 		//even if target isn't a carbon, if they have a client we can make the
 		//dummy look like what their human would look like based on their prefs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the equipment select dummy so it doesn't have randomized hair (and mcolors and such)

## Why It's Good For The Game

Mostly unimportant but I think it's nicer for the dummy to look right

Example of how the dummy looks without this fix:
<img width="803" height="470" alt="image" src="https://github.com/user-attachments/assets/babc0a4a-93a7-4ab9-90d9-9a812687e301" />

## Changelog

:cl:
fix: fixed equipment selection dummy hair (and prefs) randomization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
