### PR TITLE
updates maploaded sprites for spent autoinjectors

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -124,6 +124,12 @@
 	icon_state = "[base_icon_state][(reagents.total_volume > 0) ? null : 0]"
 	return ..()
 
+/obj/item/reagent_containers/hypospray/medipen/Initialize(mapload, vol)
+	. = ..()
+	if(!reagents || !reagents.reagent_list.len) //maploaded used up reagents
+		update_icon_state()
+		update_appearance()
+
 /obj/item/reagent_containers/hypospray/medipen/examine()
 	. = ..()
 	if(reagents && reagents.reagent_list.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Injectors that spawn in on a map already used don't _appear_ spent, which can be confusing sometimes. This fixes that so that their icons properly update.

Also fixes a bug with beakers so that the cap overlay is properly layered.
Before: 
<img width="59" height="56" alt="image" src="https://github.com/user-attachments/assets/278fefc1-c951-4ec2-9331-f567d23434d6" />

After: 
<img width="56" height="56" alt="image" src="https://github.com/user-attachments/assets/910c0fc3-8dac-4c0f-bfe3-a8a2ffdf0f54" />

Lastly, an autoinjector pen helper tool was added.

## Why It's Good For The Game

This is a fix to ensure that icons properly update when something is maploaded, that reagent caps are properly layered, and the helper may be helpful? I'm actually not very familiar with them nor what this one can be useful for.

## Changelog 

:cl: @zimon9, @Erikafox 
fix: fixed autoinjector sprites not updating upon mapload
fix: cap overlay layering inhand icon for reagent containers
add: reagent pen helper tool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
