### PR TITLE
Hazard Power Clarity

### DIFF
--- a/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/_hazard.dm
+++ b/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/_hazard.dm
@@ -27,10 +27,12 @@
 	var/can_be_disabled = FALSE
 	//Can be used for do_afters on disable checks, also toolchecks.
 	var/time_to_disable = 5 SECONDS
-	//whether this hazard has been disabled, which no longer functions and doesn't listen to hazard shutoffs.
+	//Whether this hazard has been disabled, which no longer functions and doesn't listen to hazard shutoffs.
 	var/disabled = FALSE
-	//examine text shown if can_be_disabled is true. Make sure to set this if you add a way to disable your hazard.
+	//Examine text shown if can_be_disabled is true. Make sure to set this if you add a way to disable your hazard. In context: "[src] could be disabled by [disable_text]."
 	var/disable_text = "a way you don't know! (this needs to be set)"
+	//Examine text shown when 'on' is false. In context: [src] appears to be [off_text].</span>"
+	var/off_text = "turned off"
 
 	//ID for use with hazard shutoffs, should be set per map and not in code.
 	var/id = null
@@ -124,6 +126,8 @@ evil 'code' that sets off the above procs. mappers beware!
 		. += span_notice("[src] has been disabled.</span>")
 	else if(can_be_disabled)
 		. += span_notice("[src] could be disabled by [disable_text].</span>")
+	if(!on)
+		. += span_notice("[src] appears to be [off_text].</span>")
 
 /obj/structure/hazard/proc/random_effect(start = FALSE)
 	if(QDELETED(src))

--- a/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/electrical.dm
+++ b/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/electrical.dm
@@ -32,7 +32,7 @@
 	//flags for the stun, SHOCK_NOGLOVES ignores gloves, SHOCK_NOSTUN doesn't stun (built in stun_time is seperate), SHOCK_ILLUSION does stamina damage instead.
 	var/shock_flags = SHOCK_NOGLOVES | SHOCK_NOSTUN
 	//examine text shown in can_be_disabled is TRUE
-	disable_text = "cutting the wires."
+	disable_text = "cutting the wires"
 
 /obj/structure/hazard/electrical/Initialize()
 	//if contact, need to set enter_activated

--- a/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/turf_fire.dm
+++ b/code/modules/ruins/objects_and_mobs/generic_hazards/hazard_code/turf_fire.dm
@@ -7,7 +7,7 @@
 	var/fire_color = "red"
 	var/light_fire = TRUE
 	var/random_sparks = TRUE
-	disable_text = "cutting the wires."
+	disable_text = "cutting the wires"
 
 /obj/structure/hazard/fire/do_random_effect()
 	if(random_sparks)


### PR DESCRIPTION
## About The Pull Request
<img width="749" height="98" alt="image" src="https://github.com/user-attachments/assets/8423213d-763c-4cda-8dc0-b3dfcfe5b162" />

adds examinetext for unpowered hazards

this PR also fixes some erroneous double periods in a couple disable_texts

## Why It's Good For The Game

hazard power can be confusing, especially when a hazard doesn't have a clear visual indicator for being turned off. 

## Changelog

:cl:
code: Ruin hazards now indicate their status clearly when turned off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
