### PR TITLE
Increase elzuose crystal hair opacity + base color isn't static

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -28,7 +28,6 @@
 	min_temp_comfortable = (HUMAN_BODYTEMP_NORMAL - 10)
 	max_temp_comfortable = HUMAN_BODYTEMP_NORMAL + 55
 
-	hair_color = "fixedmutcolor"
 	hair_alpha = 200
 	mutant_bodyparts = list("elzu_horns", "tail_elzu")
 	default_features = list("elzu_horns" = "None", "tail_elzu" = "None")

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -29,7 +29,7 @@
 	max_temp_comfortable = HUMAN_BODYTEMP_NORMAL + 55
 
 	hair_color = "fixedmutcolor"
-	hair_alpha = 140
+	hair_alpha = 200
 	mutant_bodyparts = list("elzu_horns", "tail_elzu")
 	default_features = list("elzu_horns" = "None", "tail_elzu" = "None")
 	species_eye_path = 'icons/mob/ethereal_parts.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This increases the alpha value of elzu crystal hair from 140 -> 200

<details> <summary> Comparing the current and proposed translucency </summary> 
<img width="151" height="499" alt="Screenshot 2026-08-11 195028" src="https://github.com/user-attachments/assets/6bfb6a7d-3d86-4914-b2c7-d1437f8afd81" />
<img width="151" height="496" alt="Screenshot 2026-08-11 195940" src="https://github.com/user-attachments/assets/c2001592-8b7a-4d3d-baa7-71f5e21dae25" />
<img width="154" height="496" alt="Screenshot 2026-08-11 195042" src="https://github.com/user-attachments/assets/b0c479c1-5633-4598-9c82-e0046e6d0e98" />
<img width="153" height="498" alt="Screenshot 2026-08-11 194829" src="https://github.com/user-attachments/assets/8a144af8-5e17-47a5-b859-a4ea1429be54" />
</details>

<details> <summary>NOW ALSO lets the base color be changed. Obviously the color can be kept the same if wanted still by copy pasting. Here's some examples of how that looks:</summary>
<img width="303" height="992" alt="Screenshot_2026-08-13_212914" src="https://github.com/user-attachments/assets/b406a941-dff9-4df4-9cc6-1ca477e4bef8" />
<img width="303" height="986" alt="Screenshot_2026-08-13_212207" src="https://github.com/user-attachments/assets/f44b038a-58e6-42a0-8cc8-d3bb964686b3" />
<img width="308" height="992" alt="Screenshot_2026-08-13_211413" src="https://github.com/user-attachments/assets/12140893-cf62-4029-8a79-e9c7291881c4" />
</details>


## Why It's Good For The Game

Few things of note:

This keeps the translucency of the crystal hair, but makes it opaque enough for sprite details to not be invisible without putting a gradient overlay on it. Gradients can still be applied for more opacity

Allows for certain things like split dye or splotch patterns to blend into the hair a bit better, without looking quite as floaty 

Makes gradients that go from the bottom up work a bit better

Can tweak the value lower if needed, or put the line change that lets the hair be colored separately.

## Changelog

:cl:
code: increases elzuose hair alpha value, lets hair base color be changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
