### PR TITLE
Replaces Sharplite SMG with Clover SMG on the Riggs

### DIFF
--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -2882,13 +2882,13 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/stock_parts/cell/gun/sharplite/empty{
-	pixel_x = 11;
-	pixel_y = 6
+/obj/item/stock_parts/cell/gun/mini{
+	pixel_x = 8;
+	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/gun/sharplite/empty{
-	pixel_x = 9;
-	pixel_y = -3
+/obj/item/stock_parts/cell/gun/mini{
+	pixel_x = 8;
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
@@ -3845,9 +3845,9 @@
 	pixel_x = -4;
 	pixel_y = 0
 	},
-/obj/item/gun/energy/sharplite/rush{
-	pixel_x = -1;
-	pixel_y = 7
+/obj/item/gun/energy/clover{
+	pixel_x = 0;
+	pixel_y = 8
 	},
 /obj/item/gun/ballistic/shotgun/flamingarrow/presawn/empty{
 	pixel_x = 0;
@@ -6905,7 +6905,7 @@
 /obj/item/clothing/under/shorts/explorer,
 /obj/item/clothing/suit/toggle/hazard,
 /obj/item/clothing/suit/toggle/chorejacket,
-/obj/structure/sign/poster/radio/icf{
+/obj/structure/sign/poster/radio/random{
 	pixel_x = 0;
 	pixel_y = -32
 	},
@@ -7671,8 +7671,8 @@
 /area/ship/cargo)
 "Uf" = (
 /obj/machinery/holopad/emergency/command,
-/obj/effect/turf_decal/box{
-	light_color = "#60869b"
+/obj/effect/turf_decal/box/white{
+	color = "#2270d0"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/bridge)


### PR DESCRIPTION
## About The Pull Request
I meant for the Riggs to have a clover smg for shiggles and to have a ship with a roundstart clover gun for flavor. Also changed some decals to not look awful.

## Why It's Good For The Game
roundstart clover gun is pretty cool

## Changelog
🆑
add: roundstart clover SMG
del: removed roundstart sharplite SMG
/:cl: