### PR TITLE
Allows bandaging for hype moments and aura instead of life threatening injuries

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -167,6 +167,7 @@
 
 	if(limb.current_gauze)
 		to_chat(user, span_warning("[user == M ? "Your" : "[M]'s"] [limb.name] is already bandaged!"))
+		return
 
 	user.visible_message(
 		span_warning("[user] begins wrapping [M]'s [limb.name] with [src]..."),

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -158,7 +158,6 @@
 	merge_type = /obj/item/stack/medical/gauze
 	var/gauze_type = /datum/bodypart_aid/gauze
 
-// gauze is only relevant for wounds, which are handled in the wounds themselves
 /obj/item/stack/medical/gauze/try_heal(mob/living/M, mob/user, silent)
 	var/obj/item/bodypart/limb = M.get_bodypart(check_zone(user.zone_selected))
 
@@ -166,27 +165,12 @@
 		to_chat(user, span_notice("There's nothing there to bandage!"))
 		return
 
-	if(!LAZYLEN(limb.wounds))
-		to_chat(user, span_notice("There's no wounds that require bandaging on [user == M ? "your" : "[M]'s"] [limb.name]!"))
-		return
-
-	var/gauzeable_wound = FALSE
-	for(var/i in limb.wounds)
-		var/datum/wound/woundies = i
-		if(woundies.wound_flags & ACCEPTS_GAUZE)
-			gauzeable_wound = TRUE
-			break
-
-	if(!gauzeable_wound)
-		to_chat(user, span_notice("There's no wounds that require bandaging on [user == M ? "your" : "[M]'s"] [limb.name]!"))
-		return
-
 	if(limb.current_gauze)
 		to_chat(user, span_warning("[user == M ? "Your" : "[M]'s"] [limb.name] is already bandaged!"))
 
 	user.visible_message(
-		span_warning("[user] begins wrapping the wounds on [M]'s [limb.name] with [src]..."),
-		span_warning("You begin wrapping the wounds on [user == M ? "your" : "[M]'s"] [limb.name] with [src]..."),
+		span_warning("[user] begins wrapping [M]'s [limb.name] with [src]..."),
+		span_warning("You begin wrapping  [user == M ? "your" : "[M]'s"] [limb.name] with [src]..."),
 	)
 
 	if(!do_after(user, (user == M ? self_delay : other_delay), target=M))
@@ -194,7 +178,7 @@
 
 	user.visible_message(
 		span_green("[user] applies [src] to [M]'s [limb.name]."),
-		span_green("You bandage the wounds on [user == M ? "your" : "[M]'s"] [limb.name]."),
+		span_green("You bandage [user == M ? "your" : "[M]'s"] [limb.name]."),
 	)
 	limb.apply_gauze(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

bodypart aid stuff is handled in the limb so it doesnt matterrrrrrrrrrr if there's wounds "oh no someone might PREMED BANDAGES" except if you do that they Explode into millions of Scraps of Paper at the slightest touch

## Why It's Good For The Game

My game goodener is on vacation right now so if you want to tell me this is stupid we will unfortunately have to fight to the death
<img width="600" height="375" alt="Himehabu_Duel_CroppedAndCut" src="https://github.com/user-attachments/assets/8f05840d-2f3f-44ff-9cb4-2c11b1af55a9" />

## Changelog

:cl: Ravenous GauzeEater
add: gauze no longer checks for wounds so you can put it on unwounded limbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
