### PR TITLE
Changes CTF ammo pickups to only regenerate the belt instead of the entire outfit

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -723,10 +723,8 @@
 		if(M in CTF.spawned_mobs)
 			var/outfit = CTF.ctf_gear
 			var/datum/outfit/O = new outfit
-			for(var/obj/item/gun/G in M)
-				qdel(G)
-			O.equip(M)
-			to_chat(M, span_notice("Ammunition reloaded!"))
+			M.equip_to_slot_or_del(new O.belt(M),ITEM_SLOT_BELT, TRUE)
+			to_chat(M, span_notice("Belt ammunition reloaded!"))
 			playsound(get_turf(M), 'sound/weapons/gun/shotgun/rack.ogg', 50, TRUE, -1)
 			qdel(src)
 			break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks the ctf ammo reload proc so that it only regenerates the outfit's belt instead of the entire outfit

## Why It's Good For The Game

This was a requested feature for https://github.com/shiptest-ss13/Shiptest/pull/6339 -- it should make ammo pickups a bit nicer to work with

## Changelog

:cl:
balance: ctf ammo pickups regenerate your belt now, not your entire outfit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
