### PR TITLE
No more magic potions.

### DIFF
--- a/code/modules/cargo/packs/trickwine.dm
+++ b/code/modules/cargo/packs/trickwine.dm
@@ -1,36 +1,40 @@
 /datum/supply_pack/food/trickwine
-	desc = "Trickwines shipped directly from illestern factories. A good replacement for underequipped Roumain ships."
+	desc = "Wine shipped directly from illestren vineyards."
 	faction = /datum/faction/srm
 	faction_discount = 0
 	faction_locked = TRUE
 
 /datum/supply_pack/food/trickwine/ashwine
 	name = "Bottle of vintage Ashwine"
-	desc = "Trickwine shipped directly from illestern factories. A good replacement for underequipped Roumain ships. Cheaper due to the ease of production and importance in ritual."
-	cost = 375
+	desc = "Medicinal wine shipped directly from illestren vineyards."
+	cost = 200
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine)
 
 /datum/supply_pack/food/trickwine/icewine
 	name = "Bottle of vintage Icewine"
-	cost = 500
+	desc = "Medicinal wine shipped directly from illestren vineyards."
+	cost = 200
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine)
 
 /datum/supply_pack/food/trickwine/shockwine
 	name = "Bottle of vintage Lightnings' Blessing"
+	desc = "Stimulating wine shipped directly from illestren vineyards."
 	cost = 500
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine)
 
 /datum/supply_pack/food/trickwine/heartwine
 	name = "Bottle of vintage Hearthflame"
+	desc = "Medicinal wine shipped directly from illestren vineyards."
 	cost = 500
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine)
 
 /datum/supply_pack/food/trickwine/forcewine
-	name = "Bottle of vintage Forcewine"
-	cost = 500
+	name = "Bottle of vintage Knifepoint"
+	desc = "Potent liquor shipped from illestren distilleries. It is highly reccomended to drink with caution."
+	cost = 100
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine)
 
 /datum/supply_pack/food/trickwine/prismwine
 	name = "Bottle of vintage Prismwine"
-	cost = 500
+	cost = 50
 	contains = list(/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine)

--- a/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
@@ -81,4 +81,4 @@
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine
 	name = "Vintage Saint-Roumain Prismwine"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/prism_wine = 45, /datum/reagent/consumable/ethanol/gin = 5)
-	desc = "Prismwine is a rather unremarkable roumian beverage."
+	desc = "Faint rainbows are cast on the surface around this bottle of clear sparkling liquid. Prismwine is not known for any particular practical effect, but it is pleasant to look at and drink leading to a popularity both in and outside the SRM."

--- a/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/breakawayflask.dm
@@ -5,8 +5,8 @@
 	icon_state = "breakawayflask"
 	item_state = "breakawayflask"
 	w_class = WEIGHT_CLASS_SMALL
-	gulp_size = 25
-	amount_per_transfer_from_this = 25
+	gulp_size = 5
+	amount_per_transfer_from_this = 5
 	volume = 50
 	throwforce = 10
 	custom_materials = list(/datum/material/glass=2500, /datum/material/plasma=500)
@@ -25,7 +25,6 @@
 /obj/item/reagent_containers/food/drinks/breakawayflask/on_reagent_change(changetype)
 	cut_overlays()
 
-	gulp_size = max(round(reagents.total_volume / 25), 25)
 	var/datum/reagent/largest_reagent = reagents.get_master_reagent()
 	if (reagents.reagent_list.len > 0)
 		if(!renamedByPlayer && vintage == FALSE)
@@ -56,30 +55,30 @@
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/ashwine
 	name = "Vintage Wine of Ash"
-	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/ash_wine = 45, /datum/reagent/consumable/ethanol/absinthe  = 5)
+	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/ash_wine = 50)
 	desc = "Wine of Ash was originally created using herbs native to Illestren, as a means of relaxing after a long hunt. The Saint-Roumain Militia has no prohibition on a little fun."
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/icewine
 	name = "Vintage Wine Of Ice"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/ice_wine = 45, /datum/reagent/consumable/ethanol/sake = 5)
-	desc = "Wine Of Ice, inspired by the frigid slopes of the 'Godforsaken Precipice' that forged the group's reputation as valiant survivalists, was engineered to both soothe overheated Hunters and freeze their foes in their tracks."
+	desc = "Wine Of Ice, inspired by the frigid slopes of the 'Godforsaken Precipice' that forged the group's reputation as valiant survivalists, it's traditionally brewed with medicinal herbs that soothe burns."
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/shockwine
 	name = "Vintage Lightnings' Blessing"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/shock_wine = 45, /datum/reagent/consumable/ethanol/vodka = 5)
-	desc = "Lightnings' Blessing, made to invigorate consumers and incapacitate targets, took inspiration from an incident early in the Saint-Roumain Militia's history, when a young Shadow stopped a rampaging beast by plunging an electrical cable that had been dislodged in the fighting into its side."
+	desc = "Lightnings' Blessing, which was made to invigorate consumers, took inspiration from an incident early in the Saint-Roumain Militia's history, when a young Shadow stopped a rampaging beast by plunging an electrical cable that had been dislodged in the fighting into its side."
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine
 	name = "Vintage Hearthflame"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/hearth_wine = 45, /datum/reagent/consumable/ethanol/hcider = 5)
-	desc = "Hearthflame is one of the most important tonics devised by the SRM – both for its potent abilities in staunching wounds or setting enemies aflame, and for its closeness to the divine fire associated with the Ashen Huntsman."
+	desc = "Hearthflame is one of the most important tonics devised by the SRM – for its potent abilities in staunching wounds and for its closeness to the divine fire associated with the Ashen Huntsman."
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/forcewine
-	name = "Vintage Saint-Roumain Forcewine"
+	name = "Roumain Knifepoint"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/force_wine = 45, /datum/reagent/consumable/ethanol/tequila = 5)
-	desc = "Forcewine was originally created as a means to create temporary shelters during long tracking expeditions. While the structures proved to be not as versatile in shape as its brewers had hoped, its utility in creating barricades or heming in hostiles was still greatly appreciated."
+	desc = "Known for its immensely alcoholic nature, Knifepoint has earned its name by being used as an antiseptic and analgesic in desperate circumstances more than once."
 
 /obj/item/reagent_containers/food/drinks/breakawayflask/vintage/prismwine
 	name = "Vintage Saint-Roumain Prismwine"
 	list_reagents = list(/datum/reagent/consumable/ethanol/trickwine/prism_wine = 45, /datum/reagent/consumable/ethanol/gin = 5)
-	desc = "Prismwine is one of the most recent additions to the Saint-Roumain Militia's reserve of trickwines. It was purpose-created for fighting hostiles that utilized more advanced energy projection attacks, such as the cryonic beams of watchers or the laser guns of interstellar pirates."
+	desc = "Prismwine is a rather unremarkable roumian beverage."

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -1,34 +1,17 @@
 ///////////////////
 // STATUS EFFECT //
 ///////////////////
-/atom/movable/screen/alert/status_effect/trickwine
-	name = "Trickwine"
-	desc = "You are empowered or weakened by a trickwine!"
-	icon_state = "breakaway_flask"
-
-/atom/movable/screen/alert/status_effect/trickwine/proc/setup(datum/reagent/consumable/ethanol/trickwine/trickwine_reagent)
-	name = trickwine_reagent.name
-	icon_state = "template"
-	cut_overlays()
-	var/icon/flask_icon = icon('icons/obj/drinks/trickwine.dmi', trickwine_reagent.breakaway_flask_icon_state)
-	add_overlay(flask_icon)
-
 /datum/status_effect/trickwine
 	id = "trick_wine"
-	alert_type = /atom/movable/screen/alert/status_effect/trickwine
 	// Try to match normal reagent tick rate based on on_mob_life
 	tick_interval = 20
+	alert_type = null
 	var/obj/effect/abstract/particle_holder/particle_generator
 	// Used to make icon for status_effect
 	var/flask_icon_state
 	var/flask_icon = 'icons/obj/drinks/trickwine.dmi'
 	// Used for mod outline
 	var/reagent_color = "#FFFFFF"
-	var/message_apply_others = "is affected by a trickwine!"
-	var/message_apply_self = "You are affected by a trickwine!"
-	var/message_remove_others = "is no longer affected by a trickwine!"
-	var/message_remove_self = "You are no longer affected by a trickwine!"
-	var/alert_desc
 	// Applied and removes with reagent
 	var/trait
 
@@ -38,11 +21,6 @@
 		CRASH("A trickwine status effect was created without a attached reagent")
 	reagent_color = trickwine_reagent.color
 	. = ..()
-	if(istype(linked_alert, /atom/movable/screen/alert/status_effect/trickwine))
-		var/atom/movable/screen/alert/status_effect/trickwine/trickwine_alert = linked_alert
-		trickwine_alert.setup(trickwine_reagent)
-		trickwine_alert.desc = alert_desc
-
 
 /datum/status_effect/trickwine/on_apply()
 	if(trait)
@@ -65,14 +43,6 @@
 //////////
 /datum/status_effect/trickwine/buff
 	id = "trick_wine_buff"
-	alert_desc = "You are empowered by a trickwine!"
-
-
-// DEBUFF //
-////////////
-/datum/status_effect/trickwine/debuff
-	id = "trick_wine_debuff"
-	alert_desc = "You are weakened by a trickwine!"
 
 //////////////
 // REAGENTS //
@@ -83,46 +53,7 @@
 	var/datum/status_effect/trickwine/debuff_effect = null
 	var/datum/status_effect/trickwine/buff_effect = null
 	//the kind of ammo you get from dipping 38 in this
-	var/obj/item/ammo_casing/c38/dip_ammo_type = null
-	var/dip_consumption = 2
 	bad_type = /datum/reagent/consumable/ethanol/trickwine
-
-/datum/reagent/consumable/ethanol/trickwine/dip_object(obj/item/I, mob/user, obj/item/reagent_containers/H)
-	. = ..()
-	if(!dip_ammo_type)
-		return
-	if(istype(I, /obj/item/ammo_casing/c38))
-		if(volume > dip_consumption)
-			var/obj/item/ammo_casing/c38/new_ammo = new dip_ammo_type(user.loc)
-			user.put_in_hands(new_ammo)
-			to_chat(user,span_notice("You dip \the [I] into the trickwine, suffusing it with the wine's effects."))
-			H.reagents.remove_reagent(src.type, dip_consumption)
-			qdel(I)
-			return TRUE
-		else
-			to_chat(user,span_warning("There's not enough trickwine left to soak \the [I]!"))
-			return FALSE
-
-	else if(istype(I, /obj/item/ammo_box/magazine/ammo_stack))
-		var/obj/item/ammo_box/magazine/ammo_stack/dip_stack = I
-		if(dip_stack.ammo_type == /obj/item/ammo_casing/c38)
-			var/trickwine_used = dip_consumption * dip_stack.ammo_count(FALSE)
-			if(volume > trickwine_used)
-				var/obj/item/ammo_box/magazine/ammo_stack/prefilled/new_stack
-				new_stack = new(user.loc, dip_stack.ammo_count(FALSE), dip_ammo_type)
-				user.put_in_hands(new_stack)
-				to_chat(user,span_notice("You dip \the [I] into the trickwine, suffusing it with the wine's effects."))
-				H.reagents.remove_reagent(src.type, trickwine_used)
-				qdel(I)
-				return TRUE
-			else
-				to_chat(user,span_warning("There's not enough trickwine left to soak \the [I]!"))
-				return FALSE
-		return FALSE
-	else
-		return FALSE
-
-
 
 /datum/reagent/consumable/ethanol/trickwine/on_mob_metabolize(mob/living/consumer)
 	if(buff_effect)
@@ -133,13 +64,6 @@
 	if(buff_effect && consumer.has_status_effect(buff_effect))
 		consumer.remove_status_effect((buff_effect))
 	..()
-
-/datum/reagent/consumable/ethanol/trickwine/expose_mob(mob/living/exposed_mob, method = TOUCH, reac_volume)
-	if(method == TOUCH)
-		if(debuff_effect)
-			exposed_mob.apply_status_effect(debuff_effect, src, (reac_volume / ETHANOL_METABOLISM) * 10)
-	return ..()
-
 
 /datum/reagent/consumable/ethanol/trickwine/ash_wine
 	name = "Wine of Ash"
@@ -152,17 +76,14 @@
 	glass_desc = "A traditional sacrament for members of the Saint-Roumain Militia. Believed to grant visions, seeing use both in ritual and entertainment within the Militia."
 	breakaway_flask_icon_state = "baflaskashwine"
 	buff_effect = /datum/status_effect/trickwine/buff/ash
-	debuff_effect = /datum/status_effect/trickwine/debuff/ash
-	dip_ammo_type = /obj/item/ammo_casing/c38/ashwine
 
 /datum/reagent/consumable/ethanol/trickwine/ash_wine/on_mob_life(mob/living/M, seconds_per_tick, times_fired)
 	var/high_message = pick("You feel far more devoted to the cause.", "You feel like you should go on a hunt.")
 	var/cleanse_message = pick("Divine light purifies you.", "You are purged of foul spirts.")
+	M.adjustToxLoss(-.5 * seconds_per_tick)
 	if(SPT_PROB(5, seconds_per_tick))
-		M.adjust_drugginess(5)
 		to_chat(M, span_notice("[high_message]"))
 	if(M.faction && ("roumain" in M.faction))
-		M.adjustToxLoss(-1 * seconds_per_tick)
 		if(SPT_PROB(5, seconds_per_tick))
 			to_chat(M, span_notice("[cleanse_message]"))
 	return ..()
@@ -178,26 +99,6 @@
 /datum/status_effect/trickwine/buff/ash/get_examine_text()
 	return span_notice("[owner.p_they(TRUE)] [owner.p_are()] filled with energy and devotion! [owner.p_their(TRUE)] eyes are dilated and [owner.p_they()] [owner.p_are()] twitching.")
 
-/datum/status_effect/trickwine/debuff/ash
-	id = "ash_wine_debuff"
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/ash/get_examine_text()
-	return span_notice("[owner.p_they(TRUE)] [owner.p_are()] covered in a thin layer of ash. [owner.p_they(TRUE)] [owner.p_are()] twitching and jittery.")
-
-/datum/status_effect/trickwine/debuff/ash/tick()
-	switch(pick("jitter", "dizzy", "drug"))
-		if("jitter")
-			owner.set_timed_status_effect(6 SECONDS * REM, /datum/status_effect/jitter, only_if_higher = TRUE)
-		if("dizzy")
-			owner.set_timed_status_effect(4 SECONDS * REM, /datum/status_effect/dizziness, only_if_higher = TRUE)
-		if("drug")
-			owner.adjust_drugginess(3)
-
 /datum/reagent/consumable/ethanol/trickwine/ice_wine
 	name = "Wine of Ice"
 	description = "A specialized brew utilized by members of the Saint-Roumain Militia, designed to assist in temperature regulation while working in hot environments. Known to give one the cold shoulder when thrown."
@@ -208,14 +109,10 @@
 	glass_desc = "A specialized brew utilized by members of the Saint-Roumain Militia, designed to assist in temperature regulation while working in hot environments. Known to give one the cold shoulder when thrown."
 	breakaway_flask_icon_state = "baflaskicewine"
 	buff_effect = /datum/status_effect/trickwine/buff/ice
-	debuff_effect = /datum/status_effect/trickwine/debuff/ice
-	dip_ammo_type = /obj/item/ammo_casing/c38/iceblox
 
 /datum/reagent/consumable/ethanol/trickwine/ice_wine/on_mob_life(mob/living/M, seconds_per_tick, times_fired)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal(), FALSE)
-	M.adjustFireLoss(-0.25)
-	if(SPT_PROB(2.5, seconds_per_tick))
-		to_chat(M, span_notice("Sweat runs down your body."))
+	M.adjustFireLoss(-0.5)
 	return ..()
 
 /datum/status_effect/trickwine/buff/ice
@@ -226,36 +123,6 @@
 	//message_remove_others = ""
 	//message_remove_self = ""
 	//alert_desc = ""
-	trait = TRAIT_NOFIRE
-
-/datum/status_effect/trickwine/debuff/ice
-	id = "ice_wine_debuff"
-	//trickwine_examine_text = ""
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-	var/icon/cube
-
-/datum/status_effect/trickwine/debuff/ice/on_apply()
-	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(owner_moved))
-	owner.Paralyze(duration)
-	to_chat(owner, span_userdanger("You become frozen in a cube!"))
-	cube = icon('icons/effects/freeze.dmi', "ice_cube")
-	var/icon/size_check = icon(owner.icon, owner.icon_state)
-	cube.Scale(size_check.Width(), size_check.Height())
-	owner.add_overlay(cube)
-	return ..()
-
-/// Blocks movement from the status effect owner
-/datum/status_effect/trickwine/debuff/ice/proc/owner_moved()
-	return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
-
-/datum/status_effect/trickwine/debuff/ice/on_remove()
-	to_chat(owner, span_notice("The cube melts!"))
-	owner.cut_overlay(cube)
-	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 
 /datum/reagent/consumable/ethanol/trickwine/shock_wine
 	name = "Lightning's Blessing"
@@ -267,27 +134,9 @@
 	glass_desc = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey. Known to have a shocking effect when thrown"
 	breakaway_flask_icon_state = "baflaskshockwine"
 	buff_effect = /datum/status_effect/trickwine/buff/shock
-	debuff_effect = /datum/status_effect/trickwine/debuff/shock
-	dip_ammo_type = /obj/item/ammo_casing/c38/shock
-
-/datum/reagent/consumable/ethanol/trickwine/shock_wine/expose_mob(mob/living/M, method=TOUCH, reac_volume)
-	if(method == TOUCH)
-		M.electrocute_act(reac_volume, src, siemens_coeff = 1, flags = SHOCK_NOSTUN|SHOCK_TESLA)
-		do_sparks(5, FALSE, M)
-		playsound(M, 'sound/machines/defib_zap.ogg', 100, TRUE)
-	return ..()
 
 /datum/status_effect/trickwine/buff/shock
 	id = "shock_wine_buff"
-	message_apply_others =  "seems to be crackling with energy!"
-	message_apply_self = "You feel like a bolt of lightning!"
-	message_remove_others = "has lost their static energy."
-	message_remove_self = "Inertia leaves your body!"
-	alert_desc = "You feel faster than lightning and cracking with energy! You are immune to shock damage and move faster!"
-	trait = TRAIT_SHOCKIMMUNE
-
-/datum/status_effect/trickwine/buff/shock/get_examine_text()
-	return span_notice("[owner.p_they(TRUE)] seem[owner.p_s()] to be crackling with energy.")
 
 /datum/status_effect/trickwine/buff/shock/on_apply()
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
@@ -296,19 +145,6 @@
 /datum/status_effect/trickwine/buff/shock/on_remove()
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/shock_wine)
 	..()
-
-/datum/status_effect/trickwine/debuff/shock
-	id = "shock_wine_debuff"
-	//trickwine_examine_text = ""
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/shock/tick()
-	if(rand(25))
-		do_sparks(5, FALSE, owner)
 
 /datum/reagent/consumable/ethanol/trickwine/hearth_wine
 	name = "Hearthflame"
@@ -320,8 +156,6 @@
 	glass_desc = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and cauterize wounds. Goes out in a blaze of glory when thrown."
 	breakaway_flask_icon_state = "baflaskhearthwine"
 	buff_effect = /datum/status_effect/trickwine/buff/hearth
-	debuff_effect = /datum/status_effect/trickwine/debuff/hearth
-	dip_ammo_type = /obj/item/ammo_casing/c38/hotshot
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor
 	var/passive_bleed_modifier = 0.4
 	/// For tracking when we tell the person we're no longer bleeding
@@ -379,77 +213,48 @@
 	//alert_desc = ""
 	trait = TRAIT_RESISTCOLD
 
-/datum/status_effect/trickwine/debuff/hearth
-	id = "hearth_wine_debuff"
-	//trickwine_examine_text = ""
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/hearth/tick()
-	//owner.fire_act()
-	var/turf/owner_turf = get_turf(owner)
-	owner_turf.ignite_turf(duration)
-	//new /obj/effect/hotspot(owner_turf, 1)
-
 /datum/reagent/consumable/ethanol/trickwine/force_wine
-	name = "Forcewine"
-	description = "Creates a barrier on the skin that catches shrapnel, and when reversed, locks threats down with a barrier."
+	name = "Knifepoint liquor"
+	description = "Immensely alcoholic roumian beverage, traditionally used as a disinfectant and painkiller."
 	color = "#709AAF"
-	boozepwr = 70
-	taste_description = "the strength of your convictions"
+	boozepwr = 170
+	taste_description = "chemical numbness"
 	glass_name = "Forcewine"
-	glass_desc = "Creates a barrier on the skin that catches shrapnel, and when reversed, locks threats down with a barrier."
+	glass_desc = "Roumian wine"
 	breakaway_flask_icon_state = "baflaskforcewine"
 	buff_effect = /datum/status_effect/trickwine/buff/force
-	debuff_effect = /datum/status_effect/trickwine/debuff/force
-	dip_ammo_type = /obj/item/ammo_casing/c38/force
+
+/datum/reagent/consumable/ethanol/trickwine/force_wine/on_mob_metabolize(mob/living/consumer)
+	//should make it so it doesn't blast your liver to bits, though the regular drunkenness can still be fatal
+	var/obj/item/organ/liver/liverinquestion = consumer.getorganslot(ORGAN_SLOT_LIVER)
+	//you would think higher alcohol_tolerance would mean less liver damage. Wrong!
+	liverinquestion.alcohol_tolerance /= 6
+	. = ..()
+
+/datum/reagent/consumable/ethanol/trickwine/force_wine/on_mob_end_metabolize(mob/living/consumer)
+	var/obj/item/organ/liver/liverinquestion = consumer.getorganslot(ORGAN_SLOT_LIVER)
+	//re enable liver blasting
+	liverinquestion.alcohol_tolerance *= 6
+	. = ..()
 
 /datum/status_effect/trickwine/buff/force
 	id = "force_wine_buff"
-	//trickwine_examine_text = ""
-	message_apply_others =  "glows a dim grey aura."
-	//message_apply_self = "You feel faster than lightning!"
-	message_remove_others = "'s aura fades away."
-	//message_remove_self = "You feel sluggish."
-	//alert_desc = ""
-	// No shrapnel seems useful
-	trait = TRAIT_PIERCEIMMUNE
+	//you ever heard how they'd give soldiers in the US civil war a bunch of whiskey before amputation. This lets you do that!
+	trait = TRAIT_ANALGESIA
 
-/datum/status_effect/trickwine/debuff/force
-	id = "force_wine_debuff"
-	//trickwine_examine_text = ""
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/force/on_apply()
-	var/turf/turf = get_turf(owner)
-	var/turf/other_turf
-	new /obj/structure/foamedmetal/forcewine(turf, duration)
-	for(var/direction in GLOB.cardinals)
-		other_turf = get_step(turf, direction)
-		new /obj/structure/foamedmetal/forcewine(other_turf, duration)
-	return ..()
 
 /datum/reagent/consumable/ethanol/trickwine/prism_wine
 	name = "Prismwine"
 	description = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to defend against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
 	color = "#F0F0F0"
-	boozepwr = 70
+	boozepwr = 50
+	quality = FOOD_AMAZING
 	taste_description = "the reflective quality of meditation"
 	glass_name = "Prismwine"
 	glass_desc = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to defend against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
 	breakaway_flask_icon_state = "baflaskprismwine"
 	buff_effect = /datum/status_effect/trickwine/buff/prism
-	debuff_effect = /datum/status_effect/trickwine/debuff/prism
-	dip_ammo_type = /obj/item/ammo_casing/c38/dumdum
 
-#define MAX_REFLECTS 3
 /datum/status_effect/trickwine/buff/prism
 	id = "prism_wine_buff"
 	//trickwine_examine_text = ""
@@ -458,63 +263,8 @@
 	//message_remove_others = ""
 	//message_remove_self = ""
 	//alert_desc = ""
-	var/reflect_count = 0
-	var/recent_movement = FALSE
 
-/datum/status_effect/trickwine/buff/prism/on_apply()
-	RegisterSignal(owner, COMSIG_CHECK_REFLECT, PROC_REF(on_check_reflect))
-	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
-	return ..()
 
-/datum/status_effect/trickwine/buff/prism/on_remove()
-	UnregisterSignal(owner, list(COMSIG_CHECK_REFLECT, COMSIG_MOVABLE_MOVED))
-	..()
 
-/datum/status_effect/trickwine/buff/prism/tick()
-	. = ..()
-	if(prob(25) && reflect_count < MAX_REFLECTS)
-		if(recent_movement)
-			adjust_charge(1)
-			to_chat(owner, span_notice("Your resin sweat builds up another layer!"))
-		else
-			to_chat(owner, span_warning("You need to keep moving to build up resin sweat!"))
-	recent_movement = FALSE
-
-/datum/status_effect/trickwine/buff/prism/proc/adjust_charge(change)
-	reflect_count = clamp(reflect_count + change, 0, MAX_REFLECTS)
-	owner.add_filter(id, 2, drop_shadow_filter(x = 0, y = -1, size = 1 + reflect_count, color = reagent_color))
-
-/datum/status_effect/trickwine/buff/prism/proc/on_check_reflect(mob/living/carbon/human/owner, def_zone)
-	SIGNAL_HANDLER
-	if(reflect_count > 0)
-		to_chat(owner, span_notice("Your resin sweat protects you!"))
-		adjust_charge(-1)
-		return TRUE
-
-// The idea is that its a resin made of sweat, therfore stay moving
-/datum/status_effect/trickwine/buff/prism/proc/on_move()
-	recent_movement = TRUE
-#undef MAX_REFLECTS
-
-/datum/status_effect/trickwine/debuff/prism
-	id = "prism_wine_debuff"
-	//trickwine_examine_text = ""
-	//message_apply_others =  ""
-	//message_apply_self = ""
-	//message_remove_others = ""
-	//message_remove_self = ""
-	//alert_desc = ""
-
-/datum/status_effect/trickwine/debuff/prism/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/the_human = owner
-		the_human.physiology.burn_mod *= 2
-	return ..()
-
-/datum/status_effect/trickwine/debuff/prism/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/the_human = owner
-		the_human.physiology.burn_mod *= 0.5
-	..()
 
 

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -101,12 +101,12 @@
 
 /datum/reagent/consumable/ethanol/trickwine/ice_wine
 	name = "Wine of Ice"
-	description = "A specialized brew utilized by members of the Saint-Roumain Militia, designed to assist in temperature regulation while working in hot environments. Known to give one the cold shoulder when thrown."
+	description = "A specialized brew utilized by members of the Saint-Roumain Militia, mixed with a set of medicinal herbs that help treat burns."
 	color = "#C0F1EE"
 	boozepwr = 70
 	taste_description = "a weighty meat, undercut by a mild pepper."
 	glass_name = "Wine of Ice"
-	glass_desc = "A specialized brew utilized by members of the Saint-Roumain Militia, designed to assist in temperature regulation while working in hot environments. Known to give one the cold shoulder when thrown."
+	glass_desc = "A specialized brew utilized by members of the Saint-Roumain Militia, mixed with a set of medicinal herbs that help treat burns."
 	breakaway_flask_icon_state = "baflaskicewine"
 	buff_effect = /datum/status_effect/trickwine/buff/ice
 
@@ -126,12 +126,12 @@
 
 /datum/reagent/consumable/ethanol/trickwine/shock_wine
 	name = "Lightning's Blessing"
-	description = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey. Known to have a shocking effect when thrown"
+	description = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey."
 	color = "#FEFEB8"
 	boozepwr = 50
 	taste_description = "a sharp and unrelenting citrus"
 	glass_name = "Lightning's Blessing"
-	glass_desc = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey. Known to have a shocking effect when thrown"
+	glass_desc = "A stimulating brew utilized by members of the Saint-Roumain Militia, created to allow trackers to keep up with highly mobile prey."
 	breakaway_flask_icon_state = "baflaskshockwine"
 	buff_effect = /datum/status_effect/trickwine/buff/shock
 
@@ -148,12 +148,12 @@
 
 /datum/reagent/consumable/ethanol/trickwine/hearth_wine
 	name = "Hearthflame"
-	description = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and cauterize wounds. Goes out in a blaze of glory when thrown."
+	description = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and staunch wounds."
 	color = "#FEE185"
 	boozepwr = 70
 	taste_description = "apple cut apart by tangy pricks"
 	glass_name = "Hearthflame"
-	glass_desc = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and cauterize wounds. Goes out in a blaze of glory when thrown."
+	glass_desc = "A fiery brew utilized by members of the Saint-Roumain Militia, engineered to heat the body and staunch wounds."
 	breakaway_flask_icon_state = "baflaskhearthwine"
 	buff_effect = /datum/status_effect/trickwine/buff/hearth
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor
@@ -215,12 +215,12 @@
 
 /datum/reagent/consumable/ethanol/trickwine/force_wine
 	name = "Knifepoint liquor"
-	description = "Immensely alcoholic roumian beverage, traditionally used as a disinfectant and painkiller."
+	description = "Immensely alcoholic Roumian beverage, occasionally used as a disinfectant and painkiller when proper medicine is not available. Hunter doctors do not reccomend any more than a thimbleful"
 	color = "#709AAF"
 	boozepwr = 170
 	taste_description = "chemical numbness"
-	glass_name = "Forcewine"
-	glass_desc = "Roumian wine"
+	glass_name = "Knifepoint"
+	glass_desc = "Immensely alcoholic Roumian beverage, occasionally used as a disinfectant and painkiller when proper medicine is not available. Hunter doctors do not reccomend any more than a thimbleful"
 	breakaway_flask_icon_state = "baflaskforcewine"
 	buff_effect = /datum/status_effect/trickwine/buff/force
 
@@ -245,13 +245,13 @@
 
 /datum/reagent/consumable/ethanol/trickwine/prism_wine
 	name = "Prismwine"
-	description = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to defend against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
+	description = "A glittering liquid that seems to always refract light passing through it into a rainbow."
 	color = "#F0F0F0"
 	boozepwr = 50
 	quality = FOOD_AMAZING
 	taste_description = "the reflective quality of meditation"
 	glass_name = "Prismwine"
-	glass_desc = "A glittering brew utilized by members of the Saint-Roumain Militia, mixed to defend against the blasts and burns of foes and fauna alike. Softens targets against your own burns when thrown."
+	glass_desc = "A glittering liquid that seems to always refract light passing through it into a rainbow."
 	breakaway_flask_icon_state = "baflaskprismwine"
 	buff_effect = /datum/status_effect/trickwine/buff/prism
 

--- a/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/trickwine_reagents.dm
@@ -80,7 +80,7 @@
 /datum/reagent/consumable/ethanol/trickwine/ash_wine/on_mob_life(mob/living/M, seconds_per_tick, times_fired)
 	var/high_message = pick("You feel far more devoted to the cause.", "You feel like you should go on a hunt.")
 	var/cleanse_message = pick("Divine light purifies you.", "You are purged of foul spirts.")
-	M.adjustToxLoss(-.5 * seconds_per_tick)
+	M.adjustToxLoss(-0.5 * seconds_per_tick)
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(M, span_notice("[high_message]"))
 	if(M.faction && ("roumain" in M.faction))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The magical effects of "trickwine" have been removed. Prices and flavor text have been updated to reflect this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trickwine was weirdly unfitting for the setting and many of the effects were "super jank" this reworks some of them to be more possible as something in the setting (mildly medicinal wine) and removes the magical effects.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add:"Knifepoint" (SRM liquor) has been added, and costs 100cr in factional SRM cargo.
del:Forcewine has been removed
del: Trickwines no longer have an effect when thrown
del:.38 ammo can no longer be dipped in Roumian wine to make magic bullets
del:Prismwine no longer has unique effects when drank.
balance: shockwine no longer makes you shockimmune
balance:Ashwine will no longer judge the strength of your convictions and will heal everyone accordingly
balance:Breakaway flasks no longer make you chug half the bottle when drank.
balance:Ash and Ice wine now cost 200cr
balance:Prismwine now costs 50cr
fix: Roumian beverages no longer give a weird status effect popup.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
