### PR TITLE
SRM now gets the "Factory New" Hunters Pride gun variants through cargo

### DIFF
--- a/code/game/objects/items/storage/filled_guncases.dm
+++ b/code/game/objects/items/storage/filled_guncases.dm
@@ -16,6 +16,10 @@
 	gun_type = /obj/item/gun/ballistic/automatic/pistol/candor
 	mag_type = /obj/item/ammo_box/magazine/m45
 
+/obj/item/storage/guncase/pistol/candor/factory
+	gun_type = /obj/item/gun/ballistic/automatic/pistol/candor/factory
+	mag_type = /obj/item/ammo_box/magazine/m45
+
 /obj/item/storage/guncase/pistol/detective
 	gun_type = /obj/item/gun/ballistic/revolver/detective
 	mag_type = /obj/item/ammo_box/c38
@@ -32,6 +36,9 @@
 /obj/item/storage/guncase/doublebarrel
 	gun_type = /obj/item/gun/ballistic/shotgun/doublebarrel
 
+/obj/item/storage/guncase/doublebarrel/roumain
+	gun_type = /obj/item/gun/ballistic/shotgun/doublebarrel/roumain
+
 /obj/item/storage/guncase/brimstone
 	gun_type = /obj/item/gun/ballistic/shotgun/brimstone
 
@@ -39,8 +46,15 @@
 	gun_type = /obj/item/gun/ballistic/rifle/illestren
 	mag_type = /obj/item/ammo_box/magazine/illestren_a850r
 
+/obj/item/storage/guncase/illestren/factory
+	gun_type = /obj/item/gun/ballistic/rifle/illestren/factory
+	mag_type = /obj/item/ammo_box/magazine/illestren_a850r
+
 /obj/item/storage/guncase/beacon
 	gun_type = /obj/item/gun/ballistic/shotgun/doublebarrel/beacon
+
+/obj/item/storage/guncase/beacon/factory
+	gun_type = /obj/item/gun/ballistic/shotgun/doublebarrel/beacon/factory
 
 /obj/item/storage/guncase/scout
 	gun_type = /obj/item/gun/ballistic/rifle/scout
@@ -49,14 +63,24 @@
 /obj/item/storage/guncase/winchester
 	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow
 
+/obj/item/storage/guncase/winchester/factory
+	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/factory
+
 /obj/item/storage/guncase/conflagration
 	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/conflagration
 
 /obj/item/storage/guncase/absolution
 	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/absolution
 
+/obj/item/storage/guncase/absolution/factory
+	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/absolution/factory
+
 /obj/item/storage/guncase/pyre
 	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/pyre
+	mag_type = /obj/item/ammo_box/a4570/empty
+
+/obj/item/storage/guncase/pyre/factory
+	gun_type = /obj/item/gun/ballistic/shotgun/flamingarrow/pyre/factory
 	mag_type = /obj/item/ammo_box/a4570/empty
 
 /obj/item/storage/guncase/firestorm

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -161,7 +161,7 @@
 				for(var/i = 0; i < amount; i++)
 					unprocessed_packs += pack
 
-			outpost_docked.market.make_order(usr, unprocessed_packs, return_crate_spawner())
+			outpost_docked.market.make_order(usr, unprocessed_packs, return_crate_spawner(), current_faction)
 
 		if("mission-act")
 			var/datum/mission/mission = locate(params["ref"])

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -206,7 +206,7 @@
 	for(var/datum/supply_pack/current_pack as anything in outpost_docked.market.supply_packs)
 		if((!current_pack.available))
 			continue
-		var/same_faction = current_pack.faction ? current_pack.faction.allowed_faction(current_faction) : FALSE
+		var/same_faction = current_pack.faction ? current_pack.faction.allowed_factions(current_faction) : FALSE
 		var/discountedcost = (same_faction && current_pack.faction_discount) ? current_pack.cost - (current_pack.cost * (current_pack.faction_discount * 0.01)) : null
 		if(current_pack.faction_locked && !same_faction)
 			continue

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -206,7 +206,7 @@
 	for(var/datum/supply_pack/current_pack as anything in outpost_docked.market.supply_packs)
 		if((!current_pack.available))
 			continue
-		var/same_faction = current_pack.faction ? current_pack.faction.allowed_factions(current_faction) : FALSE
+		var/same_faction = current_pack.faction ? current_pack.faction.allowed_faction(current_faction) : FALSE
 		var/discountedcost = (same_faction && current_pack.faction_discount) ? current_pack.cost - (current_pack.cost * (current_pack.faction_discount * 0.01)) : null
 		if(current_pack.faction_locked && !same_faction)
 			continue

--- a/code/modules/cargo/market/market.dm
+++ b/code/modules/cargo/market/market.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(cargo_landing_zones)
 /datum/cargo_market/proc/cycle_stock()
 	return
 
-/datum/cargo_market/proc/make_order(mob/user, list/unprocessed_packs, atom/landing_zone)
+/datum/cargo_market/proc/make_order(mob/user, list/unprocessed_packs, atom/landing_zone, datum/faction/our_faction)
 	while(unprocessed_packs.len > 0)
 		var/datum/supply_pack/initial_pack = unprocessed_packs[1]
 		if(initial_pack.no_bundle)
@@ -62,14 +62,14 @@ GLOBAL_LIST_EMPTY(cargo_landing_zones)
 			unprocessed_packs -= current_pack
 
 		if(combo_packs.len == 1) // No items could be bundled with the initial pack, make a single order
-			send_order(user, list(initial_pack), landing_zone)
+			send_order(user, list(initial_pack), landing_zone, our_faction)
 			unprocessed_packs -= initial_pack
 			continue
 
-		send_order(user, combo_packs, landing_zone)
+		send_order(user, combo_packs, landing_zone, our_faction)
 		unprocessed_packs -= combo_packs
 
-/datum/cargo_market/proc/send_order(mob/user, list/packs, atom/landing_zone)
+/datum/cargo_market/proc/send_order(mob/user, list/packs, atom/landing_zone, datum/faction/our_faction)
 	var/rank = "*None Provided*"
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -78,7 +78,7 @@ GLOBAL_LIST_EMPTY(cargo_landing_zones)
 		rank = "Silicon"
 	//Including the ship bank account means you cant open the crate lol
 	//var/datum/supply_order/SO = new(packs, name, rank, user.ckey, charge_account, market = current_market)
-	var/datum/supply_order/order = new(packs, user, rank, user.ckey, market = src, landing_zone = landing_zone)
+	var/datum/supply_order/order = new(packs, user, rank, user.ckey, market = src, landing_zone = landing_zone, our_faction = our_faction)
 	SScargo.queue_item(order)
 	return TRUE
 

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -21,7 +21,9 @@
 	var/method = SHIPPING_METHOD_HANGER
 	var/atom/landing_zone
 
-/datum/supply_order/New(list/supply_packs = list(), orderer, orderer_rank, orderer_ckey, paying_account, datum/cargo_market/market, atom/landing_zone)
+	var/datum/faction/orderer_faction
+
+/datum/supply_order/New(list/supply_packs = list(), orderer, orderer_rank, orderer_ckey, paying_account, datum/cargo_market/market, atom/landing_zone, datum/faction/our_faction)
 	src.supply_packs = supply_packs
 	src.orderer = orderer
 	src.orderer_rank = orderer_rank
@@ -29,6 +31,7 @@
 	src.paying_account = paying_account
 	src.market = market
 	src.landing_zone = landing_zone
+	src.orderer_faction = our_faction
 	if(src.market)
 		id = src.market.ordernum++
 	for(var/datum/supply_pack/pack in src.supply_packs)
@@ -123,6 +126,6 @@
 		ordering_ship_name = current_ship_area.mobile_port.current_ship.name
 
 	for(var/datum/supply_pack/filling_pack in supply_packs)
-		filling_pack.fill(order_crate)
+		filling_pack.fill(order_crate, src.orderer_faction)
 	generateManifest(order_crate, account_holder, ordering_ship_name)
 	return order_crate

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -111,7 +111,7 @@
 			var/atom/A = new item(C)
 			A.flags_1 |= ADMIN_SPAWNED_1
 	else
-		if (contains_factional && faction ? faction.allowed_factions(F) : FALSE)
+		if (contains_factional && faction ? faction.allowed_faction(F) : FALSE)
 			for(var/item in contains_factional)
 				new item(C)
 		else

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -111,7 +111,7 @@
 			var/atom/A = new item(C)
 			A.flags_1 |= ADMIN_SPAWNED_1
 	else
-		if (contains_factional && faction ? faction.allowed_faction(F) : FALSE)
+		if (contains_factional && F ? faction.allowed_faction(F) : FALSE)
 			for(var/item in contains_factional)
 				new item(C)
 		else

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -111,7 +111,7 @@
 			var/atom/A = new item(C)
 			A.flags_1 |= ADMIN_SPAWNED_1
 	else
-		if (contains_factional && faction ? faction.allowed_faction(F) : FALSE)
+		if (contains_factional && faction ? faction.allowed_factions(F) : FALSE)
 			for(var/item in contains_factional)
 				new item(C)
 		else

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -105,7 +105,7 @@
 	fill(C)
 	return C
 
-/datum/supply_pack/proc/fill(obj/structure/closet/crate/C, var/datum/faction/F = null)
+/datum/supply_pack/proc/fill(obj/structure/closet/crate/C, datum/faction/F = null)
 	if (admin_spawned)
 		for(var/item in contains)
 			var/atom/A = new item(C)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -17,6 +17,9 @@
 	//TODO: Deprecate contains in favor of item
 	var/list/contains = null
 
+	// if not null, overrides the contains list when the faction matches
+	var/list/contains_factional = null
+
 	/*
 	/// Path to or the item itself what this entry is for, this should be set even if you override spawn_item to spawn your item.
 	var/item
@@ -102,11 +105,15 @@
 	fill(C)
 	return C
 
-/datum/supply_pack/proc/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/proc/fill(obj/structure/closet/crate/C, var/datum/faction/F = null)
 	if (admin_spawned)
 		for(var/item in contains)
 			var/atom/A = new item(C)
 			A.flags_1 |= ADMIN_SPAWNED_1
 	else
-		for(var/item in contains)
-			new item(C)
+		if (contains_factional && faction ? faction.allowed_faction(F) : FALSE)
+			for(var/item in contains_factional)
+				new item(C)
+		else
+			for(var/item in contains)
+				new item(C)

--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -92,6 +92,7 @@
 	desc = "Contains a Candor pistol, the trusty sidearm of any spacer, produced by Hunter's Pride and chambered in .45 ACP."
 	cost = 1000
 	contains = list(/obj/item/storage/guncase/pistol/candor)
+	contains_factional = list(/obj/item/storage/guncase/pistol/candor/factory)
 	faction = /datum/faction/srm
 
 /datum/supply_pack/gun/asp
@@ -408,6 +409,7 @@
 	desc = "For when you need to deal with 2 drunkards the old-fashioned way. Contains a double-barreled shotgun, favored by Bartenders. Warranty voided if sawed off."
 	cost = 1000
 	contains = list(/obj/item/storage/guncase/doublebarrel)
+	contains_factional = list(/obj/item/storage/guncase/doublebarrel/roumain)
 	crate_name = "shotgun crate"
 	faction = /datum/faction/srm
 
@@ -683,6 +685,7 @@
 	desc = "Contains an antiquated lever action rifle intended for hunting wildlife. Chambered in .38 rounds."
 	cost = 750
 	contains = list(/obj/item/storage/guncase/winchester)
+	contains_factional = list(/obj/item/storage/guncase/winchester/factory)
 	crate_name = "rifle crate"
 	faction = /datum/faction/srm
 	faction_discount = 20
@@ -692,6 +695,7 @@
 	desc = "Contains a powerful lever-action rifle for hunting larger wildlife. Chambered in .357."
 	cost = 2000
 	contains = list(/obj/item/storage/guncase/absolution)
+	contains_factional = list(/obj/item/storage/guncase/absolution/factory)
 	crate_name = "shotguns crate"
 	faction = /datum/faction/srm
 
@@ -700,6 +704,7 @@
 	desc = "Contains a devastating but unwieldy lever-action rifle for annihilating larger wildlife. Chambered in .45-70."
 	cost = 3000
 	contains = list(/obj/item/storage/guncase/pyre)
+	contains_factional = list(/obj/item/storage/guncase/pyre/factory)
 	crate_name = "rifle crate"
 	faction = /datum/faction/srm
 
@@ -708,6 +713,7 @@
 	desc = "Contains an expertly made bolt action rifle intended for hunting wildlife. Chambered in 8x50mmR rounds."
 	cost = 1250
 	contains = list(/obj/item/storage/guncase/illestren)
+	contains_factional = list(/obj/item/storage/guncase/illestren/factory)
 	crate_name = "rifle crate"
 	faction = /datum/faction/srm
 
@@ -716,6 +722,7 @@
 	desc = "Contains a single shot break action rifle to hunt wildlife that annoys you in particular. Chambered in devastating .45-70 rounds. Warranty voided if sawed off."
 	cost = 1000
 	contains = list(/obj/item/storage/guncase/beacon)
+	contains_factional = list(/obj/item/storage/guncase/beacon/factory)
 	crate_name = "rifle crate"
 	faction = /datum/faction/srm
 


### PR DESCRIPTION
## About The Pull Request

When the SRM buys applicable Hunters Pride guns through cargo, they will now receive the special Factory New variant.
This was done by adding a new var to orders that replaces the crate contents with something else when the faction matches the pack's faction, intended for fluff differences like this.

## Why It's Good For The Game

Logical. Flavorful. Probably intended given the comments on the Candor. Flex on the indies with your badass antique double barrel.

## Changelog

:cl: cablefish
add: SRM now receives the "factory new" Hunters Pride gun variants through cargo.
/:cl:
