### PR TITLE
Craftable Dynamite and Polymer Survival Rifle

### DIFF
--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -75,7 +75,7 @@
 
 /datum/crafting_recipe/improvised_rifle
 	name = "Improvised Rifle"
-	result = /obj/item/gun/ballistic/rifle/polymer
+	result = /obj/item/gun/ballistic/rifle/polymer/empty
 	reqs = list(/obj/item/weaponcrafting/receiver = 1,
 				/obj/item/pipe = 1,
 				/obj/item/weaponcrafting/stock = 1,

--- a/code/datums/components/crafting/recipes/weapon.dm
+++ b/code/datums/components/crafting/recipes/weapon.dm
@@ -73,6 +73,18 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/improvised_rifle
+	name = "Improvised Rifle"
+	result = /obj/item/gun/ballistic/rifle/polymer
+	reqs = list(/obj/item/weaponcrafting/receiver = 1,
+				/obj/item/pipe = 1,
+				/obj/item/weaponcrafting/stock = 1,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 100
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/spear
 	name = "Spear"
 	result = /obj/item/melee/spear
@@ -106,6 +118,18 @@
 		/obj/item/grenade/chem_grenade = 2
 	)
 	parts = list(/obj/item/stock_parts/matter_bin = 1, /obj/item/grenade/chem_grenade = 2)
+	time = 50
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/dynamite
+	name = "Dynamite"
+	result = /obj/item/grenade/firecracker/dynamite
+	reqs = list(
+		/datum/reagent/gunpowder = 50,
+		/obj/item/paper = 4,
+		/obj/item/stack/cable_coil = 5
+	)
 	time = 50
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -98,3 +98,5 @@
 	)
 	can_be_sawn_off = FALSE
 	manufacturer = MANUFACTURER_NONE
+
+EMPTY_GUN_HELPER(rifle/polymer)


### PR DESCRIPTION
## About The Pull Request

Dynamite:
50 gunpowder
4 paper
5 cable

Improvised Rifle
1 receiver
1 stock
5 metal
1 pipe

## Why It's Good For The Game

Aware gunpowder has a stronger explosive just reacting normally at the same amount needed for dynamite but this is just a much easier application for it. Scraprifle also should have been craftable for a while

## Changelog

:cl:
add: You can now craft the Polymer Survival Rifle and Dynamite
/:cl:
