### PR TITLE
prevents runtimes with T4 drill missions

### DIFF
--- a/code/modules/missions/outpost/industrial_drill.dm
+++ b/code/modules/missions/outpost/industrial_drill.dm
@@ -41,7 +41,8 @@
 
 /datum/mission/acquire/industrial_drill/Destroy()
 	. = ..()
-	recall_bound(mission_drill, FALSE)
+	if(mission_drill) //a check to prevent runtimes from an attempt to delete a mission drill that was never spawned in
+		recall_bound(mission_drill, FALSE)
 
 //unfortunately: the behavior for normal mission drills is different than what I want.
 /obj/machinery/drill/sampler_mission


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR prevents a runtime that occurs with T4 drill missions are removed. The Destroy proc recalls the mission drill, but if the mission was never selected, the drill never spawned. It now has a check that ensures the drill is spawned in before attempting to delete it.

## Why It's Good For The Game

The less runtimes there are, the better

## Changelog

:cl:
fix: fixes runtimes with T4 drill missions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
