### PR TITLE
Fixes and adds food related stuff

### DIFF
--- a/code/game/objects/items/food/burger.dm
+++ b/code/game/objects/items/food/burger.dm
@@ -238,8 +238,8 @@
 	foodtypes = GRAIN | MEAT | DAIRY
 
 /obj/item/food/burger/rib
-	name = "mcrib"
-	desc = "An elusive rib shaped burger with limited availablity across the galaxy. Not as good as you remember it."
+	name = "rib sandwich"
+	desc = "A long hamburger with an imitiation of a shortrib, smothered in barbeque sauce and onions, of terran origin."
 	icon_state = "mcrib"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 2,
@@ -251,8 +251,8 @@
 	foodtypes = GRAIN | MEAT
 
 /obj/item/food/burger/mcguffin
-	name = "mcguffin"
-	desc = "A cheap and greasy imitation of an eggs benedict."
+	name = "breakfast sandwich"
+	desc = "A sliced intersolar muffin with a patty-shaped steamed and fried egg between, of terran origin."
 	icon_state = "mcguffin"
 	tastes = list("muffin" = 2, "bacon" = 3)
 	food_reagents = list(

--- a/code/game/objects/items/food/donut.dm
+++ b/code/game/objects/items/food/donut.dm
@@ -204,6 +204,19 @@
 	tastes = list("donut" = 3, "matcha" = 1)
 	is_decorated = TRUE
 
+/obj/item/food/donut/laugh
+	name = "sweet pea donut"
+	desc = "Goes great with a bottle of Bastion Bourbon!"
+	icon_state = "donut_laugh"
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/laughsyrup = 3,
+		/datum/reagent/consumable/sprinkles = 1
+	)
+	tastes = list("donut" = 3, "fizzy tutti frutti" = 1)
+	is_decorated = TRUE
+
 //////////////////////JELLY DONUTS/////////////////////////
 
 /obj/item/food/donut/jelly
@@ -343,6 +356,20 @@
 	tastes = list("jelly" = 1, "donut" = 3, "matcha" = 1)
 	is_decorated = TRUE
 
+/obj/item/food/donut/jelly/laugh
+	name = "sweet pea jelly donut"
+	desc = "Goes great with a bottle of Bastion Bourbon!"
+	icon_state = "jelly_laugh"
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/laughsyrup = 3,
+		/datum/reagent/consumable/sprinkles = 1,
+		/datum/reagent/consumable/nutriment/vitamin = 1
+	)
+	tastes = list("jelly" = 1, "donut" = 3, "fizzy tutti frutti" = 1)
+	is_decorated = TRUE
+
 //////////////////////////SLIME DONUTS/////////////////////////
 
 /obj/item/food/donut/jelly/slimejelly
@@ -462,6 +489,20 @@
 		/datum/reagent/consumable/nutriment/vitamin = 1
 	)
 	tastes = list("jelly" = 1, "donut" = 3, "matcha" = 1)
+	is_decorated = TRUE
+
+/obj/item/food/donut/jelly/slimejelly/laugh
+	name = "sweet pea jelly donut"
+	desc = "Goes great with a bottle of Bastion Bourbon!"
+	icon_state = "jelly_laugh"
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/laughsyrup = 3,
+		/datum/reagent/consumable/sprinkles = 1,
+		/datum/reagent/consumable/nutriment/vitamin = 1
+	)
+	tastes = list("jelly" = 1, "donut" = 3, "fizzy tutti frutti" = 1)
 	is_decorated = TRUE
 
 #undef DONUT_SPRINKLE_CHANCE

--- a/code/game/objects/items/food/eggs.dm
+++ b/code/game/objects/items/food/eggs.dm
@@ -163,6 +163,21 @@
 		return
 	..()
 
+/obj/item/food/scotchegg
+	name = "scotch egg"
+	desc = "A boiled egg wrapped in a delicious, seasoned meatball."
+	icon = 'icons/obj/food/egg.dmi'
+	icon_state = "scotchegg"
+	//filling_color = "#FFFFF0"
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment/protein = 6,
+		/datum/reagent/consumable/nutriment/vitamin = 2,
+		/datum/reagent/consumable/nutriment = 2
+	)
+	w_class = WEIGHT_CLASS_SMALL
+	tastes = list("egg" = 1, "meat" = 1)
+	foodtypes = MEAT | BREAKFAST
+
 /obj/item/food/benedict
 	name = "eggs benedict"
 	desc = "A popular breakfast meal consisting of a solarian muffin with ham, a poached egg, and hollaindaise. Technically, this is a meal with two eggs involved."

--- a/code/game/objects/items/food/frozen.dm
+++ b/code/game/objects/items/food/frozen.dm
@@ -279,8 +279,31 @@
 	trash_type = /obj/item/popsicle_stick
 	w_class = WEIGHT_CLASS_SMALL
 	foodtypes = DAIRY | SUGAR
-	///T his is the edible part of the popsicle.
-	var/overlay_state = "creamsicle_o"
+
+	var/overlay_state = "creamsicle_o" ///This is the edible part of the popsicle.
+	var/bite_states = 4 //This value value is used for correctly setting the bite_consumption to ensure every bite changes the sprite. Do not set to zero.
+	var/bitecount = 0
+
+
+/obj/item/food/popsicle/Initialize(mapload)
+	. = ..()
+	bite_consumption = reagents.total_volume / bite_states
+	update_icon() // make sure the popsicle overlay is primed so it's not just a stick until you start eating it
+
+/obj/item/food/popsicle/make_edible()
+	. = ..()
+	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_bite)))
+
+/obj/item/food/popsicle/update_overlays()
+	. = ..()
+	if(!bitecount)
+		. += initial(overlay_state)
+		return
+	. += "[initial(overlay_state)]_[min(bitecount, 3)]"
+
+/obj/item/food/popsicle/proc/after_bite(mob/living/eater, mob/living/feeder, bitecount)
+	src.bitecount = bitecount
+	update_appearance()
 
 /obj/item/popsicle_stick
 	name = "popsicle stick"

--- a/code/game/objects/items/food/pastry.dm
+++ b/code/game/objects/items/food/pastry.dm
@@ -248,3 +248,15 @@
 	tastes = list("pastry" = 1, "sweetness" = 1)
 	foodtypes = GRAIN | SUGAR
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/hotcrossbun
+	name = "hot-cross bun"
+	desc = "The Cross represents the Assistants that died for your sins."
+	icon_state = "hotcrossbun"
+	food_reagents = list(
+		/datum/reagent/consumable/nutriment = 6,
+		/datum/reagent/consumable/sugar = 1
+	)
+	tastes = list("pastry" = 1, "sweetness" = 1)
+	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -165,7 +165,7 @@
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/ribburger
-	name = "McRib"
+	name = "Rib Burger"
 	reqs = list(
 		/obj/item/food/bbqribs = 1, //The sauce is already included in the ribs
 		/obj/item/food/onion_slice = 1, //feel free to remove if too burdensome.
@@ -175,7 +175,7 @@
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/mcguffin
-	name = "McGuffin"
+	name = "Breakfast Sandwich"
 	reqs = list(
 		/obj/item/food/friedegg = 1,
 		/obj/item/food/meat/bacon = 2,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_donuts.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_donuts.dm
@@ -108,6 +108,14 @@
 	)
 	result = /obj/item/food/donut/matcha
 
+/datum/crafting_recipe/food/donut/laugh
+	name = "Sweet Pea Donut"
+	reqs = list(
+		/datum/reagent/consumable/laughsyrup = 3,
+		/obj/item/food/donut/plain = 1
+	)
+	result = /obj/item/food/donut/laugh
+
 //Jelly
 
 /datum/crafting_recipe/food/donut/jelly/berry
@@ -175,6 +183,14 @@
 	)
 	result = /obj/item/food/donut/jelly/matcha
 
+/datum/crafting_recipe/food/donut/jelly/laugh
+	name = "Sweet Pea Jelly Donut"
+	reqs = list(
+		/datum/reagent/consumable/laughsyrup = 3,
+		/obj/item/food/donut/jelly/plain = 1
+	)
+	result = /obj/item/food/donut/jelly/laugh
+
 //Slime
 
 /datum/crafting_recipe/food/donut/slimejelly/berry
@@ -241,3 +257,11 @@
 		/obj/item/food/donut/jelly/slimejelly/plain = 1
 	)
 	result = /obj/item/food/donut/jelly/slimejelly/matcha
+
+/datum/crafting_recipe/food/donut/slimejelly/laugh
+	name = "Sweet Pea Jelly Donut"
+	reqs = list(
+		/datum/reagent/consumable/laughsyrup = 3,
+		/obj/item/food/donut/jelly/slimejelly/plain = 1
+	)
+	result = /obj/item/food/donut/jelly/slimejelly/laugh

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -9,6 +9,16 @@
 	)
 	result = /obj/item/food/omelette
 	subcategory = CAT_EGG
+/datum/crafting_recipe/food/scotchegg
+	name = "Scotch egg"
+	reqs = list(
+		/datum/reagent/consumable/sodiumchloride = 1,
+		/datum/reagent/consumable/blackpepper = 1,
+		/obj/item/food/boiledegg = 1,
+		/obj/item/food/meatball = 1
+	)
+	result = /obj/item/food/scotchegg
+	subcategory = CAT_EGG
 
 /datum/crafting_recipe/food/chocolateegg
 	name = "Chocolate egg"
@@ -58,7 +68,7 @@
 		/obj/item/food/grown/cabbage = 1,
 	)
 	result = /obj/item/food/eggwrap
-	category = CAT_EGG
+	subcategory = CAT_EGG
 
 /datum/crafting_recipe/food/chawanmushi
 	name = "Chawanmushi"
@@ -69,4 +79,4 @@
 		/obj/item/food/grown/mushroom/chanterelle = 1
 	)
 	result = /obj/item/food/chawanmushi
-	category = CAT_EGG
+	subcategory = CAT_EGG

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -8,7 +8,7 @@
 		/obj/item/food/cheese/wedge = 1
 	)
 	result = /obj/item/food/loaded_baked_potato
-	category = CAT_MISCFOOD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/miras_potato
 	name = "Miras loaded potato"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -253,3 +253,12 @@
 	)
 	result = /obj/item/food/honeybun
 	subcategory = CAT_PASTRY
+
+/datum/crafting_recipe/food/hotcrossbun
+	name = "Hot cross bun"
+	reqs = list(
+		/obj/item/food/bread/plain = 1,
+		/datum/reagent/consumable/sugar = 1
+	)
+	result = /obj/item/food/hotcrossbun
+	subcategory = CAT_PASTRY

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -175,5 +175,5 @@
 	id = "seaweedsheet"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 60)
-	build_path = /obj/item/food/grown/seaweed
+	build_path = /obj/item/food/grown/seaweed/sheet
 	category = list("initial","Food")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed popsicles not having anything on them, biogen not making seaweed sheets and crafting menu duping two of the catagories, Re-names the mcrib and mcguffin back to what is used to be
Added Sweet pea donuts, Hot-cross Buns and scotch eggs back.
fixes #5339
Most of the stuff in the issue seemed to have already been fixed beforehand.

If anything needs to be changed please tell me.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More foods
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Sweet pea donuts, Hot-cross Buns and Scotch eggs
fix: Popsicles having no ice cream on them
fix: Crafting menu duping Misc,Food and egg-based meal catagories
fix: Biogen producing raw seaweed instead of sheets
fix: the McRib and McGuffin has been re-named
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
