### PR TITLE
FBP Elzu doesn't replace their battery organ

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/body/prosthetic.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/body/prosthetic.dm
@@ -85,3 +85,15 @@
 	)
 	allowed_species = list(/datum/species/vox)
 	bodytype = BODYTYPE_VOX
+
+/datum/sprite_accessory/body/prosthetic/elzuouse
+	name = "Prosthetic Ethereal"
+	// don't replace the stomach so they don't waste away and die
+	replacement_organs = list(
+		ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic,
+		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/robotic,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears/cybernetic,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/robot,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic,
+	)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -56,6 +56,8 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/ethereal,
 	)
 
+	prosthetic_style = /datum/sprite_accessory/body/prosthetic/elzuouse
+
 	var/current_color
 	var/EMPeffect = FALSE
 	var/static/unhealthy_color = rgb(237, 164, 149)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

FBP elzu currently replaces their battery organ with a robot stomach, meaning they can't properly feed. Fixes that.

## Changelog

:cl:
fix: FBP Elzu replacing bio battery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
