### PR TITLE
Fixes missing helmet sprite for Sarathi in NGR mining hardsuits

### DIFF
--- a/code/modules/clothing/factions/ngr.dm
+++ b/code/modules/clothing/factions/ngr.dm
@@ -226,6 +226,7 @@
 	hardsuit_type = "ngrminer"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list("melee" = 65, "bullet" = 30, "laser" = 25, "energy" = 30, "bomb" = 70, "bio" = 100, "rad" = 85, "fire" = 100, "acid" = 100)
+	supports_variations = null
 
 /////////
 //Hats//


### PR DESCRIPTION
## About The Pull Request
A `SNOUTED_VARIATION` was erroneously inherited from the base heavy mining suit.

<img width="727" height="262" alt="image" src="https://github.com/user-attachments/assets/27f4d91f-bfe6-4ddf-aed0-3784f256248a" />

they will die with no helmet

## Changelog

:cl:
fix: NGR mining hardsuit helmets should be visible again on snouted individuals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
