### PR TITLE
Flipped Tables have 25 pass through

### DIFF
--- a/code/game/machinery/cover/flipped_table.dm
+++ b/code/game/machinery/cover/flipped_table.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/flipped_tables.dmi'
 	icon_state = "table"
 	var/obj/structure/table/table_type = /obj/structure/table
+	pass_chance = 80
 
 /obj/structure/barricade/directional/flippedtable/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/cover/flipped_table.dm
+++ b/code/game/machinery/cover/flipped_table.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/flipped_tables.dmi'
 	icon_state = "table"
 	var/obj/structure/table/table_type = /obj/structure/table
-	pass_chance = 80
+	pass_chance = 25
 
 /obj/structure/barricade/directional/flippedtable/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Flipped tables are inheriting the base 50% pass chance, makes 25% pass through instead

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Flipped tables feel really bad at 50 block.

## Changelog

:cl:
balance: Flipped Tables have 25 pass chance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
