### PR TITLE
Amperage Adjustments

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -126,7 +126,7 @@
 
 /obj/item/ammo_casing/energy/laser/shotgun
 	projectile_type = /obj/projectile/beam/weak/shotgun
-	pellets = 3
+	pellets = 4
 	variance = 25
 	e_cost = 1000
 	select_name = "kill"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -146,7 +146,7 @@
 	damage = 15
 
 /obj/projectile/beam/weak/shotgun
-	damage = 22
+	damage = 20
 	armour_penetration = -10
 	var/tile_dropoff = 1
 	var/ap_dropoff = 5

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -146,11 +146,11 @@
 	damage = 15
 
 /obj/projectile/beam/weak/shotgun
-	damage = 20
+	damage = 25
 	armour_penetration = -10
 	var/tile_dropoff = 1
 	var/ap_dropoff = 5
-	var/ap_dropoff_cutoff = -35
+	var/ap_dropoff_cutoff = -20
 
 /obj/projectile/beam/weak/shotgun/Range() //10% loss per tile = max range of 10, generally
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -146,7 +146,7 @@
 	damage = 15
 
 /obj/projectile/beam/weak/shotgun
-	damage = 25
+	damage = 22
 	armour_penetration = -10
 	var/tile_dropoff = 1
 	var/ap_dropoff = 5


### PR DESCRIPTION
## About The Pull Request

Nerfed it back in this pr https://github.com/shiptest-ss13/Shiptest/pull/5073 a little over a year ago when it was the ESG, it's probably the worst "shotgun" in the modern day. Gives it an extra projectile for a bit more damage along with less AP falloff, giving it a bit less than buckshot's maximum damage (92 to 104). 

## Why It's Good For The Game

I actually did not test this at all so we'll have to fine tune from here. Slightly less performant than actual shotguns (probably) with higher than average(?) firerate so hopefully it's good

## Changelog

:cl:
balance: Amperage has more projectiles with less falloff
/:cl:
