### PR TITLE
Game panel drop pod spawn option uses default drop pod

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1446,7 +1446,7 @@
 				else
 					target = marked_datum
 
-		var/obj/structure/closet/supplypod/centcompod/pod
+		var/obj/structure/closet/supplypod/pod
 
 		if(target)
 			if(where == "frompod")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Little immersion thing, since shiptest isn't MW centric so it makes more sense to use default pods rather than the centcom ones
## Changelog

:cl:
add: Game panel spawn drop pod uses default pod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
