### PR TITLE
Fixes Solder Reagent for Electric Wounds

### DIFF
--- a/code/modules/surgery/electrical_repair.dm
+++ b/code/modules/surgery/electrical_repair.dm
@@ -110,14 +110,13 @@
 		TOOL_WELDER = 100,
 		TOOL_CAUTERY = 100,
 		/obj/item/reagent_containers = 100,
-		/obj/item = 40,
 	)
 	time = 5 SECONDS
 
 /datum/surgery_step/solder_wiring/tool_check(mob/user, obj/item/tool)
 	if(tool.tool_behaviour == TOOL_CAUTERY)
 		return TRUE
-	if(istype(tool, /obj/item) && tool.get_temperature() < SOLDER_MELTING_POINT)
+	if(tool.type == /obj/item && tool.get_temperature() < SOLDER_MELTING_POINT)
 		return FALSE
 	if(istype(tool, /obj/item/reagent_containers) && tool.reagents?.get_reagent_amount(/datum/reagent/medicine/liquid_solder) < 2)
 		to_chat(user, span_warning("You need more liquid solder to repair the wiring!"))


### PR DESCRIPTION
## About The Pull Request

Lets solder reagent be used for electric wounds again

## Why It's Good For The Game

Whoopsie daisy

## Changelog

:cl:
fix: Liquid Solder can be used for electrical ipc wounds again
/:cl:

