### PR TITLE
Gives the Akita User a Flashlight on the Apso

### DIFF
--- a/_maps/shuttles/inteq/inteq_apso.dmm
+++ b/_maps/shuttles/inteq/inteq_apso.dmm
@@ -2571,13 +2571,13 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/item/attachment/rail_light{
-	pixel_x = 6;
-	pixel_y = -4
-	},
 /obj/effect/turf_decal/trimline/opaque/yellow/line,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 3;
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps one rail light for a normal seclite on the Apso
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the Akita doesn't actually have a rail slot, fun fact. So despite having 3 rail lights, you can't use 1, and with an absence of seclites the Akita user must wallow in darkness (or, optionally, with a chump normal flashlight). 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Swapped a Rail Light for a Seclite on the Apso.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
