### PR TITLE
Drink can sanity tweaks

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -611,7 +611,7 @@
 	isGlass = FALSE
 	custom_price = 5
 	var/pierced = FALSE
-	obj_flags = CAN_BE_HIT
+	// obj_flags = CAN_BE_HIT
 
 
 /obj/item/reagent_containers/food/drinks/soda_cans/attack(mob/M, mob/user)
@@ -629,7 +629,7 @@
 	. = ..()
 	if(is_drainable() && pierced && chugged)
 		M.changeNext_move(CLICK_CD_RAPID)
-		if(iscarbon(M))
+		if(iscarbon(M) && HAS_TRAIT(M, TRAIT_LIGHT_DRINKER))
 			var/mob/living/carbon/broh = M
 			broh.adjustOxyLoss(2)
 			broh.losebreath++
@@ -644,7 +644,6 @@
 						user.visible_message("<b>[broh]</b> makes \an [pick(list("uncomfortable", "gross", "troubling"))] gurgling noise as [broh.p_they()] chug the can of [src]!")
 				if(9 to INFINITY)
 					broh.vomit(2, stun=FALSE)
-
 
 /obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()
@@ -667,13 +666,13 @@
 		open_soda(user)
 	return ..()
 
-/obj/item/reagent_containers/food/drinks/soda_cans/attacked_by(obj/item/I, mob/living/user)
+/obj/item/reagent_containers/food/drinks/soda_cans/attackby(obj/item/I, mob/living/user)
 	if(I.sharpness && !pierced && user && user.a_intent != INTENT_HARM)
 		user.visible_message("<b>[user]</b> pierces [src] with [I].", span_notice("You pierce \the [src] with [I]."))
 		playsound(src, "can_open", 50, TRUE)
 		pierced = TRUE
 		return
-	else if(I.force)
+	else if(I.force >= 5 && I.damtype == BRUTE && user.a_intent == INTENT_HARM)
 		user.visible_message("<b>[user]</b> crushes [src] with [I]! Party foul!", span_warning("You crush \the [src] with [I]! Party foul!"))
 		playsound(src, "can_open", 50, TRUE)
 		var/obj/item/trash/can/crushed_can = new /obj/item/trash/can(src.loc)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -611,8 +611,6 @@
 	isGlass = FALSE
 	custom_price = 5
 	var/pierced = FALSE
-	// obj_flags = CAN_BE_HIT
-
 
 /obj/item/reagent_containers/food/drinks/soda_cans/attack(mob/M, mob/user)
 	if(istype(M, /mob/living/carbon) && !reagents.total_volume && user.a_intent == INTENT_HARM && user.zone_selected == BODY_ZONE_HEAD)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -612,6 +612,7 @@
 	custom_price = 5
 	var/pierced = FALSE
 
+
 /obj/item/reagent_containers/food/drinks/soda_cans/attack(mob/M, mob/user)
 	if(istype(M, /mob/living/carbon) && !reagents.total_volume && user.a_intent == INTENT_HARM && user.zone_selected == BODY_ZONE_HEAD)
 		if(M == user)


### PR DESCRIPTION
## About The Pull Request

Shotgunning a drink no longer suffocates you. Unless you're a light drinker. Because it's funny.
Fixes not being able to heat up drinks with a lighter.
Crushing a drink (Party foul!) can now only be done on harm intent, with an item that deals over 5 brute damage. This is to safeguard against accidental mystery crushings.

## Why It's Good For The Game

Did you know? We have drinks in the game that come in a can that are supposed to be drank hot that you can't heat! This corrects that injustice. Also generally interactions should be sane.

## Changelog

:cl: cablefish
fix: You can now heat drink cans with a lighter.
balance: Shotgunning a drink doesn't kill you anymore. Unless you're a light drinker.
balance: Crushing a can with an item now requires you to be on harm intent with an item that deals over 5 brute damage.
/:cl: