### PR TITLE
Fixes moths being unable to eat clothing

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -33,10 +33,10 @@
 /// Wrapper for removing clothing based traits
 #define REMOVE_CLOTHING_TRAIT(mob, trait) REMOVE_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
 
-/*
+
 /// How much integrity does a shirt lose every time we bite it?
 #define MOTH_EATING_CLOTHING_DAMAGE 15
-*/
+
 
 // Base equipment delays
 /// Delay base for full-body coverage suit slot items. (hardsuits, spacesuits, radsuits, etc.)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -362,6 +362,7 @@
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
 #define ELZUOSE_CHARGE_FACTOR (0.025 * ELZUOSE_CHARGE_SCALING_MULTIPLIER) //factor at which ethereal's charge decreases
+#define CLOTHING_NUTRITION_GAIN (15 * REAGENTS_METABOLISM) // How much nutrition eating clothes as moth gives and drains
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 ///Greater numbers mean that less alcohol has greater intoxication potential

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -1,9 +1,9 @@
-#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[wound]"
+#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[wound]-[consume]"
 
-/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
+/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, consume = 0)
 	. = locate(ARMORID)
 	if (!.)
-		. = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
+		. = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound, consume)
 
 /datum/armor
 	datum_flags = DF_USE_TAG
@@ -18,8 +18,9 @@
 	var/acid
 	var/magic
 	var/wound
+	var/consume
 
-/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
+/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, consume = 0)
 	src.melee = melee
 	src.bullet = bullet
 	src.laser = laser
@@ -33,7 +34,7 @@
 	src.wound = wound
 	tag = ARMORID
 
-/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
+/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, consume = 0)
 	return getArmor(
 		src.melee+melee,
 		src.bullet+bullet,
@@ -45,7 +46,8 @@
 		src.fire+fire,
 		src.acid+acid,
 		src.magic+magic,
-		src.wound+wound
+		src.wound+wound,
+		src.consume+consume
 	)
 
 /datum/armor/proc/modifyAllRatings(modifier = 0)
@@ -60,10 +62,11 @@
 		fire+modifier,
 		acid+modifier,
 		magic+modifier,
-		wound+modifier
+		wound+modifier,
+		consume+modifier
 	)
 
-/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic)
+/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound, consume)
 	return getArmor(
 		(isnull(melee) ? src.melee : melee),
 		(isnull(bullet) ? src.bullet : bullet),
@@ -75,7 +78,8 @@
 		(isnull(fire) ? src.fire : fire),
 		(isnull(acid) ? src.acid : acid),
 		(isnull(magic) ? src.magic : magic),
-		(isnull(wound) ? src.wound : wound)
+		(isnull(wound) ? src.wound : wound),
+		(isnull(consume) ? src.consume : consume)
 	)
 
 /datum/armor/proc/getRating(rating)
@@ -93,7 +97,8 @@
 		"fire" = fire,
 		"acid" = acid,
 		"magic" = magic,
-		"wound" = wound
+		"wound" = wound,
+		"consume" = consume
 	)
 
 /datum/armor/proc/attachArmor(datum/armor/AA)
@@ -108,7 +113,8 @@
 		fire+AA.fire,
 		acid+AA.acid,
 		magic+AA.magic,
-		wound+AA.wound
+		wound+AA.wound,
+		consume+AA.consume
 	)
 
 /datum/armor/proc/detachArmor(datum/armor/AA)
@@ -123,7 +129,8 @@
 		fire-AA.fire,
 		acid-AA.acid,
 		magic-AA.magic,
-		wound-AA.wound
+		wound-AA.wound,
+		consume-AA.consume
 	)
 
 /datum/armor/vv_edit_var(var_name, var_value)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -46,6 +46,8 @@
 	var/list/durability_list = list()
 	/// If this can be eaten by a moth
 	var/moth_edible = TRUE
+	/// shamelessly stolen from TG Code
+	var/obj/item/food/clothing/moth_snack
 
 	// Not used yet
 	/// Trait modification, lazylist of traits to add/take away, on equipment/drop in the correct slot
@@ -82,22 +84,42 @@
 		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index, FALSE, TRUE))
 			add_fingerprint(usr)
 
-/obj/item/food/clothing // fuck you
+/obj/item/food/clothing // fuck you ʕ●.●ʔ
 	name = "temporary moth clothing snack item"
 	desc = "If you're reading this it means I messed up. This is related to moths eating clothes and I didn't know a better way to do it than making a new food object."
-	food_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	spawn_blacklisted = TRUE
+	bite_consumption = 0.5
+	food_reagents = list(/datum/reagent/consumable/nutriment/cloth_fibers = INFINITY)
 	tastes = list("dust" = 1, "lint" = 1)
 	foodtypes = CLOTH
+	/// A weak reference to the clothing that created us
+	var/datum/weakref/clothing
 
-/obj/item/clothing/attack(mob/M, mob/user, def_zone)
-	if(user.a_intent != INTENT_HARM && moth_edible && ismoth(M))
-		var/obj/item/food/clothing/clothing_as_food = new
-		clothing_as_food.name = name
-		if(clothing_as_food.attack(M, user, def_zone))
-			take_damage(15, sound_effect=FALSE)
-		qdel(clothing_as_food)
+/obj/item/food/clothing/make_edible()
+	. = ..()
+	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_eat)))
+
+/obj/item/food/clothing/proc/after_eat(mob/eater)
+	var/obj/item/clothing/resolved_clothing = clothing.resolve()
+	if (resolved_clothing)
+		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = CONSUME)
 	else
+		qdel(src)
+
+/obj/item/clothing/attack(mob/living/target, mob/living/user, list/modifiers, list/attack_modifiers)
+	if(user.a_intent == INTENT_HARM || !ismoth(target) || !moth_edible)
 		return ..()
+	if((clothing_flags & THICKMATERIAL) || (resistance_flags & INDESTRUCTIBLE))
+		return ..()
+	if(isnull(moth_snack))
+		create_moth_snack()
+	moth_snack.attack(target, user, modifiers)
+
+/// Creates a food object in null space which we can eat and imagine we're eating this pair of shoes
+/obj/item/clothing/proc/create_moth_snack()
+	moth_snack = new
+	moth_snack.name = name
+	moth_snack.clothing = WEAKREF(src)
 
 /obj/item/clothing/attackby(obj/item/tool, mob/user, params)
 	if(tool.get_sharpness() && cuttable)
@@ -582,6 +604,13 @@
 		var/turf/T = get_turf(src)
 		//so the shred survives potential turf change from the explosion.
 		addtimer(CALLBACK_NEW(/obj/effect/decal/cleanable/shreds, list(T, name)), 1)
+		deconstruct(FALSE)
+	if(damage_flag == CONSUME) //This allows for moths to fully consume clothing, rather than damaging it like other sources like brute
+		var/turf/current_position = get_turf(src)
+		new /obj/effect/decal/cleanable/shreds(current_position, name)
+		if(isliving(loc))
+			var/mob/living/possessing_mob = loc
+			possessing_mob.visible_message(span_danger("[src] is consumed until naught but shreds remains!"), span_boldwarning("[src] falls apart into little bits!"))
 		deconstruct(FALSE)
 	else
 		..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -120,6 +120,30 @@
 	description = "Natural tissue that keeps your stomach safe."
 	carry_food_tastes = FALSE // Don't want stomachs to leech the flavours of what they eat
 
+/datum/reagent/consumable/nutriment/cloth_fibers
+	name = "Cloth Fibers"
+	description = "It's not actually a form of nutriment but it does keep Mothpeople going for a short while..."
+	taste_description = "cloth"
+	nutriment_factor = 30 * REAGENTS_METABOLISM
+	brute_heal = 0
+	burn_heal = 0
+	///Amount of satiety that will be drained when the cloth_fibers is fully metabolized
+	var/delayed_satiety_drain = 2 * CLOTHING_NUTRITION_GAIN
+
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	. = ..()
+	if(affected_mob.satiety < MAX_SATIETY)
+		affected_mob.adjust_nutrition(CLOTHING_NUTRITION_GAIN)
+		delayed_satiety_drain += CLOTHING_NUTRITION_GAIN
+
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_delete(mob/living/carbon/affected_mob)
+	. = ..()
+	if(!iscarbon(affected_mob))
+		return
+
+	var/mob/living/carbon/carbon_mob = affected_mob
+	carbon_mob.adjust_nutrition(-delayed_satiety_drain)
+
 /datum/reagent/consumable/cooking_oil
 	name = "Cooking Oil"
 	description = "A variety of cooking oil derived from fat or plants. Used in food preparation and frying."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have shamelessly taken and stitched the moth food code from TG back together and was left with this abomination. I also made it so moths can't eat thick clothes which i believe covers most suits and armor, so moths can't chew through kevlar and metal in most cases... probably
#5132
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moths can now eat their captain's hat and shoes once more
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Moths can eat your clothes once again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
