### PR TITLE
Removes Access Restrictions from Tesla Lab Doors

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_tesla_lab.dmm
@@ -4374,7 +4374,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/grunge{
 	dir = 4;
-	req_access = list(19);
 	name = "Office"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5721,7 +5720,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	req_access = list(19);
 	name = "Recycling"
 	},
 /obj/effect/mapping_helpers/airlock/sealed,
@@ -9744,7 +9742,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/grunge{
-	req_access = list(19);
 	name = "Office"
 	},
 /turf/open/floor/plasteel/tech,
@@ -11762,7 +11759,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/grunge{
-	req_access = list(3);
 	name = "Armory"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,


### PR DESCRIPTION
## Why It's Good For The Game

It's bad design in 26, and largely not present in most ruins nowadays

## Changelog

:cl:
del: Removed access restrictions from the doors in tesla lab
/:cl: