### PR TITLE
9mm smg firerate "buff"

### DIFF
--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -206,7 +206,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/cm357)
 	weapon_weight = WEAPON_LIGHT
 	fire_sound = 'sound/weapons/gun/smg/cm5.ogg'
 	manufacturer = MANUFACTURER_MINUTEMAN
-
+	fire_delay = 0.9 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
 	spread = 3
 	spread_unwielded = 7
 

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -206,7 +206,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/cm357)
 	weapon_weight = WEAPON_LIGHT
 	fire_sound = 'sound/weapons/gun/smg/cm5.ogg'
 	manufacturer = MANUFACTURER_MINUTEMAN
-	fire_delay = 0.9 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
+	fire_delay = 0.09 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
 	spread = 3
 	spread_unwielded = 7
 

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -207,7 +207,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/cm357)
 	fire_sound = 'sound/weapons/gun/smg/cm5.ogg'
 	manufacturer = MANUFACTURER_MINUTEMAN
 	fire_delay = 0.09 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
-	spread = 3
+	spread = 4
 	spread_unwielded = 7
 
 	valid_attachments = CLIP_ATTACHMENTS

--- a/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
@@ -134,7 +134,7 @@
 	show_magazine_on_sprite = TRUE
 	manufacturer = MANUFACTURER_IMPORT
 
-	spread = 20
+	spread = 15
 	spread_unwielded = 20
 	dual_wield_spread = 35
 	wield_slowdown = SMG_SLOWDOWN

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
@@ -267,7 +267,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	icon_state = "expedition"
 	item_state = "expedition"
 	default_ammo_type = /obj/item/ammo_box/magazine/m9mm_expedition
-	spread = 3
+	spread = 4
 	fire_delay = 0.09 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m9mm_expedition,

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
@@ -268,6 +268,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	item_state = "expedition"
 	default_ammo_type = /obj/item/ammo_box/magazine/m9mm_expedition
 	spread = 3
+	fire_delay = 0.9 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m9mm_expedition,
 	) //you guys remember when the autorifle was chambered in 9mm

--- a/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/warra_sharplite/ballistics.dm
@@ -268,7 +268,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/challenger/inteq)
 	item_state = "expedition"
 	default_ammo_type = /obj/item/ammo_box/magazine/m9mm_expedition
 	spread = 3
-	fire_delay = 0.9 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
+	fire_delay = 0.09 SECONDS // despite being 1 fire delay previously, it fucking rounds up to 1.5. This makes it ACTUALLY ONE
 	allowed_ammo_types = list(
 		/obj/item/ammo_box/magazine/m9mm_expedition,
 	) //you guys remember when the autorifle was chambered in 9mm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Changes them to shoot faster (the speed they are intended to)

So it turns out 1 fire delay rounds up to 1.5 (same as PDWs) which kinda leaves the 9mm smg as just an eternally shittier pdw. Also buffs the spitters spread so it doesnt get immediately outclassed shooting at the same speed as the others

## Changelog

:cl:
balance: 9mm smg firerate buff
balance: spitter spread decrease

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
