### PR TITLE
You can put money in folders now

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -15,6 +15,8 @@
 		/obj/item/documents,
 		/obj/item/disk,
 		/obj/item/tape,
+        /obj/item/spacecash/bundle,
+        /obj/item/holochip,
 	))
 
 /obj/item/folder/Initialize()

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -15,8 +15,8 @@
 		/obj/item/documents,
 		/obj/item/disk,
 		/obj/item/tape,
-        /obj/item/spacecash/bundle,
-        /obj/item/holochip,
+		/obj/item/spacecash/bundle,
+		/obj/item/holochip,
 	))
 
 /obj/item/folder/Initialize()


### PR DESCRIPTION
## About The Pull Request

Lets you put money in folders. Both paper cash and holochips.

## Why It's Good For The Game

Folders, traditionally, are very good at holding and organizing thin paper-type things. Also allows you to make nice little packages containing both money and paperwork in a plastic biscuit to fax to people.

## Changelog

:cl: cablefish
add: You can now put money in folders.
/:cl:
