### PR TITLE
Admin Holopads

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -61,7 +61,7 @@
 			dialed_holopads += H
 			H.say("Incoming call.")
 			if(H.admin_pad)
-				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green>Incoming Holocall</font>[ADMIN_FULLMONTY(usr)]:</b> <span class='linkify'> is calling from [calling_pad.get_area_name()][ADMIN_FLW(calling_pad)] to [H.get_area_name()][ADMIN_FLW(H)]"))
+				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling [H.get_pad_name()][ADMIN_FLW(H)] from [get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]!"))
 			LAZYADD(H.holo_calls, src)
 
 	if(!dialed_holopads.len)

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -60,6 +60,8 @@
 		if(!QDELETED(H) && H.is_operational)
 			dialed_holopads += H
 			H.say("Incoming call.")
+			if(H.admin_pad)
+				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green>Incoming Holocall</font>[ADMIN_FULLMONTY(usr)]:</b> <span class='linkify'> is calling from [calling_pad.get_area_name()][ADMIN_FLW(calling_pad)] to [H.get_area_name()][ADMIN_FLW(H)]"))
 			LAZYADD(H.holo_calls, src)
 
 	if(!dialed_holopads.len)

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -61,7 +61,7 @@
 			dialed_holopads += H
 			H.say("Incoming call.")
 			if(H.admin_pad)
-				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling [H.get_pad_name()][ADMIN_FLW(H)] from [get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]!"))
+				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling <b>[H.get_pad_name()][ADMIN_FLW(H)]</b> from <b>[get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]</b>!"))
 			LAZYADD(H.holo_calls, src)
 
 	if(!dialed_holopads.len)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -107,6 +107,8 @@ Possible to do for anyone motivated enough:
 	name = "administrative holopad"
 	desc = "It's a floor-mounted device for projecting holographic images. This one is equipped with a full administrative suite."
 	secure = TRUE
+	admin_pad = TRUE
+	name_override = "Unconfigured admin holopad"
 
 /obj/machinery/holopad/secret
 	name = "one-way holopad"
@@ -340,13 +342,13 @@ Possible to do for anyone motivated enough:
 						continue
 					if (pad.is_operational && !pad.secret_pad)
 						if(pad.name_override)
-							LAZYADD(callnames[ref(pad.name_override)], pad)
+							LAZYADD(callnames[pad.name_override], pad)
 						else
 							var/area/area = get_area(pad)
 							if(area)
 								LAZYADD(callnames[area], pad)
 
-				var/result = tgui_input_list(usr, "Choose an holopad to call", "Holocall", sortNames(callnames))
+				var/result = tgui_input_list(usr, "Choose an holopad to call", "Holocall", sortList(callnames))
 				if(QDELETED(usr) || !result || outgoing_call)
 					return
 				var/interference = SSovermap.get_overmap_interference(src)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -87,6 +87,8 @@ Possible to do for anyone motivated enough:
 	var/name_override
 	///does this pad get broadcast globally at all?
 	var/secret_pad = FALSE
+	///is this holopad monitored as an 'admin' holopad? if so, calls to it create an alert.
+	var/admin_pad = FALSE
 	/// The last holopad that called this one.
 	var/caller_history
 
@@ -100,6 +102,11 @@ Possible to do for anyone motivated enough:
 	var/obj/item/circuitboard/machine/holopad/board = circuit
 	board.secure = TRUE
 	board.build_path = /obj/machinery/holopad/secure
+
+/obj/machinery/holopad/secure/admin
+	name = "administrative holopad"
+	desc = "It's a floor-mounted device for projecting holographic images. This one is equipped with a full administrative suite."
+	secure = TRUE
 
 /obj/machinery/holopad/secret
 	name = "one-way holopad"

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -101,6 +101,11 @@ Possible to do for anyone motivated enough:
 	board.secure = TRUE
 	board.build_path = /obj/machinery/holopad/secure
 
+/obj/machinery/holopad/secret
+	name = "one-way holopad"
+	desc = "It's a floor-mounted device for projecting holographic images. This one is designed to only connect outwardly."
+	secret_pad = TRUE
+
 /obj/machinery/holopad/tutorial
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1


### PR DESCRIPTION
## About The Pull Request

expands holopads a bit more
<img width="779" height="56" alt="image" src="https://github.com/user-attachments/assets/50f06425-ec52-4856-816b-06ad60454948" />

you can now set an 'admin pad' var or use the prefab of secure/admin to make a holopad that alerts you when someone is calling.

## Changelog

:cl:
add: Admin holopads, that send alerts out to chat.
/:cl:
