### PR TITLE
Fixes Corona Cabinet Overflow

### DIFF
--- a/_maps/shuttles/independent/independent_corona.dmm
+++ b/_maps/shuttles/independent/independent_corona.dmm
@@ -2571,10 +2571,6 @@
 /obj/item/plate,
 /obj/item/plate,
 /obj/item/plate,
-/obj/item/plate,
-/obj/item/plate,
-/obj/item/plate/small,
-/obj/item/plate/small,
 /obj/item/plate/small,
 /obj/item/plate/small,
 /obj/item/reagent_containers/food/drinks/modglass/small{
@@ -2594,20 +2590,6 @@
 	},
 /obj/item/reagent_containers/food/drinks/modglass/small{
 	pixel_x = 10
-	},
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_y = -4
 	},
 /obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel/patterned/brushed,


### PR DESCRIPTION
## About The Pull Request

removes a few spare items from the corona kitchen cabinet so they fit inside

## Why It's Good For The Game

in my infinite wisdom i accidentally overstuffed it putting a sink in and forgot about it

## Changelog

:cl:
fix: Corona no longer has an overstuffed kitchen cabinet
/:cl:
