### PR TITLE
Fixes missing autolathe boards

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -86,7 +86,7 @@
 	id = "space_heater"
 	build_path = /obj/item/circuitboard/machine/space_heater
 	build_type = AUTOLATHE | IMPRINTER
-	category = list ("Engineering Machinery", "initial", "Equipment")
+	category = list ("Engineering Machinery", "initial", "Machinery")
 	departmental_flags = ALL
 
 /datum/design/board/teleport_station
@@ -475,7 +475,7 @@
 	id = "ship_gravity"
 	build_type = AUTOLATHE | IMPRINTER
 	build_path = /obj/item/circuitboard/machine/ship_gravity
-	category = list("Misc. Machinery", "initial", "Equipment")
+	category = list("Misc. Machinery", "initial", "Machinery")
 
 /datum/design/board/ntnet_relay
 	name = "Machine Design (NTNet Relay Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the space heather and gravity generator not showing up in the tabs
Fixes #6758
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no EVIL secret designs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl: Casperclone
fix: Space heater and Gravity Generator not showing in the autolathe tabs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
