### PR TITLE
[DNM] removed flame range on 4.6x30mm tesla flux rounds

### DIFF
--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -32,7 +32,7 @@
 	power = 5000
 
 /obj/projectile/energy/tesla/explosive/on_hit(atom/target)
-	explosion(get_turf(loc),0,0,0,flame_range = 3)
+	explosion(get_turf(loc),0,0,0,flame_range = 0)
 	. = ..()
 
 /obj/projectile/energy/tesla_cannon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the flame range on tesla flux rounds

## Why It's Good For The Game

It always felt a tiny bit inconsistent that 4.6mm flux rounds were the only source of tesla bolts that caused fires -- and rather strong fires, at that. With how strong fires are, I don't think these projectiles should also cause fire damage on top of the shocks that they already provide.

## Changelog

:cl:
balance: removes flame range on tesla flux rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
