### PR TITLE
Tegu / Caracara Outfit Additions

### DIFF
--- a/_maps/shuttles/warra/warra_caracara.dmm
+++ b/_maps/shuttles/warra/warra_caracara.dmm
@@ -2569,6 +2569,9 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/suit/hooded/wintercoat/captain,
+/obj/item/clothing/suit/armor/warra/captain,
+/obj/item/clothing/suit/armor/warra/captain/parade,
+/obj/item/clothing/neck/cloak/warra,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm/captain)
 "EN" = (

--- a/_maps/shuttles/warra/warra_tegu.dmm
+++ b/_maps/shuttles/warra/warra_tegu.dmm
@@ -2051,6 +2051,7 @@
 /obj/item/storage/backpack/messenger,
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/under/warra/supply/qm,
+/obj/item/clothing/suit/toggle/chorejacket/warra,
 /obj/item/clothing/head/hardhat/orange,
 /obj/item/clothing/head/warra/cap/supply,
 /obj/item/clipboard,


### PR DESCRIPTION
## About The Pull Request

Adds the N+S chore jacket to the Supply Director's locker on the Tegu.
Adds the captain armor vest / parade coat / command sash to the Captain's locker on the Caracara.

## Why It's Good For The Game

Roles having their special drip is good. No self respecting captain should be caught wearing _normal armor_.

## Changelog

:cl: cablefish
add: Added a N+S chore jacket to the Supply Director's locker on the Tegu.
add: Added a captain's parade coat, armor vest, and command sash to the Captain's locker on the Caracara.
/:cl: