### PR TITLE
Goliath Fixes + Reconfigures Puru Rangi Receiver

### DIFF
--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -592,15 +592,6 @@
 "de" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/electrical)
-"df" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
 "dm" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	piping_layer = 4;
@@ -703,6 +694,15 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/ship/hallway)
+"dL" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "dR" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
@@ -903,7 +903,8 @@
 	},
 /obj/machinery/telecomms/receiver/preset_right{
 	autolinkers = list("receiverG", "hub");
-	network = "indie_commnet"
+	network = "indie_commnet";
+	freq_listening = list(1353,1459)
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/engineering/communications)
@@ -1577,6 +1578,18 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/ship/external/dark)
+"jz" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8;
+	color = "#eeac2e"
+	},
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plating,
+/area/ship/hangar)
 "jB" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
@@ -2309,6 +2322,20 @@
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/crew/office)
+"mZ" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/structure/curtain/bounty{
+	layer = 4.1
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/dorm)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4355,20 +4382,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
-"xO" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
-/obj/structure/curtain/bounty{
-	layer = 4.1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/nanoweave,
-/area/ship/crew/dorm)
 "xV" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hangar)
@@ -7693,18 +7706,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
-"SO" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#eeac2e"
-	},
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plating,
-/area/ship/hangar)
 "ST" = (
 /obj/structure/filingcabinet/double/grey{
 	dir = 8;
@@ -9796,7 +9797,7 @@ ck
 ZP
 MM
 QX
-df
+dL
 NW
 jc
 WF
@@ -10048,7 +10049,7 @@ MU
 uK
 dR
 dR
-SO
+jz
 za
 za
 Ye
@@ -10719,7 +10720,7 @@ OQ
 Ra
 LV
 eX
-xO
+mZ
 uj
 aY
 aY

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -592,6 +592,15 @@
 "de" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering/electrical)
+"df" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "dm" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
 	piping_layer = 4;
@@ -893,7 +902,7 @@
 	dir = 5
 	},
 /obj/machinery/telecomms/receiver/preset_right{
-	autolinkers = list("receiverG", "hub", "bus");
+	autolinkers = list("receiverG", "hub");
 	network = "indie_commnet"
 	},
 /turf/open/floor/plasteel/telecomms_floor,
@@ -1982,15 +1991,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway)
-"kV" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
 "kW" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -4355,6 +4355,20 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engines/starboard)
+"xO" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/structure/curtain/bounty{
+	layer = 4.1
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/dorm)
 "xV" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hangar)
@@ -5041,18 +5055,6 @@
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
-"BX" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#eeac2e"
-	},
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plating,
-/area/ship/hangar)
 "BY" = (
 /obj/structure/table/chem,
 /obj/effect/turf_decal/borderfloorblack{
@@ -7691,6 +7693,18 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"SO" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8;
+	color = "#eeac2e"
+	},
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plating,
+/area/ship/hangar)
 "ST" = (
 /obj/structure/filingcabinet/double/grey{
 	dir = 8;
@@ -7864,20 +7878,6 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hangar)
-"TR" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
-/obj/structure/curtain/bounty{
-	layer = 4.1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/nanoweave,
-/area/ship/crew/dorm)
 "TS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -9796,7 +9796,7 @@ ck
 ZP
 MM
 QX
-kV
+df
 NW
 jc
 WF
@@ -10048,7 +10048,7 @@ MU
 uK
 dR
 dR
-BX
+SO
 za
 za
 Ye
@@ -10719,7 +10719,7 @@ OQ
 Ra
 LV
 eX
-TR
+xO
 uj
 aY
 aY

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -6235,7 +6235,7 @@
 /obj/machinery/telecomms/bus/preset_one{
 	autolinkers = list("hub","processor4","bus");
 	network = "indie_commnet";
-	freq_listening = list(1353)
+	freq_listening = list(1353, 1459)
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/telecomms_floor,
@@ -7079,7 +7079,7 @@
 	},
 /obj/machinery/telecomms/server/presets/common{
 	autolinkers = list("common","hub");
-	freq_listening = list(1353);
+	freq_listening = list(1353, 1459);
 	network = "indie_commnet"
 	},
 /obj/effect/turf_decal/techfloor,

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -1569,18 +1569,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/ship/external/dark)
-"jz" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#eeac2e"
-	},
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plating,
-/area/ship/hangar)
 "jB" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
@@ -10040,7 +10028,7 @@ MU
 uK
 dR
 dR
-jz
+dR
 za
 za
 Ye

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -892,9 +892,10 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
-/obj/machinery/telecomms/receiver/preset_left/birdstation{
-	autolinkers = list("receiverG");
-	freq_listening = list(1353)
+/obj/machinery/telecomms/receiver/preset_right{
+	autolinkers = list("receiverB", "hub");
+	network = "indie_commnet";
+	freq_listening = list(1353,1459)
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/engineering/communications)
@@ -1678,16 +1679,16 @@
 /area/ship/crew/dorm/captain)
 "jQ" = (
 /obj/effect/turf_decal/industrial/traffic/fulltile,
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	dir = 1;
-	id = "goliathholohangar2"
-	},
 /obj/machinery/door/poddoor{
 	dir = 8;
 	id = "goliathblasthangar2"
 	},
 /obj/structure/cable{
 	icon_state = "0-10"
+	},
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	dir = 1;
+	id = "goliathholohangar2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hangar)
@@ -4076,15 +4077,15 @@
 /area/ship/hangar)
 "wM" = (
 /obj/effect/turf_decal/industrial/traffic/fulltile,
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "goliathholohangar2"
-	},
 /obj/machinery/door/poddoor{
 	dir = 8;
 	id = "goliathblasthangar2"
 	},
 /obj/structure/cable{
 	icon_state = "0-9"
+	},
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	id = "goliathholohangar2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hangar)
@@ -5697,6 +5698,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/storage)
 "Fn" = (
@@ -7656,6 +7658,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/storage)
+"SK" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/structure/curtain/bounty{
+	layer = 4.1
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/dorm)
 "SL" = (
 /obj/effect/turf_decal/industrial/traffic,
 /obj/structure/disposalpipe/segment{
@@ -10683,7 +10699,7 @@ OQ
 Ra
 LV
 eX
-qP
+SK
 uj
 aY
 aY

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -893,9 +893,8 @@
 	dir = 5
 	},
 /obj/machinery/telecomms/receiver/preset_right{
-	autolinkers = list("receiverB", "hub");
-	network = "indie_commnet";
-	freq_listening = list(1353,1459)
+	autolinkers = list("receiverG", "hub", "bus");
+	network = "indie_commnet"
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/engineering/communications)
@@ -1983,6 +1982,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway)
+"kV" = (
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "kW" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -5033,6 +5041,18 @@
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
+"BX" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8;
+	color = "#eeac2e"
+	},
+/obj/machinery/telecomms/hub{
+	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
+	id = "Communications Hub";
+	network = "indie_commnet"
+	},
+/turf/open/floor/plating,
+/area/ship/hangar)
 "BY" = (
 /obj/structure/table/chem,
 /obj/effect/turf_decal/borderfloorblack{
@@ -7658,20 +7678,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering/storage)
-"SK" = (
-/obj/effect/spawner/bunk_bed{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
-/obj/structure/curtain/bounty{
-	layer = 4.1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/carpet/nanoweave,
-/area/ship/crew/dorm)
 "SL" = (
 /obj/effect/turf_decal/industrial/traffic,
 /obj/structure/disposalpipe/segment{
@@ -7858,6 +7864,20 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hangar)
+"TR" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/structure/curtain/bounty{
+	layer = 4.1
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/nanoweave,
+/area/ship/crew/dorm)
 "TS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -9776,7 +9796,7 @@ ck
 ZP
 MM
 QX
-WF
+kV
 NW
 jc
 WF
@@ -10028,7 +10048,7 @@ MU
 uK
 dR
 dR
-dR
+BX
 za
 za
 Ye
@@ -10699,7 +10719,7 @@ OQ
 Ra
 LV
 eX
-SK
+TR
 uj
 aY
 aY

--- a/_maps/shuttles/independent/independent_goliath.dmm
+++ b/_maps/shuttles/independent/independent_goliath.dmm
@@ -694,15 +694,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/ship/hallway)
-"dL" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/machinery/telecomms/hub{
-	autolinkers = list("hub","bus","relay","broadcasterG","receiverG");
-	id = "Communications Hub";
-	network = "indie_commnet"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
 "dR" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8;
@@ -9797,7 +9788,7 @@ ck
 ZP
 MM
 QX
-dL
+WF
 NW
 jc
 WF

--- a/_maps/shuttles/ngr/ngr_pururangi.dmm
+++ b/_maps/shuttles/ngr/ngr_pururangi.dmm
@@ -4614,8 +4614,8 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/telecomms/receiver/preset_left/birdstation{
-	autolinkers = list("receiverG", "bus", "hub");
+/obj/machinery/telecomms/receiver/preset_right{
+	autolinkers = list("receiverG", "hub");
 	network = "ngr_commnet"
 	},
 /turf/open/floor/plasteel/telecomms_floor,

--- a/_maps/shuttles/ngr/ngr_pururangi.dmm
+++ b/_maps/shuttles/ngr/ngr_pururangi.dmm
@@ -4615,8 +4615,7 @@
 	dir = 8
 	},
 /obj/machinery/telecomms/receiver/preset_left/birdstation{
-	autolinkers = list("receiverG");
-	freq_listening = list(1353, 1205);
+	autolinkers = list("receiverG", "bus", "hub");
 	network = "ngr_commnet"
 	},
 /turf/open/floor/plasteel/telecomms_floor,

--- a/_maps/shuttles/ngr/ngr_pururangi.dmm
+++ b/_maps/shuttles/ngr/ngr_pururangi.dmm
@@ -4616,7 +4616,8 @@
 	},
 /obj/machinery/telecomms/receiver/preset_right{
 	autolinkers = list("receiverG", "hub");
-	network = "ngr_commnet"
+	network = "ngr_commnet";
+	freq_listening = list(1353,1205,1459)
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/engineering/communications/room)


### PR DESCRIPTION
## About The Pull Request

Fixes a wrong holofield, air alarm on the Goliath and reconfigures its telecomms to work, along with reconfiguring the Puru Rangi's receiver to work as well.

Also adds a welding goggles to engineer storage on Goliath

## Why It's Good For The Game

Fixes good. I believe comms should be functional when the ship is spawned in as well

## Changelog

:cl:
add: Added welding goggles to goliath engi locker
fix: Fixed nonfunctional holofield on goliath, comms on goliath, and comms on puru rangi
/:cl:

