### PR TITLE
Alien Hivemind Fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -16,7 +16,7 @@
 
 /mob/living/carbon/get_message_mods(message, list/mods)
 	var/obj/item/organ/lungs/our_lungs = getorganslot(ORGAN_SLOT_LUNGS)
-	if(our_lungs && our_lungs?.received_pressure_mult < 0.5 && !mods[WHISPER_MODE] && !HAS_TRAIT(src, TRAIT_NOBREATH))
+	if(our_lungs && our_lungs.received_pressure_mult < 0.5 && !mods[WHISPER_MODE] && !HAS_TRAIT(src, TRAIT_NOBREATH))
 		mods[WHISPER_MODE] = MODE_WHISPER
 	return ..(message, mods)
 

--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -16,9 +16,7 @@
 
 /mob/living/carbon/get_message_mods(message, list/mods)
 	var/obj/item/organ/lungs/our_lungs = getorganslot(ORGAN_SLOT_LUNGS)
-	if(!our_lungs)
-		return ..(message, mods)
-	if(our_lungs?.received_pressure_mult < 0.5 && !mods[WHISPER_MODE] && !HAS_TRAIT(src, TRAIT_NOBREATH))
+	if(our_lungs && our_lungs?.received_pressure_mult < 0.5 && !mods[WHISPER_MODE] && !HAS_TRAIT(src, TRAIT_NOBREATH))
 		mods[WHISPER_MODE] = MODE_WHISPER
 	return ..(message, mods)
 

--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -16,6 +16,8 @@
 
 /mob/living/carbon/get_message_mods(message, list/mods)
 	var/obj/item/organ/lungs/our_lungs = getorganslot(ORGAN_SLOT_LUNGS)
+	if(!our_lungs)
+		return ..(message, mods)
 	if(our_lungs?.received_pressure_mult < 0.5 && !mods[WHISPER_MODE] && !HAS_TRAIT(src, TRAIT_NOBREATH))
 		mods[WHISPER_MODE] = MODE_WHISPER
 	return ..(message, mods)


### PR DESCRIPTION
## About The Pull Request
hiveminds were broken in #5502 due to aliens lacking lungs on message mod checks. this PR adds a check for lungless mobs to rectify that.

## Why It's Good For The Game
it's nice to use aliens in events sometimes

## Changelog

:cl:
fix: Alien hiveminds should be functional again.
/:cl:
