### PR TITLE
Fixes caseless ammo causing 70,000 runtimes when fired

### DIFF
--- a/code/modules/projectiles/ammunition/_ammo_casing.dm
+++ b/code/modules/projectiles/ammunition/_ammo_casing.dm
@@ -52,6 +52,9 @@
 	///Maximum stack size of ammunition
 	var/stack_size = 15
 
+	///If the caliber is caseless or not
+	var/caseless = FALSE
+
 /obj/item/ammo_casing/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/pen))
 		if(!user.is_literate())
@@ -190,9 +193,11 @@
 	. = ..()
 
 /obj/item/ammo_casing/proc/on_eject(atom/shooter)
-	forceMove(drop_location()) //Eject casing onto ground.
+	if(caseless) //early return for caseless rounds
+		return
 	if(QDELETED(src))
 		return
+	forceMove(drop_location()) //Eject casing onto ground.
 	pixel_x = rand(-4, 4)
 	pixel_y = rand(-4, 4)
 	pixel_z = 8 //bounce time

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -2,6 +2,7 @@
 	desc = "A caseless bullet casing."
 	firing_effect_type = null
 	heavy_metal = FALSE
+	caseless = TRUE
 
 /obj/item/ammo_casing/caseless/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	. = ..()

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -136,6 +136,7 @@
 	pellets = 4
 	firing_effect_type = null
 	heavy_metal = FALSE
+	caseless = TRUE
 
 // so it doesnt drop cases, also apparently every fucking caseless gun runtimes and thats way past my ability
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -384,6 +384,8 @@
 
 // ejects the provided casing from the gun into the world
 /obj/item/gun/ballistic/proc/eject_casing(mob/user, obj/item/ammo_casing/casing)
+	if(casing.caseless) //early return for caseless calibers
+		return
 	casing.forceMove(drop_location())
 	var/angle_of_movement = (rand(-3000, 3000) / 100) + dir2angle(turn(user.dir, 180))
 	casing.AddComponent(/datum/component/movable_physics, _horizontal_velocity = rand(350, 450) / 100, _vertical_velocity = rand(400, 450) / 100, _horizontal_friction = rand(20, 24) / 100, _z_gravity = PHYSICS_GRAV_STANDARD, _z_floor = 0, _angle_of_movement = angle_of_movement, _bounce_sound = casing.bounce_sfx_override)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Caseless ammo calls a forceMove proc, but it gets deleted before the proc can be called, which causes an exception to be thrown. This PR should fix that and prevent runtimes from occurring again due to this.

## Why It's Good For The Game

I think this is the sort of bug that only became evident once caseless ammunition became more widespread in usage. This particular error seems to have been lying dormant for about two years until.

## Changelog

:cl:
fix: fixes caseless ammunition causing runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
