### PR TITLE
Blast Hammer consistency

### DIFF
--- a/code/modules/projectiles/guns/ballistic/blast_hammer.dm
+++ b/code/modules/projectiles/guns/ballistic/blast_hammer.dm
@@ -78,7 +78,7 @@
 
 /obj/item/gun/ballistic/shotgun/blasting_hammer/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = force, force_wielded = 30)
+	AddComponent(/datum/component/two_handed, force_unwielded = force, force_wielded = 40)
 
 /obj/item/gun/ballistic/shotgun/blasting_hammer/on_wield(obj/item/source, mob/user, instant)
 	. = ..()
@@ -141,6 +141,15 @@
 		demolition_mod = 10
 	else
 		demolition_mod = initial(demolition_mod)
+
+/obj/item/gun/ballistic/shotgun/blasting_hammer/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	if(HAS_TRAIT(src, TRAIT_WIELDED)) //destroys windows and grilles in one hit
+		if(istype(A, /obj/structure/window) || istype(A, /obj/structure/grille))
+			var/obj/structure/W = A
+			W.atom_destruction("axe")
 
 /obj/item/gun/ballistic/shotgun/blasting_hammer/update_icon_state()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Blasting Hammer base wielded force raised to 40 and is able to break windows without loaded ammo like the base sledge.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency with the regular sledgehammer.

## Changelog

:cl:
balance: Blast Hammer wielded force and window breaking is consistent with normal hammer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
