### PR TITLE
Cybernetic organ fix

### DIFF
--- a/code/modules/cargo/packs/cybernetics.dm
+++ b/code/modules/cargo/packs/cybernetics.dm
@@ -67,12 +67,13 @@
 
 /datum/supply_pack/cybernetic/cyberorgans
 	name = "Cybernetic Organs Replacement Pack"
-	desc = "Precision-manufactured replacement organs for those suffering catastrophic organ failure. Keep crate sealed until use, contaminants may cause rejection."
+	desc = "Precision-manufactured replacement organs - barring the eyes - for those suffering catastrophic organ failure. Keep crate sealed until use, contaminants may cause rejection."
 	cost = 2000
 	contains = list(/obj/item/organ/lungs/cybernetic/tier2,
 					/obj/item/organ/stomach/cybernetic/tier2,
 					/obj/item/organ/liver/cybernetic/tier2,
-					/obj/item/organ/heart/cybernetic/tier2)
+					/obj/item/organ/heart/cybernetic/tier2,
+					/obj/item/organ/eyes)
 	crate_name = "organs crate"
 	crate_type = /obj/structure/closet/crate/freezer
 	faction = /datum/faction/syndicate/cybersun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds eyes to cargo, specifically to the cybernetic organs cargo option, with a slight change to the description.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The only eyes one can get are from ripping other people's eyes out and using them on people that might have their eyes shot out. This fixes that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: cybernetic organs are now a complete set. However eyes aren't cybernetic. This is mentioned in cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
