### PR TITLE
Brute Pack Buff

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -137,7 +137,7 @@
 	apply_sounds = list('sound/effects/rip1.ogg', 'sound/effects/rip2.ogg')
 	self_delay = 2 SECONDS
 	other_delay = 1.5 SECONDS
-	heal_brute = 10
+	heal_brute = 15
 	grind_results = list(/datum/reagent/medicine/indomide = 10)
 	merge_type = /obj/item/stack/medical/bruise_pack
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -137,7 +137,7 @@
 	apply_sounds = list('sound/effects/rip1.ogg', 'sound/effects/rip2.ogg')
 	self_delay = 2 SECONDS
 	other_delay = 1.5 SECONDS
-	heal_brute = 15
+	heal_brute = 25
 	grind_results = list(/datum/reagent/medicine/indomide = 10)
 	merge_type = /obj/item/stack/medical/bruise_pack
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Bruise Packs heal 25 brute per use. (from 15) so they're actually notable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bruise packs are the most whatever healing in the game. They come in one 1 medkit and they're just worse sutures (sutures have the dignity of healing 15 & stopping bleeding). Makes it so they at least do something notable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Bruise Packs Heal 25 Brute per use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
