### PR TITLE
Makes agni and yelibri use planet sprites

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost_types.dm
+++ b/code/modules/overmap/objects/outpost/outpost_types.dm
@@ -207,7 +207,7 @@
 	// Uses "default" hangars (indie_space).
 
 /datum/overmap/outpost/warra_ice
-	token_icon_state = "station_asteroid"
+	token_icon_state = "station_planet"
 	main_template = /datum/map_template/outpost/warra_ice
 	elevator_template = /datum/map_template/outpost/elevator_ice
 	faction = FACTION_WARRA
@@ -237,7 +237,7 @@
 	)
 
 /datum/overmap/outpost/ngr_rock
-	token_icon_state = "station_asteroid"
+	token_icon_state = "station_planet"
 	main_template = /datum/map_template/outpost/ngr_rock
 	elevator_template = /datum/map_template/outpost/elevator_rock
 	weather_controller_type = /datum/weather_controller/rockplanet_safe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tin

## Why It's Good For The Game

Im not even sure if these are asteroid stations anymore, may be a weird holdover from when yelibris predecessor \*was\* an asteroid station
## Changelog

:cl:
add:agni and yelibris overmap icon are now planets proper
/:cl:
