### PR TITLE
Removes the ability for vending machines to advertise + Vending machines can have language now

### DIFF
--- a/code/modules/ruins/lavalandruin_code/syndicate_base.dm
+++ b/code/modules/ruins/lavalandruin_code/syndicate_base.dm
@@ -17,5 +17,4 @@
 		/obj/item/grenade/chem_grenade/cryo = 5,
 		/obj/item/grenade/chem_grenade/adv_release = 5
 	)
-	product_slogans = "It's not pyromania if you're getting paid!;You smell that? Plasma, son. Nothing else in the world smells like that.;I love the smell of Plasma in the morning."
 	resistance_flags = FIRE_PROOF

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -861,7 +861,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(!message)
 		return
 
-	say(message,FALSE,(),TRUE,speak_in)
+	say(message,FALSE,null,TRUE,speak_in)
 
 /obj/machinery/vending/power_change()
 	. = ..()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -74,6 +74,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/forcecrit = 0
 	var/num_shards = 7
 	var/list/pinned_mobs = list()
+	//What language do we use when speaking? Default is common, but you should be able to change this for clipships and such.
+	var/speak_in = /datum/language/galactic_common
 
 	/**
 	* List of products this machine sells
@@ -96,8 +98,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	*/
 	var/list/premium 	= list()
 
-	///String of slogans separated by semicolons, optional
-	var/product_slogans = ""
 	///String of small ad messages in the vending screen - random chance
 	var/product_ads = ""
 
@@ -189,8 +189,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 	if(restock_hourly)
 		addtimer(CALLBACK(src, PROC_REF(refill_inventory_full)), 60 MINUTES, TIMER_STOPPABLE|TIMER_LOOP|TIMER_DELETE_ME)
-
-	slogan_list = splittext(product_slogans, ";")
 	// So not all machines speak at the exact same time.
 	// The first time this machine says something will be at slogantime + this random value,
 	// so if slogantime is 10 minutes, it will say it at somewhere between 10 and 20 minutes after the machine is crated.
@@ -847,12 +845,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)
 		seconds_electrified--
 
-	//Pitch to the people!  Really sell it!
-	if(last_slogan + slogan_delay <= world.time && slogan_list.len > 0 && !shut_up && SPT_PROB(2.5, seconds_per_tick))
-		var/slogan = pick(slogan_list)
-		speak(slogan)
-		last_slogan = world.time
-
 	if(shoot_inventory && SPT_PROB(shoot_inventory_chance, seconds_per_tick))
 		throw_item()
 /**
@@ -869,7 +861,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(!message)
 		return
 
-	say(message, language=/datum/language/galactic_common)
+	say(message, speak_in)
 
 /obj/machinery/vending/power_change()
 	. = ..()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -781,7 +781,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				message_admins("Vending machine exploit attempted by [ADMIN_LOOKUPFLW(usr)]!")
 				return
 			if (R.amount <= 0 && R.max_amount >= 0)
-				say("Sold out of [R.name].")
+				speak("Sold out of [R.name].")
 				flick(icon_deny,src)
 				vend_ready = TRUE
 				return
@@ -790,18 +790,18 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				var/obj/item/card/bank/C = H.get_bankcard()
 
 				if(!C)
-					say("No card found.")
+					speak("No card found.")
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return
 				else if (!C.registered_account && !mining_point_vendor)
-					say("No account found.")
+					speak("No account found.")
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return
 				if(mining_point_vendor)
 					if(price_to_use > C.mining_points)
-						say("You do not possess the funds to purchase [R.name].")
+						speak("You do not possess the funds to purchase [R.name].")
 						flick(icon_deny,src)
 						vend_ready = TRUE
 						return
@@ -811,7 +811,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					if(coin_records.Find(R) || hidden_records.Find(R))
 						price_to_use = R.custom_premium_price ? R.custom_premium_price : extra_price
 					if(price_to_use && !account.has_money(price_to_use))
-						say("You do not possess the funds to purchase [R.name].")
+						speak("You do not possess the funds to purchase [R.name].")
 						flick(icon_deny,src)
 						vend_ready = TRUE
 						return
@@ -819,7 +819,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					SSblackbox.record_feedback("amount", "vending_spent", price_to_use)
 					log_econ("[price_to_use] credits were inserted into [src] by [H] to buy [R].")
 			if(last_shopper != REF(usr) || purchase_message_cooldown < world.time)
-				say("Thank you for shopping with [src]!")
+				speak("Thank you for shopping with [src]!")
 				purchase_message_cooldown = world.time + 5 SECONDS
 				last_shopper = REF(usr)
 			use_power(5)
@@ -861,7 +861,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(!message)
 		return
 
-	say(message, speak_in)
+	say(message,FALSE,(),TRUE,speak_in)
 
 /obj/machinery/vending/power_change()
 	. = ..()
@@ -967,10 +967,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 /obj/machinery/vending/custom/canLoadItem(obj/item/I, mob/user)
 	. = FALSE
 	if(loaded_items >= max_loaded_items)
-		say("There are too many items in stock.")
+		speak("There are too many items in stock.")
 		return
 	if(istype(I, /obj/item/stack))
-		say("Loose items may cause problems, try use it inside wrapping paper.")
+		speak("Loose items may cause problems, try use it inside wrapping paper.")
 		return
 	if(I.custom_price)
 		return TRUE
@@ -1019,12 +1019,12 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				var/obj/item/card/bank/C = H.get_bankcard()
 
 				if(!C)
-					say("No card found.")
+					speak("No card found.")
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return
 				else if (!C.registered_account)
-					say("No account found.")
+					speak("No account found.")
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return
@@ -1056,14 +1056,14 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 						loaded_items--
 						use_power(5)
 						if(last_shopper != REF(usr) || purchase_message_cooldown < world.time)
-							say("Thank you for buying local and purchasing [S]!")
+							speak("Thank you for buying local and purchasing [S]!")
 							purchase_message_cooldown = world.time + 5 SECONDS
 							last_shopper = REF(usr)
 						vend_ready = TRUE
 						updateUsrDialog()
 						return
 					else
-						say("You do not possess the funds to purchase this.")
+						speak("You do not possess the funds to purchase this.")
 			vend_ready = TRUE
 
 /obj/machinery/vending/custom/attackby(obj/item/I, mob/user, params)
@@ -1075,7 +1075,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			C = H.get_bankcard(TRUE)
 			if(C?.registered_account)
 				private_a = C.registered_account
-				say("\The [src] has been linked to [C].")
+				speak("\The [src] has been linked to [C].")
 
 	if(compartmentLoadAccessCheck(user))
 		if(istype(I, /obj/item/pen))

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -4,7 +4,6 @@
 	icon_state = "theater"
 	icon_deny = "theater-deny"
 	req_access = list(ACCESS_THEATRE)
-	product_slogans = "Dress for success!;Suited and booted!;It's show time!;Why leave style up to fate? Use AutoDrobe!"
 	vend_reply = "Thank you for using AutoDrobe!"
 	products = list(
 		/obj/item/clothing/under/costume/gladiator = 1,

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -76,7 +76,6 @@
 		/obj/item/reagent_containers/food/drinks/bottle/champagne = 5,
 		/obj/item/reagent_containers/food/drinks/bottle/trappist = 5)
 
-	product_slogans = "I hope nobody asks me for a cup of tea...;Alcohol is everyone's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty 'round this sector?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is everyone's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 53 FSC!;Award-winning wine!;Maximum alcohol!;Everyone loves beer.;A toast for progress!"
 	req_access = list(ACCESS_BAR)
 	refill_canister = /obj/item/vending_refill/boozeomat

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -2,7 +2,6 @@
 /obj/machinery/vending/cart
 	name = "\improper PTech"
 	desc = "Cartridges for PDAs."
-	product_slogans = "Carts to go!"
 	icon_state = "cart"
 	icon_deny = "cart-deny"
 	products = list(/obj/item/cartridge/medical = 10,

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/cigarette
 	name = "\improper ShadyCigs Deluxe"
 	desc = "If you want to get cancer, might as well do it in style."
-	product_slogans = "Space cigs taste good like a cigarette should.;I'd rather die than switch.;Smoke!;Don't believe the reports - smoke today!"
 	product_ads = "Probably not bad for you!;Don't believe the scientists!;It's good for you!;Don't quit, buy more!;Smoke!;Nicotine heaven.;Best cigarettes since 150 FSC.;Award-winning cigs."
 	icon_state = "cigs"
 	products = list(
@@ -44,7 +43,6 @@
 	name = "\improper ShadyCigs Ultra"
 	desc = "Now with extra premium products!"
 	product_ads = "Probably not bad for you!;Dope will get you through times of no money better than money will get you through times of no dope!;It's good for you!"
-	product_slogans = "Turn on, tune in, drop out!;Better living through chemistry!;Toke!;Don't forget to keep a smile on your lips and a song in your heart!"
 	products = list(
 		/obj/item/storage/fancy/cigarettes = 5,
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,

--- a/code/modules/vending/classicbeats.dm
+++ b/code/modules/vending/classicbeats.dm
@@ -3,7 +3,6 @@
 	desc = "music."
 	icon_state = "classicbeats"
 	icon_deny = "engi-deny"
-	product_slogans = "Now you too can be the master of the rumba beat!"
 	product_ads = "Chick-Chicky Boom, Chick-Chicky Boom!;Take a lesson from Cuban Pete!;It's very nice, So full of spice!;Singin' a song, All the day long!"
 	vend_reply = "Thank you for choosing Cuban Pete's"
 	light_color = LIGHT_COLOR_SLIME_LAMP

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -4,7 +4,6 @@
 	desc = "A vending machine for clothing."
 	icon_state = "clothes"
 	icon_deny = "clothes-deny"
-	product_slogans = "Dress for success!;Prepare to look swagalicious!;Look at all this swag!;Why leave style up to fate? Use the ClothesMate!"
 	vend_reply = "Thank you for using the ClothesMate!"
 	products = list(
 		/obj/item/storage/backpack = 4,

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -3,7 +3,6 @@
 	name = "\improper RobustMore Softdrinks"
 	desc = "A softdrink vendor provided by RobustMore DrinkFoods Industries, LLC."
 	icon_state = "Cola_Machine"
-	product_slogans = "RobustMore Softdrinks: More robust than a toolbox to the head!"
 	product_ads = "Refreshing!;Hope you're thirsty!;Over 10 trillion drinks sold!;Thirsty? Why not cola?;Please, have a drink!;Drink up!;The best drinks this side of the galaxy."
 	products = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/cola = 10,
@@ -42,7 +41,6 @@
 	icon_state = "red_cola"
 	name = "\improper Master Cola Vendor"
 	desc = "This vending machine offers Master Cola. Master Cola - have a drink from the past!"
-	product_slogans = "Master Cola - have a drink from the past!"
 	light_mask = "red_cola-light-mask"
 	light_color = COLOR_DARK_RED
 
@@ -50,7 +48,6 @@
 	icon_state = "space_up"
 	name = "\improper Space-up! Vendor"
 	desc = "Indulge in an explosion of flavor."
-	product_slogans = "Space-up! Like a hull breach in your mouth."
 	light_mask = "space_up-light-mask"
 	light_color = COLOR_DARK_MODERATE_LIME_GREEN
 
@@ -58,7 +55,6 @@
 	icon_state = "starkist"
 	name = "\improper Lunapunch Vendor"
 	desc = "What keeps the colonies running - Lunapunch."
-	product_slogans = "The Colonies run on Lunapunch!"
 	light_mask = "starkist-light-mask"
 	light_color = COLOR_LIGHT_ORANGE
 
@@ -71,7 +67,6 @@
 	icon_state = "pwr_game"
 	name = "\improper PAC-Fuel Vendor"
 	desc = "PAC-Fuel: stay flying straight. Enter the code on every can for a chance to win gamer merch or industrial equipment!"
-	product_slogans = "Keep flying steady with PAC-Fuel!"
 	light_mask = "pwr_game-light-mask"
 	light_color = COLOR_STRONG_VIOLET
 
@@ -89,7 +84,6 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/orange_soda = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry = 10,
 		/obj/item/reagent_containers/food/drinks/soda_cans/shoal_punch = 10)
-	product_slogans = "Every fruit you could want, at your beak! Shoal Punch!"
 	product_ads = "Every fruit you could want, at your beak!;Don't go flying dry!;Over two trillion served!;Thirsty? Get punched!;Skrikira trikxti skrmikr rakti!;Don't go dry, get Shoal Punch."
 	light_mask = "shamblers-light-mask"
 	light_color = COLOR_MOSTLY_PURE_PINK

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -2,7 +2,6 @@
 	name = "\improper Syndicate Toy Gun Vendor"
 	desc = "An ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
 	icon_state = "syndi"
-	product_slogans = "Get your cool toys today!;Quality toy weapons for cheap prices!"
 	product_ads = "Feel tough with your toys!;Express your inner child today!;Toy weapons don't kill people, but boredom does!;Who needs responsibilities when you have toy weapons?;Make your next foam fight FUN!"
 	vend_reply = "Come back for more!"
 	circuit = /obj/item/circuitboard/machine/vending/syndicatedonksofttoyvendor

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/hydroseeds
 	name = "\improper MegaSeed Servitor"
 	desc = "When you need seeds fast!"
-	product_slogans = "THIS'S WHERE TH' SEEDS LIVE! GIT YOU SOME!;Hands down the best seed selection this side 'o saturn!;Also certain mushroom varieties available, more for experts! Get certified today!"
 	product_ads = "We like plants!;Grow some crops!;Grow, baby, growww!;Aw h'yeah son!"
 	icon_state = "seeds"
 	light_mask = "seeds-light-mask"

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/hydronutrients
 	name = "\improper NutriMax"
 	desc = "A plant nutrients vendor."
-	product_slogans = "Aren't you glad you don't have to fertilize the natural way?;Now with 50% less stink!;Plants are people too!"
 	product_ads = "We like plants!;Don't you want some?;The greenest thumbs ever.;We like big plants.;Soft soil..."
 	icon_state = "nutri"
 	icon_deny = "nutri-deny"

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/snack
 	name = "\improper Getmore Chocolate Corp"
 	desc = "A snack machine courtesy of the RobustMore DrinkFoods LLC."
-	product_slogans = "Try our new nougat bar!;Twice the calories for half the price!"
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Have a snack.;Snacks are good for you!;Have something better! Get RobustMore!;Best quality snacks!;We love chocolate!;Try our new jerky!"
 	icon_state = "snack"
 	light_mask = "snack-light-mask"

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/sustenance
 	name = "\improper Sustenance Vendor"
 	desc = "A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement."
-	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor."
 	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Even prisoners deserve their daily bread!;Have some more candy corn!;Try our new ice cups!"
 	light_mask = "snack-light-mask"
 	icon_state = "sustenance"

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -2,7 +2,6 @@
 	name = "\improper Toy Gun Vendor"
 	desc = "Ages 8 and up approved vendor that dispenses toys."
 	icon_state = "nt-donk"
-	product_slogans = "Get your cool toys today!;Quality toy weapons for cheap prices!"
 	product_ads = "Feel tough with your toys!;Express your inner child today!;Toy weapons don't kill people, but bordeom does!;Who needs responsibilities when you have toy weapons?;Make your next foam fight FUN!"
 	vend_reply = "Come back for more!"
 	light_mask = "donksoft-light-mask"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A constant barrage of stationesque "jokes" gets very annoying. There is already a lot going on in the chat box, we don't need to waste chat space with "don't believe the reports! Smoke today!" Also more language is good, clipships can have League Zohillian speaking vendors.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

del: Ship vending machines recognize that they are objects and have no right to speak unless spoken to. (Some outpost vending machines can still talk)
add: Vending machines can now speak more than galactic common (only when spoken to first)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
