### PR TITLE
Fixes bullets ignoring directional structures if you're on the same tile

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -470,19 +470,24 @@
  * 0. Anything that is already in impacted is ignored no matter what. Furthermore, in any bracket, if the target atom parameter is in it, that's hit first.
  * 	Furthermore, can_hit_target is always checked. This (entire proc) is PERFORMANCE OVERHEAD!! But, it shouldn't be ""too"" bad and I frankly don't have a better *generic non snowflakey* way that I can think of right now at 3 AM.
  *		FURTHERMORE, mobs/objs have a density check from can_hit_target - to hit non dense objects over a turf, you must click on them, same for mobs that usually wouldn't get hit.
- * 1. The thing originally aimed at/clicked on
- * 2. Mobs - picks lowest buckled mob to prevent scarp piggybacking memes
- * 3. Objs
- * 4. Turf
- * 5. Nothing
+ * 1. The target if it has the ON_BORDER_1 flag since those has priority for impacts.
+ * 2. The thing originally aimed at/clicked on
+ * 3. Mobs - picks lowest buckled mob to prevent scarp piggybacking memes
+ * 4. Objs
+ * 5. Turf
+ * 6. Nothing
  */
 /obj/projectile/proc/select_target(turf/T, atom/target)
-	// 1. original
+	// 1. ON_BORDER_1 stuff
+	if(target.flags_1 & ON_BORDER_1)
+		if(can_hit_target(target, target == original, TRUE))
+			return target
+	// 2. original
 	if(can_hit_target(original, TRUE, FALSE))
 		return original
 	var/list/atom/possible = list()		// let's define these ONCE
 	var/list/atom/considering = list()
-	// 2. mobs
+	// 3. mobs
 	possible = typecache_filter_list(T, GLOB.typecache_living)	// living only
 	for(var/i in possible)
 		if(!can_hit_target(i, i == original, TRUE))
@@ -492,7 +497,7 @@
 		var/mob/living/M = pick(considering)
 		return M.lowest_buckled_mob()
 	considering.len = 0
-	// 3. objs
+	// 4. objs
 	possible = typecache_filter_list(T, GLOB.typecache_machine_or_structure)	// because why are items ever dense?
 	for(var/i in possible)
 		if(!can_hit_target(i, i == original, TRUE))
@@ -500,10 +505,10 @@
 		considering += i
 	if(considering.len)
 		return pick(considering)
-	// 4. turf
+	// 5. turf
 	if(can_hit_target(T, T == original, TRUE))
 		return T
-	// 5. nothing
+	// 6. nothing
 		// (returns null)
 
 //Returns true if the target atom is on our current turf and above the right layer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adjusts the the targeting logic of projectiles so they'll hit the directional objects/structures instead of immediately homing in on any mob on the same tile.
<details>
<summary>Video</summary>
Before:

https://github.com/user-attachments/assets/27b044ab-8ac9-4edf-bcaa-6383cdba73e1

After:

https://github.com/user-attachments/assets/1877e830-a1f7-4d16-9e82-10262f987079
</details>

This should also fix flipped tables not providing cover if you're standing on the same tiles as them.

## Why It's Good For The Game

Fixes are good. It doesn't particularly make sense to get hit by a bullet if you're standing behind a pane of reinforced glass or a firelock or whatever.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Bullets going through directional border objects if you're on the same tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
