### PR TITLE
Fix cap flipping tooltip

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -63,7 +63,7 @@
 
 /obj/item/clothing/head/soft/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click the cap to flip it [flipped ? "forwards" : "backwards"].")
+	. += span_notice("Right click the cap to flip it [flipped ? "forwards" : "backwards"].")
 
 /obj/item/clothing/head/soft/white
 	name = "white cap"


### PR DESCRIPTION
## About The Pull Request

Flipping the cap is right click not alt click. This corrects the tooltip to reflect that.

## Why It's Good For The Game

Less misinformation on the internet.

## Changelog

:cl: cablefish
spellcheck: Corrected hat flipping hotkey tooltip.
/:cl:
