### PR TITLE
Faction-Locks the Resolution

### DIFF
--- a/code/modules/cargo/packs/gun.dm
+++ b/code/modules/cargo/packs/gun.dm
@@ -554,12 +554,13 @@
 
 /datum/supply_pack/gun/resolution
 	name = "PD46 Resolution PDW Crate"
-	desc = "Contains a compact automatic personal defense weapon chambered in 4.6x30mm."
+	desc = "Contains a compact automatic personal defense weapon chambered in 4.6x30mm. For MW employee use only."
 	cost = 3500
 	contains = list(/obj/item/storage/guncase/wt550)
 	crate_name = "PDW crate"
-	faction_discount = 10
+	faction_discount = 0
 	faction = /datum/faction/warra
+	faction_locked = TRUE
 
 /datum/supply_pack/gun/bdm50
 	name = "BDM-50 'Akita' PDW Crate"


### PR DESCRIPTION
## About The Pull Request

Restricts the Resolution PDW to Warra cargo.

## Why It's Good For The Game

Doesn't make too much sense to be open-market given that the Akita/Sidewinder aren't. Appears to be a holdover from it being the WT-550 in a past life.

## Changelog

:cl: cablefish
balance: The Resolution PDW is now faction-locked to Warra.
/:cl:
