### PR TITLE
Holopad radio alerts

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -62,7 +62,7 @@
 			H.say("Incoming call.")
 			if(H.linked_radio)
 				var/obj/item/radio/linked = H.linked_radio.resolve()
-				if(linked.can_receive(unlinked_radio.frequency, list(H.get_map_zone())))
+				if(linked.can_receive(linked.frequency, list(H.get_map_zone())))
 					linked.say("Incoming holocall.")
 			if(H.admin_pad)
 				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling <b>[H.get_pad_name()][ADMIN_FLW(H)]</b> from <b>[get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]</b>!"))

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -61,8 +61,8 @@
 			dialed_holopads += H
 			H.say("Incoming call.")
 			if(H.linked_radio)
-				var/obj/item/radio/linked = linked_radio.resolve()
-				if(linked.can_receive(FREQ_COMMON, get_map_zone()))
+				var/obj/item/radio/linked = H.linked_radio.resolve()
+				if(linked.can_receive(unlinked_radio.frequency, list(H.get_map_zone())))
 					linked.say("Incoming holocall.")
 			if(H.admin_pad)
 				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling <b>[H.get_pad_name()][ADMIN_FLW(H)]</b> from <b>[get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]</b>!"))

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -60,6 +60,10 @@
 		if(!QDELETED(H) && H.is_operational)
 			dialed_holopads += H
 			H.say("Incoming call.")
+			if(H.linked_radio)
+				var/obj/item/radio/linked = linked_radio.resolve()
+				if(linked.can_receive(FREQ_COMMON, get_map_zone()))
+					linked.say("Incoming holocall.")
 			if(H.admin_pad)
 				to_chat(GLOB.admins, span_adminnotice("[icon2html(calling_holopad.icon, GLOB.admins)]<b><font color=green> Incoming Holocall! \n </font>[ADMIN_FULLMONTY(requester)]:</b><span class='linkify'> is calling <b>[H.get_pad_name()][ADMIN_FLW(H)]</b> from <b>[get_area_name(calling_holopad)][ADMIN_FLW(calling_pad)]</b>!"))
 			LAZYADD(H.holo_calls, src)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -91,6 +91,8 @@ Possible to do for anyone motivated enough:
 	var/admin_pad = FALSE
 	/// The last holopad that called this one.
 	var/caller_history
+	/// the radio linked to this holopad as a weak reference. announces when a call is incoming
+	var/datum/weakref/linked_radio
 
 /obj/machinery/holopad/secure
 	name = "secure holopad"
@@ -176,6 +178,8 @@ Possible to do for anyone motivated enough:
 	if(record_mode)
 		record_stop()
 
+	QDEL_NULL(linked_radio)
+
 	QDEL_NULL(disk)
 
 	holopads -= src
@@ -230,6 +234,17 @@ Possible to do for anyone motivated enough:
 			return
 		to_chat(user,span_notice("You insert [P] into [src]."))
 		disk = P
+		return
+
+	if(istype(P, /obj/item/radio) && panel_open)
+		to_chat(user,  span_notice("You start linking [P] to [src]..."))
+		if(do_after(user, 5 SECONDS, src))
+			if(linked_radio)
+				var/obj/item/radio/unlinked_radio = linked_radio.resolve()
+				if(unlinked_radio.can_receive(FREQ_COMMON, get_map_zone()))
+					unlinked_radio.say("Radio unlinked from holopad")
+			linked_radio = WEAKREF(P)
+			P.say("Radio linked to holopad")
 		return
 
 	return ..()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -161,6 +161,7 @@ Possible to do for anyone motivated enough:
 	. = ..()
 	if(panel_open)
 		. += span_notice("You could use a multitool to alter the circuitry inside..")
+		. += span_notice("A <b>Radio</b> could be connected for notifications.")
 
 /obj/machinery/holopad/Destroy()
 	if(outgoing_call)
@@ -241,7 +242,7 @@ Possible to do for anyone motivated enough:
 		if(do_after(user, 5 SECONDS, src))
 			if(linked_radio)
 				var/obj/item/radio/unlinked_radio = linked_radio.resolve()
-				if(unlinked_radio.can_receive(FREQ_COMMON, get_map_zone()))
+				if(unlinked_radio.can_receive(unlinked_radio.frequency, list(get_map_zone())) && unlinked_radio != P)
 					unlinked_radio.say("Radio unlinked from holopad")
 			linked_radio = WEAKREF(P)
 			P.say("Radio linked to holopad")


### PR DESCRIPTION
## About The Pull Request

You can now connect radios to holopads for long-distance phone call alerts
## Changelog

:cl:
add: You can now connect radios to holopads for long-distance phone call alerts. Simply unscrew the pad and interact with it with your radio.
/:cl:
