### PR TITLE
Makes fax spam, pest spawns, and cargo pod events adminspawn only

### DIFF
--- a/code/modules/events/fax_spam.dm
+++ b/code/modules/events/fax_spam.dm
@@ -2,7 +2,7 @@
 	name = "Fax Spam"
 	typepath = /datum/round_event/fax_spam
 	weight = 10
-	max_occurrences = 2
+	max_occurrences = 0
 	earliest_start = 5 MINUTES
 	requires_ship = TRUE
 

--- a/code/modules/events/ship/rodent_infestation.dm
+++ b/code/modules/events/ship/rodent_infestation.dm
@@ -2,7 +2,7 @@
 	name = "Small Rodent Infestation"
 	typepath = /datum/round_event/ship/rodent_infestation
 	weight = 15
-	max_occurrences = 5
+	max_occurrences = 0
 	min_players = 1
 	earliest_start = 5 MINUTES
 	admin_setup = list(

--- a/code/modules/events/ship/spider_infestation.dm
+++ b/code/modules/events/ship/spider_infestation.dm
@@ -2,7 +2,7 @@
 	name = "Spider Infestation"
 	typepath = /datum/round_event/ship/spider_infestation
 	weight = 1
-	max_occurrences = 2
+	max_occurrences = 0
 	min_players = 15
 	earliest_start = 30 MINUTES
 

--- a/code/modules/events/ship/stray_cargo.dm
+++ b/code/modules/events/ship/stray_cargo.dm
@@ -3,7 +3,7 @@
 	name = "Stray Cargo Pod"
 	typepath = /datum/round_event/ship/stray_cargo
 	weight = 1
-	max_occurrences = 2
+	max_occurrences = 0
 	min_players = 10
 	earliest_start = 10 MINUTES
 	category = EVENT_CATEGORY_BUREAUCRATIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR sets the occurrences of the fax spam, rodent spawn, spider spawn, and cargo pod events to 0, disabling them from occurring randomly.

## Why It's Good For The Game

These events didn't really add much to the game, I felt. They either too often (and in the case of fax spam, so often as to desensitize players from actually useful faxes), or they caused problems (I've seen rats spawn in, chew a wire, and then die and leave half a ship without power due to this event).

I'd argue that lotteries also fall within this umbrella, but I'll leave the floor open to maintainers regarding what should be done to them. (I've considered reflavoring them, but I can't think of anything good)

Also: pictured, a supply pod hitting cryo and destroying the lights there, as well as burning down a poster
<img width="233" height="397" alt="image" src="https://github.com/user-attachments/assets/d29baca9-1bad-4c80-a90b-bcd6360a38d5" /> 
(image courtesy of moffball)

## Changelog

:cl:
balance: removed chance for fax spam, pest spawn, and podspawn events to occur

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
