### PR TITLE
Gives the Mauler Mag 10 Rounds and the Extendo 18 rounds

### DIFF
--- a/code/modules/cargo/blackmarket/packs/ammo.dm
+++ b/code/modules/cargo/blackmarket/packs/ammo.dm
@@ -254,7 +254,7 @@
 
 /datum/blackmarket_item/ammo/mauler_mag
 	name = "Mauler Magazine"
-	desc = "A 12 round 9mm magazine for the Mauler machine pistol."
+	desc = "A 18 round 9mm magazine for the Mauler machine pistol."
 	item = /obj/item/ammo_box/magazine/m9mm_mauler/extended
 
 	cost_min = 150

--- a/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/frontier_import/ballistics.dm
@@ -95,21 +95,21 @@
 
 /obj/item/ammo_box/magazine/m9mm_mauler
 	name = "mauler pistol magazine (9mm)"
-	desc = "A 8-round magazine designed for the Mauler pistol."
+	desc = "A 10-round magazine designed for the Mauler pistol."
 	icon_state = "mauler_mag-1"
 	base_icon_state = "mauler_mag"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = "9mm"
-	max_ammo = 8
+	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m9mm_mauler/extended
 	name = "mauler machine pistol extended magazine (9mm)"
-	desc = "A 12-round magazine designed for the Mauler machine pistol."
+	desc = "A 18-round magazine designed for the Mauler machine pistol."
 	icon_state = "mauler_extended_mag-1"
 	base_icon_state = "mauler_extended_mag"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = "9mm"
-	max_ammo = 12
+	max_ammo = 18
 
 /obj/item/ammo_box/magazine/m9mm_mauler/update_icon_state()
 	. = ..()


### PR DESCRIPTION
## Why It's Good For The Game

it's pretty bad

## Changelog

:cl:
balance: Mauler base mag has 10 rounds and extended has 18
/:cl:
