### PR TITLE
Fixes bad Glass Icon States on certain sodas and other reagents

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents/mixed_drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents/mixed_drinks.dm
@@ -311,7 +311,6 @@
 	boozepwr = 25
 	quality = DRINK_VERYGOOD
 	taste_description = "spicy toxins"
-	glass_icon_state = "toxinsspecialglass"
 	glass_name = "Toxins Special"
 	glass_desc = "Traditionally lit with a welder while the server is blindfolded, but you don't want to cause an ACTUAL accident here."
 
@@ -471,7 +470,7 @@
 	boozepwr = 70
 	quality = DRINK_NICE
 	taste_description = "soda"
-	glass_icon_state = "whiskeysodaglass2"
+	glass_icon_state = "whiskeysodaglass"
 	glass_name = "whiskey soda"
 	glass_desc = "Bitter and refreshing."
 
@@ -901,7 +900,6 @@
 	quality = DRINK_VERYGOOD
 	taste_description = "a numbing sensation"
 	metabolization_rate = 1 * REAGENTS_METABOLISM
-	glass_icon_state = "neurotoxinglass"
 	glass_name = "Neurotoxin"
 	glass_desc = "The story goes that this drink was made on a bet between Cybersun chemists, debating if a drink could be used to put down a suspected Makosso-Warra spy. While morphine wasn't <i>supposed</i> to be used, it put them down all the same."
 
@@ -1071,7 +1069,6 @@
 	boozepwr = 40
 	taste_description = "stale bread with a staler aftertaste"
 	nutriment_factor = 2 * REAGENTS_METABOLISM
-	glass_icon_state = "squirt_cider"
 	glass_name = "Squirt Cider"
 	glass_desc = "Squirt cider will toughen you right up. Too bad about the musty aftertaste."
 
@@ -1129,7 +1126,6 @@
 	taste_description = "mint and chocolate"
 	boozepwr = 25
 	quality = DRINK_GOOD
-	glass_icon_state = "peppermint_patty"
 	glass_name = "Peppermint Patty"
 	glass_desc = "A boozy, minty hot cocoa that warms your belly on a cold night."
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -209,7 +209,6 @@
 	description = "The fatty, still liquid part of milk."
 	color = "#DFD7AF" // rgb: 223, 215, 175
 	taste_description = "creamy milk"
-	glass_icon_state  = "glass_white"
 	glass_name = "glass of cream"
 	glass_desc = "It's a bit thick to drink straight."
 
@@ -377,7 +376,6 @@
 	description = "A refreshing beverage."
 	color = "#743c05" // rgb: 16, 8, 0
 	taste_description = "cola"
-	glass_icon_state  = "glass_brown"
 	glass_name = "glass of cola"
 	glass_desc = "A carbonated cola. You should drink it before it gets flat!"
 
@@ -392,7 +390,6 @@
 	color = "#EEFF00" // rgb: 238, 255, 0
 	quality = DRINK_VERYGOOD
 	taste_description = "carbonated battery acid with a spoonful of sugar"
-	glass_icon_state = "crosstalk_glass"
 	glass_name = "glass of Crosstalk"
 	glass_desc = "The amount of sugar and chemicals in this drink makes your eyes water."
 
@@ -899,7 +896,6 @@
 	name = "Beef Broth"
 	color = "#100800" // rgb: 16, 8, 0 , just like cola
 	taste_description = "pure beef essence"
-	glass_icon_state  = "glass_brown"
 	glass_name = "glass of Master Cola?"
 	glass_desc = "A glass of what appears to be refreshing Space Cola."
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -430,7 +430,6 @@
 	description = "A Kalixcian drink made from a plant that tastes similar to sassafrass, which is used in root beer. A stumpy drake holding a mug of it is on the front."
 	color = "#732a03"
 	taste_description = "root beer" // FALSE ADVERTISING
-	glass_icon_state = "tadrixx_glass"
 	glass_name = "glass of Tadrixx"
 	glass_desc = "A cup of fizzy Tadrixx. It smells sweet."
 
@@ -473,7 +472,6 @@
 	description = "A spinoff of the popular Molten Bubbles drink from Kalixcis, made to emulate the flavor of spiced grape instead. It's... not exactly convincing or a very good mix."
 	color = "#5f2010"
 	taste_description = "spiced grape soda"
-	glass_icon_state = "plasma_fizz_glass"
 	glass_name = "glass of Plasma Fizz"
 	glass_desc = "A glass of Plasma Fizz. The spices (and fake grape flavoring) wrinkles your nose."
 
@@ -568,7 +566,6 @@
 	color = "#88b488" // rgb: 243, 155, 3
 	overdose_threshold = 60
 	taste_description = "tooth-rotting sweetness"
-	glass_icon_state = "xeno_energy_glass"
 	glass_name = "glass of Xeno Energy"
 	glass_desc = "A glass of Xeno Energy. It seems to swirl and roil outside of the can..."
 
@@ -609,7 +606,6 @@
 	quality = DRINK_NICE
 	overdose_threshold = 80
 	taste_description = "creamy coffee"
-	glass_icon_state = "soy_latte"
 	glass_name = "soy latte"
 	glass_desc = "A nice and refreshing beverage. It goes well with a book, if you have the time to read."
 
@@ -634,7 +630,6 @@
 	quality = DRINK_NICE
 	overdose_threshold = 80
 	taste_description = "bitter cream"
-	glass_icon_state = "cafe_latte"
 	glass_name = "cafe latte"
 	glass_desc = "A nice, strong, refreshing beverage. It goes well with a book, if you have the time to read."
 
@@ -788,7 +783,6 @@
 	nutriment_factor = 3 * REAGENTS_METABOLISM
 	color = "#4f3a11" // rgb: 64, 48, 16
 	taste_description = "creamy chocolate"
-	glass_icon_state  = "chocolateglass"
 	glass_name = "glass of hot cocoa."
 	glass_desc = "A favorite winter drink from the Solar Confederation. Good for warming yourself up."
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -5,7 +5,6 @@
 	metabolization_rate = 5 //fast rate so it disappears fast.
 	taste_description = "iron"
 	taste_mult = 1.3
-	glass_icon_state = "glass_red"
 	glass_name = "glass of tomato juice"
 	glass_desc = "Are you sure this is tomato juice?"
 
@@ -845,7 +844,6 @@
 	description = "Required for welders. Flammable."
 	color = "#660000" // rgb: 102, 0, 0
 	taste_description = "gross metal"
-	glass_icon_state = "dr_gibb_glass"
 	glass_name = "glass of welder fuel"
 	glass_desc = "Unless you're an industrial tool, this is probably not safe for consumption."
 	process_flags = ORGANIC | SYNTHETIC


### PR DESCRIPTION
## About The Pull Request

Makes a bunch of reagents not have broken glass sprites (by removing them largely to fit the new glasses)

## Why It's Good For The Game

Fixes good

## Changelog

:cl:
fix: Fixes bad icons on certain reagents in glasses
/:cl:
