### PR TITLE
Fixes Vortex Anomalies Destroying Themselves

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_vortex.dm
+++ b/code/game/objects/effects/anomalies/anomalies_vortex.dm
@@ -63,6 +63,9 @@
 			if(EXPLODE_LIGHT)
 				SSexplosions.lowturf += T
 
+/obj/effect/anomaly/vortex/ex_act(severity, target)
+	return FALSE // to prevent blowing oneself up
+
 /obj/effect/anomaly/vortex/planetary
 	immortal = TRUE
 	immobile = TRUE

--- a/code/game/objects/effects/spawners/random/anomaly.dm
+++ b/code/game/objects/effects/spawners/random/anomaly.dm
@@ -7,7 +7,6 @@
 		/obj/effect/anomaly/grav/planetary,
 		/obj/effect/anomaly/hallucination/planetary,
 		/obj/effect/anomaly/pyro/planetary,
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/grav/high/planetary,
 		/obj/effect/anomaly/heartbeat/planetary,
 		/obj/effect/anomaly/sparkler/planetary,
@@ -36,7 +35,6 @@
 		/obj/effect/anomaly/bluespace/planetary,
 		/obj/effect/anomaly/flux/planetary,
 		/obj/effect/anomaly/grav/planetary,
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/grav/high/planetary,
 		/obj/effect/anomaly/heartbeat/planetary,
 		/obj/effect/anomaly/tvstatic/planetary,
@@ -129,7 +127,6 @@
 		/obj/effect/anomaly/grav/planetary,
 		/obj/effect/anomaly/hallucination/planetary,
 		/obj/effect/anomaly/pyro/planetary,
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/grav/high/planetary,
 		/obj/effect/anomaly/heartbeat/planetary,
 		/obj/effect/anomaly/sparkler/planetary,
@@ -161,7 +158,6 @@
 		/obj/effect/anomaly/grav/planetary,
 		/obj/effect/anomaly/hallucination/planetary,
 		/obj/effect/anomaly/pyro/planetary,
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/plasmasoul/planetary,
 	)
 
@@ -179,7 +175,6 @@
 		/obj/effect/anomaly/bluespace/planetary,
 		/obj/effect/anomaly/grav/planetary,
 		/obj/effect/anomaly/hallucination/planetary,
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/grav/high/planetary,
 		/obj/effect/anomaly/plasmasoul/planetary,
 		/obj/effect/anomaly/phantom/planetary,
@@ -196,7 +191,6 @@
 /obj/effect/spawner/random/anomaly/waste
 	name = "Waste anomaly spawner"
 	loot = list(
-		/obj/effect/anomaly/vortex/planetary,
 		/obj/effect/anomaly/heartbeat/planetary,
 		/obj/effect/anomaly/veins/planetary,
 		/obj/effect/anomaly/plasmasoul/planetary,


### PR DESCRIPTION
## About The Pull Request

Did you know? Vortex anomalies are actually supposed to spawn on several planets, but were never seen because as soon as they hit themselves with a devastation-tier explosion (inevitable) they are destroyed!

You will not see them however as this also removes vortex anomalies from the planetary pool since they do evil things to turfs at the moment.

## Why It's Good For The Game

<img width="400" height="681" alt="image" src="https://github.com/user-attachments/assets/1e38bc24-1a06-40bd-9430-932a860c6207" />


## Changelog

:cl: cablefish
fix: Vortex anomalies no longer near-instantly delete themselves.
/:cl:
