### PR TITLE
Add JSDoc type annotations to selectPing function

### DIFF
--- a/tgui/packages/tgui-panel/ping/selectors.js
+++ b/tgui/packages/tgui-panel/ping/selectors.js
@@ -4,4 +4,8 @@
  * @license MIT
  */
 
+/**
+ * @param {object} state
+ * @returns {any}
+ */
 export const selectPing = (state) => state.ping;


### PR DESCRIPTION
## Background
The public exported function `selectPing` in `tgui/packages/tgui-panel/ping/selectors.js` was missing type annotations. Adding JSDoc type annotations improves code readability, maintainability, and facilitates better integration with TypeScript or other type-checking tools without altering functionality.

## Changes
- Added JSDoc type annotation to the `selectPing` function, specifying the `state` parameter as `object` and the return type as `any`.

## Verification
Since this change only adds comments and does not modify the function's logic or API, it should be safe. You can verify by:
1. Running existing tests to ensure no regressions.
2. Checking that the code still executes as expected in the application.
3. Optionally, using a linter or TypeScript compiler (if configured) to confirm type annotations are correctly formatted.