### PR TITLE
Simple Mobs can now be affected by hazardous pressure

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -243,6 +243,11 @@ Override makes it so the alert is not replaced until cleared by a clear_alert wi
 	desc = "The air around you is hazardously thick. A fire suit would protect you."
 	icon_state = "highpressure"
 
+/atom/movable/screen/alert/badpressure
+	name = "Bad Pressure"
+	desc = "The air pressure around you is hazardous. Try moving somewhere else."
+	icon_state = "lowpressure"
+
 /atom/movable/screen/alert/blind
 	name = "Blind"
 	desc = "You can't see! This may be caused by a genetic defect, eye trauma, being unconscious, \

--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -70,6 +70,8 @@
 	atmos_requirements = IMMUNE_ATMOS_REQS
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 
@@ -139,6 +141,8 @@
 	atmos_requirements = IMMUNE_ATMOS_REQS
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	icon_state = "frontiersmanpounder"
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
@@ -204,6 +208,8 @@
 	icon_state = "frontiersmanrangedrifle_space"
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 
@@ -280,6 +286,8 @@
 	icon_state = "frontiersmenrangedelite_space"
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
 
@@ -402,6 +410,8 @@
 	atmos_requirements = IMMUNE_ATMOS_REQS
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	icon_state = "frontiersmanrangedak47_space"
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 	armor_base = /obj/item/clothing/suit/space/hardsuit/security/independent/frontier
@@ -462,6 +472,8 @@
 	atmos_requirements = IMMUNE_ATMOS_REQS
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	icon_state = "frontiersmanrangedminigun_space"
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier/space
 

--- a/code/modules/mob/living/simple_animal/hostile/human/human.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/human.dm
@@ -32,6 +32,9 @@
 
 	unsuitable_atmos_damage = 15
 	minbodytemp = 180
+
+	minimum_pressure = HAZARD_LOW_PRESSURE
+	maximum_pressure = HAZARD_HIGH_PRESSURE
 	status_flags = CANPUSH
 
 	footstep_type = FOOTSTEP_MOB_SHOE

--- a/code/modules/mob/living/simple_animal/hostile/human/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/pirate.dm
@@ -72,6 +72,8 @@
 	icon_living = "piratespaceranged"
 	icon_dead = "piratespaceranged_dead"
 	atmos_requirements = IMMUNE_ATMOS_REQS
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	minbodytemp = 0
 	speed = 1
 	armor_base = /obj/item/clothing/suit/space

--- a/code/modules/mob/living/simple_animal/hostile/human/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/skeleton.dm
@@ -15,6 +15,8 @@
 	melee_damage_upper = 15
 	minbodytemp = 0
 	maxbodytemp = 1500
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	healable = 0 //they're skeletons how would bruise packs help them??
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -31,6 +31,8 @@
 	icon_living = "syndicate_space"
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	speed = 1
 
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/ramzi/space
@@ -188,6 +190,8 @@
 	icon_living = "syndicate_space_knife"
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	speed = 1
 	projectile_deflect_chance = 0
 
@@ -541,6 +545,8 @@
 	atmos_requirements = IMMUNE_ATMOS_REQS
 	minbodytemp = 0
 	maxbodytemp = 1000
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 	speed = 1
 	rapid = 2
 	projectilesound = 'sound/weapons/gun/pistol/asp.ogg'
@@ -798,6 +804,8 @@
 	armor_base = /obj/item/clothing/suit/space/syndicate/ramzi
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/ramzi/space/soft/surplus
 	environment_smash = ENVIRONMENT_SMASH_NONE
+	minimum_pressure = 0
+	maximum_pressure = INFINITY
 
 /mob/living/simple_animal/hostile/human/ramzi/civilian/towel
 	name = "Ramzi Clique Soapmaster"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -371,8 +371,8 @@
 
 	if(!environment_pressure_is_safe())
 		adjustHealth(unsuitable_atmos_damage)
-			if(unsuitable_atmos_damage > 0)
-				throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 2)
+		if(unsuitable_atmos_damage > 0)
+			throw_alert("pressure", /atom/movable/screen/alert/badpressure, 2)
 	else
 		clear_alert("pressure")
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -65,6 +65,10 @@
 	///This damage is taken when atmos doesn't fit all the requirements above.
 	var/unsuitable_atmos_damage = 2
 
+	///The safe pressure for this mob
+	var/minimum_pressure = 0
+	var/maximum_pressure = INFINITY
+
 	//Defaults to zero so Ian can still be cuddly. Moved up the tree to living! This allows us to bypass some hardcoded stuff.
 	melee_damage_lower = 0
 	melee_damage_upper = 0
@@ -338,6 +342,17 @@
 	if((areatemp < minbodytemp) || (areatemp > maxbodytemp))
 		. = FALSE
 
+/mob/living/simple_animal/proc/environment_pressure_is_safe()
+	. = TRUE
+	if(isturf(loc) && isopenturf(loc))
+		var/turf/open/ST = loc
+		if(ST.air)
+			if(ST.air.return_pressure() < minimum_pressure || ST.air.return_pressure() > maximum_pressure)
+				. = FALSE
+		else
+			if(minimum_pressure > 0)
+				. = FALSE
+
 /mob/living/simple_animal/handle_environment(datum/gas_mixture/environment)
 	var/atom/A = loc
 	if(isturf(A))
@@ -353,6 +368,13 @@
 			throw_alert(ALERT_NOT_ENOUGH_OXYGEN, /atom/movable/screen/alert/not_enough_oxy)
 	else
 		clear_alert(ALERT_NOT_ENOUGH_OXYGEN)
+
+	if(!environment_pressure_is_safe())
+		adjustHealth(unsuitable_atmos_damage)
+			if(unsuitable_atmos_damage > 0)
+				throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 2)
+	else
+		clear_alert("pressure")
 
 	handle_temperature_damage()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now set max/min safe pressures for simple mobs. Human simple mobs have been set to be affected by pressure.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If a human simple mob had internals, they could space walk perfectly fine in just a plain uniform. Makes simple mobs take damage a bit more realistically and act to expectation. 

## Changelog

:cl:
add: Simple mobs can take pressure damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
