### PR TITLE
Fixes infinite reskinning on camo clothing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -368,7 +368,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/examine(mob/user)
 	. = ..()
 
-	if(unique_reskin && !current_skin)
+	if((unique_reskin && !current_skin) || (unique_reskin && (obj_flags & INFINITE_RESKIN)))
 		. += span_notice("<b>Alt-click</b> it to reskin it.")
 
 	. += span_notice("[gender == PLURAL ? "They are" : "It is"] a <b>[weightclass2text(w_class)]</b> item.")

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -508,6 +508,18 @@
 		"Urban" = "militarywebbing_urban",
 		)
 
+//this might seem obtuse instead of setting allow_post_reskins to TRUE, but then the reskin menu would open every alt click, which is not good for a storage item
+/obj/item/storage/belt/military/examine(mob/user)
+	. = ..()
+	if(unique_reskin && current_skin)
+		. += "You can <b>Ctrl-Click</b> [src] to reskin it again after skinning it."
+
+/obj/item/storage/belt/military/CtrlClick(mob/user)
+	. = ..()
+	if(isliving(user) && in_range(src, user))
+		current_skin = null
+		to_chat(user, "You can reskin [src] again wtih <b>Alt-Click</b>.")
+
 /obj/item/storage/belt/military/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -508,17 +508,17 @@
 		"Urban" = "militarywebbing_urban",
 		)
 
-//this might seem obtuse instead of setting allow_post_reskins to TRUE, but then the reskin menu would open every alt click, which is not good for a storage item
+//this might seem obtuse instead of allowing infinte reskins, but then the reskin menu would open every alt click, which is not good for a storage item such as this
 /obj/item/storage/belt/military/examine(mob/user)
 	. = ..()
 	if(unique_reskin && current_skin)
-		. += "You can <b>Ctrl-Click</b> [src] to reskin it again after skinning it."
+		. += "You can [span_bold("Ctrl-Click")] [src] to reskin it again after skinning it."
 
 /obj/item/storage/belt/military/CtrlClick(mob/user)
 	. = ..()
 	if(isliving(user) && in_range(src, user))
 		current_skin = null
-		to_chat(user, "You can reskin [src] again wtih <b>Alt-Click</b>.")
+		to_chat(user, "You can now reskin [src] again wtih [span_bold("Alt-Click")].")
 
 /obj/item/storage/belt/military/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -204,6 +204,7 @@
 	can_flashlight = TRUE
 	dog_fashion = null
 	supports_variations = KEPORI_VARIATION
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list(
 		"None" = "helmetalt",
 		"Desert" = "helmetalt_desert",
@@ -246,6 +247,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF | SEALS_EYES
 	dog_fashion = null
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list(
 		"None" = "riot",
 		"Desert" = "riot_desert",
@@ -472,6 +474,8 @@
 	dog_fashion = null
 	supports_variations = null
 	content_overlays = TRUE
+
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list(
 		"None" = "m10helm",
 		"Desert" = "m10helm_desert",
@@ -487,6 +491,7 @@
 	can_flashlight = TRUE
 	dog_fashion = null
 	supports_variations = null
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list(
 		"None" = "x11helm",
 		"Desert" = "x11helm_desert",

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -56,6 +56,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	supports_variations = VOX_VARIATION | DIGITIGRADE_VARIATION_NO_NEW_ICON
 	slowdown = 0 //one day...
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list(
 		"None" = "marine_light",
 		"Desert" = "marine_light_desert",

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -276,6 +276,7 @@
 	icon_state = "camo"
 	item_state = "fatigues"
 
+	obj_flags = INFINITE_RESKIN
 	unique_reskin = list("Urban" = "camo",
 		"Desert" = "camo_desert",
 		"Woodland" = "camo_woodland",

--- a/code/modules/food_and_drinks/drinks/drinks/modglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/modglass.dm
@@ -5,7 +5,7 @@
 
 //glass variant defines, if you're adding new glasses make sure to update these
 #define SMALL_VARIANTS 6
-#define MEDIUM_VARIANTS 14
+#define MEDIUM_VARIANTS 13
 #define LARGE_VARIANTS 5
 
 //garnish layer defines, higher numbers go above low ones, add more of these if you manage to get sprites that can fit in a new part of the glass
@@ -23,13 +23,9 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	name = "malleable glass"
 	desc = "Not your standard drinking glass!"
 	icon = 'icons/obj/food/modglass.dmi'
-	lefthand_file = 'icons/obj/drinks/drinks_lefthand.dmi'
-	righthand_file = 'icons/obj/drinks/drinks_righthand.dmi'
-
 	icon_state = "mglass-1-"
-	item_state = "glass"
 	fill_icon = 'icons/obj/food/modglass_fillings.dmi'
-	fill_icon_thresholds = list(1,50,90)
+	fill_icon_thresholds = list(50,90)
 	amount_per_transfer_from_this = 10
 	volume = 50
 	custom_materials = list(/datum/material/glass=500, /datum/material/silver=100)
@@ -112,7 +108,6 @@ GLOBAL_LIST_EMPTY(glass_variants)
  * if the garnish is a "rim" garnish, it is instead split into two halves, one drawn below all others,
  * and one above all others, allowing garnishes to be placed "inside" the glass
  */
-
 /obj/item/reagent_containers/food/drinks/modglass/update_overlays()
 	. = ..()
 	var/rimtype = garnishes["1"]
@@ -137,7 +132,6 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	desc = "you should not see this"
 	icon = 'icons/obj/food/modglass_garnishes_items.dmi'
 	icon_state = "rim"
-	w_class = WEIGHT_CLASS_TINY
 	var/garnish_state = "rim"
 	var/garnish_layer = GARNISH_RIM
 
@@ -151,19 +145,13 @@ GLOBAL_LIST_EMPTY(glass_variants)
 //this will allow it to layer over things inside the glass
 /obj/item/garnish/salt
 	name = "salt garnish"
-	desc = "Harvested from the tears of wasteplanet explorers."
+	desc = "Harvested from the tears of the saltiest assistant."
 
 /obj/item/garnish/ash
 	name = "ash garnish"
 	desc = "But why would you do this though."
 	icon_state = "drim"
 	garnish_state = "drim"
-
-/obj/item/garnish/chilipowder
-	name = "chili powder garnish"
-	desc = "For that jalapeño margarita touch."
-	icon_state = "chilirim"
-	garnish_state = "chilirim"
 
 /obj/item/garnish/puce
 	name = "puce garnish"
@@ -219,13 +207,6 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	garnish_state = "orange"
 	garnish_layer = GARNISH_RIGHT
 
-/obj/item/garnish/apple
-	name = "apple wedge"
-	desc = "An uncommon topping for your drink, but will work just as well."
-	icon_state = "apple"
-	garnish_state = "apple"
-	garnish_layer = GARNISH_RIGHT
-
 /obj/item/garnish/cherry
 	name = "bunch of cherries"
 	desc = "A classic topping for your drink."
@@ -239,13 +220,6 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	desc = "This would look good in a martini."
 	icon_state = "olives"
 	garnish_state = "olives"
-	garnish_layer = GARNISH_LEFT
-
-/obj/item/garnish/pineapples
-	name = "skewered pineapple chunks"
-	desc = "This would look good in a drink."
-	icon_state = "pineappleslice"
-	garnish_state = "pineappleslice"
 	garnish_layer = GARNISH_LEFT
 
 /obj/item/garnish/umbrellared
@@ -268,31 +242,3 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	icon_state = "umbrellagreen"
 	garnish_state = "umbrellagreen"
 	garnish_layer = GARNISH_LEFT
-
-/obj/item/garnish/straw
-	name = "paper straw"
-	desc = "A paper straw meant to be used with drinks."
-	icon_state = "paperstraw"
-	garnish_state = "paperstraw"
-	garnish_layer = GARNISH_LEFT
-
-/obj/item/garnish/stripedstraw
-	name = "red striped paper straw"
-	desc = "A red striped paper straw meant to be used with drinks. Perfect with smoothies."
-	icon_state = "stripedstraw"
-	garnish_state = "stripedstraw"
-	garnish_layer = GARNISH_LEFT
-
-/obj/item/garnish/woodmixingstick
-	name = "wooden mixing stick"
-	desc = "A wooden mixing stick. While it would be great for mixing drinks, it's actually used to garnish drinking glasses, go figure."
-	icon_state = "woodmixingstick"
-	garnish_state = "woodmixingstick"
-	garnish_layer = GARNISH_RIGHT
-
-/obj/item/garnish/blackmixingstick
-	name = "black mixing stick"
-	desc = "A black mixing stick made of plastic. While it would be great for mixing drinks, it's actually used to garnish drinking glasses, go figure."
-	icon_state = "blackmixingstick"
-	garnish_state = "blackmixingstick"
-	garnish_layer = GARNISH_RIGHT

--- a/code/modules/food_and_drinks/drinks/drinks/modglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/modglass.dm
@@ -5,7 +5,7 @@
 
 //glass variant defines, if you're adding new glasses make sure to update these
 #define SMALL_VARIANTS 6
-#define MEDIUM_VARIANTS 13
+#define MEDIUM_VARIANTS 14
 #define LARGE_VARIANTS 5
 
 //garnish layer defines, higher numbers go above low ones, add more of these if you manage to get sprites that can fit in a new part of the glass
@@ -23,9 +23,13 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	name = "malleable glass"
 	desc = "Not your standard drinking glass!"
 	icon = 'icons/obj/food/modglass.dmi'
+	lefthand_file = 'icons/obj/drinks/drinks_lefthand.dmi'
+	righthand_file = 'icons/obj/drinks/drinks_righthand.dmi'
+
 	icon_state = "mglass-1-"
+	item_state = "glass"
 	fill_icon = 'icons/obj/food/modglass_fillings.dmi'
-	fill_icon_thresholds = list(50,90)
+	fill_icon_thresholds = list(1,50,90)
 	amount_per_transfer_from_this = 10
 	volume = 50
 	custom_materials = list(/datum/material/glass=500, /datum/material/silver=100)
@@ -108,6 +112,7 @@ GLOBAL_LIST_EMPTY(glass_variants)
  * if the garnish is a "rim" garnish, it is instead split into two halves, one drawn below all others,
  * and one above all others, allowing garnishes to be placed "inside" the glass
  */
+
 /obj/item/reagent_containers/food/drinks/modglass/update_overlays()
 	. = ..()
 	var/rimtype = garnishes["1"]
@@ -132,6 +137,7 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	desc = "you should not see this"
 	icon = 'icons/obj/food/modglass_garnishes_items.dmi'
 	icon_state = "rim"
+	w_class = WEIGHT_CLASS_TINY
 	var/garnish_state = "rim"
 	var/garnish_layer = GARNISH_RIM
 
@@ -145,13 +151,19 @@ GLOBAL_LIST_EMPTY(glass_variants)
 //this will allow it to layer over things inside the glass
 /obj/item/garnish/salt
 	name = "salt garnish"
-	desc = "Harvested from the tears of the saltiest assistant."
+	desc = "Harvested from the tears of wasteplanet explorers."
 
 /obj/item/garnish/ash
 	name = "ash garnish"
 	desc = "But why would you do this though."
 	icon_state = "drim"
 	garnish_state = "drim"
+
+/obj/item/garnish/chilipowder
+	name = "chili powder garnish"
+	desc = "For that jalapeño margarita touch."
+	icon_state = "chilirim"
+	garnish_state = "chilirim"
 
 /obj/item/garnish/puce
 	name = "puce garnish"
@@ -207,6 +219,13 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	garnish_state = "orange"
 	garnish_layer = GARNISH_RIGHT
 
+/obj/item/garnish/apple
+	name = "apple wedge"
+	desc = "An uncommon topping for your drink, but will work just as well."
+	icon_state = "apple"
+	garnish_state = "apple"
+	garnish_layer = GARNISH_RIGHT
+
 /obj/item/garnish/cherry
 	name = "bunch of cherries"
 	desc = "A classic topping for your drink."
@@ -220,6 +239,13 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	desc = "This would look good in a martini."
 	icon_state = "olives"
 	garnish_state = "olives"
+	garnish_layer = GARNISH_LEFT
+
+/obj/item/garnish/pineapples
+	name = "skewered pineapple chunks"
+	desc = "This would look good in a drink."
+	icon_state = "pineappleslice"
+	garnish_state = "pineappleslice"
 	garnish_layer = GARNISH_LEFT
 
 /obj/item/garnish/umbrellared
@@ -242,3 +268,31 @@ GLOBAL_LIST_EMPTY(glass_variants)
 	icon_state = "umbrellagreen"
 	garnish_state = "umbrellagreen"
 	garnish_layer = GARNISH_LEFT
+
+/obj/item/garnish/straw
+	name = "paper straw"
+	desc = "A paper straw meant to be used with drinks."
+	icon_state = "paperstraw"
+	garnish_state = "paperstraw"
+	garnish_layer = GARNISH_LEFT
+
+/obj/item/garnish/stripedstraw
+	name = "red striped paper straw"
+	desc = "A red striped paper straw meant to be used with drinks. Perfect with smoothies."
+	icon_state = "stripedstraw"
+	garnish_state = "stripedstraw"
+	garnish_layer = GARNISH_LEFT
+
+/obj/item/garnish/woodmixingstick
+	name = "wooden mixing stick"
+	desc = "A wooden mixing stick. While it would be great for mixing drinks, it's actually used to garnish drinking glasses, go figure."
+	icon_state = "woodmixingstick"
+	garnish_state = "woodmixingstick"
+	garnish_layer = GARNISH_RIGHT
+
+/obj/item/garnish/blackmixingstick
+	name = "black mixing stick"
+	desc = "A black mixing stick made of plastic. While it would be great for mixing drinks, it's actually used to garnish drinking glasses, go figure."
+	icon_state = "blackmixingstick"
+	garnish_state = "blackmixingstick"
+	garnish_layer = GARNISH_RIGHT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a feature regression in some random pr that broke this. This has been annoying me for a year now, but seeing as i need to do this anyways for something unrelated (malleable glass skinning being a very strange system) i may as well get this out the way

## Why It's Good For The Game

I Noticed when it was broken, just barely got around to it

## Changelog

:cl:
fix: Camo fatigues and armor should be infinitely reskinnable again.
/:cl:
