### PR TITLE
Remove unique reskins from CM-24 and Frontiersman LTV

### DIFF
--- a/code/modules/clothing/factions/frontiersmen.dm
+++ b/code/modules/clothing/factions/frontiersmen.dm
@@ -90,6 +90,7 @@
 	icon = 'icons/obj/clothing/faction/frontiersmen/suits.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/faction/frontiersmen/suits.dmi'
 	vox_override_icon = 'icons/mob/clothing/faction/frontiersmen/vox.dmi'
+	unique_reskin = null
 
 /obj/item/clothing/suit/armor/frontier
 	name = "reinforced fur coat"

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -549,6 +549,7 @@ NO_MAG_GUN_HELPER(automatic/marksman/f4/inteq)
 	lefthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/lefthand.dmi'
 	righthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/righthand.dmi'
 	mob_overlay_icon = 'icons/obj/guns/manufacturer/clip_lanchester/onmob.dmi'
+	unique_reskin = null
 
 	icon_state = "cm24"
 	item_state = "cm24"


### PR DESCRIPTION
What it says on the tin.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Itty bitty two line PR adding `unique_reskin: null` to the CM-24 and Frontiersman Light Tactical Vest to fix [6417](https://github.com/shiptest-ss13/Shiptest/issues/6417). Neither of them had the variants in their respective icon files so it turned them [invisible](https://youtu.be/rp0n9RPoDI4).

## Why It's Good For The Game

They don't need reskins and turning your equipment [invisible](https://youtu.be/rp0n9RPoDI4) because of a misclick is bad.

## Changelog

:cl:
fix: Reskin issues with the CM-24 and Light Tactical Vest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
