### PR TITLE
Bruise treatment kits now come with equal parts bone gel and tape

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -75,8 +75,12 @@
 	singular_name = "surgical tape"
 	desc = "Made for patching broken bones back together alongside bone gel."
 	prefix = "surgical"
+	amount = 1
 	conferred_embed = list("embed_chance" = 30, "pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE)
-	custom_price = 500
+	custom_price = 100
+
+/obj/item/stack/sticky_tape/surgical/four
+	amount = 4
 
 /obj/item/stack/tape
 	name = "packaging tape"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -254,8 +254,8 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/medigel/hadrakine = 1,
 		/obj/item/storage/pill_bottle/indomide = 1,
-		/obj/item/stack/medical/bone_gel = 1,
-		/obj/item/stack/sticky_tape/surgical = 1,
+		/obj/item/stack/medical/bone_gel/four = 1,
+		/obj/item/stack/sticky_tape/surgical/four = 1,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/splint = 1,
 		/obj/item/reagent_containers/hypospray/medipen/silfrine = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the quantity of bone gel in bruise treatment packs from 1 to 4 and the quantity of surgical tape from 5 to 4. It also causes surgical tape purchased from the outpost vender to come in packs of 1 instead of 5 with their price brought down from 500 credits to 100 credits.

## Why It's Good For The Game

Oftentimes, when using a bruise kit, you only get one bone gel to work with, and you end up with an excess of surgical tape. You could buy bone gel at the outpost vender, but you have to be aware that the amounts are unequal in the first place. Additionally, if you need more surgical tape from the outpost vender, you have to buy them in packs of 5 for 500 credits, which can be unaffordable, or wasteful if you want to treat a single bone break. This change should help these tools be used more often by players.

## Changelog

:cl:
balance: changed quantities of bone gel and surgical tape in bruise kits to be equal and reduced number of surgical tape packs that needed to be bought at once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
