### PR TITLE
allows screwdrivers to be autolathable via right click

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -268,6 +268,14 @@
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all()
 
+/obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
+	if(istype(O, /obj/item/screwdriver))
+		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+		materials.OnAttackBy(materials, O, user)
+	else
+		attackby(O, user, params)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/machinery/autolathe/attackby(obj/item/O, mob/living/user, params)
 	if (busy)
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -272,9 +272,8 @@
 	if(O.tool_behaviour == TOOL_SCREWDRIVER)
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 		materials.OnAttackBy(materials, O, user)
-	else
-		attackby(O, user, params)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/living/user, params)
 	if (busy)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -269,7 +269,7 @@
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
-	if(istype(O, /obj/item/screwdriver))
+	if(O.tool_behaviour == TOOL_SCREWDRIVER)
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 		materials.OnAttackBy(materials, O, user)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that screwdrivers can be autolathed via right clicking on an autolathe with them. Standard deconstruction functionality via left click is retained.

<img width="477" height="475" alt="dreamseeker_JSsy6drXwT" src="https://github.com/user-attachments/assets/8962a50e-5730-436d-a9b2-f695d14dc407"/>

## Why It's Good For The Game

Have you or a loved one ever accidentally printed out 50 screwdrivers instead of 50 marker beacons? Now you can undo your mistake instead of stuffing them all in the trash bin. (This also reduces a bit of inconsistency with respect to lathing tools)

## Changelog

:cl:
add: Added ability to reclaim material on screwdrivers via autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
