### PR TITLE
Shell Casings no longer trip landmines

### DIFF
--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -115,7 +115,7 @@
 
 /// Can this mine trigger on the passed movable?
 /obj/item/mine/proc/can_trigger(atom/movable/on_who)
-	if(triggered || !isturf(loc) || !armed || iseffect(on_who) || istype(on_who, /obj/item/mine))
+	if(triggered || !isturf(loc) || !armed || iseffect(on_who) || istype(on_who, /obj/item/ammo_casing)|| istype(on_who, /obj/item/mine))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -115,8 +115,13 @@
 
 /// Can this mine trigger on the passed movable?
 /obj/item/mine/proc/can_trigger(atom/movable/on_who)
-	if(triggered || !isturf(loc) || !armed || iseffect(on_who) || istype(on_who, /obj/item/ammo_casing)|| istype(on_who, /obj/item/mine))
+
+	if(triggered || !isturf(loc) || !armed || iseffect(on_who) || istype(on_who, /obj/item/mine))
 		return FALSE
+	if isitem(on_who)
+		var/obj/item/stupidthing = on_who
+		if(stupidthing.w_class < WEIGHT_CLASS_NORMAL)
+			return FALSE
 	return TRUE
 
 /// When something sets off a mine

--- a/code/game/objects/items/devices/mines.dm
+++ b/code/game/objects/items/devices/mines.dm
@@ -120,7 +120,7 @@
 		return FALSE
 	if isitem(on_who)
 		var/obj/item/stupidthing = on_who
-		if(stupidthing.w_class < WEIGHT_CLASS_NORMAL)
+		if(stupidthing.w_class < WEIGHT_CLASS_SMALL)
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
Shell casings no longer trip landmines.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Shell casings setting off nearby landmines is really frustrating + illogical (landmines usually require some degree of pressure, not just a shell casing bouncing off it) + it killed me in round so I have to nerf it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Shell casings cannot set of landmines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
