### PR TITLE
adds gun glunking

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/human.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/human.dm
@@ -94,20 +94,7 @@
 		dropped_gun.actually_shoots = FALSE
 		dropped_gun.desc += span_warning("\nIt appears to be irreparably broken.")
 		// broken overlay
-		var/index = "[REF(initial(dropped_gun.icon))]-[initial(dropped_gun.icon_state)]"
-		var/static/list/scuff_cache = list()
-		var/icon/scuff = scuff_cache[index]
-		if(!scuff) // we only need to generate each scuff overlay once
-			scuff = icon(initial(dropped_gun.icon), initial(dropped_gun.icon_state))
-			var/icon/temp = icon('icons/effects/item_damage.dmi', "itemdamaged")
-			temp.Scale(64, 32)
-			temp.Shift(EAST, 32) // we put two side by side so it fits on guns
-			temp.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_OVERLAY)
-			scuff.Blend("#fff", ICON_ADD)
-			scuff.Blend(temp, ICON_MULTIPLY)
-			scuff_cache[index] = scuff
-		var/mutable_appearance/scuff_instance = new(scuff)
-		dropped_gun.add_overlay(scuff_instance)
+		dropped_gun.glunkify()
 
 	// BALLISTICS - apply wear, mag drop chance, and empty the mag partially
 	if(istype(dropped_gun, /obj/item/gun/ballistic))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -35,6 +35,7 @@
 
 	// FIRING //
 	var/actually_shoots = TRUE // is this gun real and not a dud
+	var/glunked = FALSE //controls whether the gun gets a glunked overlay. separate from actually_shoots.
 	var/fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
 	var/vary_fire_sound = TRUE
 	var/fire_sound_volume = 50
@@ -166,6 +167,27 @@
 	build_firemodes()
 	if(slot_flags & ITEM_SLOT_SUITSTORE)
 		ADD_TRAIT(src, TRAIT_FORCE_SUIT_STORAGE, REF(src))
+
+	if(glunked && !actually_shoots)
+		desc += span_warning("\nIt appears to be irreparably broken.")
+	else
+		desc += span_warning("\nIt appears to be extremely worn down.")
+
+	if(glunked)
+		var/index = "[REF(initial(icon))]-[initial(icon_state)]"
+		var/static/list/scuff_cache = list()
+		var/icon/scuff = scuff_cache[index]
+		if(!scuff) // we only need to generate each scuff overlay once
+			scuff = icon(initial(icon), initial(icon_state))
+			var/icon/temp = icon('icons/effects/item_damage.dmi', "itemdamaged")
+			temp.Scale(64, 32)
+			temp.Shift(EAST, 32) // we put two side by side so it fits on guns
+			temp.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_OVERLAY)
+			scuff.Blend("#fff", ICON_ADD)
+			scuff.Blend(temp, ICON_MULTIPLY)
+			scuff_cache[index] = scuff
+		var/mutable_appearance/scuff_instance = new(scuff)
+		add_overlay(scuff_instance)
 
 /obj/item/gun/ComponentInitialize()
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -170,24 +170,11 @@
 
 	if(glunked && !actually_shoots)
 		desc += span_warning("\nIt appears to be irreparably broken.")
-	else
+	else if (glunked && actually_shoots)
 		desc += span_warning("\nIt appears to be extremely worn down.")
 
 	if(glunked)
-		var/index = "[REF(initial(icon))]-[initial(icon_state)]"
-		var/static/list/scuff_cache = list()
-		var/icon/scuff = scuff_cache[index]
-		if(!scuff) // we only need to generate each scuff overlay once
-			scuff = icon(initial(icon), initial(icon_state))
-			var/icon/temp = icon('icons/effects/item_damage.dmi', "itemdamaged")
-			temp.Scale(64, 32)
-			temp.Shift(EAST, 32) // we put two side by side so it fits on guns
-			temp.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_OVERLAY)
-			scuff.Blend("#fff", ICON_ADD)
-			scuff.Blend(temp, ICON_MULTIPLY)
-			scuff_cache[index] = scuff
-		var/mutable_appearance/scuff_instance = new(scuff)
-		add_overlay(scuff_instance)
+		glunkify()
 
 /obj/item/gun/ComponentInitialize()
 	. = ..()
@@ -247,6 +234,22 @@
 	if(muzzle_flash)
 		QDEL_NULL(muzzle_flash)
 	return ..()
+
+/obj/item/gun/proc/glunkify()
+	var/index = "[REF(initial(icon))]-[initial(icon_state)]"
+	var/static/list/scuff_cache = list()
+	var/icon/scuff = scuff_cache[index]
+	if(!scuff) // we only need to generate each scuff overlay once
+		scuff = icon(initial(icon), initial(icon_state))
+		var/icon/temp = icon('icons/effects/item_damage.dmi', "itemdamaged")
+		temp.Scale(64, 32)
+		temp.Shift(EAST, 32) // we put two side by side so it fits on guns
+		temp.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_OVERLAY)
+		scuff.Blend("#fff", ICON_ADD)
+		scuff.Blend(temp, ICON_MULTIPLY)
+		scuff_cache[index] = scuff
+	var/mutable_appearance/scuff_instance = new(scuff)
+	add_overlay(scuff_instance)
 
 /obj/item/gun/handle_atom_del(atom/A)
 	if(A == chambered)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a mapload initialize option for guns to give them the overlay that dropped and irreparable weapons get. This option was made separate from the actually_fires variable in order for a slight added bit of granularity in case anyone wanted to make a fucked up looking but functional gun.

## Why It's Good For The Game

Offers another lever for mappers to use

## Changelog

:cl:
add: Adds maploaded gun glunking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
