### PR TITLE
Leyak hardsuit changes

### DIFF
--- a/_maps/shuttles/hardliner/hardliners_leyak.dmm
+++ b/_maps/shuttles/hardliner/hardliners_leyak.dmm
@@ -3420,15 +3420,15 @@
 /area/ship/hallway/central)
 "PB" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/syndi/hl,
 /obj/effect/turf_decal/industrial/fire/cee{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 4
 	},
-/obj/item/clothing/mask/gas/syndicate,
 /obj/machinery/light/directional/north,
+/obj/item/clothing/suit/space/hardsuit/stealth/hardliners,
+/obj/item/clothing/mask/gas/syndicate,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/security)
 "PF" = (
@@ -3604,19 +3604,19 @@
 /area/ship/security)
 "RP" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/syndi/hl,
 /obj/effect/turf_decal/industrial/fire/cee{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 8
 	},
-/obj/item/clothing/mask/gas/syndicate,
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -20;
 	pixel_y = -6
 	},
+/obj/item/clothing/suit/space/hardsuit/stealth/hardliners,
+/obj/item/clothing/mask/gas/syndicate,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/security)
 "RV" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps out the two whitereds the ops get to asura. I think its technically worse but more fitting for the ship that literally has a stealth gen to have more mobile suits.

## Why It's Good For The Game
I feel like three whitereds is kinda strong still. And a bit boring. And doesnt leave for much round progression armor wise since most default to it.

## Changelog

:cl:
add: leyak hardsuit change
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
