### PR TITLE
Removes Strafing from Melee Pirate Mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/clip.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/clip.dm
@@ -11,7 +11,6 @@
 	faction = list(FACTION_ANTAG_DEFECTORS)
 	loot = list()
 	check_friendly_fire = TRUE
-	dodging = TRUE
 	rapid_melee = 2
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/ramzi
 

--- a/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/frontiersman.dm
@@ -13,7 +13,6 @@
 	footstep_type = FOOTSTEP_MOB_SHOE
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/frontier
 	r_hand = /obj/item/melee/knife/survival
-	dodging = TRUE
 
 /mob/living/simple_animal/hostile/human/frontier/civilian
 	name = "Frontiersman Doorguard"
@@ -45,7 +44,6 @@
 	armour_penetration = 20
 	r_hand = /obj/item/melee/trench_club
 	sharpness = SHARP_NONE
-	dodging = TRUE
 
 /mob/living/simple_animal/hostile/human/frontier/mace/internals
 	icon_state = "frontiersmanmelee_mask"
@@ -65,7 +63,6 @@
 	l_hand = /obj/item/brass_knuckles
 	r_hand = null
 	sharpness = SHARP_NONE
-	dodging = TRUE
 
 /mob/living/simple_animal/hostile/human/frontier/junkie/internals
 	icon_state = "frontiersmanmelee_mask"

--- a/code/modules/mob/living/simple_animal/hostile/human/solgov.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/solgov.dm
@@ -16,4 +16,3 @@
 	footstep_type = FOOTSTEP_MOB_SHOE
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/solgov/sonnensoldner
 	l_hand = /obj/item/melee/duelenergy/halberd
-	dodging = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -18,7 +18,6 @@
 	faction = list(FACTION_RAMZI)
 	loot = list()
 	check_friendly_fire = TRUE
-	dodging = TRUE
 	rapid_melee = 2
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/ramzi
 

--- a/code/modules/mob/living/simple_animal/hostile/human/warra.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/warra.dm
@@ -11,7 +11,6 @@
 	faction = list(ROLE_DEATHSQUAD)
 	check_friendly_fire = TRUE
 	loot = list()
-	dodging = TRUE
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/vigilitas_private
 	armor_base = /obj/item/clothing/suit/armor/warra
 


### PR DESCRIPTION
## About The Pull Request

Removes the dodge strafing that melee pirate mobs do

## Why It's Good For The Game

Players can't move like them. Feels immersion breaking to have every guy with a shank pulling the Rust crackhead melee moves (which actually slows you down if you do diagonal move as a player) and keeping the same speed

## Changelog

:cl:
balance: Pirate melee mobs no longer strafe
/:cl: