### PR TITLE
Puppis adjustment

### DIFF
--- a/_maps/configs/minutemen_puppis.json
+++ b/_maps/configs/minutemen_puppis.json
@@ -36,11 +36,7 @@
 		},
 		"Minuteman": {
 			"outfit": "/datum/outfit/job/clip/minutemen/grunt",
-			"slots": 1
-		},
-		"Reservist": {
-			"outfit": "/datum/outfit/job/clip/minutemen/grunt/reserve",
-			"slots": 1
+			"slots": 2
 		}
 	},
 	"enabled": true

--- a/_maps/shuttles/minutemen/minutemen_puppis.dmm
+++ b/_maps/shuttles/minutemen/minutemen_puppis.dmm
@@ -1160,11 +1160,13 @@
 /area/ship/security/armory)
 "mo" = (
 /obj/effect/turf_decal/industrial/warning/green/fulltile,
-/obj/structure/rack,
-/obj/item/gun_maint_kit{
-	pixel_x = 1;
-	pixel_y = 1
+/obj/machinery/suit_storage_unit/inherit/industrial{
+	req_access_txt = "1";
+	name = "minuteman suit storage unit"
 	},
+/obj/item/clothing/suit/space/hardsuit/clip_patroller,
+/obj/item/clothing/mask/gas/clip,
+/obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -1662,6 +1664,10 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/spline/plain/opaque/blue{
 	dir = 8
+	},
+/obj/item/storage/backpack/duffelbag/sec{
+	pixel_x = 4;
+	pixel_y = 11
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -2766,12 +2772,12 @@
 /area/ship/crew/ccommons)
 "DB" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_x = 4;
-	pixel_y = 11
-	},
 /obj/effect/turf_decal/spline/plain/opaque/blue{
 	dir = 8
+	},
+/obj/item/gun_maint_kit{
+	pixel_x = 0;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -3358,6 +3364,10 @@
 	id = "pup_armory"
 	},
 /obj/machinery/light/directional/south,
+/obj/item/gun/energy/kalix/clip{
+	pixel_x = 0;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "KM" = (
@@ -3814,6 +3824,13 @@
 /obj/item/ammo_box/magazine/cm23{
 	pixel_x = 12;
 	pixel_y = -4
+	},
+/obj/item/stock_parts/cell/gun/kalix{
+	pixel_x = -7
+	},
+/obj/item/stock_parts/cell/gun/kalix{
+	pixel_x = -8;
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cuts the reservist, adds a minuteman instead. Adds supplies to the ship in order to equip that minuteman (hardsuit, another ecm6)
<img width="642" height="422" alt="image" src="https://github.com/user-attachments/assets/251f7178-b7f1-4349-b5d5-6cfdd5ff7125" />

## Why It's Good For The Game
The reservist is literally just dirt poor minuteman. Looking back on it I think its lame.

## Changelog

:cl:
add: minuteman slot on puppis, gear to support them
del: reservist slot on puppis
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
