### PR TITLE
[DNM] Fixes security HUDs so that they show job icons again

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -54,7 +54,7 @@
 //data HUD (medhud, sechud) defines
 //Don't forget to update human/New() if you change these!
 #define DATA_HUD_SECURITY_BASIC "sec_basic"
-#define DATA_HUD_SECURITY_ADVANCED "sec_adv"
+#define DATA_HUD_SECURITY_ADVANCED 2
 #define DATA_HUD_MEDICAL_BASIC "med_basic"
 #define DATA_HUD_MEDICAL_ADVANCED "med_adv"
 #define DATA_HUD_DIAGNOSTIC_BASIC "diag_basic"

--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -54,7 +54,7 @@
 //data HUD (medhud, sechud) defines
 //Don't forget to update human/New() if you change these!
 #define DATA_HUD_SECURITY_BASIC "sec_basic"
-#define DATA_HUD_SECURITY_ADVANCED 2
+#define DATA_HUD_SECURITY_ADVANCED 2 //I know this looks bad but I could not find another solution no matter how deeply I dug
 #define DATA_HUD_MEDICAL_BASIC "med_basic"
 #define DATA_HUD_MEDICAL_ADVANCED "med_adv"
 #define DATA_HUD_DIAGNOSTIC_BASIC "diag_basic"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the define for security huds so that they're an integer again, as job icons weren't showing up when a string entry was used for them instead

<img width="116" height="102" alt="image" src="https://github.com/user-attachments/assets/463bc03c-1dec-4ad3-a9e8-31a738d1da4a" />

## Why It's Good For The Game

I know the solution is kind of terrible, but I tried to dig deep into the problem and I got as far as figuring out that hud_atoms weren't being added when the list entry was a string, but they _were_ being added when the entry was an integer. What's especially confusing is that, during debugging, I found that byond correctly loaded the right hud datum regardless of what the entry was, be it a string or an integer. It's just the fact that hud_atoms aren't being added for this datum unless its entry is given as an integer.

## Changelog

:cl:
fix: fixed hud job icons so that they show up again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
