### PR TITLE
Assorted Warra Spellcheck

### DIFF
--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -597,7 +597,7 @@
 ///like all real 'less' than lethal crowd control options this is, in fact, not very good at being nonlethal
 /obj/item/mine/proximity/explosive/sting
 	name = "\improper'Stinger' Crowd Management Device"
-	desc = "A \"less\" than lethal crowd control weapon, designed to demoralise and scatter anti-NT protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
+	desc = "A \"less\" than lethal crowd control weapon, designed to demoralise and scatter anti-MW protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
 
 	range_heavy = 0
 	range_light = 1

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -597,7 +597,7 @@
 ///like all real 'less' than lethal crowd control options this is, in fact, not very good at being nonlethal
 /obj/item/mine/proximity/explosive/sting
 	name = "\improper'Stinger' Crowd Management Device"
-	desc = "A \"less\" than lethal crowd control weapon, designed to demoralise and scatter protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
+	desc = "A \"less\" than lethal crowd control weapon, designed to demoralize and scatter protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
 
 	range_heavy = 0
 	range_light = 1

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -597,7 +597,7 @@
 ///like all real 'less' than lethal crowd control options this is, in fact, not very good at being nonlethal
 /obj/item/mine/proximity/explosive/sting
 	name = "\improper'Stinger' Crowd Management Device"
-	desc = "A \"less\" than lethal crowd control weapon, designed to demoralise and scatter anti-MW protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
+	desc = "A \"less\" than lethal crowd control weapon, designed to demoralise and scatter protestors. The bands of ballistic gel inside strike targets and incapacitate without causing serious maiming. In Theory."
 
 	range_heavy = 0
 	range_light = 1

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -747,7 +747,7 @@
 	faction_locked = TRUE
 
 /datum/supply_pack/gun/hades
-	name = "AL655 Plasma Assault Rifle crate"
+	name = "AL655 'Hades' Plasma Assault Rifle crate"
 	desc = "Contains a high-energy, automatic plasma rifle. For Makosso-Warra employee use only."
 	cost = 5000
 	contains = list(/obj/item/storage/guncase/hades)

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -8,8 +8,8 @@
 /* VI */
 
 /datum/supply_pack/magazine/co9mm_mag
-	name = "9mm Commander Magazine Crate"
-	desc = "Contains a 9mm magazine for the standard-issue Commander pistol, with a capacity of twelve rounds."
+	name = "9mm Pistol Magazine Crate"
+	desc = "Contains a 9mm magazine for the Challenger and Challenger pistols, with a capacity of twelve rounds."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 	faction = /datum/faction/warra

--- a/code/modules/cargo/packs/magazines.dm
+++ b/code/modules/cargo/packs/magazines.dm
@@ -9,7 +9,7 @@
 
 /datum/supply_pack/magazine/co9mm_mag
 	name = "9mm Pistol Magazine Crate"
-	desc = "Contains a 9mm magazine for the Challenger and Challenger pistols, with a capacity of twelve rounds."
+	desc = "Contains a 9mm magazine for the Challenger and Champion pistols, with a capacity of twelve rounds."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 	faction = /datum/faction/warra

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
@@ -437,7 +437,7 @@ NO_MAG_GUN_HELPER(automatic/smg/resolution/inteq)
 
 /obj/item/gun/ballistic/shotgun/automatic/negotiator
 	name = "Advantage AST12 Negotiator"
-	desc = "A pump-action shotgun with a twin-tube design that allows the user to switch between two ammo types on demand, or simply double their available ammunition."
+	desc = "An automatic shotgun with a twin-tube design that allows the user to switch between two ammo types on demand, or simply double their available ammunition."
 
 	icon = 'icons/obj/guns/manufacturer/warra_sharplite/48x32.dmi'
 	lefthand_file = 'icons/obj/guns/manufacturer/warra_sharplite/lefthand.dmi'


### PR DESCRIPTION
## About The Pull Request

Makes Negotiator description line up with its actual function. Makes some Warra cargo listings properly reference the guns they are for. Removes NT reference from stinger mine.

## Why It's Good For The Game

Glue!

## Changelog

:cl: cablefish
spellcheck: The Negotiator no longer lies and tells you it's pump-action.
spellcheck: Made Warra cargo listings more clear.
spellcheck: Removed Nanotrasen.
/:cl:
