### PR TITLE
Tile Fixes for Downed Transport and Hardliner Holdout

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
@@ -65,9 +65,7 @@
 	id = "general_room_shutters";
 	name = "window shutters"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "au" = (
 /obj/structure/toilet{
@@ -178,9 +176,7 @@
 	pixel_y = 4;
 	pixel_x = 6
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "bH" = (
 /obj/machinery/light/directional/north,
@@ -375,9 +371,7 @@
 	pixel_y = 6;
 	pixel_x = -3
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "dG" = (
 /obj/structure/guncloset,
@@ -614,9 +608,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "grid_dark"
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "eR" = (
 /turf/open/floor/plating/asteroid/icerock/smooth,
@@ -643,9 +635,7 @@
 /obj/item/storage/cans/sixsoda,
 /obj/item/storage/cans/sixbeer,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "fm" = (
 /obj/structure/grille,
@@ -695,9 +685,7 @@
 	pixel_y = 7;
 	pixel_x = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "fL" = (
 /obj/effect/decal/cleanable/crayon{
@@ -834,9 +822,7 @@
 	pixel_x = -1
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "gU" = (
 /obj/structure/fence/door,
@@ -856,9 +842,7 @@
 "gW" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "gX" = (
 /obj/effect/turf_decal/borderfloorblack/corner{
@@ -1122,9 +1106,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "grid_dark"
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "iv" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1212,9 +1194,7 @@
 	pixel_x = -1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "jE" = (
 /obj/machinery/light/directional/north{
@@ -1354,15 +1334,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "kq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "kr" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -1428,9 +1404,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "kY" = (
 /obj/structure/catwalk/over,
@@ -1548,9 +1522,7 @@
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "lR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
@@ -1762,9 +1734,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "grid_dark"
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "mZ" = (
 /obj/structure/barricade/wooden/crude/snow,
@@ -1911,9 +1881,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "om" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1991,9 +1959,7 @@
 	start_charge = 0
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "oI" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -2152,9 +2118,7 @@
 /obj/item/melee/knife{
 	pixel_x = -5
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "pI" = (
 /obj/effect/mob_spawn/human/corpse/pgf/downed_copilot,
@@ -2357,9 +2321,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "sc" = (
 /obj/structure/cable{
@@ -2457,9 +2419,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "sK" = (
 /obj/effect/decal/cleanable/crayon{
@@ -3549,9 +3509,7 @@
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "Bv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Bx" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -3598,9 +3556,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "Cc" = (
 /obj/structure/flora/tree/dead{
@@ -3633,9 +3589,7 @@
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "CC" = (
 /obj/structure/closet/crate/large,
@@ -3783,9 +3737,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "DF" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -3819,9 +3771,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -3865,9 +3815,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Ek" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
@@ -4452,9 +4400,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "HX" = (
 /obj/structure/platform/wood{
@@ -4676,9 +4622,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Jz" = (
 /obj/structure/cable{
@@ -4701,9 +4645,7 @@
 /obj/machinery/microwave{
 	pixel_y = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "JF" = (
 /obj/structure/lattice{
@@ -4736,9 +4678,7 @@
 "Kj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Kl" = (
 /obj/structure/table/wood,
@@ -4768,9 +4708,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "Ky" = (
 /obj/item/shard{
@@ -4804,9 +4742,7 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/ruin/powered/icemoon/downed_transport/ramshackle_workroom)
 "KE" = (
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "KI" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -4863,9 +4799,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel{
-	icon_state = "grid_dark"
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "Lw" = (
 /obj/structure/railing{
@@ -5002,9 +4936,7 @@
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "MG" = (
 /obj/effect/turf_decal/siding/wood,
@@ -5722,9 +5654,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "Th" = (
 /obj/structure/flora/tree/pine{
@@ -5783,9 +5713,7 @@
 "Tz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "TC" = (
 /obj/structure/flora/driftwood{
@@ -5853,9 +5781,7 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "TZ" = (
 /obj/machinery/door/airlock/external/glass{
@@ -5912,9 +5838,7 @@
 	pixel_y = -1;
 	pixel_x = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Ui" = (
 /obj/machinery/light/small/broken{
@@ -6110,9 +6034,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "monotile_light"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "VP" = (
 /obj/effect/turf_decal/borderfloorblack/corner{
@@ -6400,9 +6322,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "tiled_dark"
-	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "YF" = (
 /obj/structure/mirror{

--- a/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
@@ -138,7 +138,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "bs" = (
 /obj/effect/decal/fakelattice,
@@ -200,7 +200,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/broken/directional/east,
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "ch" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -423,7 +423,7 @@
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ed" = (
 /obj/structure/cable{
@@ -819,7 +819,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "gY" = (
 /obj/structure/cable{
@@ -872,7 +872,7 @@
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "hk" = (
 /obj/machinery/space_heater,
@@ -1027,7 +1027,7 @@
 	pixel_x = 9;
 	pixel_y = 7
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "in" = (
 /obj/structure/railing{
@@ -1046,7 +1046,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "is" = (
 /obj/structure/platform/wood/corner{
@@ -1742,7 +1742,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/stairs{
+/turf/open/floor/plasteel/stairs/icemoon{
 	icon = 'icons/obj/stairs.dmi';
 	dir = 4
 	},
@@ -2575,7 +2575,7 @@
 	dir = 4;
 	id = "barrow_loading_door"
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "uh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2674,7 +2674,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "uT" = (
 /obj/item/clothing/shoes/winterboots{
@@ -2926,7 +2926,7 @@
 	dir = 4;
 	id = "barrow_loading_door"
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "xo" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -2938,7 +2938,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "xx" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -3219,7 +3219,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs{
+/turf/open/floor/plasteel/stairs/icemoon{
 	icon = 'icons/obj/stairs.dmi';
 	dir = 1
 	},
@@ -3260,7 +3260,7 @@
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "zN" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2,
@@ -3312,7 +3312,7 @@
 /obj/item/taperecorder/preset/downed_transport{
 	name = "Cockpit Flight Recorder"
 	},
-/turf/open/floor/plasteel/stairs,
+/turf/open/floor/plasteel/stairs/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3332,7 +3332,7 @@
 /obj/structure/salvageable/computer{
 	dir = 1
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "Ao" = (
 /obj/structure/catwalk/over,
@@ -3363,7 +3363,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Av" = (
 /obj/structure/window/fulltile,
@@ -3463,7 +3463,7 @@
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/machinery/light/small/broken/directional/west,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ct" = (
 /obj/structure/fence{
@@ -4057,7 +4057,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ga" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -4686,7 +4686,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Ly" = (
 /obj/structure/destructible/tribal_torch/lit{
@@ -4720,7 +4720,7 @@
 "LT" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/structure/cable/yellow,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "LV" = (
 /obj/structure/fence/post,
@@ -4873,7 +4873,7 @@
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 2
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "Ni" = (
 /obj/structure/destructible/tribal_torch/lit{
@@ -4949,7 +4949,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 2
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Of" = (
 /obj/structure/flora/tree/pine{
@@ -5026,7 +5026,7 @@
 	pixel_x = -2
 	},
 /obj/effect/mapping_helpers/chair/tim_buckley,
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Oq" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -5130,7 +5130,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "PS" = (
 /turf/open/floor/plating/asteroid/icerock/cracked,
@@ -5152,7 +5152,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/pgf/downed_pilot,
 /obj/effect/mapping_helpers/chair/tim_buckley,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Qc" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -5284,7 +5284,7 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "QY" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5368,7 +5368,7 @@
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/asteroid/ice_demon,
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "RO" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -5398,7 +5398,7 @@
 /obj/item/clipboard{
 	pixel_x = 6
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "RY" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -5469,7 +5469,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/stairs{
+/turf/open/floor/plasteel/stairs/icemoon{
 	icon = 'icons/obj/stairs.dmi';
 	dir = 1
 	},
@@ -5546,7 +5546,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/plasteel/patterned/brushed/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Tz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5850,7 +5850,7 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	icon_state = "blood2"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "VI" = (
 /obj/effect/turf_decal/corner/opaque/red/diagonal,
@@ -5871,7 +5871,7 @@
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "VR" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -5951,7 +5951,7 @@
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/crystal,
-/turf/open/floor/pod/dark,
+/turf/open/floor/pod/dark/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "Ww" = (
 /obj/structure/railing/corner/wood,
@@ -6225,7 +6225,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
+/turf/open/floor/plasteel/tech/techmaint/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Ze" = (
 /obj/structure/cable/blue{

--- a/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
@@ -26,7 +26,7 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ah" = (
 /obj/structure/flora/driftwood{
@@ -40,7 +40,7 @@
 /obj/effect/turf_decal/etherbor/left{
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ap" = (
 /obj/structure/flora/grass/both,
@@ -79,9 +79,7 @@
 	},
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "aA" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -96,9 +94,7 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "aD" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -125,9 +121,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "aT" = (
 /obj/item/flashlight/lantern{
@@ -154,7 +148,7 @@
 "bD" = (
 /obj/item/stack/cable_coil/cut/blue,
 /obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "bF" = (
 /obj/structure/table/wood,
@@ -181,9 +175,7 @@
 "bH" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/box,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "bJ" = (
 /turf/closed/indestructible/rock/schist,
@@ -194,9 +186,7 @@
 /area/ruin/powered/icemoon/downed_transport/delapidated_cabin)
 "bS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "bU" = (
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -224,7 +214,7 @@
 /obj/effect/turf_decal/industrial/warning/dust,
 /obj/effect/turf_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -232,9 +222,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "cz" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -247,9 +235,7 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/ruin/powered/icemoon/downed_transport/leaning_shack)
 "cA" = (
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "cB" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -281,9 +267,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "cH" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -345,9 +329,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 6
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
@@ -362,7 +344,7 @@
 "dp" = (
 /obj/structure/catwalk/over,
 /obj/effect/decal/cleanable/glass/strange,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "dD" = (
 /obj/structure/table/wood,
@@ -377,9 +359,7 @@
 /obj/structure/guncloset,
 /obj/item/gun/ballistic/shotgun/hellfire/empty,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "dO" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -388,9 +368,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "dP" = (
 /obj/structure/window/plasma/reinforced{
@@ -407,7 +385,7 @@
 	id = "barrow_starboard_nacelle"
 	},
 /obj/machinery/power/smes/shuttle,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "dQ" = (
 /obj/machinery/light/directional/south{
@@ -423,7 +401,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "dU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -461,7 +439,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ee" = (
 /obj/structure/flora/tree/dead,
@@ -526,7 +504,7 @@
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ep" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -553,7 +531,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barrow_windows"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ew" = (
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -564,9 +542,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "eG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -580,7 +556,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "eH" = (
 /obj/structure/flora/tree/dead{
@@ -655,15 +631,13 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barrow_windows"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "fo" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 2
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "fq" = (
 /obj/structure/fence/corner{
@@ -708,9 +682,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "fR" = (
 /turf/open/floor/plating/asteroid/icerock,
@@ -719,9 +691,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "fY" = (
 /obj/machinery/light/directional/west,
@@ -733,7 +703,7 @@
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "fZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -755,9 +725,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "gi" = (
 /obj/structure/cable{
@@ -806,7 +774,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "gG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "gO" = (
 /obj/item/storage/toolbox/mechanical{
@@ -866,7 +834,7 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/item/crowbar/large,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ha" = (
 /obj/structure/flora/tree/dead{
@@ -893,7 +861,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-9"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "hh" = (
 /obj/structure/ladder/unbreakable{
@@ -942,17 +910,13 @@
 	pixel_x = 7;
 	pixel_y = 0
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "hz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "hA" = (
 /obj/structure/fence/post{
@@ -992,7 +956,7 @@
 /obj/machinery/power/apc/auto_name/directional/south{
 	start_charge = 0
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "hP" = (
 /obj/machinery/power/apc/auto_name/directional/west{
@@ -1010,9 +974,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "hT" = (
 /obj/effect/turf_decal/spline/fancy/transparent/green,
@@ -1030,7 +992,7 @@
 	pixel_y = 8;
 	pixel_x = 17
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ih" = (
 /obj/structure/table/wood,
@@ -1112,9 +1074,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "iD" = (
 /obj/structure/chair/office{
@@ -1123,7 +1083,7 @@
 /obj/structure/catwalk/over,
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "iE" = (
 /obj/structure/rack,
@@ -1147,9 +1107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "iR" = (
 /turf/closed/wall/concrete,
@@ -1164,9 +1122,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 2
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "jj" = (
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -1208,9 +1164,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "jI" = (
 /obj/machinery/atmospherics/components/binary/pressure_valve{
@@ -1227,16 +1181,14 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "jK" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_3"
-	},
+/turf/open/floor/concrete/slab_3,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "jO" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4,
@@ -1274,7 +1226,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "jT" = (
 /obj/structure/sign/number,
@@ -1310,7 +1262,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Port Nacelle"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "kk" = (
 /obj/structure/fence,
@@ -1344,7 +1296,7 @@
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/glass/plastitanium,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ks" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1353,9 +1305,7 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "kt" = (
 /obj/structure/flora/rock,
@@ -1389,7 +1339,7 @@
 	},
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "kW" = (
 /obj/structure/cable{
@@ -1411,7 +1361,7 @@
 /obj/structure/cable{
 	icon_state = "6-9"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "kZ" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1420,24 +1370,20 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/overmap_encounter/planetoid/cave/explored)
 "la" = (
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "le" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "lg" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "li" = (
 /obj/structure/flora/tree/dead/tall{
@@ -1470,9 +1416,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "ly" = (
 /obj/machinery/door/firedoor/border_only{
@@ -1495,11 +1439,11 @@
 	name = "Cockpit";
 	locked = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "lD" = (
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "lG" = (
 /obj/item/shard/plastitanium{
@@ -1528,9 +1472,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
 	dir = 9
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "lT" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -1608,9 +1550,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "mf" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -1637,7 +1577,7 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "mm" = (
 /obj/machinery/light/directional/north,
@@ -1655,7 +1595,7 @@
 	pixel_y = 0;
 	pixel_x = -14
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "mr" = (
 /obj/machinery/light/directional/north,
@@ -1686,7 +1626,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "mw" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "my" = (
 /turf/closed/mineral/random/snow,
@@ -1706,7 +1646,7 @@
 	id = "barrow_port_nacelle"
 	},
 /obj/machinery/power/smes/shuttle,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "mF" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
@@ -1718,9 +1658,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "mY" = (
 /obj/machinery/door/airlock/security{
@@ -1764,15 +1702,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "nf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "nj" = (
 /obj/machinery/light_switch{
@@ -1835,7 +1771,7 @@
 	id = "general_room_shutters";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "nG" = (
 /obj/effect/spawner/bunk_bed{
@@ -1911,9 +1847,7 @@
 	layer = 3.1
 	},
 /obj/item/soap,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "ot" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -1944,7 +1878,7 @@
 /obj/item/flashlight/flare{
 	on = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "oy" = (
 /obj/structure/chair/stool/bar{
@@ -1975,7 +1909,7 @@
 "oN" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "oW" = (
 /turf/closed/wall/mineral/wood,
@@ -1984,9 +1918,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 5
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "pe" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -2055,7 +1987,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barrow_windows"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "pw" = (
 /obj/structure/fence/door,
@@ -2170,7 +2102,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barrow_bridge"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "qc" = (
 /obj/structure/flora/tree/pine{
@@ -2202,7 +2134,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/shuttle/engine/electric,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "qD" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -2224,9 +2156,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "qS" = (
 /obj/structure/railing/wood{
@@ -2267,7 +2197,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ri" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -2290,7 +2220,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "rP" = (
 /obj/effect/decal/cleanable/garbage{
@@ -2378,9 +2308,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "so" = (
 /turf/template_noop,
@@ -2409,9 +2337,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "sF" = (
 /obj/structure/cable{
@@ -2452,9 +2378,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "sN" = (
 /obj/structure/fence/post{
@@ -2472,9 +2396,7 @@
 	},
 /obj/item/towel,
 /obj/item/towel,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "sU" = (
 /obj/structure/cable{
@@ -2484,9 +2406,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "ta" = (
 /obj/structure/table,
@@ -2509,7 +2429,7 @@
 	pixel_x = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "tg" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -2547,11 +2467,11 @@
 	},
 /obj/effect/decal/cleanable/glass/plastitanium,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "tA" = (
 /obj/structure/girder,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "tD" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2570,7 +2490,7 @@
 	icon_state = "lattice-127"
 	},
 /obj/structure/girder,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "tF" = (
 /obj/structure/cable{
@@ -2582,9 +2502,7 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/cans/sixsoda,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "tK" = (
 /obj/structure/railing/corner/wood{
@@ -2644,9 +2562,7 @@
 /obj/item/clothing/shoes/workboots/mining{
 	pixel_y = -10
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_3"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "ug" = (
 /obj/machinery/door/firedoor/border_only{
@@ -2670,7 +2586,7 @@
 /obj/effect/turf_decal/etherbor/center{
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ui" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -2684,16 +2600,14 @@
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "uA" = (
 /obj/item/light/tube/broken{
 	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "uF" = (
 /obj/structure/cable{
@@ -2710,7 +2624,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "uG" = (
 /obj/structure/chair/wood{
@@ -2746,7 +2660,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "uQ" = (
 /obj/structure/closet/emcloset/wall/directional/south,
@@ -2801,7 +2715,7 @@
 	pixel_y = 14;
 	pixel_x = -3
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "vp" = (
 /obj/structure/flora/tree/dead{
@@ -2830,7 +2744,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "vI" = (
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "vK" = (
 /obj/item/shard{
@@ -2855,7 +2769,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "vT" = (
 /obj/structure/sign/warning/explosives{
@@ -2867,9 +2781,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "wm" = (
 /obj/effect/turf_decal/spline/fancy/opaque/green{
@@ -2879,16 +2791,14 @@
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "wp" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
 /obj/item/mine/pressure/explosive/rusty/live,
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "wu" = (
 /obj/structure/flora/rock/pile/icy,
@@ -2936,7 +2846,7 @@
 	dir = 4;
 	id = "barrow_port_nacelle"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "wE" = (
 /obj/structure/cable{
@@ -2955,7 +2865,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "wK" = (
 /obj/structure/fence/door,
@@ -2970,9 +2880,7 @@
 	},
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "wW" = (
 /obj/item/food/energybar,
@@ -3030,7 +2938,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "xx" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -3064,9 +2972,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "xN" = (
 /obj/structure/barricade/wooden,
@@ -3079,7 +2985,7 @@
 /mob/living/simple_animal/hostile/human/hermit/survivor{
 	desc = "A wild-eyed figure, wearing tattered mining equipment and boasting a malformed body."
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "xS" = (
 /obj/structure/platform/wood/corner{
@@ -3129,9 +3035,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "yu" = (
 /turf/open/floor/plating/asteroid/snow/lit,
@@ -3183,9 +3087,7 @@
 	pixel_y = 4;
 	pixel_x = 2
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "yF" = (
 /obj/structure/railing/corner,
@@ -3218,15 +3120,13 @@
 	pixel_y = -9
 	},
 /obj/item/blackbox,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "yG" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "yO" = (
 /obj/structure/lattice{
@@ -3270,7 +3170,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "zg" = (
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
@@ -3288,9 +3188,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "zl" = (
 /obj/structure/showcase/machinery/tv{
@@ -3378,18 +3276,14 @@
 	pixel_y = -3
 	},
 /obj/machinery/atmospherics/components/binary/pump/on/layer4,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_3"
-	},
+/turf/open/floor/concrete/slab_3,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "zT" = (
 /obj/structure/filingcabinet/double{
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "zW" = (
 /obj/item/stack/ore/salvage/scrapmetal{
@@ -3422,13 +3316,11 @@
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ac" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ag" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "Am" = (
 /obj/structure/flora/rock/pile{
@@ -3461,7 +3353,7 @@
 	pixel_y = 13;
 	pixel_x = 11
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Ap" = (
 /obj/machinery/power/smes/engineering{
@@ -3532,9 +3424,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "BI" = (
 /obj/structure/bed/dogbed{
@@ -3661,7 +3551,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "general_room_shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Dn" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -3707,9 +3597,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "Dz" = (
 /turf/open/floor/plasteel/stairs/wood/icemoon{
@@ -3756,9 +3644,7 @@
 "DH" = (
 /obj/structure/chair,
 /obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "DI" = (
 /obj/structure/cable{
@@ -3782,7 +3668,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "DP" = (
 /obj/effect/turf_decal/siding/wood/end,
@@ -3865,7 +3751,7 @@
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Ez" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -3911,9 +3797,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "EJ" = (
 /obj/structure/flora/tree/dead/tall{
@@ -3923,9 +3807,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "EK" = (
 /obj/machinery/space_heater,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_2/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "EO" = (
 /obj/structure/cable{
@@ -4052,7 +3934,7 @@
 	pixel_y = 5;
 	pixel_x = -6
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Fq" = (
 /obj/structure/cable{
@@ -4078,7 +3960,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ft" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -4091,9 +3973,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "FD" = (
 /obj/structure/table/reinforced,
@@ -4107,14 +3987,12 @@
 	pixel_y = 6
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "FF" = (
 /obj/structure/catwalk/over,
 /mob/living/simple_animal/hostile/asteroid/old_demon,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "FH" = (
 /obj/item/paper/crumpled/fluff{
@@ -4149,7 +4027,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "FQ" = (
 /obj/structure/fence/post,
@@ -4193,9 +4071,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "Gb" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -4218,16 +4094,14 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Gk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4{
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "Gm" = (
 /obj/structure/salvageable/autolathe,
@@ -4239,9 +4113,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "Gs" = (
 /obj/effect/turf_decal/spline/fancy/transparent/green,
@@ -4249,7 +4121,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Gt" = (
 /obj/item/stack/cable_coil/cut/red{
@@ -4264,7 +4136,7 @@
 "GI" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "GR" = (
 /obj/structure/flora/tree/pine{
@@ -4284,14 +4156,12 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "Hd" = (
 /obj/machinery/autolathe,
 /obj/structure/catwalk/over,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Hk" = (
 /obj/structure/sign/warning/incident{
@@ -4305,7 +4175,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "general_room_shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crew_accomodations)
 "Ht" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -4322,9 +4192,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "Hy" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -4357,7 +4225,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "HE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "HI" = (
 /obj/structure/table/wood/reinforced,
@@ -4385,7 +4253,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "HS" = (
 /obj/effect/turf_decal/corner/opaque/red/diagonal,
@@ -4469,7 +4337,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "IH" = (
 /obj/structure/closet/secure_closet/miningcloset{
@@ -4504,9 +4372,7 @@
 /obj/item/trash/sosjerky{
 	pixel_x = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_2"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "IK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -4519,7 +4385,7 @@
 	dir = 8
 	},
 /obj/structure/catwalk/over,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "IN" = (
 /obj/structure/table/wood,
@@ -4557,9 +4423,7 @@
 	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "IU" = (
 /obj/structure/table/wood/reinforced,
@@ -4628,9 +4492,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "JA" = (
 /obj/structure/cable{
@@ -4638,7 +4500,7 @@
 	},
 /obj/structure/catwalk/over,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "JB" = (
 /obj/structure/table/wood,
@@ -4669,7 +4531,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Kf" = (
 /obj/machinery/door/airlock/wood,
@@ -4692,9 +4554,7 @@
 	pixel_x = 13
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "Km" = (
 /turf/closed/wall,
@@ -4875,9 +4735,7 @@
 /area/overmap_encounter/planetoid/ice/explored)
 "Mf" = (
 /obj/machinery/holopad/emergency/security,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "Mi" = (
 /obj/structure/flora/driftwood{
@@ -4970,7 +4828,7 @@
 	pixel_x = -5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "MQ" = (
 /turf/closed/wall/mineral/wood,
@@ -5009,7 +4867,7 @@
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Na" = (
 /obj/effect/turf_decal/borderfloorblack{
@@ -5079,9 +4937,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 1
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "NU" = (
 /obj/effect/turf_decal/spline/fancy/opaque/green{
@@ -5119,7 +4975,7 @@
 	pixel_x = -26
 	},
 /obj/structure/catwalk/over/plated_catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ol" = (
 /obj/effect/turf_decal/spline/fancy/opaque/green{
@@ -5142,7 +4998,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 2
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Om" = (
 /turf/closed/wall/rust,
@@ -5196,9 +5052,7 @@
 	pixel_y = -10
 	},
 /obj/item/clothing/glasses/meson,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_3"
-	},
+/turf/open/floor/concrete/slab_3/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "ON" = (
 /mob/living/simple_animal/hostile/human/hermit/ranged/shotgun,
@@ -5214,17 +5068,13 @@
 	layer = 3.3
 	},
 /obj/structure/curtain,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "OP" = (
 /obj/machinery/computer/security/retro{
 	dir = 4
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "OS" = (
 /obj/structure/fence/post,
@@ -5326,15 +5176,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "Qh" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 9
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "Qm" = (
 /turf/open/floor/plating/asteroid/icerock,
@@ -5380,7 +5228,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "QF" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -5399,9 +5247,7 @@
 /turf/open/floor/plating/asteroid/icerock/cracked,
 /area/ruin/unpowered/icemoon/downed_transport/abandoned_mineshaft)
 "QI" = (
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "QL" = (
 /obj/structure/cable{
@@ -5410,7 +5256,7 @@
 /obj/structure/catwalk/over,
 /obj/effect/decal/cleanable/glass/strange,
 /obj/effect/decal/cleanable/glass/strange,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "QU" = (
 /obj/structure/chair/sofa/olive/old/left{
@@ -5463,15 +5309,13 @@
 	},
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/microwave,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "Rh" = (
 /obj/structure/catwalk/over,
 /obj/effect/decal/cleanable/glass/strange,
 /mob/living/simple_animal/hostile/asteroid/ice_demon,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Rm" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
@@ -5494,7 +5338,7 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Rr" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -5508,16 +5352,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
 	dir = 9
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "RJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "RK" = (
 /obj/effect/turf_decal/borderfloorblack/corner{
@@ -5584,7 +5426,7 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Sl" = (
 /obj/structure/flora/tree/pine{
@@ -5667,9 +5509,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "Tw" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -5678,9 +5518,7 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "Ty" = (
 /obj/structure/cable{
@@ -5733,7 +5571,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "TO" = (
 /obj/structure/platform{
@@ -5773,7 +5611,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "TY" = (
 /obj/structure/chair/stool/bar{
@@ -5849,9 +5687,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_4"
-	},
+/turf/open/floor/concrete/slab_4/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mineshaft_prep_room)
 "Uo" = (
 /obj/effect/turf_decal/corner_steel_grid{
@@ -5883,9 +5719,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "UM" = (
 /obj/structure/cable{
@@ -5896,7 +5730,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating,
 /area/ruin/unpowered/icemoon/downed_transport/barracks)
 "UP" = (
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -5913,9 +5747,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "UT" = (
 /obj/structure/destructible/tribal_torch/lit{
@@ -5966,7 +5798,7 @@
 /obj/machinery/space_heater{
 	pixel_y = 12
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/mining_power_station)
 "Vl" = (
 /obj/structure/platform/corner{
@@ -5978,9 +5810,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer/layer2{
 	dir = 4
 	},
-/turf/open/floor/concrete/icemoon{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/atmospherics_shed)
 "Vr" = (
 /obj/structure/closet/secure_closet/armory2{
@@ -5994,15 +5824,13 @@
 /obj/item/storage/box/ammo/a12g_buckshot{
 	pixel_y = 1
 	},
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "Vv" = (
 /obj/effect/turf_decal/spline/fancy/opaque/green{
 	dir = 6
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "VA" = (
 /obj/effect/turf_decal/industrial/hatch/yellow,
@@ -6079,7 +5907,7 @@
 /obj/item/flashlight/flare{
 	on = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Wk" = (
 /obj/structure/flora/tree/dead{
@@ -6103,11 +5931,11 @@
 	icon_state = "1-6"
 	},
 /obj/structure/door_assembly/door_assembly_grunge,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Wo" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Wq" = (
 /obj/structure/flora/tree/pine,
@@ -6150,7 +5978,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "WQ" = (
 /obj/item/mine/pressure/explosive/rusty/live,
@@ -6172,7 +6000,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Xn" = (
 /obj/effect/decal/cleanable/blood/drip{
@@ -6190,7 +6018,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "XB" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -6236,7 +6064,7 @@
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/the_descent)
 "Ya" = (
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Yg" = (
 /obj/machinery/door/airlock/engineering{
@@ -6285,9 +6113,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/concrete{
-	icon_state = "conc_slab_1"
-	},
+/turf/open/floor/concrete/slab_1,
 /area/ruin/unpowered/icemoon/downed_transport/security_office)
 "Yl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -6295,7 +6121,7 @@
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/tech/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "Ys" = (
 /obj/effect/decal/fakelattice,
@@ -6306,7 +6132,7 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/ruin/powered/icemoon/downed_transport/ramshackle_workroom)
 "Yy" = (
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "YD" = (
 /turf/closed/wall/rust,
@@ -6334,9 +6160,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/concrete{
-	icon_state = "conc_tiles"
-	},
+/turf/open/floor/concrete/tiles,
 /area/ruin/unpowered/icemoon/downed_transport/bathhouse)
 "YI" = (
 /obj/structure/chair/comfy/beige,
@@ -6379,9 +6203,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "YT" = (
 /obj/machinery/light_switch{
@@ -6420,15 +6242,13 @@
 /obj/effect/decal/cleanable/robot_debris/up{
 	pixel_y = 11
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/overmap_encounter/planetoid/ice/explored)
 "Zk" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 2
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer4{
@@ -6444,7 +6264,7 @@
 /area/ruin/powered/icemoon/downed_transport/delapidated_cabin)
 "ZK" = (
 /obj/effect/decal/cleanable/glass/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/unpowered/icemoon/downed_transport/crashed_shuttle)
 "ZL" = (
 /obj/machinery/camera/directional/north{
@@ -6492,9 +6312,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/concrete/pavement/icemoon{
-	light_range = 2
-	},
+/turf/open/floor/concrete/pavement/icemoon/lit,
 /area/overmap_encounter/planetoid/ice/explored)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_hardliner_holdout.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_hardliner_holdout.dmm
@@ -3,7 +3,7 @@
 /obj/effect/turf_decal/trimline/opaque/red/line{
 	dir = 1
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "aj" = (
 /obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
@@ -41,7 +41,7 @@
 /obj/structure/fence/cut/large{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "ax" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
@@ -175,7 +175,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "bu" = (
 /obj/structure/grille,
@@ -188,7 +188,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "bO" = (
 /obj/structure/guncloset,
@@ -245,6 +245,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ruin/lavaland/holdout/office)
+"ci" = (
+/obj/structure/catwalk/over/plated_catwalk/white,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/lava,
+/area/overmap_encounter/planetoid/lava/explored)
 "cm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "holdoutfleawindow"
@@ -303,7 +310,7 @@
 /obj/structure/crate_shelf,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "cK" = (
 /obj/effect/turf_decal/industrial/hatch{
@@ -420,7 +427,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/grid/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "dL" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -483,7 +490,7 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "eS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -583,7 +590,7 @@
 "fz" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /obj/item/ammo_casing/spent/rifle_steel,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "fB" = (
 /obj/structure/barricade/sandbags,
@@ -651,7 +658,7 @@
 "gk" = (
 /obj/structure/rack,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "gl" = (
 /obj/structure/cable{
@@ -955,7 +962,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk/over/plated_catwalk/white,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "iI" = (
 /obj/structure/cable/yellow{
@@ -973,7 +980,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "iQ" = (
 /obj/effect/turf_decal/techfloor/corner,
@@ -1027,7 +1034,7 @@
 "jk" = (
 /obj/effect/turf_decal/trimline/opaque/red/line,
 /obj/machinery/porta_turret/ruin/ramzi/light,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "jp" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
@@ -1080,7 +1087,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "jN" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/corner{
@@ -1267,7 +1274,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "ln" = (
 /obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
@@ -1316,11 +1323,11 @@
 	dir = 9;
 	layer = 2.041
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "lE" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "lR" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
@@ -1391,7 +1398,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "mj" = (
 /obj/structure/flora/ausbushes/grassybush/hell,
@@ -1409,7 +1416,7 @@
 	dir = 8
 	},
 /obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "mo" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/warning{
@@ -1483,7 +1490,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "nb" = (
 /obj/structure/cable{
@@ -1705,7 +1712,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "oP" = (
 /obj/structure/fence{
@@ -1781,7 +1788,7 @@
 /obj/structure/window/plasma/reinforced{
 	dir = 1
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "ph" = (
 /obj/structure/closet/secure_closet{
@@ -1796,7 +1803,7 @@
 	},
 /obj/item/storage/belt/security/webbing/ramzi/alt,
 /obj/item/clothing/head/ramzi/beret,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/grid/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "pi" = (
 /obj/effect/decal/cleanable/blood/squirt{
@@ -1842,7 +1849,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "po" = (
 /obj/effect/turf_decal/borderfloorwhite,
@@ -1872,7 +1879,7 @@
 "pp" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/corner,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "pq" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
@@ -1919,7 +1926,7 @@
 "pH" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
 /obj/structure/barricade/sandbags,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "pP" = (
 /obj/effect/turf_decal/siding/black{
@@ -1945,7 +1952,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "holdoutfleawindow"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "pU" = (
 /obj/structure/cable{
@@ -2000,14 +2007,14 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "qo" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "qw" = (
 /obj/item/trash/syndi_cakes{
@@ -2153,7 +2160,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "sn" = (
 /obj/structure/railing/corner,
@@ -2231,7 +2238,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "te" = (
 /obj/effect/turf_decal/industrial/fire,
@@ -2364,7 +2371,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "uP" = (
 /obj/item/circuitboard/machine/telecomms/receiver,
@@ -2508,7 +2515,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "wc" = (
 /obj/machinery/button/door{
@@ -2530,13 +2537,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/lavaland/holdout/mess)
-"wg" = (
-/obj/structure/catwalk/over/plated_catwalk/white,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/overmap_encounter/planetoid/lava/explored)
 "wi" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
@@ -2667,7 +2667,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech/grid/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "wU" = (
 /obj/structure/cable/yellow{
@@ -2705,7 +2705,7 @@
 /obj/structure/fence/cut/large{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "xq" = (
 /obj/machinery/porta_turret/ship/hardliners{
@@ -2844,7 +2844,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/grid/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "yy" = (
 /obj/effect/anomaly/pyro/planetary,
@@ -2856,7 +2856,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "yM" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
@@ -2993,7 +2993,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
 	dir = 6
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "zD" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -3150,7 +3150,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "Bl" = (
 /obj/structure/table/reinforced,
@@ -3188,7 +3188,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "Bw" = (
 /obj/structure/extinguisher_cabinet/directional/west{
@@ -3266,7 +3266,7 @@
 /area/ruin/lavaland/holdout/tcomms)
 "Cj" = (
 /obj/structure/catwalk/over/plated_catwalk/white,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "Cm" = (
 /obj/effect/turf_decal/stairs,
@@ -3310,7 +3310,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
 	dir = 10
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "Cz" = (
 /obj/machinery/power/terminal{
@@ -3323,7 +3323,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "CC" = (
 /obj/structure/grille,
@@ -3357,7 +3357,7 @@
 	id = "holdoutfleashield"
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "CQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -3430,7 +3430,7 @@
 /turf/open/floor/plating/asteroid/purple/lit,
 /area/overmap_encounter/planetoid/lava/explored)
 "Dz" = (
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "DC" = (
 /obj/structure/flora/ausbushes/hell,
@@ -3567,7 +3567,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "EO" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
@@ -3802,7 +3802,7 @@
 /obj/effect/turf_decal/trimline/opaque/red/line,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "Gu" = (
 /obj/structure/barricade/sandbags,
@@ -3931,7 +3931,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_box/magazine/m57_39_sidewinder/empty,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "GZ" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
@@ -4112,7 +4112,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "II" = (
 /obj/structure/flora/rock/pile,
@@ -4516,7 +4516,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "LV" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
@@ -4563,7 +4563,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "Mt" = (
 /obj/machinery/telecomms/bus,
@@ -4653,7 +4653,7 @@
 /obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus,
 /obj/item/clothing/suit/space/syndicate/ramzi/surplus,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/grid/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "MZ" = (
 /obj/structure/cable{
@@ -4777,7 +4777,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "holdoutfleawindow"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/ruin/lavaland/holdout/ramziflea)
 "Ob" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
@@ -4893,7 +4893,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "OA" = (
 /obj/structure/table,
@@ -4923,7 +4923,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "OH" = (
 /obj/effect/turf_decal/siding/black{
@@ -5239,7 +5239,7 @@
 	dir = 1
 	},
 /obj/machinery/porta_turret/ruin/ramzi/light,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "QT" = (
 /obj/machinery/door/firedoor/border_only{
@@ -5262,7 +5262,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "Ra" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
@@ -5400,7 +5400,7 @@
 /area/ruin/lavaland/holdout/warehousea)
 "Sx" = (
 /obj/effect/turf_decal/trimline/opaque/red/line,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull/reinforced/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "SB" = (
 /obj/item/multitool{
@@ -5713,7 +5713,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "Vr" = (
 /obj/structure/cable{
@@ -5743,7 +5743,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "VK" = (
 /obj/effect/turf_decal/siding/black{
@@ -5883,7 +5883,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/ruin/lavaland/holdout/office)
 "WL" = (
 /mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth{
@@ -5970,7 +5970,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "Xn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6030,7 +6030,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior/lavaland,
 /area/ruin/lavaland/holdout/office)
 "XP" = (
 /obj/structure/cable/yellow{
@@ -6105,7 +6105,7 @@
 /area/ruin/lavaland/holdout/kitchen)
 "Yx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/mono/white/lavaland,
 /area/overmap_encounter/planetoid/lava/explored)
 "YE" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
@@ -6189,7 +6189,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid/dark,
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland,
 /area/ruin/lavaland/holdout/ramziflea)
 "YW" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line,
@@ -6284,7 +6284,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lava,
 /area/overmap_encounter/planetoid/lava/explored)
 "ZD" = (
 /obj/effect/turf_decal/siding/black{
@@ -7035,7 +7035,7 @@ Ex
 QC
 aC
 sY
-wg
+ci
 lm
 zk
 gj
@@ -7568,7 +7568,7 @@ OH
 ZE
 au
 Bt
-wg
+ci
 uM
 zk
 fD
@@ -7805,11 +7805,11 @@ ZE
 au
 WK
 ao
-wg
+ci
 av
-wg
+ci
 ee
-wg
+ci
 Ox
 ZC
 hJ
@@ -8040,7 +8040,7 @@ kx
 ZE
 Dg
 Bt
-wg
+ci
 uM
 wC
 UX
@@ -8453,7 +8453,7 @@ Oo
 wk
 uE
 iC
-wg
+ci
 uM
 wC
 Ko

--- a/_maps/RandomRuins/LavaRuins/lavaland_hardliner_holdout.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_hardliner_holdout.dmm
@@ -3056,7 +3056,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior,
 /area/ruin/lavaland/holdout/office)
 "Au" = (
 /obj/item/stack/ore/salvage/scraptitanium,
@@ -3832,7 +3832,7 @@
 	turret_flags = 62
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior,
 /area/ruin/lavaland/holdout/office)
 "GI" = (
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line,
@@ -6008,7 +6008,7 @@
 	},
 /obj/effect/turf_decal/corner/opaque/syndiered/half,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull,
+/turf/open/floor/engine/hull/interior,
 /area/ruin/lavaland/holdout/office)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -364,6 +364,9 @@
 	icon_state = "stairs-wood-r"
 	base_icon_state = "stairs-wood-r"
 
+/turf/open/floor/plasteel/stairs/dark
+	color = COLOR_FLOORTILE_GRAY
+
 /turf/open/floor/plasteel/rockvault
 	icon_state = "rockvault"
 	base_icon_state = "rockvault"

--- a/code/game/turfs/open/floor/plating/icemoon.dm
+++ b/code/game/turfs/open/floor/plating/icemoon.dm
@@ -315,3 +315,18 @@
 /turf/open/floor/concrete/pavement/icemoon/lit
 	light_range = 2
 	light_power = 1
+
+/turf/open/floor/plating/rust/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/plasteel/tech/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/pod/dark/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT

--- a/code/game/turfs/open/floor/plating/icemoon.dm
+++ b/code/game/turfs/open/floor/plating/icemoon.dm
@@ -330,3 +330,25 @@
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 	planetary_atmos = TRUE
 	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/plasteel/tech/techmaint/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/plasteel/dark/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/plasteel/stairs/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+/turf/open/floor/plasteel/patterned/brushed/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	light_color = COLOR_ICEPLANET_LIGHT
+
+

--- a/code/game/turfs/open/floor/plating/lavaland.dm
+++ b/code/game/turfs/open/floor/plating/lavaland.dm
@@ -187,3 +187,28 @@
 	light_range = 2
 	light_power = 0.6
 	light_color = COLOR_LAVAPLANET_LIGHT
+
+/turf/open/floor/plasteel/mono/white/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	light_color = COLOR_LAVAPLANET_LIGHT
+	planetary_atmos = TRUE
+
+/turf/open/floor/engine/hull/interior/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	light_color = COLOR_LAVAPLANET_LIGHT
+	planetary_atmos = TRUE
+
+/turf/open/floor/plasteel/tech/grid/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	light_color = COLOR_LAVAPLANET_LIGHT
+	planetary_atmos = TRUE
+
+/turf/open/floor/engine/hull/reinforced/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	light_color = COLOR_LAVAPLANET_LIGHT
+	planetary_atmos = TRUE
+
+/turf/open/floor/plasteel/patterned/grid/dark/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	light_color = COLOR_LAVAPLANET_LIGHT
+	planetary_atmos = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes atmos for exterior tiles, fixes a bunch of var edited tiles on downed transport to use the actual subtyped tiles, fixes turret plating in Hardliner holdout to not cause massive space wind.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Maintains maps

## Changelog

:cl:
fix: Tiles on Downed Transport and Hardliner Holdout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
