### PR TITLE
[DNM] Makes all the machine pistols full auto

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -82,8 +82,8 @@
 	)
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
-	fire_delay = 0.4 SECONDS
-	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
+	fire_delay = 0.2 SECONDS
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 	manufacturer = MANUFACTURER_MINUTEMAN
 

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -82,7 +82,7 @@
 	)
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.07 SECONDS
 	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 	manufacturer = MANUFACTURER_MINUTEMAN

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -69,7 +69,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/cm70
 	name = "CM-70 machine pistol"
-	desc = "A compact machine pistol designed to rapidly fire 3-round bursts. Popular with officers and certain special units, the CM-70 is incredibly dangerous at close range. Chambered in 9mm."
+	desc = "A compact machine pistol designed to rapidly fire 9mm ammo. Popular with officers and certain special units, the CM-70 is incredibly dangerous at close range. Chambered in 9mm."
 	icon = 'icons/obj/guns/manufacturer/clip_lanchester/48x32.dmi'
 	lefthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/lefthand.dmi'
 	righthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/righthand.dmi'

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -299,8 +299,9 @@ NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake/inteq)
 	recoil = 0.5
 	recoil_unwielded = 3
 	burst_size = 2
-	burst_delay = 0.1 SECONDS
-	fire_delay = 0.4 SECONDS
+	burst_delay = 0.07 SECONDS
+	fire_delay = 0.1 SECONDS
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
 
 /obj/item/ammo_box/magazine/m9mm_rattlesnake
 	name = "Rattlesnake magazine (9mm)"

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -266,7 +266,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 	wear_minor_threshold = 240
 	wear_major_threshold = 720
 	wear_maximum = 1200
-	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 
 NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake)

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -262,11 +262,11 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
-	fire_delay = 0.4 SECONDS
+	fire_delay = 0.7 SECONDS
 	wear_minor_threshold = 240
 	wear_major_threshold = 720
 	wear_maximum = 1200
-	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_BURST)
+	gun_firemodes = list(FIREMODE_SEMIAUTO, FIREMODE_FULLAUTO)
 	default_firemode = FIREMODE_SEMIAUTO
 
 NO_MAG_GUN_HELPER(automatic/pistol/rattlesnake)

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -262,7 +262,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/asp)
 
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
-	fire_delay = 0.7 SECONDS
+	fire_delay = 0.07 SECONDS
 	wear_minor_threshold = 240
 	wear_major_threshold = 720
 	wear_maximum = 1200

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
@@ -43,7 +43,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger)
 
 /obj/item/gun/ballistic/automatic/pistol/champion
 	name = "Advantage PHB Champion"
-	desc = "A large, burst-fire machine pistol featuring an impressive recoil compensation assembly, making it substantially more stable and accurate than most machine pistols. Chambered in 9mm."
+	desc = "A large machine pistol featuring an impressive recoil compensation assembly, making it substantially more stable and accurate than most machine pistols. Chambered in 9mm."
 	icon_state = "champion"
 	item_state = "champion"
 	icon = 'icons/obj/guns/manufacturer/warra_sharplite/48x32.dmi'
@@ -85,7 +85,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger)
 
 	burst_size = 3
 	burst_delay = 0.1 SECONDS
-	fire_delay = 0.4 SECONDS
+	fire_delay = 0.08 SECONDS
 
 	wear_minor_threshold = 240
 	wear_major_threshold = 720


### PR DESCRIPTION
## About The Pull Request

i said i'd make a test pr for this

All machine pistols now have a rapid fire full auto mode rather than a burst. 
The cottonmouth's burst has had its speed improved.

## Changelog

:cl:
balance: made all the machine pistols full auto
/:cl:
