### PR TITLE
Rachnid web engoodening

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/spider.dm
@@ -23,7 +23,7 @@
 	loreblurb = "Rachnids are aliens with coincidental physiological similarities to Sol's spiders. Despite visible adaptations that would make them excellent hunters, modern Rachnidian culture revolves around honing the skills and talents of oneself, treating them as forms of self-expression. Rachnids tend to focus on their work intensely, priding themselves on a job well done and languishing if they see themselves as underperforming in their field."
 	var/web_cooldown = 30
 	var/web_ready = TRUE
-	var/spinner_rate = 75
+	var/spinner_rate = 15
 
 	species_organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,
@@ -51,12 +51,6 @@
 	if(unique)
 		return random_unique_spider_name()
 	return spider_name()
-
-/datum/species/spider/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	if(chem.type == /datum/reagent/toxin/pestkiller)
-		H.adjustToxLoss(3)
-		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM)
-	return ..()
 
 /mob/living/carbon/human/species/spider
 	race = /datum/species/spider
@@ -105,10 +99,10 @@
 		to_chat(H, span_warning("There's already a web here!"))
 		return
 	// Should have some minimum amount of food before trying to activate
-	var/nutrition_threshold = NUTRITION_LEVEL_FED
+	var/nutrition_threshold = NUTRITION_LEVEL_HUNGRY
 	if (H.nutrition >= nutrition_threshold)
 		to_chat(H, "<i>You begin spinning some web...</i>")
-		if(!do_after(H, 10 SECONDS, T, hidden = TRUE))
+		if(!do_after(H, 2.5 SECONDS, T, hidden = TRUE))
 			to_chat(H, span_warning("Your web spinning was interrupted!"))
 			return
 		if(prob(75))
@@ -119,7 +113,7 @@
 		to_chat(H, "<i>You weave a web on the ground with your spinneret!</i>")
 
 	else
-		to_chat(H, span_warning("You're too hungry to spin web right now, eat something first!"))
+		to_chat(H, span_warning("You're too hungry to spin a web right now, eat something first!"))
 		return
 /*
 	This took me far too long to figure out so I'm gonna document it here.
@@ -137,7 +131,7 @@
 	if(E.web_ready == FALSE)
 		to_chat(H, span_warning("You need to wait awhile to regenerate web fluid."))
 		return
-	var/nutrition_threshold = NUTRITION_LEVEL_FED
+	var/nutrition_threshold = NUTRITION_LEVEL_HUNGRY
 	if (H.nutrition >= nutrition_threshold)
 		to_chat(H, "<span class='warning'>You pull out a strand from your spinneret, ready to wrap a target. <BR> \
 		(Press ALT+CLICK or MMB on the target to start wrapping.)</span>")
@@ -145,7 +139,7 @@
 		RegisterSignals(H, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(cocoonAtom))
 		return
 	else
-		to_chat(H, span_warning("You're too hungry to spin web right now, eat something first!"))
+		to_chat(H, span_warning("You're too hungry to spin a web right now, eat something first!"))
 		return
 
 /datum/action/innate/spin_cocoon/proc/cocoonAtom(mob/living/carbon/human/species/spider/H, atom/movable/A)
@@ -180,6 +174,7 @@
 			H.visible_message(span_danger("[H] wraps [A] into a large cocoon!"))
 			return
 		else
+			C.icon_state = pick("cocoon1", "cocoon2","cocoon3")
 			A.forceMove(C)
 			H.visible_message(span_danger("[H] wraps [A] into a cocoon!"))
 			return


### PR DESCRIPTION
Rachnid webs now use a less comical quantity of nutrition. Cocooned objects will get an appropriate sprite. Rachnids can web floor tiles faster (2.5 seconds from 10). Rachnids no longer take extra damage from pesticide. Makes the failed to web text slightly better. The hunger requirement for when you can web has been changed to when you can visibly see your character is hungry.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Spiders can more than 4 webs. Webs use proper sprites. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:

balance:Rachnids use and need less nutrition to spin webs.
balance:Rachnids spin webs faster. Cocoons are uneffected.
del:Rachnids no longer take extra damage from pesticide.
fix:Weird grammar in the failure to spin webs text.
fix:Cocoons use proper sprites when applied to an object

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
