### PR TITLE
Scales reward for completing additional lode scans of a drill

### DIFF
--- a/code/modules/missions/outpost/drill_mission.dm
+++ b/code/modules/missions/outpost/drill_mission.dm
@@ -228,3 +228,8 @@
 		say("Required samples gathered. Additional samples valued at [200*mission_class]cr per. Now shutting down!")
 		if(active)
 			stop_mining()
+
+	if(num_current > (num_wanted + 3))
+		say("Core sample collector full. Unable to continue drilling.")
+		if(active)
+			stop_mining()

--- a/code/modules/missions/outpost/drill_mission.dm
+++ b/code/modules/missions/outpost/drill_mission.dm
@@ -4,7 +4,7 @@
 /datum/mission/drill
 	name = "Class 1 core sample mission"
 	desc = "We require geological information from one of the neighboring planetoids. \
-			Please anchor the drill in place and defend it until it has gathered enough samples. \
+			Please anchor the drill in place and defend it until it has gathered enough samples.  \
 			Operation of the core sampling drill is extremely dangerous, caution is advised. "
 	value = 2500
 	weight = 11
@@ -98,7 +98,7 @@
 
 /datum/mission/drill/turn_in()
 	//Gives players a little extra money for going past the mission goal
-	value += (sampler.num_current - num_wanted)*200
+	value += (sampler.num_current - num_wanted)*(200*class_wanted)
 	if(punchcard)
 		//500 credit punchcard
 		value += 500
@@ -209,7 +209,7 @@
 	. = ..()
 	. += span_notice("The drill contains [num_current] of the [num_wanted] samples needed.")
 	if(num_current>=num_wanted)
-		. += span_notice("Additional samples can be gathered for 200 credits per sample.")
+		. += span_notice("Additional samples can be gathered for [200*mission_class] credits per sample.")
 
 /obj/machinery/drill/mission/start_mining()
 	if(orevein_wanted && !istype(our_vein, orevein_wanted))
@@ -225,6 +225,6 @@
 
 	if(num_current == num_wanted)
 		SEND_SIGNAL(src, COMSIG_DRILL_SAMPLES_DONE)
-		say("Required samples gathered. Additional samples valued at 200cr per. Now shutting down!")
+		say("Required samples gathered. Additional samples valued at [200*mission_class]cr per. Now shutting down!")
 		if(active)
 			stop_mining()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that instead of any additional lode being equal to 200 credits, it scales by a factor of the drill mission class. Class 2 drills net 400 credits per additional lode, and class 3 drills net 600 credits.

Additional ore lodes are capped at 4 extra lodes.

## Why It's Good For The Game

This change should make it more worthwhile to do extra scans on higher-tiered drills. As it is now, obtaining additional lodes becomes less and less worth doing the higher the class of drill you're doing, and this change should address that.

## Changelog

:cl:
balance: scales additional lode redemption based on drill class, up to a maximum of 4 additional lodes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
