### PR TITLE
Makes the CM82 Casket Mag Normal Sized

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -104,6 +104,7 @@
 	caliber = "5.56x42mm"
 	max_ammo = 60
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/p16/casket/empty
 	start_empty = TRUE


### PR DESCRIPTION
## Why It's Good For The Game

Normal-sized like the other casket/drum mags

## Changelog

:cl:
balance: CM82 casket mag is now normal-sized instead of small-sized
/:cl:

