### PR TITLE
removes a runtime with motion-sensitive cameras and the proximity_monitor datum

### DIFF
--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -6,11 +6,6 @@
 
 /area/ai_monitored/Initialize(mapload)
 	. = ..()
-	if(mapload)
-		for (var/obj/machinery/camera/M in src)
-			if(M.isMotion())
-				motioncameras.Add(M)
-				M.set_area_motion(src)
 
 //Only need to use one camera
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -43,8 +43,6 @@
 	var/datum/component/empprotection/emp_component
 
 	var/internal_light = TRUE //Whether it can light up when an AI views it
-	///Proximity monitor associated with this atom, for motion sensitive cameras.
-	var/datum/proximity_monitor/proximity_monitor
 
 	/// A copy of the last paper object that was shown to this camera.
 	var/obj/item/paper/last_shown_paper
@@ -98,19 +96,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 16)
 	for(var/i in network)
 		network -= i
 		network += "[REF(port)][i]"
-
-/obj/machinery/camera/proc/create_prox_monitor()
-	if(!proximity_monitor)
-		proximity_monitor = new(src, 1)
-		RegisterSignal(proximity_monitor, COMSIG_QDELETING, PROC_REF(proximity_deleted))
-
-/obj/machinery/camera/proc/proximity_deleted()
-	SIGNAL_HANDLER
-	proximity_monitor = null
-
-/obj/machinery/camera/proc/set_area_motion(area/A)
-	area_motion = A
-	create_prox_monitor()
 
 /obj/machinery/camera/Destroy()
 	if(can_use())

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -75,9 +75,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 16)
 			upgradeEmpProof()
 		else if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
 			upgradeEmpProof(TRUE)
-
-		if(assembly.proxy_module)
-			upgradeMotion()
 	else
 		assembly = new(src)
 		assembly.state = 4 //STATE_FINISHED
@@ -124,11 +121,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 16)
 		. += "It has an X-ray photodiode installed."
 	else
 		. += span_info("It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.")
-	if(isMotion())
-		. += "It has a proximity sensor installed."
-	else
-		. += span_info("It can be upgraded with a <b>proximity sensor</b>.")
-
 	if(!status)
 		. += span_info("It's currently deactivated.")
 		if(!panel_open && powered())
@@ -225,9 +217,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 16)
 	if(choice == assembly.emp_module)
 		assembly.drop_upgrade(assembly.emp_module)
 		removeEmpProof()
-	if(choice == assembly.proxy_module)
-		assembly.drop_upgrade(assembly.proxy_module)
-		removeMotion()
 	I.play_tool_sound(src)
 	return TRUE
 
@@ -303,17 +292,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera, 16)
 				if(attacking_item.use_tool(src, user, 0, amount=1))
 					upgradeEmpProof(FALSE, TRUE)
 					to_chat(user, span_notice("You attach [attacking_item] into [assembly]'s inner circuits."))
-			else
-				to_chat(user, span_warning("[src] already has that upgrade!"))
-			return
-
-		else if(istype(attacking_item, /obj/item/assembly/prox_sensor))
-			if(!isMotion())
-				if(!user.temporarilyRemoveItemFromInventory(attacking_item))
-					return
-				upgradeMotion()
-				to_chat(user, span_notice("You attach [attacking_item] into [assembly]'s inner circuits."))
-				qdel(attacking_item)
 			else
 				to_chat(user, span_warning("[src] already has that upgrade!"))
 			return

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -91,12 +91,6 @@
 			var/obj/machinery/camera/contained_camera = loc
 			contained_camera.removeEmpProof(malf_emp_firmware_present) //make sure we don't remove MALF upgrades
 
-	else if(A == proxy_module)
-		emp_module = null
-		if(istype(loc, /obj/machinery/camera))
-			var/obj/machinery/camera/contained_camera = loc
-			contained_camera.removeMotion()
-
 	return ..()
 
 

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -6,10 +6,6 @@
 	var/alarm_delay = 30 // Don't forget, there's another 3 seconds in queueAlarm()
 
 /obj/machinery/camera/process(seconds_per_tick)
-	// motion camera event loop
-	if(!isMotion())
-		. = PROCESS_KILL
-		return
 	if(machine_stat & EMPED)
 		return
 	if (detectTime > 0)
@@ -84,33 +80,3 @@
 
 /obj/machinery/camera/motion/thunderdome/secondary
 	c_tag = "Arena 2"
-
-
-/obj/machinery/camera/motion/thunderdome/Initialize()
-	. = ..()
-	proximity_monitor.set_range(7)
-
-/obj/machinery/camera/motion/thunderdome/HasProximity(atom/movable/AM as mob|obj)
-	if (!isliving(AM) || get_area(AM) != get_area(src))
-		return
-	localMotionTargets |= WEAKREF(AM)
-	if (!detectTime)
-		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
-			TV.notify(TRUE)
-	detectTime = world.time + 30 SECONDS
-
-/obj/machinery/camera/motion/thunderdome/process(seconds_per_tick)
-	if (!detectTime)
-		return
-
-	for (var/datum/weakref/targetref in localMotionTargets)
-		var/mob/target = targetref.resolve()
-		if(QDELETED(target) || target.stat == DEAD || get_dist(src, target) > 7 || get_area(src) != get_area(target))
-			localMotionTargets -= targetref
-
-	if (localMotionTargets.len)
-		detectTime = world.time + 30 SECONDS
-	else if (world.time > detectTime)
-		detectTime = 0
-		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
-			TV.notify(FALSE)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -8,12 +8,6 @@
 	. = ..()
 	upgradeEmpProof()
 
-// EMP + Motion
-
-/obj/machinery/camera/emp_proof/motion/Initialize()
-	. = ..()
-	upgradeMotion()
-
 // X-ray
 
 /obj/machinery/camera/xray
@@ -24,15 +18,6 @@
 	. = ..()
 	upgradeXRay()
 
-// MOTION
-/obj/machinery/camera/motion
-	start_active = TRUE
-	name = "motion-sensitive security camera"
-
-/obj/machinery/camera/motion/Initialize()
-	. = ..()
-	upgradeMotion()
-
 // ALL UPGRADES
 /obj/machinery/camera/all
 	start_active = TRUE
@@ -42,7 +27,6 @@
 	. = ..()
 	upgradeEmpProof()
 	upgradeXRay()
-	upgradeMotion()
 
 // AUTONAME
 
@@ -115,24 +99,3 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname, 16)
 		upgrades &= ~CAMERA_UPGRADE_XRAY
 	update_appearance()
 
-
-
-/obj/machinery/camera/proc/isMotion()
-	return upgrades & CAMERA_UPGRADE_MOTION
-
-/obj/machinery/camera/proc/upgradeMotion()
-	if(isMotion())
-		return
-	if(name == initial(name))
-		name = "motion-sensitive security camera"
-	if(!assembly.proxy_module)
-		assembly.proxy_module = new(assembly)
-	upgrades |= CAMERA_UPGRADE_MOTION
-	create_prox_monitor()
-
-/obj/machinery/camera/proc/removeMotion()
-	if(name == "motion-sensitive security camera")
-		name = "security camera"
-	upgrades &= ~CAMERA_UPGRADE_MOTION
-	if(!area_motion)
-		QDEL_NULL(proximity_monitor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Motion-sensitive cameras in the thunderdome were contributing to hundreds of runtimes. They are unused anyway in cameras, so I'm deleting the datum for cameras with this PR. 

## Why It's Good For The Game

Runtimes are bad, and this feature was lying unused anyway

## Changelog

:cl:
fix: fixes runtime with proximity monitors on cameras
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
