### PR TITLE
Adds color preset selection to the decal painter

### DIFF
--- a/code/game/objects/items/decal_painter.dm
+++ b/code/game/objects/items/decal_painter.dm
@@ -198,14 +198,14 @@
 		// grayscale colors
 		"White"                    = COLOR_WHITE,
 		"Off-White"                = COLOR_OFF_WHITE,
-		"Gray (Very Light)"        = COLOR_VERY_LIGHT_GRAY,
 		"Silver"                   = COLOR_SILVER,
 		"Gray"                     = COLOR_GRAY,
+		"Gray (Very Light)"        = COLOR_VERY_LIGHT_GRAY,
 		"Gray (Floor Tile)"        = COLOR_FLOORTILE_GRAY,
 		"Gray (Monotile)"          = COLOR_MONOTILE,
 		"Gray (Dark Tile)"         = COLOR_TILE_DARK_GRAY,
-		"Black (Almost)"           = COLOR_ALMOST_BLACK,
 		"Black"                    = COLOR_BLACK,
+		"Black (Almost)"           = COLOR_ALMOST_BLACK,
 		"Black (Half-transparent)" = COLOR_HALF_TRANSPARENT_BLACK,
 
 		// reds
@@ -217,6 +217,8 @@
 		"Red (Grayish)"     = COLOR_LIGHT_GRAYISH_RED,
 		"Red (Soft)"        = COLOR_SOFT_RED,
 		"Red (Bubblegum)"   = COLOR_BUBBLEGUM_RED,
+		"Red (Gray)"        = COLOR_RED_GRAY,
+		"Red (Pale Gray)"   = COLOR_PALE_RED_GRAY,
 		"Maroon"            = COLOR_MAROON,
 
 		// oranges
@@ -236,6 +238,8 @@
 
 		// greens
 		"Green"                = COLOR_GREEN,
+		"Green (Gray)"         = COLOR_GREEN_GRAY,
+		"Green (Pale Gray)"    = COLOR_PALE_GREEN_GRAY,
 		"Olive"                = COLOR_OLIVE,
 		"Lime (Vibrant)"       = COLOR_VIBRANT_LIME,
 		"Lime"                 = COLOR_LIME,
@@ -244,14 +248,16 @@
 		"Lime (Moderate Dark)" = COLOR_DARK_MODERATE_LIME_GREEN,
 
 		// blues
-		"Blue"            = COLOR_BLUE,
-		"Blue (Bright)"   = COLOR_BRIGHT_BLUE,
-		"Blue (Moderate)" = COLOR_MODERATE_BLUE,
-		"Blue (Light)"    = COLOR_BLUE_LIGHT,
-		"Blue (Navy)"     = COLOR_NAVY,
-		"Cyan"            = COLOR_CYAN,
-		"Cyan (Dark)"     = COLOR_DARK_CYAN,
-		"Teal"            = COLOR_TEAL,
+		"Blue"             = COLOR_BLUE,
+		"Blue (Bright)"    = COLOR_BRIGHT_BLUE,
+		"Blue (Moderate)"  = COLOR_MODERATE_BLUE,
+		"Blue (Light)"     = COLOR_BLUE_LIGHT,
+		"Blue (Navy)"      = COLOR_NAVY,
+		"Blue (Gray)"      = COLOR_BLUE_GRAY,
+		"Blue (Pale Gray)" = COLOR_PALE_BLUE_GRAY,
+		"Cyan"             = COLOR_CYAN,
+		"Cyan (Dark)"      = COLOR_DARK_CYAN,
+		"Teal"             = COLOR_TEAL,
 
 		// pinks and purples
 		"Pink"               = COLOR_PINK,
@@ -261,6 +267,8 @@
 		"Magenta (Strong)"   = COLOR_STRONG_MAGENTA,
 		"Purple"             = COLOR_PURPLE,
 		"Purple (Dark)"      = COLOR_DARK_PURPLE,
+		"Purple (Gray)"      = COLOR_PURPLE_GRAY,
+		"Purple (Pale Gray)" = COLOR_PALE_PURPLE_GRAY,
 		"Violet"             = COLOR_VIOLET,
 		"Violet (Strong)"    = COLOR_STRONG_VIOLET,
 
@@ -268,16 +276,6 @@
 		"Beige"      = COLOR_BEIGE,
 		"Brown"      = COLOR_BROWN,
 		"Dark Brown" = COLOR_DARK_BROWN,
-
-		// grayed colors
-		"Green (Gray)"       = COLOR_GREEN_GRAY,
-		"Green (Pale Gray)"  = COLOR_PALE_GREEN_GRAY,
-		"Blue (Gray)"        = COLOR_BLUE_GRAY,
-		"Blue (Pale Gray)"   = COLOR_PALE_BLUE_GRAY,
-		"Red (Gray)"         = COLOR_RED_GRAY,
-		"Red (Pale Gray)"    = COLOR_PALE_RED_GRAY,
-		"Purple (Gray)"      = COLOR_PURPLE_GRAY,
-		"Purple (Pale Gray)" = COLOR_PALE_PURPLE_GRAY,
 
 		// wood colors
 		"Wood (Generic)"   = WOOD_COLOR_GENERIC,

--- a/code/game/objects/items/decal_painter.dm
+++ b/code/game/objects/items/decal_painter.dm
@@ -194,20 +194,6 @@
 
 	// preset colors matching color defines used in mapping
 	var/list/preset_colors = list(
-		// misc tile colors (???)
-		"Gray (Monotile)"  = COLOR_MONOTILE,
-		"Gray (Dark Tile)" = COLOR_TILE_DARK_GRAY,
-		"Warning"          = COLOR_WARNING,
-
-		// wood colors
-		"Wood (Generic)"   = WOOD_COLOR_GENERIC,
-		"Wood (Rich)"      = WOOD_COLOR_RICH,
-		"Wood (Pale)"      = WOOD_COLOR_PALE,
-		"Wood (Pale 2)"    = WOOD_COLOR_PALE2,
-		"Wood (Pale 3)"    = WOOD_COLOR_PALE3,
-		"Wood (Black)"     = WOOD_COLOR_BLACK,
-		"Wood (Chocolate)" = WOOD_COLOR_CHOCOLATE,
-		"Wood (Yellow)"    = WOOD_COLOR_YELLOW,
 
 		// grayscale colors
 		"White"                    = COLOR_WHITE,
@@ -216,6 +202,8 @@
 		"Silver"                   = COLOR_SILVER,
 		"Gray"                     = COLOR_GRAY,
 		"Gray (Floor Tile)"        = COLOR_FLOORTILE_GRAY,
+		"Gray (Monotile)"          = COLOR_MONOTILE,
+		"Gray (Dark Tile)"         = COLOR_TILE_DARK_GRAY,
 		"Black (Almost)"           = COLOR_ALMOST_BLACK,
 		"Black"                    = COLOR_BLACK,
 		"Black (Half-transparent)" = COLOR_HALF_TRANSPARENT_BLACK,
@@ -244,6 +232,7 @@
 		"Yellow"             = COLOR_YELLOW,
 		"Yellow (Vivid)"     = COLOR_VIVID_YELLOW,
 		"Yellow (Very Soft)" = COLOR_VERY_SOFT_YELLOW,
+		"Yellow (Warning)"   = COLOR_WARNING,
 
 		// greens
 		"Green"                = COLOR_GREEN,
@@ -289,11 +278,22 @@
 		"Red (Pale Gray)"    = COLOR_PALE_RED_GRAY,
 		"Purple (Gray)"      = COLOR_PURPLE_GRAY,
 		"Purple (Pale Gray)" = COLOR_PALE_PURPLE_GRAY,
+
+		// wood colors
+		"Wood (Generic)"   = WOOD_COLOR_GENERIC,
+		"Wood (Rich)"      = WOOD_COLOR_RICH,
+		"Wood (Pale)"      = WOOD_COLOR_PALE,
+		"Wood (Pale 2)"    = WOOD_COLOR_PALE2,
+		"Wood (Pale 3)"    = WOOD_COLOR_PALE3,
+		"Wood (Black)"     = WOOD_COLOR_BLACK,
+		"Wood (Chocolate)" = WOOD_COLOR_CHOCOLATE,
+		"Wood (Yellow)"    = WOOD_COLOR_YELLOW,
 		)
 
 /obj/item/decal_painter/afterattack(atom/A, mob/user, proximity, params)
 	if(!proximity)
 		return
+
 	var/turf/open/floor/F = A
 	if(!istype(F))
 		to_chat(user, span_warning("\The [src] can only be used on flooring."))

--- a/code/game/objects/items/decal_painter.dm
+++ b/code/game/objects/items/decal_painter.dm
@@ -192,10 +192,108 @@
 	"trimline_arrow_cw_fill","trimline_arrow_ccw_fill","trimline_warn","trimline_warn_fill"
 	)
 
+	// preset colors matching color defines used in mapping
+	var/list/preset_colors = list(
+		// misc tile colors (???)
+		"Gray (Monotile)"  = COLOR_MONOTILE,
+		"Gray (Dark Tile)" = COLOR_TILE_DARK_GRAY,
+		"Warning"          = COLOR_WARNING,
+
+		// wood colors
+		"Wood (Generic)"   = WOOD_COLOR_GENERIC,
+		"Wood (Rich)"      = WOOD_COLOR_RICH,
+		"Wood (Pale)"      = WOOD_COLOR_PALE,
+		"Wood (Pale 2)"    = WOOD_COLOR_PALE2,
+		"Wood (Pale 3)"    = WOOD_COLOR_PALE3,
+		"Wood (Black)"     = WOOD_COLOR_BLACK,
+		"Wood (Chocolate)" = WOOD_COLOR_CHOCOLATE,
+		"Wood (Yellow)"    = WOOD_COLOR_YELLOW,
+
+		// grayscale colors
+		"White"                    = COLOR_WHITE,
+		"Off-White"                = COLOR_OFF_WHITE,
+		"Gray (Very Light)"        = COLOR_VERY_LIGHT_GRAY,
+		"Silver"                   = COLOR_SILVER,
+		"Gray"                     = COLOR_GRAY,
+		"Gray (Floor Tile)"        = COLOR_FLOORTILE_GRAY,
+		"Black (Almost)"           = COLOR_ALMOST_BLACK,
+		"Black"                    = COLOR_BLACK,
+		"Black (Half-transparent)" = COLOR_HALF_TRANSPARENT_BLACK,
+
+		// reds
+		"Red"               = COLOR_RED,
+		"Red (Mostly Pure)" = COLOR_MOSTLY_PURE_RED,
+		"Red (Dark)"        = COLOR_DARK_RED,
+		"Red (Light)"       = COLOR_RED_LIGHT,
+		"Red (Vivid)"       = COLOR_VIVID_RED,
+		"Red (Grayish)"     = COLOR_LIGHT_GRAYISH_RED,
+		"Red (Soft)"        = COLOR_SOFT_RED,
+		"Red (Bubblegum)"   = COLOR_BUBBLEGUM_RED,
+		"Maroon"            = COLOR_MAROON,
+
+		// oranges
+		"Orange"                 = COLOR_ORANGE,
+		"Orange (Tan)"           = COLOR_TAN_ORANGE,
+		"Orange (Bright)"        = COLOR_BRIGHT_ORANGE,
+		"Orange (Light)"         = COLOR_LIGHT_ORANGE,
+		"Orange (Pale)"          = COLOR_PALE_ORANGE,
+		"Orange (Dark)"          = COLOR_DARK_ORANGE,
+		"Orange (Moderate Dark)" = COLOR_DARK_MODERATE_ORANGE,
+
+		// yellows
+		"Yellow"             = COLOR_YELLOW,
+		"Yellow (Vivid)"     = COLOR_VIVID_YELLOW,
+		"Yellow (Very Soft)" = COLOR_VERY_SOFT_YELLOW,
+
+		// greens
+		"Green"                = COLOR_GREEN,
+		"Olive"                = COLOR_OLIVE,
+		"Lime (Vibrant)"       = COLOR_VIBRANT_LIME,
+		"Lime"                 = COLOR_LIME,
+		"Lime (Very Pale)"     = COLOR_VERY_PALE_LIME_GREEN,
+		"Lime (Very Dark)"     = COLOR_VERY_DARK_LIME_GREEN,
+		"Lime (Moderate Dark)" = COLOR_DARK_MODERATE_LIME_GREEN,
+
+		// blues
+		"Blue"            = COLOR_BLUE,
+		"Blue (Bright)"   = COLOR_BRIGHT_BLUE,
+		"Blue (Moderate)" = COLOR_MODERATE_BLUE,
+		"Blue (Light)"    = COLOR_BLUE_LIGHT,
+		"Blue (Navy)"     = COLOR_NAVY,
+		"Cyan"            = COLOR_CYAN,
+		"Cyan (Dark)"     = COLOR_DARK_CYAN,
+		"Teal"            = COLOR_TEAL,
+
+		// pinks and purples
+		"Pink"               = COLOR_PINK,
+		"Pink (Mostly Pure)" = COLOR_MOSTLY_PURE_PINK,
+		"Pink (Faded)"       = COLOR_FADED_PINK,
+		"Magenta"            = COLOR_MAGENTA,
+		"Magenta (Strong)"   = COLOR_STRONG_MAGENTA,
+		"Purple"             = COLOR_PURPLE,
+		"Purple (Dark)"      = COLOR_DARK_PURPLE,
+		"Violet"             = COLOR_VIOLET,
+		"Violet (Strong)"    = COLOR_STRONG_VIOLET,
+
+		// browns
+		"Beige"      = COLOR_BEIGE,
+		"Brown"      = COLOR_BROWN,
+		"Dark Brown" = COLOR_DARK_BROWN,
+
+		// grayed colors
+		"Green (Gray)"       = COLOR_GREEN_GRAY,
+		"Green (Pale Gray)"  = COLOR_PALE_GREEN_GRAY,
+		"Blue (Gray)"        = COLOR_BLUE_GRAY,
+		"Blue (Pale Gray)"   = COLOR_PALE_BLUE_GRAY,
+		"Red (Gray)"         = COLOR_RED_GRAY,
+		"Red (Pale Gray)"    = COLOR_PALE_RED_GRAY,
+		"Purple (Gray)"      = COLOR_PURPLE_GRAY,
+		"Purple (Pale Gray)" = COLOR_PALE_PURPLE_GRAY,
+		)
+
 /obj/item/decal_painter/afterattack(atom/A, mob/user, proximity, params)
 	if(!proximity)
 		return
-
 	var/turf/open/floor/F = A
 	if(!istype(F))
 		to_chat(user, span_warning("\The [src] can only be used on flooring."))
@@ -234,7 +332,8 @@
 		</center>
 		<div class='statusDisplay'>Direction: [dir2text(decal_dir)]</div>
 		<center>
-			<a href="byond://?src=[UID()];choose_color=1">Choose Color</a>
+			<a href="byond://?src=[UID()];choose_color=1">Custom Color</a>
+			<a href="byond://?src=[UID()];choose_color_preset=1">Preset Colors</a>
 		</center>
 	"}
 
@@ -286,6 +385,11 @@
 			var/chosen_colour = input(usr, "", "Choose Color", decal_color) as color|null
 			if (!isnull(chosen_colour) && usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
 				decal_color = chosen_colour
+	if(href_list["choose_color_preset"])
+		if(!(color_disallowed.Find(decal_state)))
+			var/preset = input("Please choose a color preset.", "[src]") as null|anything in preset_colors
+			if(preset)
+				decal_color = preset_colors[preset]
 
 
 	decal_icon = icon('icons/turf/decals/decals.dmi', decal_state, decal_dir)


### PR DESCRIPTION
## About The Pull Request

Adds a popup containing some color presets to the decal painter. These are based off of the color defines that mappers use. 

<img width="252" height="368" alt="image" src="https://github.com/user-attachments/assets/f729ad27-69a3-437c-83f1-f1be98e94e34" />
<br>
<img width="314" height="275" alt="image" src="https://github.com/user-attachments/assets/82a1e628-2820-40d9-86bf-0882698bb995" />


## Why It's Good For The Game

Makes picking consistent colors much much easier. Lets you more easily fix the mappers' hard work after you accidentally rip it up with a crowbar. 

## Changelog

:cl: cablefish
add: Added a color preset menu to the decal painter.
/:cl: