### PR TITLE
Make world_topic/manifest public

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -261,7 +261,6 @@
 
 /datum/world_topic/manifest //Inspired by SunsetStation
 	keyword = "manifest"
-	require_comms_key = TRUE //not really needed, but I don't think any bot besides ours would need it
 
 /datum/world_topic/manifest/Run(list/input)
 	. = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes world/topic_manifest (the thing that the discord bot uses to get who's playing what on the server) no longer require a comms key to access. That's all, no changes to any gameplay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's not.. *bad* for the game? It doesn't really affect the game at all. In all honesty I'm only wanting this because I'm trying to write a python script to make a prettier manifest for a personal project. 

world/topic_manifest doesn't affect the server at all or grant any information that wouldn't be visible to anyone using !manifest in the discord. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
server: world_topic/manifest no longer requires comms_key
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
