### PR TITLE
Beach Bunkers Check Fix

### DIFF
--- a/_maps/RandomRuins/BeachRuins/beach_bunkers.dmm
+++ b/_maps/RandomRuins/BeachRuins/beach_bunkers.dmm
@@ -1362,7 +1362,6 @@
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach/bunker/side_two)
 "re" = (
-/mob/living/basic/mouse/rat,
 /obj/item/reagent_containers/food/drinks/bottle/moonshine{
 	pixel_y = 3;
 	pixel_x = -8
@@ -3649,7 +3648,6 @@
 /turf/open/floor/concrete/reinforced,
 /area/ruin/beach/bunker/side_one)
 "US" = (
-/mob/living/basic/mouse/rat,
 /obj/item/food/deadmouse{
 	pixel_y = 5
 	},


### PR DESCRIPTION
## About The Pull Request

<img width="256" height="224" alt="image" src="https://github.com/user-attachments/assets/c8e9d3c9-2c1c-4ab4-ac35-95fc204b8c4e" />

these mice in beach_bunkers.dmm like attempting to open the locked airlocks during checks, which allegedly causes the checks to fail. quote from rye:

> okay so durng ruin spawn during this one specific test, a rat spawns and attempts to open a airlock, however when a ruin is either being cleaned up or spawning, this airlock doesnt have a wire datum

<img width="1346" height="842" alt="image" src="https://github.com/user-attachments/assets/e62058f5-e725-4da6-97cd-f46cd6588e57" />

i don't know a smart way of fixing this, so the mice have been murdered.

## Changelog

:cl:
fix: The living mice have been removed from beach_bunker.dmm's moonshine storage for crimes of esoteric code check failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
