### PR TITLE
Disables CTF ready-up

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -233,22 +233,7 @@
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/machinery/capture_the_flag/attack_ghost(mob/user)
 	if(ctf_enabled == FALSE)
-		if(user.client && user.client.holder)
-			var/response = alert("Enable CTF?", "CTF", "Yes", "No")
-			if(response == "Yes")
-				toggle_all_ctf(user)
-			return
-
-
-		people_who_want_to_play |= user.ckey
-		var/num = people_who_want_to_play.len
-		var/remaining = CTF_REQUIRED_PLAYERS - num
-		if(remaining <= 0)
-			people_who_want_to_play.Cut()
-			toggle_all_ctf()
-		else
-			to_chat(user, span_notice("CTF has been requested. [num]/[CTF_REQUIRED_PLAYERS] have readied up."))
-
+		to_chat(user, span_notice("CTF is not enabled. Go play the game!"))
 		return
 
 	if(!SSticker.HasRoundStarted())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The CTF ready-up system, where four players can start CTF on their own even if CTF is disabled, is removed in this PR

## Why It's Good For The Game

This PR is to prevent players from being able to start CTF even though it's disabled by default. This makes it so that if it's set as disabled, it cannot be enabled unless an admin starts it.

## Changelog

:cl:
code: removed player agency to start CTF on their own
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
