### PR TITLE
Flaming Arrow Buff

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -57,7 +57,7 @@
 	name = "winchester internal magazine"
 	ammo_type = /obj/item/ammo_casing/c38
 	caliber = ".38"
-	max_ammo = 12
+	max_ammo = 18
 
 /obj/item/ammo_box/magazine/internal/shot/winchester/presawn
 	max_ammo = 7

--- a/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/hunter_pride/ballistics.dm
@@ -806,7 +806,7 @@ EMPTY_GUN_HELPER(rifle/illestren/factory)
 	cartridge_wording = "bullet"
 	can_be_sawn_off = TRUE
 
-	wield_slowdown = RIFLE_SLOWDOWN
+	wield_slowdown = LIGHT_RIFLE_SLOWDOWN
 	wield_delay = 0.65 SECONDS
 
 	unique_attachments = list(
@@ -946,6 +946,8 @@ EMPTY_GUN_HELPER(shotgun/flamingarrow/bolt)
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/internal/shot/winchester/absolution,
 	)
+	//had to add this because the absolution went off the flaming arrowbasetype and I don't intend to buff the abs
+	wield_slowdown = RIFLE_SLOWDOWN
 
 	slot_offsets = list(
 		ATTACHMENT_SLOT_MUZZLE = list(


### PR DESCRIPTION
The flaming arrow is underwhelming, this gives it something closer to being goodish maybe? Buffs ammo to 18 rounds and lowers the slowdown one tier. from slowdown RIFLE_SLOWDOWN to LIGHT_RIFLE_SLOWDOWN

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Flaming arrow bad >> Flaming Arrow less bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

balance: The flaming arrow has had its internal magazine expanded to 18 rounds (prev 12) The wielded slowdown has also been decreased by 0.1

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
