### PR TITLE
Fixes Space Tiles on Fractus

### DIFF
--- a/_maps/shuttles/cybersun/cybersun_fractus.dmm
+++ b/_maps/shuttles/cybersun/cybersun_fractus.dmm
@@ -3603,15 +3603,6 @@
 "ND" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/security/armory)
-"NU" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "zbridge"
-	},
-/turf/open/space/basic,
-/area/ship/bridge)
 "Oa" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable/cyan{
@@ -4497,15 +4488,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/hallway/central)
-"Zn" = (
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "zbridge"
-	},
-/turf/open/space/basic,
-/area/space)
 "Zq" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8;
@@ -5349,14 +5331,14 @@ qI
 qI
 qI
 qI
-Zn
-NU
+ud
+ud
 om
 rb
 CD
 rd
 Qg
-NU
+ud
 ud
 qI
 qI


### PR DESCRIPTION
## Why It's Good For The Game

Seems Baseball's fixes didn't commit properly. Fixes bad turfs in the bridge

## Changelog

:cl:
fix: Fractus no longer has space tiles
/:cl:

