### PR TITLE
Gives the "naked" MW/VI Captain variants a telebaton

### DIFF
--- a/code/modules/clothing/outfits/factions/warra.dm
+++ b/code/modules/clothing/outfits/factions/warra.dm
@@ -71,7 +71,6 @@
 	neck = null
 	l_hand = null
 	belt = null
-	backpack_contents = null
 
 /datum/outfit/job/warra/captain/ns/empty
 	name = "Makosso-Warra - Captain (N+S Logistics) (Naked)"
@@ -125,7 +124,6 @@
 	gloves = null
 	neck = null
 	belt = null
-	backpack_contents = null
 
 /datum/outfit/job/warra/captain/centcom
 	name = "Makosso-Warra - Captain (Central Command)"


### PR DESCRIPTION
## About The Pull Request

Gives the "naked" outfits for MW and VI captains a telescopic baton, like the "naked" variant for the N+S captain has. This affects the Caracara, Magpie, and Capercaille. 

## Why It's Good For The Game

All the other MW/VI ships have a telebaton for their captain, don't see why these two should lack this essential piece of assistant bullying equipment. 

## Changelog

:cl: cablefish
add: The captain on the Capercaille, Magpie, and Caracara now have a telescopic baton.
/:cl: