### PR TITLE
Disables random lottery events

### DIFF
--- a/code/modules/events/ship/lottery.dm
+++ b/code/modules/events/ship/lottery.dm
@@ -4,7 +4,7 @@
 	weight = 2
 	earliest_start = 20 MINUTES
 	min_players = 10
-	max_occurrences = 1
+	max_occurrences = 0
 
 /datum/round_event/ship/lottery
 	var/creds_won = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables random ship lottery events.

## Why It's Good For The Game

The outpost subshuttle has won 10,000 credits!

It's kind-of goofy that once per round someone can win between 100 and TEN THOUSAND credits for doing Absolutely Nothing.

## Changelog

:cl:
balance: Ship lottery disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
