### PR TITLE
fixes gun pointblanks

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -252,8 +252,10 @@
 		zoom(user, user.dir, FALSE) //we can only stay zoomed in if it's in our hands	//yeah and we only unzoom if we're actually zoomed using the gun!!
 
 /obj/item/gun/attack(mob/M as mob, mob/user)
-	if(user.a_intent == INTENT_HARM || !actually_shoots) //Flogging
+	if(user.a_intent == INTENT_DISARM || !actually_shoots) //Flogging
 		return ..()
+	else
+		afterattack(M, user)
 	return
 
 //called after the gun has successfully fired its chambered ammo.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -40,6 +40,7 @@
 	var/fire_sound_volume = 50
 	var/dry_fire_sound = 'sound/weapons/gun/general/dry_fire.ogg'
 	var/dry_fire_text = "click"
+	var/allow_fire = TRUE //temporary variable that switches when attempting to bash an enemy on disarm intent
 
 	// RELOADING //
 	var/obj/item/ammo_casing/chambered = null // round currently chambered
@@ -252,10 +253,8 @@
 		zoom(user, user.dir, FALSE) //we can only stay zoomed in if it's in our hands	//yeah and we only unzoom if we're actually zoomed using the gun!!
 
 /obj/item/gun/attack(mob/M as mob, mob/user)
-	if(user.a_intent == INTENT_DISARM || !actually_shoots) //Flogging
+	if(user.a_intent == INTENT_DISARM || !actually_shoots) //lets you beat up someone without shooting them
 		return ..()
-	else
-		afterattack(M, user)
 	return
 
 //called after the gun has successfully fired its chambered ammo.
@@ -280,6 +279,8 @@
 	return
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
+	if(!allow_fire) //prevents firing the gun when you don't want the gun to fire
+		return
 	if(fire_gun(target, user, flag, params))
 		return TRUE
 	return ..()
@@ -301,7 +302,7 @@
 	if(flag)
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || user.a_intent == INTENT_HARM) //melee attack
+		if(!ismob(target) || user.a_intent == INTENT_DISARM) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -206,7 +206,7 @@
 
 /// Handles weapon condition. Returning TRUE prevents process_chamber from automatically loading a new round
 /obj/item/gun/ballistic/proc/condition_check(from_firing = TRUE, atom/shooter)
-	if(bolt_type == BOLT_TYPE_NO_BOLT || !from_firing || !magazine.ammo_count(FALSE)) //The revolver is one of the most reliable firearms ever designed, as long as you don't need to fire any more than six bullets at something. Which, of course, you do not.
+	if(bolt_type == BOLT_TYPE_NO_BOLT || !from_firing || !magazine?.ammo_count(FALSE)) //The revolver is one of the most reliable firearms ever designed, as long as you don't need to fire any more than six bullets at something. Which, of course, you do not.
 		return FALSE
 	last_jam++
 	if(gun_wear < wear_minor_threshold)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that you can fire point blank into an enemy again instead of just smacking them with your gun. (when on harm intent)

If you do want to smack someone with your gun, you can go into disarm intent, or safety your gun.

This PR also fixes a minor runtime that happens when a gun with a magazine and a bullet in the chamber fires the gun while there's no magazine. The gun tries to pull information for the magazine it's supposed to have for ammo counters, but it assumes there'll always be one (and typically, this is true). The check was changed so now it's only a fuzzy check.

## Why It's Good For The Game

I've seen a lot of frustration expressed when characters smack an enemy instead of shooting them, which happens when the player controlling that character wanted to shoot that enemy instead of hitting them. This should resolve that issue. 

## Changelog

:cl:
fix: fixed being unable to point-blank enemies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
