### PR TITLE
Adds a rezadone patch to cargo.

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -194,6 +194,14 @@
 	contains = list(/obj/item/storage/box/medigels)
 	crate_name = "empty medical gel crate"
 
+/datum/supply_pack/medical/rezadone_patch
+	name = "Rezadone Patch Single-Pack"
+	desc = "Contains a singular Rezadone patch for de-husking a patient."
+	cost = 800
+	contains = list(/obj/item/reagent_containers/pill/patch/rezadone)
+	crate_name = "rezadone patch crate"
+
+
 /* Hypospray supplies */
 
 /datum/supply_pack/medical/mkii_hypo

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -60,3 +60,8 @@
 	name = "strider patch"
 	desc = "A patch made to give the user a burst of physical endurance."
 	list_reagents = list(/datum/reagent/drug/cinesia = 10, /datum/reagent/medicine/hadrakine = 5)
+
+/obj/item/reagent_containers/pill/patch/rezadone
+	name = "rezadone patch"
+	desc = "A patch of a rejuvinating agent, capable of de-husking a body."
+	list_reagents = list(/datum/reagent/medicine/rezadone = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some talk in the discord about this being an option, decided that I would make it.
The price is iffy, I believe Lemon said 1000 credits originally but looking at other meds on the cargo list I thought that was quite pricey, 800 feels like enough for a relatively hard to make chem that won't be purchased too often. This is up for change.

I plan on updating this if PR#6720 gets merged, and shove it into a disposable medical pack.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds an alternative to ghettocheming synthflesh if someone gets husked. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Rezadone patch in cargo.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
