### PR TITLE
adds salbutamol to the outpost med vender

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -59,7 +59,7 @@
 /datum/supply_pack/medical/salbutamol_canister
 	name = "Salbutamol Inhaler Canister Single-Pack"
 	desc = "Contains one inhaler canister filled with aerosolized salbutamol, a potent bronchodilator."
-	cost = 200
+	cost = 100
 	contains = list(/obj/item/reagent_containers/inhaler_canister/salbutamol)
 
 /*

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -283,7 +283,6 @@
 /obj/item/inhaler/salbutamol
 	name = "salbutamol inhaler"
 	icon_state = "inhaler_medical"
-	custom_price = 150
 	initial_canister_path = /obj/item/reagent_containers/inhaler_canister/salbutamol
 
 /obj/item/reagent_containers/inhaler_canister/salbutamol

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -283,6 +283,7 @@
 /obj/item/inhaler/salbutamol
 	name = "salbutamol inhaler"
 	icon_state = "inhaler_medical"
+	custom_price = 150
 	initial_canister_path = /obj/item/reagent_containers/inhaler_canister/salbutamol
 
 /obj/item/reagent_containers/inhaler_canister/salbutamol
@@ -290,6 +291,7 @@
 	desc = "A small canister filled with aerosolized reagents for use in an inhaler. This one contains salbutamol, a potent bronchodilator that can stop \
 	asthma attacks in their tracks."
 	icon_state = "canister_medical"
+	custom_price = 100
 	list_reagents = list(/datum/reagent/medicine/salbutamol = 30)
 
 /obj/item/inhaler/salbutamol/rescue

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -40,8 +40,8 @@
 		/obj/item/storage/pill_bottle/placebatol = 10,
 		/obj/item/reagent_containers/hypospray/medipen/placebatol = 10,
 		/obj/item/inhaler/placebatol = 10,
-		/obj/item/inhaler/salbutamol = 5,
-		/obj/item/reagent_containers/inhaler_canister/salbutamol = 5,
+		/obj/item/inhaler/medical = 5,
+		/obj/item/reagent_containers/inhaler_canister/salbutamol = 10,
 	)
 	premium = list(
 		/obj/item/reagent_containers/medigel/hadrakine = 3,

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -21,6 +21,7 @@
 		/obj/item/stack/medical/ointment = 8,
 		/obj/item/stack/medical/bone_gel = 8,
 		/obj/item/stack/sticky_tape/surgical = 8,
+		/obj/item/inhaler/medical = 5,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 4,
 		/obj/item/reagent_containers/hypospray/medipen/oculine = 6,
 		/obj/item/reagent_containers/hypospray/medipen/inacusiate = 6,
@@ -39,8 +40,7 @@
 		/obj/item/reagent_containers/syringe/antiviral = 4,
 		/obj/item/storage/pill_bottle/placebatol = 10,
 		/obj/item/reagent_containers/hypospray/medipen/placebatol = 10,
-		/obj/item/inhaler/placebatol = 10,
-		/obj/item/inhaler/medical = 5,
+		/obj/item/reagent_containers/inhaler_canister/placebatol = 10,
 		/obj/item/reagent_containers/inhaler_canister/salbutamol = 10,
 	)
 	premium = list(
@@ -48,7 +48,7 @@
 		/obj/item/reagent_containers/medigel/quardexane = 3,
 		/obj/item/storage/pill_bottle/stardrop = 5,
 		/obj/item/storage/pill_bottle/rcyte = 5,
-		/obj/item/inhaler/sting = 5,
+		/obj/item/reagent_containers/inhaler_canister/sting = 5,
 	)
 
 /obj/item/vending_refill/wallmed

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -39,7 +39,9 @@
 		/obj/item/reagent_containers/syringe/antiviral = 4,
 		/obj/item/storage/pill_bottle/placebatol = 10,
 		/obj/item/reagent_containers/hypospray/medipen/placebatol = 10,
-		/obj/item/inhaler/placebatol = 10
+		/obj/item/inhaler/placebatol = 10,
+		/obj/item/inhaler/salbutamol = 5,
+		/obj/item/reagent_containers/inhaler_canister/salbutamol = 5,
 	)
 	premium = list(
 		/obj/item/reagent_containers/medigel/hadrakine = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR allows salbutamol inhaler refills to be purchased from the outpost medical vender, and replaces inhaler purchases with their cartridge type instead. A generic empty inhaler is sold for use alongside these cartridges. It also reduces the price of salbutamol refills from 200 credits to 100 credits.

## Why It's Good For The Game

I think it'd be nice to have salbutamol inhalers be more easily accessible outside of oxygen kits, and it would also be nice for their cartridges to be a bit cheaper

## Changelog

:cl:
add: added salbutamol refills to the outpost med
remove: replaces prescription inhalers and sting inhalers with the relevant cartridge type
balance: reduced price of salbutamol refill kits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
