### PR TITLE
Decreases aggro range of the tesla hermits

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/survivors.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/survivors.dm
@@ -193,6 +193,7 @@
 	casingtype = /obj/item/ammo_casing/c46x30mm/tesla
 	r_hand = /obj/item/gun/ballistic/automatic/smg/skm_carbine
 	mob_spawner = /obj/effect/mob_spawn/human/corpse/damaged/whitesands
+	aggro_vision_range = 7
 
 //survivor corpses
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
My deckhand (extremely new) walked a bit too close, aggrod this thing from off-screen, and turned half of my crew into paste that doctors were scared to fix, basically ending the round there and then. I do not think that's particularly fun. 
Counterplay is basically "know this one ruin has those". Strong enemies like this should be reactable to without metaknowledge of their existance.

They still react if you shoot them also.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Decreased aggro range of tesla rifle hermits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
