### PR TITLE
Rebalancing the Energy Halberd

### DIFF
--- a/code/game/objects/items/melee/dualenergy.dm
+++ b/code/game/objects/items/melee/dualenergy.dm
@@ -23,6 +23,7 @@
 	var/list/possible_colors = list("red", "blue", "green", "purple", "yellow")
 	var/impale_flavor_text = "twirl"
 	var/hack_flavor_text = ""
+	var/hit_reflect_chance = 10
 
 /obj/item/melee/duelenergy/Initialize()
 	. = ..()
@@ -91,13 +92,15 @@
 		impale(user)
 		return
 
-/obj/item/melee/duelenergy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+/obj/item/melee/duelenergy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 35, damage = 0, attack_type = MELEE_ATTACK)
+	if(attack_type == PROJECTILE_ATTACK)
+		final_block_chance = projectile_block_chance //Don't bring a sword to a gunfight
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
 		return ..()
 	return FALSE
 
 /obj/item/melee/duelenergy/IsReflect()
-	if(HAS_TRAIT(src, TRAIT_WIELDED))
+	if((HAS_TRAIT(src, TRAIT_WIELDED))&&(prob(hit_reflect_chance)))
 		return TRUE
 
 /obj/item/melee/duelenergy/process(seconds_per_tick)
@@ -164,7 +167,7 @@
  */
 /obj/item/melee/duelenergy/halberd
 	name = "energy halberd"
-	desc = "For when a normal halberd just isnt enough."
+	desc = "A Solarian hardlight weapon harkening back to the polearms of Terran antiquity. Most popularly seen as a ceremonial weapon, this space-age modernization of the halberd is still more than capable of ending a disagreement quickly."
 	icon_state = "halberd"
 	base_icon_state = "halberd"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
@@ -174,6 +177,10 @@
 	light_range = 4
 	impale_flavor_text = "swing"
 	hack_flavor_text = "HLBRDRNBW_ENGAGE"
+	block_chance = 35
+	force = 15
+	throwforce = 15
+	demolition_mod = 1.5
 
 /obj/item/melee/duelenergy/halberd/green
 	possible_colors = list("green")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A bit of a touchup on the Solarian energy halberd to remove the jedi-level laser deflecting skills it imbued on anyone who picked it up.

Drops the chance for a user to successfully deflect a laser with the bladed edge of their polearm to a far more reasonable 10% from 100%.

Gives the halberd a 35% melee parry/block chance, up from 0%. This is 5% more than the sabres/swords.

 Gives the halberd a 1.5 demolition mod, reasonable for a poleaxe about as tall as a person. Can take down a door in 8 hits opposed to a sledghammer's 4.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Energy halberds being able to deflect 100% of incoming laser projectiles from any direction was just silly, leftover mechanics from the double e-sword built for station server nukie balance.

These changes give the energy halberd some reasonable upgrades in areas it should perform well while removing the jedi-super deflection.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: rebalanced the energy halberd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
