### PR TITLE
Wood tiles don't perpetually burn

### DIFF
--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -21,6 +21,14 @@
 	color = WOOD_COLOR_GENERIC
 	flammability = 3
 
+/turf/open/floor/wood/break_tile()
+	broken = TRUE
+	update_appearance()
+
+/turf/open/floor/wood/burn_tile()
+	burnt = TRUE
+	update_appearance()
+
 /turf/open/floor/wood/beach
 	initial_gas_mix = BEACHPLANET_DEFAULT_ATMOS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Wood tiles now eventually burn away like carpet instead of being ignited forever.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes are good


## Changelog

:cl:
fix: Wood tiles burning forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
