### PR TITLE
two bore buff

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -122,7 +122,7 @@
 /obj/projectile/bullet/pellet/buckshot/twobore
 	name = "two-bore pellet"
 	damage = 30
-	armour_penetration = -25
+	armour_penetration = 5
 	tile_dropoff = 3
 	bullet_identifier = "massive pellet"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game

Changes its AP from -25 to 5. Right now I feel like I can reasonably walk up to a two bore and be slightly okay if I have good bullet armor. I should not think this at all.

## Changelog

:cl:
add: two bore buff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
