### PR TITLE
Removes the hide hair flag from wigs.

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -142,7 +142,6 @@
 	icon_state = "hair_vlong"
 	mob_overlay_icon = 'icons/mob/human_face.dmi'
 	item_state = "pwig"
-	flags_inv = HIDEHAIR
 	slot_flags = ITEM_SLOT_HEAD | ITEM_SLOT_NECK
 	color = "#000000"
 	var/hairstyle = "Very Long Hair"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For reasons I cannot discern despite it being FINE for AGES before this wearing a wig as a sarathi will randomly remove your ears. I would simply figure out why it does that (completely at random, there is no consistency it just randomly removes them any time you put something on or take something off) and fix it that way but I am not a coder. I am barely even an admin. Regardless I find the idea of having two simultaneous fuckass hairstyles to be amusing so it's not like we're losing anything by changing it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<img width="165" height="163" alt="2026-09-01_18-40-00" src="https://github.com/user-attachments/assets/0aa1ba29-7372-4d41-871a-56ab14953335" /> 
<img width="98" height="128" alt="image" src="https://github.com/user-attachments/assets/483e42ee-9f19-45c1-84d4-0f3689be8e7e" />


MY FUCKING EARSSSSSSSSSSS
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Wearing a wig will no longer send your beautiful srothi ears on an all expense paid vacation to some zohilan pocket dimension. You can also wear a wig on top of your hair now, if you want to look really stupid. I guess.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
