### PR TITLE
damage adjustments to the bayonets and gun melee

### DIFF
--- a/code/game/objects/items/attachments/bayonet.dm
+++ b/code/game/objects/items/attachments/bayonet.dm
@@ -12,6 +12,8 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_POINTY
+	attack_cooldown = LIGHT_WEAPON_CD
+	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
 	slot = ATTACHMENT_SLOT_MUZZLE
 
 	pixel_shift_x = 1

--- a/code/game/objects/items/attachments/bayonet.dm
+++ b/code/game/objects/items/attachments/bayonet.dm
@@ -5,8 +5,8 @@
 	item_state = "bayonet"
 	lefthand_file = 'icons/mob/inhands/weapons/knifes_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/knifes_righthand.dmi'
-	force = 15
-	throwforce = 10
+	force = 18
+	throwforce = 18
 	pickup_sound =  'sound/items/handling/knife1_pickup.ogg'
 	drop_sound = 'sound/items/handling/knife3_drop.ogg'
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/attachments/energy_bayonet.dm
+++ b/code/game/objects/items/attachments/energy_bayonet.dm
@@ -9,6 +9,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_NONE
+	attack_cooldown = LIGHT_WEAPON_CD
 	slot = ATTACHMENT_SLOT_MUZZLE
 	attach_features_flags = ATTACH_TOGGLE | ATTACH_REMOVABLE_HAND
 
@@ -39,6 +40,7 @@
 	sharpness = toggled ? SHARP_POINTY : SHARP_NONE
 	force = toggled ? 20 : 3
 	throwforce = toggled ? 15 : 2
+	embedding = toggled ? list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10 "ignore_throwspeed_threshold" = TRUE) : null
 
 /obj/item/attachment/energy_bayonet/attack_self(mob/user)
 	toggle_attachment()

--- a/code/game/objects/items/attachments/energy_bayonet.dm
+++ b/code/game/objects/items/attachments/energy_bayonet.dm
@@ -37,8 +37,8 @@
 	set_light_on(toggled)
 	update_icon()
 	sharpness = toggled ? SHARP_POINTY : SHARP_NONE
-	force = toggled ? 19 : 3
-	throwforce = toggled ? 14 : 2
+	force = toggled ? 20 : 3
+	throwforce = toggled ? 15 : 2
 
 /obj/item/attachment/energy_bayonet/attack_self(mob/user)
 	toggle_attachment()

--- a/code/game/objects/items/attachments/energy_bayonet.dm
+++ b/code/game/objects/items/attachments/energy_bayonet.dm
@@ -40,7 +40,6 @@
 	sharpness = toggled ? SHARP_POINTY : SHARP_NONE
 	force = toggled ? 20 : 3
 	throwforce = toggled ? 15 : 2
-	embedding = toggled ? list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10 "ignore_throwspeed_threshold" = TRUE) : null
 
 /obj/item/attachment/energy_bayonet/attack_self(mob/user)
 	toggle_attachment()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -13,7 +13,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
-	force = 5
+	force = 10
 
 	bad_type = /obj/item/gun
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases gun melee from 5 to 10
Increases bayonet damage from 15 to 18
Increases energy bayonet damage from 19 to 20

Lets bayonets have knife stats like faster attack speed and embed chance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Smacking someone with my big hunk of wood and metal doing the same damage as punching someone bare handed feels bad and doesn't make a lot of sense.

Bayonets up to this point were just survival knives that can stick to your gun and were meh at best. For the increase in price over a survival knife, this will make the bayonet tangibly better but not insanely powerful or as good as a combat knife.

The energy bayonet adjustment is just 1 damage difference and it makes things easier. It cost 500 credits which is more than a combat knife so it's fair to be on par with it's damage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: rebalanced gun related melee options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
