### PR TITLE
Syndicate Assault Cyborg Update

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -941,7 +941,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/gun/energy/printer,
-		/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg,
+		/obj/item/gun/ballistic/rocketlauncher/mako/light,
 		/obj/item/card/emag/borg,
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher/mini,

--- a/code/modules/projectiles/ammunition/energy/lmg.dm
+++ b/code/modules/projectiles/ammunition/energy/lmg.dm
@@ -1,9 +1,10 @@
-/obj/item/ammo_casing/energy/c3dbullet
-	projectile_type = /obj/projectile/bullet/c3d
+/obj/item/ammo_casing/energy/integrated_lmg
+	projectile_type = /obj/projectile/bullet/a556_42
 	select_name = "spraydown"
-	fire_sound = 'sound/weapons/gun/smg/shot.ogg'
+	fire_sound = 'sound/weapons/gun/rifle/hydra.ogg'
 	e_cost = 20
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect
+	delay = 0.08 // Match integrated LMG
 
 /obj/item/ammo_casing/energy/ctac
 	projectile_type = /obj/projectile/bullet/ctac

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -22,20 +22,6 @@
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
 		chamber_round()
 
-/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg
-	desc = "A heavy grenade launcher with an oversized 6-shot cylinder."
-	name = "multi grenade launcher"
-	icon = 'icons/mecha/mecha_equipment.dmi'
-	icon_state = "mecha_grenadelnchr"
-	bad_type = /obj/item/gun/ballistic/revolver/grenadelauncher/cyborg
-	default_ammo_type = /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
-	allowed_ammo_types = list(
-		/obj/item/ammo_box/magazine/internal/cylinder/grenademulti,
-	)
-
-/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg/attack_self()
-	return
-
 GLOBAL_LIST_INIT(rpg_scrawlings, list(
 	"\"FRONT TOWARDS ENEMY\"",
 	"\"MY WIFE LEFT ME\"",

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -198,21 +198,22 @@
 /* 3d printer 'pseudo guns' for borgs */
 
 /obj/item/gun/energy/printer
-	name = "integrated LMG"
-	desc = "A modified energy weapon re-designed to fire 3D-printed flechettes, pulled directly from the cyborg's internal power source."
-	icon_state = "l6_cyborg"
-	icon = 'icons/obj/guns/projectile.dmi'
+	name = "integrated SAW-80 LMG"
+	desc = "A modified Hydra-80 SAW integrated directly into the Assault platform, with a built-in ammo printer pulling directly from the internal cell."
+	icon_state = "hydra_lmg"
+	icon = 'icons/obj/guns/manufacturer/scarborough/48x32.dmi'
 	default_ammo_type = /obj/item/stock_parts/cell/secborg
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/secborg,
 	)
-	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
+	ammo_type = list(/obj/item/ammo_casing/energy/integrated_lmg)
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
 
-	fire_delay = 0.3 SECONDS
+	burst_delay = 0.08 SECONDS
+	fire_delay = 0.08 SECONDS
 
-	gun_firemodes = list(FIREMODE_FULLAUTO)
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_FULLAUTO
 
 /obj/item/gun/energy/printer/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Syndicate assault cyborgs now have integrated SAW-80s and a 4-shot Light Mako. Previously they were just completely ass and their LMG had a 5 second shot delay. This makes them, well... a bit more intimidating. 

## Why It's Good For The Game

When one of these walks up it should be properly scary and not be a coughing baby.

## Changelog

:cl:
balance: Syndicate Assault Cyborg now has an integrated SAW-80 and Light MAKO.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
