### PR TITLE
Remove Phorid TF

### DIFF
--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -66,12 +66,9 @@
 			if(L)
 				L.adjust_fire_stacks(20) //dipping into a stream of plasma would probably make you more flammable than usual
 				L.adjust_bodytemperature(-rand(10,20)) //its cold, man
-				if(ishuman(L))//are they a carbon?
-					var/mob/living/carbon/human/PP = L
-
-					if(prob(35)) //used to be used to slowly convert limbs, I'm not changing the mechnical function outside of removing limb/species conversion, so plasma just kinda random crits now lol.
-						PP.adjustToxLoss(15)
-						PP.adjustFireLoss(25)
+				if(prob(35)) //used to be used to slowly convert limbs, I'm not changing the mechnical function outside of removing limb/species conversion, so plasma just kinda random crits now lol.
+					L.adjustToxLoss(15)
+					L.adjustFireLoss(25)
 
 /obj/vehicle/ridden/lavaboat/plasma
 	name = "plasma boat"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -67,48 +67,11 @@
 				L.adjust_fire_stacks(20) //dipping into a stream of plasma would probably make you more flammable than usual
 				L.adjust_bodytemperature(-rand(10,20)) //its cold, man
 				if(ishuman(L))//are they a carbon?
-					//var/list/plasma_parts = list()//a list of the organic parts to be turned into plasma limbs
-					//var/list/robo_parts = list()//keep a reference of robotic parts so we know if we can turn them into a plasmaman
 					var/mob/living/carbon/human/PP = L
-					//var/S = PP.dna.species
-					//if(istype(S, /datum/species/plasmaman) || istype(S, /datum/species/android)) //ignore plasmamen/robotic species
-						//continue
 
-					//var/obj/item/bodypart/limb
-					//for(var/zone in PP.bodyparts)
-						//limb = PP.bodyparts[zone]
-						//if(!limb)
-							//continue
-						//if(IS_ORGANIC_LIMB(limb) && limb.limb_id != "plasmaman") //getting every organic, non-plasmaman limb (augments/androids are immune to this)
-							//plasma_parts += limb
-						//if(!IS_ORGANIC_LIMB(limb))
-							//robo_parts += limb
-
-					if(prob(35)) //checking if the delay is over & if the victim actually has any parts to nom
+					if(prob(35)) //used to be used to slowly convert limbs, I'm not changing the mechnical function outside of removing limb/species conversion, so plasma just kinda random crits now lol.
 						PP.adjustToxLoss(15)
 						PP.adjustFireLoss(25)
-						//if(plasma_parts.len)
-							//var/obj/item/bodypart/NB = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs for dismember() to use
-							//NB.limb_id = "plasmaman" //change the species_id of the limb to that of a plasmaman
-							//NB.static_icon = 'icons/mob/species/plasmaman/bodyparts.dmi'
-							//NB.no_update = TRUE
-							//NB.change_bodypart_status()
-							//PP.force_scream()
-							//if(!HAS_TRAIT(PP, TRAIT_ANALGESIA))
-								//PP.visible_message(
-									//span_warning("[L] screams in pain as [L.p_their()] [NB] melts down to the bone!"),
-									//span_userdanger("You scream out in pain as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
-							//else
-								//PP.visible_message(
-									//span_warning("[L] lets out panicked gasps as [L.p_their()] [NB] melts down to the bone!"),
-									//span_userdanger("You gasp in shock as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
-						//if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
-							//PP.ignite_mob()
-							//PP.set_species(/datum/species/plasmaman)
-							//PP.visible_message(
-								//span_warning("[L] bursts into a brilliant purple flame as [L.p_their()] entire body is that of a skeleton!"),
-								//span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))
-
 
 /obj/vehicle/ridden/lavaboat/plasma
 	name = "plasma boat"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -67,47 +67,47 @@
 				L.adjust_fire_stacks(20) //dipping into a stream of plasma would probably make you more flammable than usual
 				L.adjust_bodytemperature(-rand(10,20)) //its cold, man
 				if(ishuman(L))//are they a carbon?
-					var/list/plasma_parts = list()//a list of the organic parts to be turned into plasma limbs
-					var/list/robo_parts = list()//keep a reference of robotic parts so we know if we can turn them into a plasmaman
+					//var/list/plasma_parts = list()//a list of the organic parts to be turned into plasma limbs
+					//var/list/robo_parts = list()//keep a reference of robotic parts so we know if we can turn them into a plasmaman
 					var/mob/living/carbon/human/PP = L
-					var/S = PP.dna.species
-					if(istype(S, /datum/species/plasmaman) || istype(S, /datum/species/android)) //ignore plasmamen/robotic species
-						continue
+					//var/S = PP.dna.species
+					//if(istype(S, /datum/species/plasmaman) || istype(S, /datum/species/android)) //ignore plasmamen/robotic species
+						//continue
 
-					var/obj/item/bodypart/limb
-					for(var/zone in PP.bodyparts)
-						limb = PP.bodyparts[zone]
-						if(!limb)
-							continue
-						if(IS_ORGANIC_LIMB(limb) && limb.limb_id != "plasmaman") //getting every organic, non-plasmaman limb (augments/androids are immune to this)
-							plasma_parts += limb
-						if(!IS_ORGANIC_LIMB(limb))
-							robo_parts += limb
+					//var/obj/item/bodypart/limb
+					//for(var/zone in PP.bodyparts)
+						//limb = PP.bodyparts[zone]
+						//if(!limb)
+							//continue
+						//if(IS_ORGANIC_LIMB(limb) && limb.limb_id != "plasmaman") //getting every organic, non-plasmaman limb (augments/androids are immune to this)
+							//plasma_parts += limb
+						//if(!IS_ORGANIC_LIMB(limb))
+							//robo_parts += limb
 
 					if(prob(35)) //checking if the delay is over & if the victim actually has any parts to nom
 						PP.adjustToxLoss(15)
 						PP.adjustFireLoss(25)
-						if(plasma_parts.len)
-							var/obj/item/bodypart/NB = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs for dismember() to use
-							NB.limb_id = "plasmaman" //change the species_id of the limb to that of a plasmaman
-							NB.static_icon = 'icons/mob/species/plasmaman/bodyparts.dmi'
-							NB.no_update = TRUE
-							NB.change_bodypart_status()
-							PP.force_scream()
-							if(!HAS_TRAIT(PP, TRAIT_ANALGESIA))
-								PP.visible_message(
-									span_warning("[L] screams in pain as [L.p_their()] [NB] melts down to the bone!"),
-									span_userdanger("You scream out in pain as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
-							else
-								PP.visible_message(
-									span_warning("[L] lets out panicked gasps as [L.p_their()] [NB] melts down to the bone!"),
-									span_userdanger("You gasp in shock as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
-						if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
-							PP.ignite_mob()
-							PP.set_species(/datum/species/plasmaman)
-							PP.visible_message(
-								span_warning("[L] bursts into a brilliant purple flame as [L.p_their()] entire body is that of a skeleton!"),
-								span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))
+						//if(plasma_parts.len)
+							//var/obj/item/bodypart/NB = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs for dismember() to use
+							//NB.limb_id = "plasmaman" //change the species_id of the limb to that of a plasmaman
+							//NB.static_icon = 'icons/mob/species/plasmaman/bodyparts.dmi'
+							//NB.no_update = TRUE
+							//NB.change_bodypart_status()
+							//PP.force_scream()
+							//if(!HAS_TRAIT(PP, TRAIT_ANALGESIA))
+								//PP.visible_message(
+									//span_warning("[L] screams in pain as [L.p_their()] [NB] melts down to the bone!"),
+									//span_userdanger("You scream out in pain as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
+							//else
+								//PP.visible_message(
+									//span_warning("[L] lets out panicked gasps as [L.p_their()] [NB] melts down to the bone!"),
+									//span_userdanger("You gasp in shock as your [NB] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
+						//if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
+							//PP.ignite_mob()
+							//PP.set_species(/datum/species/plasmaman)
+							//PP.visible_message(
+								//span_warning("[L] bursts into a brilliant purple flame as [L.p_their()] entire body is that of a skeleton!"),
+								//span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))
 
 
 /obj/vehicle/ridden/lavaboat/plasma


### PR DESCRIPTION
The code that causes plasma tiles to turn you into a phorid has been commented out, it now just kills you.  Let me know if I should just delete all of it, but idunno if its needed for some reason??? so its staying just disabled.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The transformation was buggy and also forcing people to play a different species is bad. Forcing people to play phorid of all species is double bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
del:Plasma tiles can no longer turn you into a phorid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
