### PR TITLE
Adds throwing items into trash cans

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -34,6 +34,17 @@
 	else
 		return ..()
 
+/obj/structure/closet/crate/bin/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	if(opened && isitem(AM))
+		if(prob(75))
+			AM.forceMove(src.loc)
+			visible_message(span_notice("[AM] lands in [src]."))
+		else
+			visible_message(span_notice("[AM] bounces off of [src]'s rim!"))
+			return ..()
+	else
+		return ..()
+
 /obj/structure/closet/crate/bin/proc/do_animate()
 	playsound(loc, open_sound, 15, TRUE, -3)
 	flick("animate_largebins", src)


### PR DESCRIPTION
## About The Pull Request

You can now toss items into trash cans, with a chance to bounce off the rim. Largely adapted from disposal bin code.

## Why It's Good For The Game

Funny interaction that I've been sorely missing since ships mostly have trash cans and not disposal bins.

## Changelog

:cl: cablefish
add: You can now throw items into trash cans.
/:cl:
