### PR TITLE
Fixes a variety of floor painter related issues

### DIFF
--- a/code/game/objects/items/decal_painter.dm
+++ b/code/game/objects/items/decal_painter.dm
@@ -7,10 +7,10 @@
 	pickup_sound =  'sound/items/handling/device_pickup.ogg'
 	drop_sound = 'sound/items/handling/device_drop.ogg'
 	icon_state = "floor_sprayer"
-	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Use it inhand to change the design, and Ctrl-Click to switch to decal-painting mode."
+	desc = "An advanced autopainter capable of applying decorative finishes to standard floor tiles. These finishes are removed when the floor tile is pried up. Use it inhand to change the design."
 
 	var/floor_icon
-	var/floor_state = "steel"
+	var/floor_state = "tiled_gray"
 	var/floor_dir = SOUTH
 
 	item_state = "electronic"
@@ -18,9 +18,11 @@
 	var/list/allowed_directions = list("south")
 
 	var/static/list/allowed_states = list(
-		"steel", "dark", "white", "freezer", "tile_full", "cargo_one_full",
-		"kafel_full", "monotile", "grid", "ridged", "stairs",
-		"stairs-l", "stairs-m", "stairs-r", "stairs-old", "stairs-t", "stairs-b"
+		"tiled_gray", "tiled_dark", "tiled_light", "tile_full",
+		"kafel_full", "ridged", "grid", "grid_dark",
+		"monotile_gray", "monotile_dark", "monotile_light", "cargo_one_full",
+		"stairs", "stairs-l", "stairs-m", "stairs-r",
+		"stairs-old", "stairs-t", "stairs-b"
 	)
 
 	var/static/list/floor_four_dirs = list(
@@ -34,7 +36,7 @@
 
 	var/turf/open/floor/plasteel/F = A
 	if(!istype(F) || istype(F, /turf/open/floor/plasteel/tech))
-		to_chat(user, span_warning("\The [src] can only be used on plasteel flooring."))
+		to_chat(user, span_warning("\The [src] can only be used on standard metal floor tiles."))
 		return
 
 	F.icon_state = floor_state
@@ -135,7 +137,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
 	item_state = "decalsprayer"
-	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles. Decals break when the floor tiles are removed. Use it inhand to change the design."
+	desc = "An advanced autopainter for applying decals to floor tiles. These decals are removed when the floor tile is pried up. Use it inhand to change the design."
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500)
 
 	var/decal_icon

--- a/code/game/objects/items/stacks/sheets/recipes/recipes_metal.dm
+++ b/code/game/objects/items/stacks/sheets/recipes/recipes_metal.dm
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
-	new/datum/stack_recipe("plasteel floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
+	new/datum/stack_recipe("standard floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
 	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \
 	null, \
 	new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 40, one_per_turf = TRUE, on_floor = TRUE, trait_booster = TRAIT_QUICK_BUILD, trait_modifier = 0.75), \


### PR DESCRIPTION
## About The Pull Request

Removed broken tile icon states from the floor painter. Added missing tile icon states to the floor painter. Removed misinformation from the item description. Removed some player-facing mentions of "plasteel floor tiles".

## Why It's Good For The Game

Items should work correctly.

## Changelog

:cl: cablefish
fix: The floor painter no longer has broken icon states.
spellcheck: "Plasteel floor tiles" (the metal ones) are now "Standard floor tiles".
/:cl: