### PR TITLE
Reagents Autowiki now lists all reagents, not just products of reactions

### DIFF
--- a/code/modules/autowiki/pages/reactions.dm
+++ b/code/modules/autowiki/pages/reactions.dm
@@ -25,11 +25,11 @@ Autowiki/Reagent
 	for(var/datum/chemical_reaction/reaction as anything in all_reactions)
 		var/required_chems = ""
 		for(var/datum/reagent/required_chem_type as anything in reaction.required_reagents)
-			var/has_tooltip = (required_chem_type in mixable_reagents) && !(required_chem_type in reaction.results) && !(required_chem_type in GLOB.base_reagents)
+			var/has_tooltip = (required_chem_type in mixable_reagents) && !(required_chem_type in reaction.results)
 			required_chems += format_required_reagent(required_chem_type, reaction.required_reagents[required_chem_type], has_tooltip)
 
 		for(var/datum/reagent/required_catalyst_type as anything in reaction.required_catalysts)
-			var/has_tooltip = (required_catalyst_type in mixable_reagents) && !(required_catalyst_type in reaction.results) && !(required_catalyst_type in GLOB.base_reagents)
+			var/has_tooltip = (required_catalyst_type in mixable_reagents) && !(required_catalyst_type in reaction.results)
 			required_chems += format_required_reagent(required_catalyst_type, reaction.required_catalysts[required_catalyst_type], has_tooltip, "Catalyst")
 
 		for(var/datum/reagent/result_chem_type as anything in reaction.results)

--- a/code/modules/autowiki/pages/reagents.dm
+++ b/code/modules/autowiki/pages/reagents.dm
@@ -1,19 +1,25 @@
 /datum/autowiki/reagents
 	page = "Template:Autowiki/Content/Reagents"
+	var/list/unmixable_reagents = list()
 
 /datum/autowiki/reagents/generate()
 	var/output = list()
 
+	var/list/all_reagents = subtypesof(/datum/reagent)
 	var/list/mixable_reagents = list()
 	for(var/type in subtypesof(/datum/chemical_reaction))
 		var/datum/chemical_reaction/reaction = new type
 		mixable_reagents |= reaction.results
 		qdel(reaction)
 
+	unmixable_reagents = all_reagents - mixable_reagents
+
 	var/list/categories = list()
 
-	for(var/reagent in mixable_reagents)
+	for(var/reagent in all_reagents)
 		var/datum/reagent/chem = new reagent
+		if (chem.autowiki_hidden || chem.type == chem.bad_type)
+			continue
 
 		LAZYINITLIST(categories[chem.category])
 		categories[chem.category] += list(chem)
@@ -38,7 +44,10 @@
 
 	for(var/datum/reagent/reagent as anything in reagents)
 		output += "! style='background-color: #FFEE88;' | [include_template("anchor", list("1" = escape_value(reagent.name)))][escape_value(reagent.name)] <span style='color:[escape_value(reagent.color)];background-color:[escape_value(reagent.color)]'>__</span>\n"
-		output += "|[include_template("Autowiki/Content/Reactions/[escape_value(reagent.name)]")]\n"
+		if (reagent.type in unmixable_reagents)
+			output += "! style='background-color: #DDD;' |\n"
+		else
+			output += "|[include_template("Autowiki/Content/Reactions/[escape_value(reagent.name)]")]\n"
 		output += "|[escape_value(reagent.description)]\n"
 		output += "|data-sort-value=[reagent.metabolization_rate]|[reagent.metabolization_rate] units per tick\n"
 		output += "|[reagent.overdose_threshold || "data-sort-value=0|N/A"]\n"

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -72,6 +72,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/process_flags = ORGANIC
 	///How good of an accelerant is this reagent
 	var/accelerant_quality = 0
+	///If we don't show this on the autowiki reagents list, for things like Adminordrazine
+	var/autowiki_hidden = FALSE
+	///Path of the abstract parent type, to avoid doing stuff for things like /datum/reagent/drug
+	var/bad_type = /datum/reagent
 
 	///The section of the autowiki chem table this reagent will be under
 	var/category = "Misc"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -4,6 +4,7 @@
 	taste_description = "bitterness"
 	category = "Drug"
 	var/trippy = TRUE //Does this drug make you trip?
+	bad_type = /datum/reagent/drug
 
 /datum/reagent/drug/on_mob_end_metabolize(mob/living/M)
 	if(trippy)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -14,6 +14,7 @@
 	category = "Food and Drink"
 	var/nutriment_factor = 1 * REAGENTS_METABOLISM
 	var/quality = 0	//affects mood, typically higher for mixed drinks with more complex recipes
+	bad_type = /datum/reagent/consumable
 
 /datum/reagent/consumable/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, times_fired)
 	current_cycle++

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/_medicine_reagents.dm
@@ -2,6 +2,7 @@
 	name = "Medicine"
 	taste_description = "bitterness"
 	category = "Medicine"
+	bad_type = /datum/reagent/medicine
 
 /datum/reagent/medicine/on_mob_life(mob/living/carbon/M, seconds_per_tick, times_fired)
 	current_cycle++

--- a/code/modules/reagents/chemistry/reagents/medical_reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents/misc_reagents.dm
@@ -11,6 +11,7 @@
 	color = "#E0BB00" //golden for the gods
 	can_synth = FALSE
 	taste_description = "badmins"
+	autowiki_hidden = TRUE
 
 /datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/M)
 	M.reagents.remove_all_type(/datum/reagent/toxin, 5*REM, 0, 1)

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -85,6 +85,7 @@
 	//the kind of ammo you get from dipping 38 in this
 	var/obj/item/ammo_casing/c38/dip_ammo_type = null
 	var/dip_consumption = 2
+	bad_type = /datum/reagent/consumable/ethanol/trickwine
 
 /datum/reagent/consumable/ethanol/trickwine/dip_object(obj/item/I, mob/user, obj/item/reagent_containers/H)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Also adds `autowiki_hidden` and `bad_type` to /datum/reagent, for hiding certain reagents (like Adminordrazine), and for hiding abstract types like /datum/reagent/medicine

<img width="1681" height="589" alt="image" src="https://github.com/user-attachments/assets/b54c07c7-768a-49ca-9f24-30e91807c64c" />
(Preview of Misc. chemicals)

[Manually compiled output](https://shiptest.net/wiki/User:Ical92/Reagents)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better wiki reference, especially for flora chemicals, which are used for medicine or as components but have no reference on the wiki.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Autowiki for all reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
