### PR TITLE
Minor overmap fixes

### DIFF
--- a/code/modules/overmap/star_systems/_star_system.dm
+++ b/code/modules/overmap/star_systems/_star_system.dm
@@ -158,8 +158,8 @@
 		generator_type = CONFIG_GET(string/overmap_generator_type)
 	if(!size)
 		size = CONFIG_GET(number/overmap_size)
-	if(!max_overmap_dynamic_events)
-		max_overmap_dynamic_events = isnull(max_overmap_dynamic_events)
+	if(isnull(max_overmap_dynamic_events))
+		max_overmap_dynamic_events = CONFIG_GET(number/max_overmap_dynamic_events)
 
 
 	overmap_container = new/list(size, size, 0)

--- a/code/modules/overmap/star_systems/wilderness.dm
+++ b/code/modules/overmap/star_systems/wilderness.dm
@@ -12,11 +12,14 @@
 		"..burn bright, burn fast..",
 	)
 
+	size = 20
+	max_overmap_dynamic_events = 7
 	///Bool for if the system is unique, and should only be spawned once during overmap gen
 	var/unique_system = FALSE
 
 /datum/overmap_star_system/wilderness/create_map()
-	max_overmap_dynamic_events = CONFIG_GET(number/max_overmap_dynamic_events)
+	//max_overmap_dynamic_events = CONFIG_GET(number/max_overmap_dynamic_events)
+
 	. = ..()
 
 /* to-do: heat signature

--- a/code/modules/overmap/star_systems/wilderness.dm
+++ b/code/modules/overmap/star_systems/wilderness.dm
@@ -17,11 +17,6 @@
 	///Bool for if the system is unique, and should only be spawned once during overmap gen
 	var/unique_system = FALSE
 
-/datum/overmap_star_system/wilderness/create_map()
-	//max_overmap_dynamic_events = CONFIG_GET(number/max_overmap_dynamic_events)
-
-	. = ..()
-
 /* to-do: heat signature
 /datum/overmap_star_system/wilderness/acid_nebula
 	event_probabilities = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes wilderness have custom size and dynamic values

## Why It's Good For The Game
Seems intention was to make wilderness have different values than default, and also config broke

## Changelog

:cl:
fix: Wilderness sectors should now have correct parameters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
