### PR TITLE
Makes iced coffee not blue

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -310,7 +310,7 @@
 /datum/reagent/consumable/icecoffee
 	name = "Iced Coffee"
 	description = "Coffee and ice, refreshing and cool."
-	color = "#112a3b" // rgb: 16, 40, 56
+	color = "#572b07" // rgb: 72, 32, 0
 	nutriment_factor = 0
 	overdose_threshold = 80
 	taste_description = "bitter coldness"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes iced coffee the same color as normal coffee instead of being blue.

## Why It's Good For The Game

ICED COFFEE IS NOT FUCKING BLUE

## Changelog

:cl: cablefish
fix: Iced coffee is no longer blue.
/:cl: