### PR TITLE
Agni Car Battery Fix

### DIFF
--- a/_maps/outpost/ngr_rock.dmm
+++ b/_maps/outpost/ngr_rock.dmm
@@ -2530,7 +2530,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fluff/vehicle_battery,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6203,6 +6202,10 @@
 	},
 /turf/open/floor/concrete/slab_1,
 /area/outpost/cargo)
+"ni" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/water/tar,
+/area/outpost/vacant_rooms/office)
 "nk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -7150,7 +7153,6 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/ore/salvage/scraptitanium,
 /turf/open/floor/plating,
 /area/outpost/vacant_rooms/office)
 "pj" = (
@@ -9199,7 +9201,6 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/rust,
 /area/outpost/vacant_rooms/office)
 "tI" = (
@@ -11759,6 +11760,10 @@
 	},
 /turf/open/floor/plasteel/tech/ngr_outpost,
 /area/outpost/hallway/aft)
+"zm" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/water/tar,
+/area/outpost/vacant_rooms/office)
 "zn" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#412e25";
@@ -17608,6 +17613,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech/ngr_outpost,
 /area/outpost/hallway/central)
+"LR" = (
+/obj/structure/fluff/vehicle_battery,
+/turf/open/water/tar,
+/area/outpost/vacant_rooms/office)
 "LS" = (
 /obj/machinery/door/poddoor/shutters/indestructible,
 /obj/effect/turf_decal/techfloor{
@@ -17809,6 +17818,10 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating/ngr_outpost,
 /area/outpost/hallway/aft)
+"Ms" = (
+/obj/item/stack/ore/salvage/scrapuranium,
+/turf/open/water/tar,
+/area/outpost/vacant_rooms/office)
 "Mt" = (
 /obj/effect/turf_decal/corner/opaque/tan{
 	dir = 9
@@ -26243,7 +26256,7 @@ Np
 dC
 bd
 aW
-WX
+ni
 Pn
 AZ
 dC
@@ -26358,7 +26371,7 @@ iD
 CG
 AZ
 dC
-WX
+Ms
 WX
 WX
 ua
@@ -26478,7 +26491,7 @@ AZ
 pR
 WX
 WX
-WX
+zm
 ph
 AZ
 OO
@@ -26593,7 +26606,7 @@ uj
 MP
 tO
 fx
-WX
+LR
 WX
 NX
 Ur
@@ -26710,7 +26723,7 @@ RA
 AZ
 AZ
 WX
-WX
+ni
 WX
 tH
 wB
@@ -26828,8 +26841,8 @@ dC
 bd
 qU
 WT
-WX
-WX
+Ms
+LR
 AZ
 AZ
 OO

--- a/_maps/outpost/ngr_rock.dmm
+++ b/_maps/outpost/ngr_rock.dmm
@@ -2530,6 +2530,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/vehicle_battery,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -3879,10 +3880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/outpost/crew/canteen)
-"iB" = (
-/obj/item/stack/ore/salvage/scrapmetal,
-/turf/open/water/tar,
-/area/outpost/vacant_rooms/office)
 "iD" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -3890,11 +3887,7 @@
 	dir = 4
 	},
 /obj/effect/decal/fakelattice,
-/obj/structure/fluff{
-	name = "Geothermal Power Tap";
-	desc = "A complex machine that drills into the soil below it to gather thermal power.";
-	icon = 'icons/obj/power.dmi';
-	icon_state = "rtg";
+/obj/structure/fluff/geothermal{
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/elevatorshaft,
@@ -4156,10 +4149,6 @@
 	},
 /turf/open/floor/plasteel/tech/ngr_outpost,
 /area/outpost/hallway/central)
-"jj" = (
-/obj/item/stack/ore/salvage/scrapuranium,
-/turf/open/water/tar,
-/area/outpost/vacant_rooms/office)
 "jk" = (
 /obj/effect/turf_decal/corner/opaque/tan/three_quarters{
 	dir = 8
@@ -5263,10 +5252,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
-"ls" = (
-/obj/item/stack/ore/salvage/scraptitanium,
-/turf/open/water/tar,
-/area/outpost/vacant_rooms/office)
 "lt" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -7165,6 +7150,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/ore/salvage/scraptitanium,
 /turf/open/floor/plating,
 /area/outpost/vacant_rooms/office)
 "pj" = (
@@ -9213,6 +9199,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
+/obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/rust,
 /area/outpost/vacant_rooms/office)
 "tI" = (
@@ -9421,12 +9408,7 @@
 /area/outpost/hallway/central)
 "ua" = (
 /obj/effect/decal/fakelattice,
-/obj/structure/fluff{
-	name = "vehicle battery";
-	desc = "An old, battery-acid crusted vehicle cell, completely useless, and probably a hazard to even breath next to.";
-	icon = 'icons/obj/power.dmi';
-	icon_state = "bg-cell"
-	},
+/obj/structure/fluff/vehicle_battery,
 /turf/open/floor/plating/rust,
 /area/outpost/vacant_rooms/office)
 "ub" = (
@@ -11654,11 +11636,6 @@
 	dir = 8
 	},
 /area/outpost/hallway/aft)
-"yX" = (
-/obj/effect/decal/fakelattice,
-/obj/item/stack/ore/salvage/scrapuranium,
-/turf/open/water/tar,
-/area/outpost/vacant_rooms/office)
 "yY" = (
 /obj/effect/turf_decal/corner/opaque/beige/diagonal{
 	dir = 4
@@ -13347,10 +13324,6 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/hazard/spray/steam/transparent_safe,
 /turf/open/floor/plasteel/elevatorshaft,
-/area/outpost/vacant_rooms/office)
-"CH" = (
-/obj/effect/decal/fakelattice,
-/turf/open/water/tar,
 /area/outpost/vacant_rooms/office)
 "CJ" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -18201,15 +18174,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations)
-"Ns" = (
-/obj/structure/fluff{
-	name = "vehicle battery";
-	desc = "An old, battery-acid crusted vehicle cell, completely useless, and probably a hazard to even breath next to.";
-	icon = 'icons/obj/power.dmi';
-	icon_state = "bg-cell"
-	},
-/turf/open/water/tar,
-/area/outpost/vacant_rooms/office)
 "Nu" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -26279,7 +26243,7 @@ Np
 dC
 bd
 aW
-iB
+WX
 Pn
 AZ
 dC
@@ -26394,7 +26358,7 @@ iD
 CG
 AZ
 dC
-yX
+WX
 WX
 WX
 ua
@@ -26514,7 +26478,7 @@ AZ
 pR
 WX
 WX
-ls
+WX
 ph
 AZ
 OO
@@ -26629,7 +26593,7 @@ uj
 MP
 tO
 fx
-Ns
+WX
 WX
 NX
 Ur
@@ -26745,9 +26709,9 @@ Ab
 RA
 AZ
 AZ
-CH
-iB
-CH
+WX
+WX
+WX
 tH
 wB
 AZ
@@ -26864,8 +26828,8 @@ dC
 bd
 qU
 WT
-jj
-Ns
+WX
+WX
 AZ
 AZ
 OO

--- a/code/game/MapData/outposts/ngr_rock.dm
+++ b/code/game/MapData/outposts/ngr_rock.dm
@@ -68,3 +68,15 @@ NGR_OUTPOST_OUTSIDE_TURF_HELPER(plasteel/stairs/left)
 /turf/open/water/ngr_outpost/underground
 	light_range = 0
 
+/obj/structure/fluff/vehicle_battery
+	name = "vehicle battery"
+	desc = "An old, battery-acid crusted vehicle cell, completely useless, and probably a hazard to even breathe next to."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "bg-cell"
+
+/obj/structure/fluff/geothermal
+	name = "Geothermal Power Tap"
+	desc = "A complex machine that drills into the soil below it to gather thermal power."
+	density = 1
+	icon = 'icons/obj/power.dmi'
+	icon_state = "rtg"


### PR DESCRIPTION
## About The Pull Request
<img width="288" height="224" alt="image" src="https://github.com/user-attachments/assets/7575bd0e-9bd1-400c-9e6b-4c49a641bc64" />

the objects submersed in tar in the maintenance sections of agni appear to be making this check fail:

<img width="1164" height="471" alt="image" src="https://github.com/user-attachments/assets/ae986050-db9d-4dcd-9e6f-64d30f1ae126" />

this PR rectifies that, and also relocates the var-edited fluff objects to the outpost's mapdata file.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Agni's car battery room has been cleaned up to rectify mysterious check failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
