### PR TITLE
Blanks no longer shoot pellets & execution bugfix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -645,6 +645,7 @@
 #define BRAINS_BLOWN_THROW_SPEED 1
 
 /obj/item/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params, bypass_timer)
+	var/killspeople = TRUE
 	if(!ishuman(user) || !ishuman(target))
 		return
 
@@ -675,6 +676,9 @@
 
 	current_cooldown = FALSE
 
+	if(chambered.BB.nodamage || !chambered.BB.damage || chambered.BB.damage_type == STAMINA)
+		killspeople = FALSE
+
 	target.visible_message(span_warning("[user] pulls the trigger!"), span_userdanger("[(user == target) ? "You pull" : "[user] pulls"] the trigger!"))
 
 	if(chambered && chambered.BB && can_trigger_gun(user))
@@ -687,11 +691,11 @@
 		if(brain_to_blast)
 
 			//Check if the projectile is actually damaging and not of type STAMINA
-			if(chambered.BB.nodamage || !chambered.BB.damage || chambered.BB.damage_type == STAMINA)
+				//Remove brain of the mob shot
+			if(killspeople)
+				brain_to_blast.Remove(target)
+			else
 				return
-
-			//Remove brain of the mob shot
-			brain_to_blast.Remove(target)
 
 			var/turf/splat_turf = get_turf(target)
 			//Move the brain of the person shot to selected turf

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -131,3 +131,4 @@
 	damage = 30
 	range = 2
 	armour_penetration = -70
+	bullet_identifier = "\improper shockwave"


### PR DESCRIPTION

The execution shot was weird and buggy because it checked the bullet after the one you shot, so there'd be weird circumstances where you would fail to execute someone. The projectile fired by blanks also didn't have a name so it showed up as pellets which is bad. I meant to just fix blanks but got distracted, so this is a double feature. this is not a oneline bug fix.. its at least three.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Blanks don't shoot pellets. The bullet you execute someone with is the one you're executing them with, not the next one in the magazine. (fixes good)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

fix: Blank shotgun shells no longer cause damage via pellet, they do however still do damage if you are too close.
fix: Execution code checks the bullet you are shooting for its ability to kill people. previously the last round in a magazine could not execute.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
