### PR TITLE
[TM FIRST I BEG] Small map loading optimization

### DIFF
--- a/code/datums/mapgen/_MapGenerator.dm
+++ b/code/datums/mapgen/_MapGenerator.dm
@@ -16,7 +16,6 @@
 		gen_turf.AfterChange(CHANGETURF_IGNORE_AIR)
 
 		QUEUE_SMOOTH(gen_turf)
-		QUEUE_SMOOTH_NEIGHBORS(gen_turf)
 
 		for(var/turf/open/space/adj in RANGE_TURFS(1, gen_turf))
 			adj.check_starlight(gen_turf)

--- a/code/datums/mapgen/planetary/_PlanetGenerator.dm
+++ b/code/datums/mapgen/planetary/_PlanetGenerator.dm
@@ -189,7 +189,6 @@
 		gen_turf.AfterChange(CHANGETURF_IGNORE_AIR)
 
 		QUEUE_SMOOTH(gen_turf)
-		QUEUE_SMOOTH_NEIGHBORS(gen_turf)
 
 		for(var/turf/open/space/adj in RANGE_TURFS(1, gen_turf))
 			adj.check_starlight(gen_turf)


### PR DESCRIPTION
## About The Pull Request

Normally when we add things to the turf smoothing queue, we add the neighbors too, so they are updated as well.
However, we shouldn't need to do this during planet gen, since we're already adding the entire planet to the smoothing queue. This eliminates a bunch of unnecessary calls.

I tested this on a local and the map generated with correct smoothing. Maps seemed to generate a little faster but I cannot say definitively at this point whether or not it has any performance benefits yet.

## Why It's Good For The Game

Sliiiiiightly faster mapload.

## Changelog

:cl: cablefish
fix: Map loading should be ever so slightly faster.
/:cl: