### PR TITLE
Removes crufty hug/handshake emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -24,21 +24,6 @@
 	message = "grumbles!"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/human/handshake
-	key = "handshake"
-	message = "shakes their own hands."
-	message_param = "shakes hands with %t."
-	hands_use_check = TRUE
-	emote_type = EMOTE_AUDIBLE
-
-/datum/emote/living/carbon/human/hug
-	key = "hug"
-	key_third_person = "hugs"
-	message = "hugs themself."
-	message_param = "hugs %t."
-	hands_use_check = TRUE
-	emote_type = EMOTE_AUDIBLE
-
 /datum/emote/living/carbon/human/mumble
 	key = "mumble"
 	key_third_person = "mumbles"


### PR DESCRIPTION
## About The Pull Request

Kills the *hug and *handshake emotes because you can already hug and handshake people through help intent interactions and the way they work is stupid and they're never used except for occasionally baiting people into shaking their own hands. In front of everyone. Shamefully. 

## Why It's Good For The Game

Less bait in the emote list.

## Changelog

:cl: cablefish
del: Removed nonfunctional hug and handshake emotes.
/:cl: