### PR TITLE
Surgery scanner and pill press tooltip improvements

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -466,8 +466,7 @@ GENE SCANNER
 	if(target.surgeries.len)
 		var/list/render_list = "<span class='boldannounce ml-1'>The patient is undergoing the following surgeries:</span><br>"
 		for(var/datum/surgery/procedure in target.surgeries)
-			render_list += "<span class='notice ml-1'>[capitalize(parse_zone(procedure.location))]:<br>"
-			render_list += "[capitalize(procedure.name)]: "
+			render_list += "<span class='notice ml-1'>[capitalize(procedure.name)] ([capitalize(parse_zone(procedure.location))]): "
 			var/datum/surgery_step/surgery_step = procedure.get_surgery_step()
 			var/chems_needed = surgery_step.get_chem_list()
 			var/alternative_step

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -466,7 +466,8 @@ GENE SCANNER
 	if(target.surgeries.len)
 		var/list/render_list = "<span class='boldannounce ml-1'>The patient is undergoing the following surgeries:</span><br>"
 		for(var/datum/surgery/procedure in target.surgeries)
-			render_list += "<span class='notice ml-1'>[capitalize(procedure.name)]: "
+			render_list += "<span class='notice ml-1'>[capitalize(parse_zone(procedure.location))]:<br>"
+			render_list += "[capitalize(procedure.name)]: "
 			var/datum/surgery_step/surgery_step = procedure.get_surgery_step()
 			var/chems_needed = surgery_step.get_chem_list()
 			var/alternative_step

--- a/code/game/objects/items/melee/plasma_cutter.dm
+++ b/code/game/objects/items/melee/plasma_cutter.dm
@@ -52,6 +52,7 @@
 /obj/item/plasmacutter/examine(mob/user)
 	. = ..()
 	. += span_notice("You can <b>Control+Click</b> the plasmacutter to change its mode. It is currently set to <b>[powered ? tool_behaviour : "off"]</b>")
+	. += span_notice("The plasma cutter can be turned [powered ? "off" : "on"] by using <b>Unique Action (default space)</b> while held in two hands.")
 
 /obj/item/plasmacutter/CtrlClick(mob/user)
 	. = ..()

--- a/code/game/objects/items/melee/plasma_cutter.dm
+++ b/code/game/objects/items/melee/plasma_cutter.dm
@@ -52,7 +52,6 @@
 /obj/item/plasmacutter/examine(mob/user)
 	. = ..()
 	. += span_notice("You can <b>Control+Click</b> the plasmacutter to change its mode. It is currently set to <b>[powered ? tool_behaviour : "off"]</b>")
-	. += span_notice("The plasma cutter can be turned [powered ? "off" : "on"] by using <b>Unique Action (default space)</b> while held in two hands.")
 
 /obj/item/plasmacutter/CtrlClick(mob/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_press.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_press.dm
@@ -31,8 +31,8 @@
 
 /obj/machinery/chem_press/examine(mob/user)
 	. = ..()
-	. += span_notice("There's a <b>small screw</b> that can <b>help</b> to adjust the pill size.")
-	. += span_notice("There's a small dial you could <b>push</b> with a <b>screwdriver</b> to adjust the pill color.")
+	. += span_notice("Left click with a <b>screwdriver</b> to adjust the pill size.")
+	. += span_notice("Right click with a <b>screwdriver</b> to adjust the pill color.")
 	if(!bottle)
 		. += span_notice("The <b>pill bottle</b> slot is empty.")
 	if(!beaker)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Surgery scanner now tells you the body zone of each surgery.
Pill press is more clear about what you need to do to it.

## Why It's Good For The Game

We love tooltips yes we do, tooltips for me and tooltips for you

## Changelog

:cl: cablefish
add: Surgery scanner tells you the surgery body zones now
spellcheck: Pill press tooltip is now more clear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
