### PR TITLE
Fixes Wallcloset Paths

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_command_post.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_command_post.dmm
@@ -3243,7 +3243,7 @@
 /turf/open/floor/carpet/green,
 /area/ruin/icemoon/command_post/officer)
 "En" = (
-/obj/structure/closet/wall/med/directional/north,
+/obj/structure/closet/wall/white/med/directional/north,
 /obj/item/bonesetter{
 	pixel_x = -3;
 	pixel_y = 7

--- a/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_downed_transport.dmm
@@ -1723,7 +1723,7 @@
 /turf/open/floor/plating/asteroid/icerock,
 /area/ruin/unpowered/icemoon/downed_transport/abandoned_mineshaft)
 "na" = (
-/obj/structure/closet/wall/med/directional/east{
+/obj/structure/closet/wall/white/med/directional/east{
 	name = "first aid locker";
 	dir = 1;
 	pixel_x = 0;

--- a/_maps/RandomRuins/JungleRuins/jungle_serene_hunts.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungle_serene_hunts.dmm
@@ -5059,7 +5059,7 @@
 /turf/open/floor/engine,
 /area/ruin/powered/hunts/barn)
 "Qe" = (
-/obj/structure/closet/wall/med/directional/north{
+/obj/structure/closet/wall/white/med/directional/north{
 	icon_door = "med_wall";
 	name = "First Aid Closet"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_abandonedlisteningpost.dmm
@@ -2101,7 +2101,7 @@
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
 	dir = 1
 	},
-/obj/structure/closet/wall/med/directional/north,
+/obj/structure/closet/wall/white/med/directional/north,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/box/masks,
 /turf/open/floor/hangar/plasteel/white,

--- a/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_mining_installation.dmm
@@ -7987,7 +7987,7 @@
 /turf/open/floor/plasteel/patterned/rockplanet/lit,
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "SP" = (
-/obj/structure/closet/wall/chem/directional/south,
+/obj/structure/closet/wall/white/chem/directional/south,
 /obj/item/towel,
 /obj/item/towel{
 	pixel_x = -3;

--- a/_maps/RandomRuins/RockRuins/rockplanet_ngr_mining_colony.dmm
+++ b/_maps/RandomRuins/RockRuins/rockplanet_ngr_mining_colony.dmm
@@ -490,7 +490,7 @@
 "bF" = (
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/closet/wall/med/directional/east,
+/obj/structure/closet/wall/white/med/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/ruin/rockplanet/ngrcolony/mine_supplies)
 "bG" = (

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_pubbytown.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_pubbytown.dmm
@@ -3722,7 +3722,7 @@
 /area/ruin/whitesands/pubbytown/guard)
 "Pr" = (
 /obj/structure/table/chem,
-/obj/structure/closet/wall/med/directional/east,
+/obj/structure/closet/wall/white/med/directional/east,
 /turf/open/floor/plasteel/white/whitesands,
 /area/ruin/whitesands/pubbytown/wreck)
 "Pu" = (

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_facility.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_facility.dmm
@@ -6610,7 +6610,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted,
-/obj/structure/closet/wall/chem/directional/north,
+/obj/structure/closet/wall/white/chem/directional/north,
 /obj/item/soap,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/patterned,

--- a/_maps/RandomRuins/WasteRuins/wasteplanet_recyclebay.dmm
+++ b/_maps/RandomRuins/WasteRuins/wasteplanet_recyclebay.dmm
@@ -5761,7 +5761,7 @@
 /area/ruin/wasteplanet/recycle_bay/eva)
 "MK" = (
 /obj/structure/table,
-/obj/structure/closet/wall/med/directional/south,
+/obj/structure/closet/wall/white/med/directional/south,
 /obj/item/reagent_containers/syringe/contraband/morphine,
 /obj/item/reagent_containers/syringe/contraband/morphine,
 /obj/item/storage/firstaid/regular,

--- a/_maps/shuttles/independent/independent_rigger.dmm
+++ b/_maps/shuttles/independent/independent_rigger.dmm
@@ -2052,7 +2052,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/wall/med/directional/east{
+/obj/structure/closet/wall/white/med/directional/east{
 	icon_door = "med_wall"
 	},
 /obj/item/storage/firstaid/brute{
@@ -3329,7 +3329,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/structure/closet/wall/med/directional/east{
+/obj/structure/closet/wall/white/med/directional/east{
 	icon_door = "med_wall"
 	},
 /obj/structure/table/chem,

--- a/_maps/shuttles/ngr/ngr_pururangi.dmm
+++ b/_maps/shuttles/ngr/ngr_pururangi.dmm
@@ -2349,7 +2349,7 @@
 	pixel_y = 14;
 	pixel_x = -5
 	},
-/obj/structure/closet/wall/chem/directional/north{
+/obj/structure/closet/wall/white/chem/directional/north{
 	icon_door = "med_wall";
 	icon_state = "freezer_wall";
 	name = "chemistry supplies cabinet"

--- a/_maps/shuttles/pirate/pirate_silverfish.dmm
+++ b/_maps/shuttles/pirate/pirate_silverfish.dmm
@@ -4621,7 +4621,7 @@
 	pixel_x = -9;
 	pixel_y = 0
 	},
-/obj/structure/closet/wall/med/directional/east{
+/obj/structure/closet/wall/white/med/directional/east{
 	name = "medical supplies"
 	},
 /obj/item/storage/firstaid/medical,

--- a/code/game/objects/structures/crates_lockers/closets/wallmount.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wallmount.dm
@@ -16,7 +16,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/red, 27)
 
 /obj/structure/closet/wall/eng
 	icon_state = "engi_wall"
-	icon_door = "sec_wall"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/eng, 27)
 
@@ -39,15 +38,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/white, 27)
 /obj/structure/closet/wall/white/chem
 	icon_door = "chemical_wall"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/chem, 27)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/white/chem, 27)
 
 /obj/structure/closet/wall/white/med
 	icon_door = "med_wall"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/med, 27)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/white/med, 27)
 
 /obj/structure/closet/wall/freezer
 	icon_state = "freezer_wall"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/closet/wall/freezer, 27)
 
 //special
 

--- a/tools/UpdatePaths/Scripts/6752_wallclosets.txt
+++ b/tools/UpdatePaths/Scripts/6752_wallclosets.txt
@@ -1,0 +1,2 @@
+/obj/structure/closet/wall/chem : /obj/structure/closet/wall/white/chem{@OLD}
+/obj/structure/closet/wall/med : /obj/structure/closet/wall/white/med{@OLD}

--- a/tools/UpdatePaths/Scripts/6752_wallclosets.txt
+++ b/tools/UpdatePaths/Scripts/6752_wallclosets.txt
@@ -1,2 +1,12 @@
 /obj/structure/closet/wall/chem : /obj/structure/closet/wall/white/chem{@OLD}
+/obj/structure/closet/wall/chem/directional : /obj/structure/closet/wall/white/chem/directional{@OLD}
+/obj/structure/closet/wall/chem/directional/north : /obj/structure/closet/wall/white/chem/directional/north{@OLD}
+/obj/structure/closet/wall/chem/directional/east : /obj/structure/closet/wall/white/chem/directional/east{@OLD}
+/obj/structure/closet/wall/chem/directional/west : /obj/structure/closet/wall/white/chem/directional/west{@OLD}
+/obj/structure/closet/wall/chem/directional/south : /obj/structure/closet/wall/white/chem/directional/south{@OLD}
 /obj/structure/closet/wall/med : /obj/structure/closet/wall/white/med{@OLD}
+/obj/structure/closet/wall/med/directional : /obj/structure/closet/wall/white/chem/directional{@OLD}
+/obj/structure/closet/wall/med/directional/north : /obj/structure/closet/wall/white/med/directional/north{@OLD}
+/obj/structure/closet/wall/med/directional/east : /obj/structure/closet/wall/white/med/directional/east{@OLD}
+/obj/structure/closet/wall/med/directional/west : /obj/structure/closet/wall/white/med/directional/west{@OLD}
+/obj/structure/closet/wall/med/directional/south : /obj/structure/closet/wall/white/med/directional/south{@OLD}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Wallclosets should now all be corretly pathed, white/med & chem now have directionals & /eng has a correct door and /med and /chem don't exist (they weren't supposed to exist)
## Why It's Good For The Game
Things being pathed properly reduces mapping errors, that's good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: wallcloset paths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
