### PR TITLE
Adds the E-40 magazine to outpost cargo

### DIFF
--- a/code/modules/cargo/blackmarket/packs/ammo.dm
+++ b/code/modules/cargo/blackmarket/packs/ammo.dm
@@ -63,9 +63,9 @@
 	desc = "A 30 round magazine for the E-40 Hybrid Rifle."
 	item = /obj/item/ammo_box/magazine/e40
 
-	cost_min = 400
-	cost_max = 800
-	stock = 6
+	cost_min = 200
+	cost_max = 400
+	stock = 4
 	availability_prob = 0
 
 /datum/blackmarket_item/ammo/cm23_mag

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -380,6 +380,14 @@
 	contains = list(/obj/item/ammo_box/magazine/m12g_slammer)
 	cost = 300
 
+/* E-40 */
+
+/datum/supply_pack/magazine/e40
+	name = "E-40 Caseless Magazine Crate"
+	desc = "Contains a 30-round magazine for the E-40 Hybrid Rifle in .299 Eohoma Caseless."
+	contains = list(/obj/item/ammo_box/magazine/e40/empty)
+	cost = 400
+
 /* energy weapons */
 
 /datum/supply_pack/magazine/guncell

--- a/code/modules/projectiles/guns/manufacturer/eoehoma/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/eoehoma/ballistics.dm
@@ -212,6 +212,9 @@
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
+/obj/item/ammo_box/magazine/e40/empty
+	start_empty = TRUE
+
 //laser
 
 /obj/item/gun/energy/laser/e40_laser_secondary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the E-40's ballistic magazine to the outpost. This PR also lowers the blackmarket price of them to make it still worthwhile to check if any are available before committing to a purchase.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Starting with a gun you have to gamble on extra magazines for sucks, actually, and shouldn't be a thing. Price is 400cr, above standard AR price of 300cr, just as a nod to the concept that these are no longer widely manufactured and are likely sourced from more limited stocks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Raleigh fans rejoice, .299 magazines for the E-40 platform can now be purchased from the outpost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
