### PR TITLE
Allows you to interact with clipboards with double-examine

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -109,6 +109,9 @@
 	ui_interact(user)
 	return
 
+/obj/item/clipboard/examine_more(mob/user)
+	ui_interact(user)
+
 /obj/item/clipboard/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -110,6 +110,7 @@
 	return
 
 /obj/item/clipboard/examine_more(mob/user)
+	. = ..()
 	ui_interact(user)
 
 /obj/item/clipboard/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Computer consoles were given the ability to be interacted with from a distance with the double-examine feature (shift clicking on an item twice quickly) a while back, and this PR aims to bring that same interactability to clipboards. 

## Why It's Good For The Game

This is an extremely minor thing, but I feel like it would help the user experience while using clipboards a tiny bit if this feature were available

## Changelog

:cl:
add: Added double-examine interaction with clipboards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
