### PR TITLE
Electronic Voicebox quirk

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -108,6 +108,7 @@
 #define span_revennotice(str) ("<span class='revennotice'>" + str + "</span>")
 #define span_revenwarning(str) ("<span class='revenwarning'>" + str + "</span>")
 #define span_robot(str) ("<span class='robot'>" + str + "</span>")
+#define span_noticerobot(str) ("<span class='noticerobot'>" + str + "</span>")
 #define span_rose(str) ("<span class='rose'>" + str + "</span>")
 #define span_sans(str) ("<span class='sans'>" + str + "</span>")
 #define span_sciradio(str) ("<span class='sciradio'>" + str + "</span>")

--- a/code/__DEFINES/traits/traits.dm
+++ b/code/__DEFINES/traits/traits.dm
@@ -279,6 +279,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NAIVE "naive"
 #define TRAIT_PRIMITIVE "primitive"
 #define TRAIT_GUNSLINGER "gunslinger"
+#define TRAIT_ELECTRONIC_VOICEBOX "electronic_voicebox"
 #define TRAIT_SPECIAL_TRAUMA_BOOST "special_trauma_boost" ///Increases chance of getting special traumas, makes them harder to cure
 #define TRAIT_BLOODCRAWL_EAT "bloodcrawl_eat"
 #define TRAIT_SPACEWALK "spacewalk"

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -39,7 +39,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		"Smoker" = list(SPECIES_IPC, SPECIES_PLASMAMAN),
 		"Asthma" = list(SPECIES_IPC, SPECIES_PLASMAMAN),
 		"Robust Metabolism" = list(SPECIES_IPC, SPECIES_ELZUOSE),
-		"Fast Metabolism" = list(SPECIES_IPC, SPECIES_ELZUOSE)
+		"Fast Metabolism" = list(SPECIES_IPC, SPECIES_ELZUOSE),
+		"Electronic Voicebox" = list(SPECIES_IPC),
 	)
 
 	for(var/client/client in GLOB.clients)

--- a/code/datums/traits/neutral/electronic_voicebox.dm
+++ b/code/datums/traits/neutral/electronic_voicebox.dm
@@ -1,7 +1,6 @@
 /datum/quirk/electronic_voicebox
 	name = "Electronic Voicebox"
 	desc = "Instead of a set of flesh-and-blood vocal cords, you have a digital voicebox inside of you."
-	mob_traits = list(TRAIT_ELECTRONIC_VOICEBOX)
 	value = 0
 	gain_text = span_noticerobot("Your voice sounds a bit different...")
 	lose_text = span_notice("Your voice goes back to normal.")

--- a/code/datums/traits/neutral/electronic_voicebox.dm
+++ b/code/datums/traits/neutral/electronic_voicebox.dm
@@ -1,0 +1,17 @@
+/datum/quirk/electronic_voicebox
+	name = "Electronic Voicebox"
+	desc = "Instead of a set of flesh-and-blood vocal cords, you have a digital voicebox inside of you."
+	mob_traits = list(TRAIT_ELECTRONIC_VOICEBOX)
+	value = 0
+	gain_text = span_noticerobot("Your voice sounds a bit different...")
+	lose_text = span_notice("Your voice goes back to normal.")
+	medical_record_text = "Patient has an electronic voicebox."
+
+/datum/quirk/electronic_voicebox/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/organ/tongue/robot/new_voicebox = new /obj/item/organ/tongue/robot
+	new_voicebox.Insert(H, drop_if_replaced = FALSE)
+
+/datum/quirk/electronic_voicebox/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.regenerate_organs()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -34,7 +34,7 @@
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
 
-/obj/item/organ/tongue/Insert(mob/living/carbon/M, special = 0)
+/obj/item/organ/tongue/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	..()
 	if (modifies_speech)
 		RegisterSignal(M, COMSIG_MOB_SAY, PROC_REF(handle_speech))

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -149,6 +149,10 @@
 	. = ..()
 	languages_possible = languages_possible_robot
 
+/obj/item/organ/tongue/robot/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_ELECTRONIC_VOICEBOX, ROUNDSTART_TRAIT)
+
 /obj/item/organ/tongue/robot/emp_act(severity)
 	owner.apply_effect(EFFECT_STUTTER, 120)
 	owner.force_scream()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -151,7 +151,7 @@
 
 /obj/item/organ/tongue/robot/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	. = ..()
-	ADD_TRAIT(owner, TRAIT_ELECTRONIC_VOICEBOX, ROUNDSTART_TRAIT)
+	ADD_TRAIT(owner, TRAIT_ELECTRONIC_VOICEBOX, ORGAN_TRAIT)
 
 /obj/item/organ/tongue/robot/emp_act(severity)
 	owner.apply_effect(EFFECT_STUTTER, 120)

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -965,6 +965,7 @@
 #include "code\datums\traits\neutral\ageusia.dm"
 #include "code\datums\traits\neutral\bald.dm"
 #include "code\datums\traits\neutral\deviant_tastes.dm"
+#include "code\datums\traits\neutral\electronic_voicebox.dm"
 #include "code\datums\traits\neutral\gunslinger.dm"
 #include "code\datums\traits\neutral\monochromatic.dm"
 #include "code\datums\traits\neutral\musician.dm"

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -705,6 +705,11 @@ em {
   font-family: 'Courier New', cursive, sans-serif;
 }
 
+.noticerobot {
+  font-family: 'Courier New', cursive, sans-serif;
+  color: #6685f5;
+}
+
 .tape_recorder {
   color: #ff0000;
   font-family: 'Courier New', cursive, sans-serif;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -747,6 +747,11 @@ h2.alert {
   font-family: 'Courier New', cursive, sans-serif;
 }
 
+.noticerobot {
+  font-family: 'Courier New', cursive, sans-serif;
+  color: #000099;
+}
+
 .tape_recorder {
   color: #800000;
   font-family: 'Courier New', cursive, sans-serif;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a quirk that allows a non-IPC player to spawn in with a robot voicebox instead of their species tongue. It does not give a player the ability to speak Encoded.

A new span class, noticerobotic was made for this pr, and the Insert proc for tongues was modified so that it takes the ``drop_if_replaced`` argument to pass on to its parent proc

## Why It's Good For The Game

This was a requested feature in order to allow for players to make non-robotic characters with robotic voices -- be it due to a botched surgery, excessive smoking, or what have you.

## Changelog

:cl:
add: Added the electronic voicebox quirk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
