### PR TITLE
Fixes kepori being vertical on beds

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -83,6 +83,15 @@
 	M.buckling = null
 	M.set_buckled(src)
 	M.setDir(dir)
+
+	if(iskepori(M)) // flip kepori so they aren't vertical on a horizontal bed
+		if(dir & NORTH)
+			M.setDir(EAST)
+		else if(dir & SOUTH)
+			M.setDir(WEST)
+		M.set_lying_angle(180)
+		M.pixel_x = 8
+
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/restrained/buckled)
 	M.set_glide_size(glide_size)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -84,7 +84,7 @@
 	M.set_buckled(src)
 	M.setDir(dir)
 
-	if(iskepori(M)) // flip kepori so they aren't vertical on a horizontal bed
+	if(iskepori(M) && buckle_lying != NO_BUCKLE_LYING && buckle_lying != 0) // flip kepori so they aren't vertical on a horizontal bed
 		if(dir & NORTH)
 			M.setDir(EAST)
 		else if(dir & SOUTH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes buckle_mob() to set the lying_angle of kepori to be 180 degrees, so that they will lay on their backs instead of on their faces or tails. Also pixelshifts them so they're fully on the bed/operating table/stasis table.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
now your bird isn't vertical during surgery
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: kepori now flip horizontally onto beds instead of balancing on their noses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
