### PR TITLE
Fixes and buffs grinding grains into flour

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -223,10 +223,10 @@
 
 /obj/item/food/grown/on_grind(simulated=FALSE)
 	. = list()
-	var/nutriment = reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)
-	if(grind_results && grind_results.len)
+	var/nutri_amount = reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)
+	if(grind_results?.len)
 		for(var/reagent_type in grind_results)
-			.[grind_results[reagent_type]] = nutriment
+			.[reagent_type] = nutri_amount
 		if(!simulated)
 			reagents.del_reagent(/datum/reagent/consumable/nutriment)
 			reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -11,7 +11,7 @@
 	potency = 30
 	icon_dead = "wheat-dead"
 	mutatelist = list(/obj/item/seeds/wheat/oat, /obj/item/seeds/wheat/meat)
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.27)
 
 /obj/item/food/grown/wheat
 	seed = /obj/item/seeds/wheat


### PR DESCRIPTION
## About The Pull Request

Fixes grinding plants with special grind results like wheat->flour. Instead of runtiming it makes the right thing now. Yay.
Buffs the amount of flour from default potency wheat from 3 to 15 so you can actually reasonably get flour out of foraged / purchased wheat.

## Why It's Good For The Game

Features should work. Features shouldn't suck. Third thing.

## Changelog

:cl: cablefish
fix: Foods with special grind results (eg. wheat -> flour) now work again.
balance: Grinding grains gives 15u of their reagent now instead of 3.
/:cl: