### PR TITLE
Makes painkillers make you less sleepy

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
@@ -25,9 +25,9 @@
 	if(current_cycle >= 5)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "numb", /datum/mood_event/narcotic_light, name)
 	switch(current_cycle)
-		if(60)
+		if(375) // more than 30 units makes you sleepy
 			to_chat(M, span_warning("You feel drowsy..."))
-		if(61 to INFINITY)
+		if(376 to INFINITY)
 			M.drowsyness += 0.5 * seconds_per_tick
 	..()
 
@@ -72,12 +72,12 @@
 	if(current_cycle >= 5)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "numb", /datum/mood_event/narcotic_medium, name)
 	switch(current_cycle)
-		if(29)
+		if(75) // more than 15 units makes you sleepy
 			to_chat(M, span_warning("You start to feel tired..."))
-		if(30 to 59)
+		if(76 to 104)
 			M.drowsyness += 0.5 * seconds_per_tick
-		if(60 to INFINITY)
-			M.Sleeping(20 * seconds_per_tick)
+		if(105 to INFINITY)
+			M.Sleeping(20 * seconds_per_tick) // honk mimimi
 			. = 1
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/pain_reagents.dm
@@ -72,11 +72,11 @@
 	if(current_cycle >= 5)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "numb", /datum/mood_event/narcotic_medium, name)
 	switch(current_cycle)
-		if(75) // more than 15 units makes you sleepy
+		if(50) // more than 10 units makes you sleepy
 			to_chat(M, span_warning("You start to feel tired..."))
-		if(76 to 104)
+		if(51 to 74)
 			M.drowsyness += 0.5 * seconds_per_tick
-		if(105 to INFINITY)
+		if(75 to INFINITY)
 			M.Sleeping(20 * seconds_per_tick) // honk mimimi
 			. = 1
 	..()


### PR DESCRIPTION
## About The Pull Request

Makes tramal only make you sleepy at 30u (up from 5u) and morphine only make you sleepy at 10u (up from 5u).

## Why It's Good For The Game

Taking a tramal pen shouldn't put you in sleep hell for 20 minutes. Low doses of painkillers should be safe for surgery/RP, only hardcore juicers should get sent to sleep world.

## Changelog

:cl: cablefish
balance: Morphine and tramal make you less sleepy now.
/:cl: