### PR TITLE
Fixes telecomms log monitor crate

### DIFF
--- a/code/modules/cargo/packs/telecomms.dm
+++ b/code/modules/cargo/packs/telecomms.dm
@@ -160,5 +160,5 @@
 	desc = "A radio packet inspection system. Accesses logs stored on radio servers and prints them in a sapient-readable format."
 	cost = 1000
 	contains = list(
-		/obj/item/circuitboard/computer/message_monitor
+		/obj/item/circuitboard/computer/comm_server
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Telecomminications Log Monitor Crate now correctly contains a server monitoring console circuit board, instead of a PDA monitor board.

:cl:
fix: Fixed telecomms log monitor crate containing the wrong circuit board.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
