### PR TITLE
Adds a single-use spray for dehusking into cargo.

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -68,6 +68,12 @@
 	cost = 100
 	contains = list(/obj/item/reagent_containers/inhaler_canister/salbutamol)
 
+/datum/supply_pack/medical/dehusk_single
+	name = "High-Strength Synthflesh Spray Single-Pack"
+	desc = "Contains one single-shot spray bottle with synthflesh, intended to be used for severe body water loss."
+	cost = 800
+	contains = list(/obj/item/reagent_containers/spray/dehusk)
+
 /*
 		Tools
 */

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -349,3 +349,17 @@
 		"Blue" = "sprayer_med_blue"
 	)
 	unique_reskin_changes_inhand = TRUE
+
+/obj/item/reagent_containers/spray/dehusk
+	name = "flesh replacement spray bottle"
+	desc = "A pre-filled, single-shot, high-strength synthflesh spray capable of restoring a body's water content after severe, extensive burns. A bolded label on the bottle states, '<b>APPLY ONLY AFTER TREATMENT OF TISSUE DAMAGE</b>'."
+	icon = 'icons/obj/chemical/medicine.dmi'
+	icon_state = "sprayer_med_yellow"
+	item_state = "sprayer_med_yellow"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
+	spray_range = 1
+	stream_range = 1
+	volume = 100
+	list_reagents = list(/datum/reagent/medicine/synthflesh = 100)
+	amount_per_transfer_from_this = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 100u, single-shot spray of synthflesh into cargo for de-husking a patient.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This gives crews an option that isn't getting the deckhand to ghettochem.
Original suggestions said to have this option priced at 1000 credits, but I feel like 800 is a better middle ground, still more expensive than making it by yourself via brute kits, but not equal in price to bundles of painkillers and whole crates of blood.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Adds a high-strength synthflesh spray for dehusking into cargo.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
