### PR TITLE
Fancy coffeemaker no longer takes cartridges, which it can't use

### DIFF
--- a/code/modules/food_and_drinks/coffee/machine/impressa.dm
+++ b/code/modules/food_and_drinks/coffee/machine/impressa.dm
@@ -112,6 +112,10 @@
 	if(panel_open) //Can't insert objects when its screwed open
 		return TRUE
 
+	if(istype(attack_item, /obj/item/coffee_cartridge) && !(attack_item.item_flags & ABSTRACT))
+		balloon_alert(user, "this doesn't take cartridges!")
+		return TRUE
+
 	if(istype(attack_item, /obj/item/reagent_containers/glass/coffeepot) && !(attack_item.item_flags & ABSTRACT) && attack_item.is_open_container())
 		var/obj/item/reagent_containers/glass/coffeepot/new_pot = attack_item
 		if(!user.transferItemToLoc(new_pot, src))


### PR DESCRIPTION
## About The Pull Request

Fixes being able to put cartridges into the fancy coffee maker, which cannot use them

## Why It's Good For The Game

au au au au au au au au au au au

## Changelog

:cl: cablefish
fix: You can no longer put coffee cartridges into the fancy coffee maker, which cannot use them.
/:cl: