### PR TITLE
changes some small ships spawn limit to two

### DIFF
--- a/_maps/configs/independent_corona.json
+++ b/_maps/configs/independent_corona.json
@@ -19,7 +19,7 @@
 	"starting_funds": 6000,
 	"tranist_x_offset": 0,
 	"tranist_y_offset": -5,
-	"limit": 1,
+	"limit": 2,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/gown",

--- a/_maps/configs/independent_ivory.json
+++ b/_maps/configs/independent_ivory.json
@@ -18,7 +18,7 @@
 	],
 
 	"starting_funds": 2500,
-	"limit": 2,
+	"limit": 1,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/gown",

--- a/_maps/configs/independent_ivory.json
+++ b/_maps/configs/independent_ivory.json
@@ -18,7 +18,7 @@
 	],
 
 	"starting_funds": 2500,
-	"limit": 1,
+	"limit": 2,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/gown",

--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -19,7 +19,7 @@
 	"starting_funds": 1500,
 	"map_path": "_maps/shuttles/independent/independent_kilo.dmm",
 	"token_icon_state": "ship_small_generic",
-	"limit": 1,
+	"limit": 2,
 	"job_slots": {
 		"Captain": {
 			"outfit": "/datum/outfit/job/independent/captain/cheap",

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -16,7 +16,7 @@
 		"SPACE"
 	],
 	"map_path": "_maps/shuttles/independent/independent_mudskipper.dmm",
-	"limit": 1,
+	"limit": 2,
 	"starting_funds": 1500,
 	"tranist_x_offset": -20,
 	"tranist_y_offset": -20,

--- a/_maps/configs/independent_rhode.json
+++ b/_maps/configs/independent_rhode.json
@@ -17,7 +17,7 @@
 	],
 	"map_path": "_maps/shuttles/independent/independent_rhode.dmm",
 	"token_icon_state": "ship_small_generic",
-	"limit": 1,
+	"limit": 2,
 	"starting_funds": 1500,
 	"tranist_x_offset": -15,
 	"tranist_y_offset": -10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ships in question:
Mudskipper
Rhode
Kilo
Corona

## Why It's Good For The Game
Maptainer discussion. Despite both the mudskipper and corona being 5 crew now, they're both reasonably small+general enough to warrant two slots.

## Changelog

:cl:
add: changes some small ships spawn limit to two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
